### PR TITLE
feat(projects): Add Projects Module with R&M enhancements

### DIFF
--- a/hrms/api/projects.py
+++ b/hrms/api/projects.py
@@ -898,6 +898,275 @@ def get_stores_list():
     return {"stores": stores}
 
 
+# ==============================================================================
+# CHARGING WORKFLOW
+# ==============================================================================
+
+
+@frappe.whitelist()
+def assess_maintenance_request(request_id, concern_type, notes=None):
+    """
+    Technician assesses the request and sets concern type.
+
+    Args:
+        request_id: The maintenance request name
+        concern_type: "Wear & Tear", "Supplier Deficiency", "Contractor Deficiency"
+        notes: Optional assessment notes
+
+    Returns:
+        {"success": True, "message": "...", "request": {...}}
+    """
+    if not request_id:
+        frappe.throw(_("Request ID is required"))
+
+    valid_concern_types = ["Wear & Tear", "Supplier Deficiency", "Contractor Deficiency"]
+    if concern_type not in valid_concern_types:
+        frappe.throw(_("Invalid concern type. Must be one of: {0}").format(", ".join(valid_concern_types)))
+
+    if not frappe.db.exists("BEI Maintenance Request", request_id):
+        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+
+    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+    doc.concern_type = concern_type
+
+    if notes:
+        doc.add_comment("Comment", f"Assessment: {notes}")
+
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Request {0} assessed as {1}").format(request_id, concern_type),
+        "request": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def set_maintenance_charge(request_id, charge_amount, charging_reason):
+    """
+    Set a charge to store for a maintenance request.
+
+    Args:
+        request_id: The maintenance request name
+        charge_amount: Amount to charge
+        charging_reason: Reason for the charge
+
+    Returns:
+        {"success": True, "message": "...", "request": {...}}
+    """
+    if not request_id:
+        frappe.throw(_("Request ID is required"))
+
+    if not charge_amount or flt(charge_amount) <= 0:
+        frappe.throw(_("Charge amount must be greater than 0"))
+
+    if not charging_reason:
+        frappe.throw(_("Charging reason is required"))
+
+    if not frappe.db.exists("BEI Maintenance Request", request_id):
+        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+
+    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+    doc.charge_to_store = 1
+    doc.charge_amount = flt(charge_amount)
+    doc.charging_reason = charging_reason
+    doc.status = "Pending Acknowledgement"
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Charge of {0} set for {1}. Pending store acknowledgement.").format(
+            doc.charge_amount, request_id
+        ),
+        "request": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def acknowledge_maintenance_charge(request_id):
+    """
+    Store supervisor acknowledges charge to store.
+
+    Args:
+        request_id: The maintenance request name
+
+    Returns:
+        {"success": True, "message": "..."}
+    """
+    if not request_id:
+        frappe.throw(_("Request ID is required"))
+
+    if not frappe.db.exists("BEI Maintenance Request", request_id):
+        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+
+    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+
+    if not doc.charge_to_store:
+        frappe.throw(_("This request has no charge to acknowledge"))
+
+    if doc.store_acknowledged:
+        frappe.throw(_("Charge already acknowledged"))
+
+    doc.store_acknowledged = 1
+    doc.acknowledged_by = frappe.session.user
+    doc.acknowledgement_date = nowdate()
+    doc.status = "Verified"
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Charge acknowledged for {0}").format(request_id)
+    }
+
+
+@frappe.whitelist()
+def get_pending_charges(store=None, page=1, page_size=20):
+    """
+    Get maintenance requests with pending store charges.
+
+    Args:
+        store: Filter by specific store (optional)
+        page: Page number (default: 1)
+        page_size: Items per page (default: 20)
+
+    Returns:
+        {
+            "requests": [...],
+            "total": int,
+            "page": int,
+            "page_size": int
+        }
+    """
+    filters = {
+        "charge_to_store": 1,
+        "store_acknowledged": 0,
+        "status": ["in", ["Completed", "Pending Acknowledgement"]]
+    }
+
+    if store:
+        filters["store"] = store
+
+    page = int(page)
+    page_size = int(page_size)
+
+    total = frappe.db.count("BEI Maintenance Request", filters)
+
+    requests = frappe.get_all(
+        "BEI Maintenance Request",
+        filters=filters,
+        fields=[
+            "name", "store", "store_code", "request_date", "issue_category",
+            "description", "charge_amount", "charging_reason", "concern_type",
+            "priority", "status"
+        ],
+        order_by="request_date desc",
+        limit_page_length=page_size,
+        limit_start=(page - 1) * page_size
+    )
+
+    # Get store names
+    for req in requests:
+        if req.store:
+            req["store_name"] = frappe.db.get_value("Warehouse", req.store, "warehouse_name")
+
+    return {
+        "requests": requests,
+        "total": total,
+        "page": page,
+        "page_size": page_size
+    }
+
+
+@frappe.whitelist()
+def add_maintenance_materials(request_id, materials):
+    """
+    Add materials to a maintenance request.
+
+    Args:
+        request_id: The maintenance request name
+        materials: List of materials [{material, quantity, unit, unit_cost}, ...]
+
+    Returns:
+        {"success": True, "message": "...", "request": {...}}
+    """
+    if not request_id:
+        frappe.throw(_("Request ID is required"))
+
+    if not frappe.db.exists("BEI Maintenance Request", request_id):
+        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+
+    if isinstance(materials, str):
+        materials = json.loads(materials)
+
+    if not materials or not isinstance(materials, list):
+        frappe.throw(_("Materials must be a non-empty list"))
+
+    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+
+    total_materials_cost = 0
+    for mat in materials:
+        quantity = flt(mat.get("quantity", 1))
+        unit_cost = flt(mat.get("unit_cost", 0))
+        total_cost = quantity * unit_cost
+        total_materials_cost += total_cost
+
+        doc.append("materials", {
+            "material": mat.get("material"),
+            "quantity": quantity,
+            "unit": mat.get("unit", "pcs"),
+            "unit_cost": unit_cost,
+            "total_cost": total_cost
+        })
+
+    doc.materials_cost = total_materials_cost
+    doc.total_cost = total_materials_cost + flt(doc.labor_cost or 0)
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("{0} materials added to {1}").format(len(materials), request_id),
+        "request": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def update_maintenance_costs(request_id, labor_hours=None, labor_cost=None):
+    """
+    Update labor costs for a maintenance request.
+
+    Args:
+        request_id: The maintenance request name
+        labor_hours: Hours of labor
+        labor_cost: Cost of labor
+
+    Returns:
+        {"success": True, "message": "...", "request": {...}}
+    """
+    if not request_id:
+        frappe.throw(_("Request ID is required"))
+
+    if not frappe.db.exists("BEI Maintenance Request", request_id):
+        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+
+    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+
+    if labor_hours is not None:
+        doc.labor_hours = flt(labor_hours)
+
+    if labor_cost is not None:
+        doc.labor_cost = flt(labor_cost)
+
+    # Recalculate total cost
+    doc.total_cost = flt(doc.materials_cost or 0) + flt(doc.labor_cost or 0)
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Costs updated for {0}").format(request_id),
+        "request": doc.as_dict()
+    }
+
+
 @frappe.whitelist()
 def get_maintenance_categories():
     """
@@ -916,3 +1185,1035 @@ def get_maintenance_categories():
         categories = ["Electrical", "Plumbing", "Mechanical", "Pest", "Security", "Network", "Architectural", "Other"]
 
     return {"categories": categories}
+
+
+# ==============================================================================
+# PROJECT MANAGEMENT
+# ==============================================================================
+
+
+@frappe.whitelist()
+def get_project_dashboard():
+    """
+    Get projects grouped by stage for kanban dashboard.
+
+    Returns:
+        {
+            "pre_design": [...],
+            "design": [...],
+            ...
+            "summary": {"total_active": int, "total_budget": float}
+        }
+    """
+    stages = ["Pre-Design", "Design", "Bidding", "Pre-Construction",
+              "Construction", "Post-Construction", "Completed"]
+
+    result = {}
+    for stage in stages:
+        projects = frappe.get_all(
+            "BEI Project",
+            filters={"stage": stage, "status": ["!=", "Cancelled"]},
+            fields=[
+                "name", "project_name", "project_type", "store", "store_code",
+                "target_opening_date", "progress_percent", "contract_amount",
+                "priority", "project_manager"
+            ],
+            order_by="priority desc, target_opening_date asc"
+        )
+
+        # Get project manager names
+        for proj in projects:
+            if proj.project_manager:
+                proj["project_manager_name"] = frappe.db.get_value(
+                    "Employee", proj.project_manager, "employee_name"
+                )
+
+        key = stage.lower().replace("-", "_").replace(" ", "_")
+        result[key] = projects
+
+    # Summary stats
+    total_active = frappe.db.count("BEI Project", {
+        "stage": ["not in", ["Completed", "Cancelled", "On Hold"]],
+        "status": ["!=", "Cancelled"]
+    })
+
+    total_budget = frappe.db.sql("""
+        SELECT COALESCE(SUM(contract_amount), 0)
+        FROM `tabBEI Project`
+        WHERE stage NOT IN ('Completed', 'Cancelled', 'On Hold')
+        AND status != 'Cancelled'
+    """)[0][0]
+
+    result["summary"] = {
+        "total_active": total_active,
+        "total_budget": flt(total_budget),
+        "stages": stages
+    }
+
+    return result
+
+
+@frappe.whitelist()
+def get_project_detail(project):
+    """
+    Get full project detail with related documents.
+
+    Args:
+        project: The project name (e.g., PROJ-2026-0001)
+
+    Returns:
+        {
+            "project": {...},
+            "site_inspections": [...],
+            "bids": [...],
+            "permits": [...],
+            "milestones": [...],
+            "open_punchlist": [...],
+            "punchlist_count": int
+        }
+    """
+    if not project:
+        frappe.throw(_("Project name is required"))
+
+    if not frappe.db.exists("BEI Project", project):
+        frappe.throw(_("Project {0} not found").format(project))
+
+    doc = frappe.get_doc("BEI Project", project)
+    project_data = doc.as_dict()
+
+    # Get project manager name
+    if doc.project_manager:
+        project_data["project_manager_name"] = frappe.db.get_value(
+            "Employee", doc.project_manager, "employee_name"
+        )
+
+    # Get contractor name
+    if doc.contractor:
+        project_data["contractor_name"] = frappe.db.get_value(
+            "BEI Supplier", doc.contractor, "supplier_name"
+        )
+
+    # Get site inspections
+    site_inspections = frappe.get_all(
+        "BEI Site Inspection",
+        filters={"project": project},
+        fields=["name", "inspection_date", "inspection_type", "status",
+                "overall_status", "inspector_name"],
+        order_by="inspection_date desc"
+    )
+
+    # Get bids
+    bids = frappe.get_all(
+        "BEI Project Bid",
+        filters={"project": project},
+        fields=["name", "contractor", "contractor_name", "total_amount",
+                "final_amount", "status", "is_awarded", "submission_date"],
+        order_by="submission_date desc"
+    )
+
+    # Get permits
+    permits = frappe.get_all(
+        "BEI Project Permit",
+        filters={"project": project},
+        fields=["name", "permit_type", "status", "permit_number",
+                "approval_date", "expiry_date"],
+        order_by="permit_type"
+    )
+
+    # Get milestones
+    milestones = frappe.get_all(
+        "BEI Project Milestone",
+        filters={"project": project},
+        fields=["name", "milestone_name", "milestone_type", "status",
+                "target_date", "actual_date", "completion_percentage",
+                "billing_amount", "payment_status"],
+        order_by="sequence asc"
+    )
+
+    # Get open punchlist items
+    punchlist = frappe.get_all(
+        "BEI Punchlist Item",
+        filters={"project": project, "status": ["not in", ["Closed", "Waived"]]},
+        fields=["name", "category", "severity", "status", "location",
+                "description", "due_date"],
+        order_by="severity desc, due_date asc"
+    )
+
+    # Count total punchlist items
+    total_punchlist = frappe.db.count("BEI Punchlist Item", {"project": project})
+    closed_punchlist = frappe.db.count("BEI Punchlist Item", {
+        "project": project,
+        "status": ["in", ["Closed", "Waived"]]
+    })
+
+    return {
+        "project": project_data,
+        "site_inspections": site_inspections,
+        "bids": bids,
+        "permits": permits,
+        "milestones": milestones,
+        "open_punchlist": punchlist,
+        "punchlist_count": {
+            "total": total_punchlist,
+            "open": len(punchlist),
+            "closed": closed_punchlist
+        }
+    }
+
+
+@frappe.whitelist()
+def advance_project_stage(project, new_stage, notes=None):
+    """
+    Move project to a new stage.
+
+    Args:
+        project: The project name
+        new_stage: The new stage
+        notes: Optional notes for the stage change
+
+    Returns:
+        {"success": True, "message": "...", "project": {...}}
+    """
+    valid_stages = ["Pre-Design", "Design", "Bidding", "Pre-Construction",
+                    "Construction", "Post-Construction", "Completed",
+                    "On Hold", "Cancelled"]
+
+    if new_stage not in valid_stages:
+        frappe.throw(_("Invalid stage: {0}").format(new_stage))
+
+    if not frappe.db.exists("BEI Project", project):
+        frappe.throw(_("Project {0} not found").format(project))
+
+    doc = frappe.get_doc("BEI Project", project)
+    old_stage = doc.stage
+    doc.stage = new_stage
+    doc.last_update_date = nowdate()
+
+    if notes:
+        doc.notes = notes
+        doc.add_comment("Comment", f"Stage changed from {old_stage} to {new_stage}: {notes}")
+
+    # Update status based on stage
+    if new_stage == "Completed":
+        doc.status = "Completed"
+        doc.actual_completion_date = nowdate()
+    elif new_stage in ["On Hold", "Cancelled"]:
+        doc.status = new_stage
+    else:
+        doc.status = "Active"
+
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Project {0} moved from {1} to {2}").format(
+            project, old_stage, new_stage
+        ),
+        "project": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def update_project_progress(project, progress_percent, notes=None):
+    """
+    Update project progress percentage.
+
+    Args:
+        project: The project name
+        progress_percent: New progress percentage (0-100)
+        notes: Optional progress notes
+
+    Returns:
+        {"success": True, "message": "...", "project": {...}}
+    """
+    if not frappe.db.exists("BEI Project", project):
+        frappe.throw(_("Project {0} not found").format(project))
+
+    progress = flt(progress_percent)
+    if progress < 0 or progress > 100:
+        frappe.throw(_("Progress must be between 0 and 100"))
+
+    doc = frappe.get_doc("BEI Project", project)
+    doc.progress_percent = progress
+    doc.last_update_date = nowdate()
+
+    if notes:
+        doc.notes = notes
+
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Project {0} progress updated to {1}%").format(project, progress),
+        "project": doc.as_dict()
+    }
+
+
+# ==============================================================================
+# SITE INSPECTIONS
+# ==============================================================================
+
+
+@frappe.whitelist()
+def submit_site_inspection(inspection_id):
+    """
+    Submit a site inspection for approval.
+
+    Args:
+        inspection_id: The site inspection name
+
+    Returns:
+        {"success": True, "message": "...", "inspection": {...}}
+    """
+    if not frappe.db.exists("BEI Site Inspection", inspection_id):
+        frappe.throw(_("Site inspection {0} not found").format(inspection_id))
+
+    doc = frappe.get_doc("BEI Site Inspection", inspection_id)
+
+    if doc.status != "Draft":
+        frappe.throw(_("Only draft inspections can be submitted"))
+
+    doc.status = "Submitted"
+    doc.submitted_by = frappe.session.user
+    doc.submitted_at = now_datetime()
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Site inspection {0} submitted for approval").format(inspection_id),
+        "inspection": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def approve_site_inspection(inspection_id, approval_notes=None):
+    """
+    Approve a submitted site inspection.
+
+    Args:
+        inspection_id: The site inspection name
+        approval_notes: Optional approval notes
+
+    Returns:
+        {"success": True, "message": "...", "inspection": {...}}
+    """
+    if not frappe.db.exists("BEI Site Inspection", inspection_id):
+        frappe.throw(_("Site inspection {0} not found").format(inspection_id))
+
+    doc = frappe.get_doc("BEI Site Inspection", inspection_id)
+
+    if doc.status != "Submitted":
+        frappe.throw(_("Only submitted inspections can be approved"))
+
+    doc.status = "Approved"
+    doc.approved_by = frappe.session.user
+    doc.approved_date = nowdate()
+
+    if approval_notes:
+        doc.add_comment("Comment", f"Approved: {approval_notes}")
+
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Site inspection {0} approved").format(inspection_id),
+        "inspection": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def reject_site_inspection(inspection_id, rejection_reason):
+    """
+    Reject a submitted site inspection.
+
+    Args:
+        inspection_id: The site inspection name
+        rejection_reason: Reason for rejection
+
+    Returns:
+        {"success": True, "message": "...", "inspection": {...}}
+    """
+    if not rejection_reason:
+        frappe.throw(_("Rejection reason is required"))
+
+    if not frappe.db.exists("BEI Site Inspection", inspection_id):
+        frappe.throw(_("Site inspection {0} not found").format(inspection_id))
+
+    doc = frappe.get_doc("BEI Site Inspection", inspection_id)
+
+    if doc.status != "Submitted":
+        frappe.throw(_("Only submitted inspections can be rejected"))
+
+    doc.status = "Rejected"
+    doc.rejection_reason = rejection_reason
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Site inspection {0} rejected").format(inspection_id),
+        "inspection": doc.as_dict()
+    }
+
+
+# ==============================================================================
+# BID MANAGEMENT
+# ==============================================================================
+
+
+@frappe.whitelist()
+def get_bid_comparison(project):
+    """
+    Get bid comparison for a project.
+
+    Args:
+        project: The project name
+
+    Returns:
+        {
+            "project": {...},
+            "bids": [...],
+            "lowest_bid": {...} or None,
+            "awarded_bid": {...} or None
+        }
+    """
+    if not frappe.db.exists("BEI Project", project):
+        frappe.throw(_("Project {0} not found").format(project))
+
+    project_doc = frappe.get_doc("BEI Project", project)
+
+    bids = frappe.get_all(
+        "BEI Project Bid",
+        filters={"project": project, "status": ["!=", "Withdrawn"]},
+        fields=[
+            "name", "contractor", "contractor_name", "submission_date",
+            "base_amount", "vat_amount", "total_amount", "final_amount",
+            "status", "technical_score", "financial_score", "overall_score",
+            "is_awarded"
+        ],
+        order_by="total_amount asc"
+    )
+
+    lowest_bid = bids[0] if bids else None
+    awarded_bid = next((b for b in bids if b.is_awarded), None)
+
+    return {
+        "project": {
+            "name": project_doc.name,
+            "project_name": project_doc.project_name,
+            "approved_budget": project_doc.approved_budget
+        },
+        "bids": bids,
+        "lowest_bid": lowest_bid,
+        "awarded_bid": awarded_bid,
+        "bid_count": len(bids)
+    }
+
+
+@frappe.whitelist()
+def evaluate_bid(bid_id, technical_score, financial_score, evaluation_notes=None):
+    """
+    Evaluate a project bid.
+
+    Args:
+        bid_id: The bid name
+        technical_score: Technical evaluation score (0-100)
+        financial_score: Financial evaluation score (0-100)
+        evaluation_notes: Optional notes
+
+    Returns:
+        {"success": True, "message": "...", "bid": {...}}
+    """
+    if not frappe.db.exists("BEI Project Bid", bid_id):
+        frappe.throw(_("Bid {0} not found").format(bid_id))
+
+    tech = flt(technical_score)
+    fin = flt(financial_score)
+
+    if tech < 0 or tech > 100 or fin < 0 or fin > 100:
+        frappe.throw(_("Scores must be between 0 and 100"))
+
+    doc = frappe.get_doc("BEI Project Bid", bid_id)
+    doc.technical_score = tech
+    doc.financial_score = fin
+    doc.overall_score = (tech * 0.6) + (fin * 0.4)  # 60% technical, 40% financial
+    doc.status = "Under Review"
+
+    if evaluation_notes:
+        doc.evaluation_notes = evaluation_notes
+
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Bid {0} evaluated with overall score {1}%").format(
+            bid_id, round(doc.overall_score, 1)
+        ),
+        "bid": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def award_bid(bid_id, final_amount=None, award_notes=None):
+    """
+    Award a bid to a contractor.
+
+    Args:
+        bid_id: The bid name
+        final_amount: Negotiated final amount (optional)
+        award_notes: Award notes (optional)
+
+    Returns:
+        {"success": True, "message": "...", "bid": {...}}
+    """
+    if not frappe.db.exists("BEI Project Bid", bid_id):
+        frappe.throw(_("Bid {0} not found").format(bid_id))
+
+    doc = frappe.get_doc("BEI Project Bid", bid_id)
+
+    # Check no other bid is awarded for this project
+    existing_award = frappe.db.exists("BEI Project Bid", {
+        "project": doc.project,
+        "is_awarded": 1,
+        "name": ["!=", bid_id]
+    })
+
+    if existing_award:
+        frappe.throw(_("Another bid is already awarded for this project"))
+
+    doc.is_awarded = 1
+    doc.status = "Awarded"
+    doc.award_date = nowdate()
+    doc.awarded_by = frappe.session.user
+
+    if final_amount:
+        doc.final_amount = flt(final_amount)
+    else:
+        doc.final_amount = doc.total_amount
+
+    if award_notes:
+        doc.award_notes = award_notes
+
+    doc.save()
+
+    # Update project with contractor info
+    project = frappe.get_doc("BEI Project", doc.project)
+    project.contractor = doc.contractor
+    project.contract_amount = doc.final_amount
+    project.save()
+
+    # Mark other bids as not awarded
+    frappe.db.sql("""
+        UPDATE `tabBEI Project Bid`
+        SET status = 'Not Awarded'
+        WHERE project = %s AND name != %s AND status NOT IN ('Withdrawn', 'Awarded')
+    """, (doc.project, bid_id))
+
+    return {
+        "success": True,
+        "message": _("Bid {0} awarded to {1}").format(bid_id, doc.contractor_name),
+        "bid": doc.as_dict()
+    }
+
+
+# ==============================================================================
+# MILESTONES
+# ==============================================================================
+
+
+@frappe.whitelist()
+def complete_milestone(milestone_id, actual_date=None, notes=None):
+    """
+    Mark a milestone as completed.
+
+    Args:
+        milestone_id: The milestone name
+        actual_date: Actual completion date (defaults to today)
+        notes: Completion notes
+
+    Returns:
+        {"success": True, "message": "...", "milestone": {...}}
+    """
+    if not frappe.db.exists("BEI Project Milestone", milestone_id):
+        frappe.throw(_("Milestone {0} not found").format(milestone_id))
+
+    doc = frappe.get_doc("BEI Project Milestone", milestone_id)
+    doc.status = "Completed"
+    doc.completion_percentage = 100
+    doc.actual_date = actual_date or nowdate()
+
+    # Calculate variance
+    if doc.target_date and doc.actual_date:
+        doc.days_variance = date_diff(doc.actual_date, doc.target_date)
+
+    doc.save()
+
+    # Update project progress based on completed milestones
+    _update_project_progress_from_milestones(doc.project)
+
+    return {
+        "success": True,
+        "message": _("Milestone {0} completed").format(doc.milestone_name),
+        "milestone": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def verify_milestone(milestone_id, verification_notes=None):
+    """
+    Verify a completed milestone.
+
+    Args:
+        milestone_id: The milestone name
+        verification_notes: Verification notes
+
+    Returns:
+        {"success": True, "message": "...", "milestone": {...}}
+    """
+    if not frappe.db.exists("BEI Project Milestone", milestone_id):
+        frappe.throw(_("Milestone {0} not found").format(milestone_id))
+
+    doc = frappe.get_doc("BEI Project Milestone", milestone_id)
+
+    if doc.status != "Completed":
+        frappe.throw(_("Only completed milestones can be verified"))
+
+    doc.status = "Verified"
+    doc.verified = 1
+    doc.verified_by = frappe.session.user
+    doc.verification_date = nowdate()
+
+    if verification_notes:
+        doc.verification_notes = verification_notes
+
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Milestone {0} verified").format(doc.milestone_name),
+        "milestone": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def create_milestone_billing(milestone_id):
+    """
+    Create a payment request for a verified milestone.
+
+    Args:
+        milestone_id: The milestone name
+
+    Returns:
+        {"success": True, "message": "...", "milestone": {...}, "payment_request": {...}}
+    """
+    if not frappe.db.exists("BEI Project Milestone", milestone_id):
+        frappe.throw(_("Milestone {0} not found").format(milestone_id))
+
+    doc = frappe.get_doc("BEI Project Milestone", milestone_id)
+
+    if doc.status != "Verified":
+        frappe.throw(_("Only verified milestones can be billed"))
+
+    if doc.payment_request:
+        frappe.throw(_("Payment request already exists: {0}").format(doc.payment_request))
+
+    if not doc.billing_amount or flt(doc.billing_amount) <= 0:
+        frappe.throw(_("Billing amount must be greater than 0"))
+
+    # Get project details
+    project = frappe.get_doc("BEI Project", doc.project)
+
+    # Create payment request
+    payment_request = frappe.new_doc("BEI Payment Request")
+    payment_request.supplier = project.contractor
+    payment_request.amount = doc.billing_amount
+    payment_request.description = f"Progress billing for {project.project_name} - {doc.milestone_name}"
+    payment_request.insert()
+
+    # Link payment request to milestone
+    doc.payment_request = payment_request.name
+    doc.payment_status = "Billed"
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Payment request {0} created for milestone {1}").format(
+            payment_request.name, doc.milestone_name
+        ),
+        "milestone": doc.as_dict(),
+        "payment_request": payment_request.as_dict()
+    }
+
+
+def _update_project_progress_from_milestones(project_name):
+    """
+    Internal: Update project progress based on milestone completion.
+    """
+    milestones = frappe.get_all(
+        "BEI Project Milestone",
+        filters={"project": project_name},
+        fields=["completion_percentage"]
+    )
+
+    if milestones:
+        avg_progress = sum(m.completion_percentage or 0 for m in milestones) / len(milestones)
+        frappe.db.set_value("BEI Project", project_name, "progress_percent", avg_progress)
+
+
+# ==============================================================================
+# PUNCHLIST
+# ==============================================================================
+
+
+@frappe.whitelist()
+def get_punchlist(project, status=None, category=None, severity=None, page=1, page_size=50):
+    """
+    Get punchlist items for a project.
+
+    Args:
+        project: The project name
+        status: Filter by status (optional)
+        category: Filter by category (optional)
+        severity: Filter by severity (optional)
+        page: Page number
+        page_size: Items per page
+
+    Returns:
+        {
+            "items": [...],
+            "total": int,
+            "page": int,
+            "summary": {...}
+        }
+    """
+    if not frappe.db.exists("BEI Project", project):
+        frappe.throw(_("Project {0} not found").format(project))
+
+    filters = {"project": project}
+
+    if status:
+        filters["status"] = status
+
+    if category:
+        filters["category"] = category
+
+    if severity:
+        filters["severity"] = severity
+
+    page = int(page)
+    page_size = int(page_size)
+
+    total = frappe.db.count("BEI Punchlist Item", filters)
+
+    items = frappe.get_all(
+        "BEI Punchlist Item",
+        filters=filters,
+        fields=[
+            "name", "category", "severity", "status", "location",
+            "description", "due_date", "assigned_to", "contractor",
+            "photo", "resolved_date"
+        ],
+        order_by="severity desc, status asc, due_date asc",
+        limit_page_length=page_size,
+        limit_start=(page - 1) * page_size
+    )
+
+    # Get summary by severity
+    summary = {}
+    for sev in ["Critical", "Major", "Minor", "Cosmetic"]:
+        summary[sev.lower()] = frappe.db.count("BEI Punchlist Item", {
+            "project": project,
+            "severity": sev,
+            "status": ["not in", ["Closed", "Waived"]]
+        })
+
+    return {
+        "items": items,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "summary": summary
+    }
+
+
+@frappe.whitelist()
+def add_punchlist_item(
+    project,
+    category,
+    location,
+    description,
+    severity="Minor",
+    photo=None,
+    assigned_to=None,
+    contractor=None,
+    due_date=None
+):
+    """
+    Add a punchlist item to a project.
+
+    Args:
+        project: The project name
+        category: Issue category
+        location: Location in the project
+        description: Issue description
+        severity: Critical, Major, Minor, Cosmetic (default: Minor)
+        photo: Photo attachment (optional)
+        assigned_to: Assigned user (optional)
+        contractor: Assigned contractor (optional)
+        due_date: Due date (optional)
+
+    Returns:
+        {"success": True, "message": "...", "item": {...}}
+    """
+    if not frappe.db.exists("BEI Project", project):
+        frappe.throw(_("Project {0} not found").format(project))
+
+    doc = frappe.new_doc("BEI Punchlist Item")
+    doc.project = project
+    doc.category = category
+    doc.location = location
+    doc.description = description
+    doc.severity = severity
+    doc.status = "Open"
+    doc.reported_by = frappe.session.user
+    doc.reported_at = now_datetime()
+
+    if photo:
+        doc.photo = photo
+
+    if assigned_to:
+        doc.assigned_to = assigned_to
+
+    if contractor:
+        doc.contractor = contractor
+
+    if due_date:
+        doc.due_date = due_date
+
+    doc.insert()
+
+    return {
+        "success": True,
+        "message": _("Punchlist item {0} created").format(doc.name),
+        "item": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def resolve_punchlist_item(item_id, resolution_notes, after_photo=None):
+    """
+    Mark a punchlist item as resolved.
+
+    Args:
+        item_id: The punchlist item name
+        resolution_notes: Notes about the resolution
+        after_photo: Photo after fix (optional)
+
+    Returns:
+        {"success": True, "message": "...", "item": {...}}
+    """
+    if not resolution_notes:
+        frappe.throw(_("Resolution notes are required"))
+
+    if not frappe.db.exists("BEI Punchlist Item", item_id):
+        frappe.throw(_("Punchlist item {0} not found").format(item_id))
+
+    doc = frappe.get_doc("BEI Punchlist Item", item_id)
+
+    if doc.status in ["Closed", "Waived"]:
+        frappe.throw(_("Item is already closed"))
+
+    doc.status = "Resolved"
+    doc.resolution_notes = resolution_notes
+    doc.resolved_date = nowdate()
+    doc.resolved_by = frappe.session.user
+
+    if after_photo:
+        doc.after_photo = after_photo
+
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Punchlist item {0} resolved").format(item_id),
+        "item": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def close_punchlist_item(item_id):
+    """
+    Close a resolved punchlist item after verification.
+
+    Args:
+        item_id: The punchlist item name
+
+    Returns:
+        {"success": True, "message": "...", "item": {...}}
+    """
+    if not frappe.db.exists("BEI Punchlist Item", item_id):
+        frappe.throw(_("Punchlist item {0} not found").format(item_id))
+
+    doc = frappe.get_doc("BEI Punchlist Item", item_id)
+
+    if doc.status != "Resolved":
+        frappe.throw(_("Only resolved items can be closed"))
+
+    doc.status = "Closed"
+    doc.verified = 1
+    doc.verified_by = frappe.session.user
+    doc.verification_date = nowdate()
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Punchlist item {0} closed").format(item_id),
+        "item": doc.as_dict()
+    }
+
+
+@frappe.whitelist()
+def waive_punchlist_item(item_id, reason):
+    """
+    Waive a punchlist item (accept as-is).
+
+    Args:
+        item_id: The punchlist item name
+        reason: Reason for waiving
+
+    Returns:
+        {"success": True, "message": "...", "item": {...}}
+    """
+    if not reason:
+        frappe.throw(_("Waiver reason is required"))
+
+    if not frappe.db.exists("BEI Punchlist Item", item_id):
+        frappe.throw(_("Punchlist item {0} not found").format(item_id))
+
+    doc = frappe.get_doc("BEI Punchlist Item", item_id)
+
+    if doc.status in ["Closed", "Waived"]:
+        frappe.throw(_("Item is already closed"))
+
+    doc.status = "Waived"
+    doc.resolution_notes = f"WAIVED: {reason}"
+    doc.resolved_date = nowdate()
+    doc.resolved_by = frappe.session.user
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Punchlist item {0} waived").format(item_id),
+        "item": doc.as_dict()
+    }
+
+
+# ==============================================================================
+# PERMIT MANAGEMENT
+# ==============================================================================
+
+
+@frappe.whitelist()
+def get_permit_checklist(project):
+    """
+    Get permit status checklist for a project.
+
+    Args:
+        project: The project name
+
+    Returns:
+        {
+            "project": {...},
+            "permits": [...],
+            "summary": {"total": int, "approved": int, "pending": int}
+        }
+    """
+    if not frappe.db.exists("BEI Project", project):
+        frappe.throw(_("Project {0} not found").format(project))
+
+    project_doc = frappe.get_doc("BEI Project", project)
+
+    permits = frappe.get_all(
+        "BEI Project Permit",
+        filters={"project": project},
+        fields=[
+            "name", "permit_type", "permit_number", "status",
+            "issuing_authority", "application_date", "approval_date",
+            "expiry_date", "total_fees"
+        ],
+        order_by="permit_type"
+    )
+
+    # Summary
+    total = len(permits)
+    approved = len([p for p in permits if p.status == "Approved"])
+    pending = len([p for p in permits if p.status in ["Not Started", "In Progress", "Pending Requirements", "Submitted"]])
+
+    return {
+        "project": {
+            "name": project_doc.name,
+            "project_name": project_doc.project_name,
+            "store_code": project_doc.store_code
+        },
+        "permits": permits,
+        "summary": {
+            "total": total,
+            "approved": approved,
+            "pending": pending,
+            "completion_rate": round((approved / total * 100), 1) if total > 0 else 0
+        }
+    }
+
+
+@frappe.whitelist()
+def update_permit_status(permit_id, status, permit_number=None, approval_date=None, expiry_date=None, remarks=None):
+    """
+    Update permit status and details.
+
+    Args:
+        permit_id: The permit name
+        status: New status
+        permit_number: Permit number (if approved)
+        approval_date: Approval date (if approved)
+        expiry_date: Expiry date (if applicable)
+        remarks: Optional remarks
+
+    Returns:
+        {"success": True, "message": "...", "permit": {...}}
+    """
+    valid_statuses = ["Not Started", "In Progress", "Pending Requirements",
+                      "Submitted", "Approved", "Rejected", "Expired", "Renewed"]
+
+    if status not in valid_statuses:
+        frappe.throw(_("Invalid status: {0}").format(status))
+
+    if not frappe.db.exists("BEI Project Permit", permit_id):
+        frappe.throw(_("Permit {0} not found").format(permit_id))
+
+    doc = frappe.get_doc("BEI Project Permit", permit_id)
+    old_status = doc.status
+    doc.status = status
+
+    if permit_number:
+        doc.permit_number = permit_number
+
+    if approval_date:
+        doc.approval_date = approval_date
+
+    if expiry_date:
+        doc.expiry_date = expiry_date
+
+    if remarks:
+        doc.remarks = remarks
+
+    # Calculate total fees
+    doc.total_fees = flt(doc.application_fee or 0) + flt(doc.permit_fee or 0)
+
+    doc.save()
+
+    return {
+        "success": True,
+        "message": _("Permit {0} status updated from {1} to {2}").format(
+            doc.permit_type, old_status, status
+        ),
+        "permit": doc.as_dict()
+    }

--- a/hrms/hr/doctype/bei_maintenance_completion/bei_maintenance_completion.json
+++ b/hrms/hr/doctype/bei_maintenance_completion/bei_maintenance_completion.json
@@ -55,7 +55,7 @@
 			"fieldname": "store",
 			"fieldtype": "Link",
 			"label": "Store",
-			"options": "BEI Store",
+			"options": "Warehouse",
 			"read_only": 1
 		},
 		{

--- a/hrms/hr/doctype/bei_maintenance_material/__init__.py
+++ b/hrms/hr/doctype/bei_maintenance_material/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt

--- a/hrms/hr/doctype/bei_maintenance_material/bei_maintenance_material.json
+++ b/hrms/hr/doctype/bei_maintenance_material/bei_maintenance_material.json
@@ -1,0 +1,62 @@
+{
+	"actions": [],
+	"creation": "2026-02-04 00:00:00.000000",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"material",
+		"quantity",
+		"unit",
+		"unit_cost",
+		"total_cost"
+	],
+	"fields": [
+		{
+			"fieldname": "material",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Material",
+			"reqd": 1
+		},
+		{
+			"fieldname": "quantity",
+			"fieldtype": "Float",
+			"in_list_view": 1,
+			"label": "Quantity"
+		},
+		{
+			"fieldname": "unit",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Unit"
+		},
+		{
+			"fieldname": "unit_cost",
+			"fieldtype": "Currency",
+			"in_list_view": 1,
+			"label": "Unit Cost",
+			"precision": "2"
+		},
+		{
+			"fieldname": "total_cost",
+			"fieldtype": "Currency",
+			"in_list_view": 1,
+			"label": "Total Cost",
+			"precision": "2",
+			"read_only": 1
+		}
+	],
+	"istable": 1,
+	"links": [],
+	"modified": "2026-02-04 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "HR",
+	"name": "BEI Maintenance Material",
+	"owner": "Administrator",
+	"permissions": [],
+	"sort_field": "creation",
+	"sort_order": "ASC",
+	"states": [],
+	"track_changes": 1
+}

--- a/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.json
+++ b/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.json
@@ -30,6 +30,22 @@
 		"column_break_assignment",
 		"scheduled_date",
 		"estimated_cost",
+		"section_charging",
+		"concern_type",
+		"charge_to_store",
+		"charge_amount",
+		"charging_reason",
+		"column_break_charging",
+		"store_acknowledged",
+		"acknowledged_by",
+		"acknowledgement_date",
+		"section_costs",
+		"materials",
+		"materials_cost",
+		"column_break_costs",
+		"labor_hours",
+		"labor_cost",
+		"total_cost",
 		"section_resolution",
 		"completion",
 		"column_break_resolution",
@@ -84,7 +100,7 @@
 			"in_list_view": 1,
 			"in_standard_filter": 1,
 			"label": "Status",
-			"options": "Open\nAssigned\nIn Progress\nCompleted\nVerified\nCancelled"
+			"options": "Open\nAssigned\nIn Progress\nCompleted\nPending Acknowledgement\nVerified\nCancelled"
 		},
 		{
 			"default": "Normal",
@@ -182,6 +198,101 @@
 			"fieldtype": "Currency",
 			"label": "Estimated Cost",
 			"precision": "2"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_charging",
+			"fieldtype": "Section Break",
+			"label": "Charging"
+		},
+		{
+			"fieldname": "concern_type",
+			"fieldtype": "Select",
+			"label": "Concern Type",
+			"options": "Wear & Tear\nSupplier Deficiency\nContractor Deficiency"
+		},
+		{
+			"default": "0",
+			"fieldname": "charge_to_store",
+			"fieldtype": "Check",
+			"label": "Charge to Store"
+		},
+		{
+			"depends_on": "charge_to_store",
+			"fieldname": "charge_amount",
+			"fieldtype": "Currency",
+			"label": "Charge Amount",
+			"precision": "2"
+		},
+		{
+			"depends_on": "charge_to_store",
+			"fieldname": "charging_reason",
+			"fieldtype": "Small Text",
+			"label": "Charging Reason"
+		},
+		{
+			"fieldname": "column_break_charging",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "0",
+			"fieldname": "store_acknowledged",
+			"fieldtype": "Check",
+			"label": "Store Acknowledged",
+			"read_only": 1
+		},
+		{
+			"fieldname": "acknowledged_by",
+			"fieldtype": "Link",
+			"label": "Acknowledged By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "acknowledgement_date",
+			"fieldtype": "Date",
+			"label": "Acknowledgement Date",
+			"read_only": 1
+		},
+		{
+			"fieldname": "section_costs",
+			"fieldtype": "Section Break",
+			"label": "Costs & Materials"
+		},
+		{
+			"fieldname": "materials",
+			"fieldtype": "Table",
+			"label": "Materials Used",
+			"options": "BEI Maintenance Material"
+		},
+		{
+			"fieldname": "materials_cost",
+			"fieldtype": "Currency",
+			"label": "Materials Cost",
+			"precision": "2",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_costs",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "labor_hours",
+			"fieldtype": "Float",
+			"label": "Labor Hours"
+		},
+		{
+			"fieldname": "labor_cost",
+			"fieldtype": "Currency",
+			"label": "Labor Cost",
+			"precision": "2"
+		},
+		{
+			"fieldname": "total_cost",
+			"fieldtype": "Currency",
+			"label": "Total Cost",
+			"precision": "2",
+			"read_only": 1
 		},
 		{
 			"fieldname": "section_resolution",

--- a/hrms/hr/doctype/bei_project/__init__.py
+++ b/hrms/hr/doctype/bei_project/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt

--- a/hrms/hr/doctype/bei_project/bei_project.json
+++ b/hrms/hr/doctype/bei_project/bei_project.json
@@ -1,0 +1,431 @@
+{
+	"actions": [],
+	"allow_rename": 0,
+	"autoname": "format:PROJ-{YYYY}-{####}",
+	"creation": "2026-02-04 00:00:00.000000",
+	"default_view": "List",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"section_basic",
+		"project_name",
+		"project_type",
+		"store",
+		"store_code",
+		"column_break_basic",
+		"stage",
+		"status",
+		"priority",
+		"section_details",
+		"description",
+		"scope_of_work",
+		"column_break_details",
+		"project_manager",
+		"area_manager",
+		"section_schedule",
+		"target_start_date",
+		"actual_start_date",
+		"target_completion_date",
+		"column_break_schedule",
+		"actual_completion_date",
+		"target_opening_date",
+		"actual_opening_date",
+		"section_budget",
+		"approved_budget",
+		"contract_amount",
+		"column_break_budget",
+		"total_actual_cost",
+		"variance",
+		"section_contractor",
+		"contractor",
+		"contractor_contact",
+		"column_break_contractor",
+		"contractor_email",
+		"contractor_phone",
+		"section_progress",
+		"progress_percent",
+		"last_update_date",
+		"column_break_progress",
+		"notes",
+		"section_documents",
+		"architectural_plans",
+		"construction_contract",
+		"column_break_documents",
+		"permits_folder",
+		"photos_folder",
+		"section_audit",
+		"created_by",
+		"created_at",
+		"column_break_audit",
+		"modified_by_user",
+		"modified_at"
+	],
+	"fields": [
+		{
+			"fieldname": "section_basic",
+			"fieldtype": "Section Break",
+			"label": "Project Details"
+		},
+		{
+			"fieldname": "project_name",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Project Name",
+			"reqd": 1
+		},
+		{
+			"fieldname": "project_type",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Project Type",
+			"options": "New Store\nRenovation\nExpansion\nRelocation\nMajor Repair",
+			"reqd": 1
+		},
+		{
+			"fieldname": "store",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Store",
+			"options": "Warehouse"
+		},
+		{
+			"fetch_from": "store.warehouse_name",
+			"fieldname": "store_code",
+			"fieldtype": "Data",
+			"label": "Store Code",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_basic",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "Pre-Design",
+			"fieldname": "stage",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Stage",
+			"options": "Pre-Design\nDesign\nBidding\nPre-Construction\nConstruction\nPost-Construction\nCompleted\nOn Hold\nCancelled",
+			"reqd": 1
+		},
+		{
+			"default": "Active",
+			"fieldname": "status",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Status",
+			"options": "Active\nOn Hold\nCompleted\nCancelled"
+		},
+		{
+			"default": "Normal",
+			"fieldname": "priority",
+			"fieldtype": "Select",
+			"in_standard_filter": 1,
+			"label": "Priority",
+			"options": "Urgent\nHigh\nNormal\nLow"
+		},
+		{
+			"fieldname": "section_details",
+			"fieldtype": "Section Break",
+			"label": "Description"
+		},
+		{
+			"fieldname": "description",
+			"fieldtype": "Text",
+			"label": "Project Description"
+		},
+		{
+			"fieldname": "scope_of_work",
+			"fieldtype": "Text Editor",
+			"label": "Scope of Work"
+		},
+		{
+			"fieldname": "column_break_details",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "project_manager",
+			"fieldtype": "Link",
+			"label": "Project Manager",
+			"options": "Employee"
+		},
+		{
+			"fieldname": "area_manager",
+			"fieldtype": "Link",
+			"label": "Area Manager",
+			"options": "Employee"
+		},
+		{
+			"fieldname": "section_schedule",
+			"fieldtype": "Section Break",
+			"label": "Schedule"
+		},
+		{
+			"fieldname": "target_start_date",
+			"fieldtype": "Date",
+			"label": "Target Start Date"
+		},
+		{
+			"fieldname": "actual_start_date",
+			"fieldtype": "Date",
+			"label": "Actual Start Date"
+		},
+		{
+			"fieldname": "target_completion_date",
+			"fieldtype": "Date",
+			"label": "Target Completion Date"
+		},
+		{
+			"fieldname": "column_break_schedule",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "actual_completion_date",
+			"fieldtype": "Date",
+			"label": "Actual Completion Date"
+		},
+		{
+			"fieldname": "target_opening_date",
+			"fieldtype": "Date",
+			"in_list_view": 1,
+			"label": "Target Opening Date"
+		},
+		{
+			"fieldname": "actual_opening_date",
+			"fieldtype": "Date",
+			"label": "Actual Opening Date"
+		},
+		{
+			"fieldname": "section_budget",
+			"fieldtype": "Section Break",
+			"label": "Budget & Costs"
+		},
+		{
+			"fieldname": "approved_budget",
+			"fieldtype": "Currency",
+			"label": "Approved Budget",
+			"precision": "2"
+		},
+		{
+			"fieldname": "contract_amount",
+			"fieldtype": "Currency",
+			"in_list_view": 1,
+			"label": "Contract Amount",
+			"precision": "2"
+		},
+		{
+			"fieldname": "column_break_budget",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "total_actual_cost",
+			"fieldtype": "Currency",
+			"label": "Total Actual Cost",
+			"precision": "2",
+			"read_only": 1
+		},
+		{
+			"fieldname": "variance",
+			"fieldtype": "Currency",
+			"label": "Budget Variance",
+			"precision": "2",
+			"read_only": 1
+		},
+		{
+			"fieldname": "section_contractor",
+			"fieldtype": "Section Break",
+			"label": "Contractor"
+		},
+		{
+			"fieldname": "contractor",
+			"fieldtype": "Link",
+			"label": "Contractor",
+			"options": "BEI Supplier"
+		},
+		{
+			"fieldname": "contractor_contact",
+			"fieldtype": "Data",
+			"label": "Contractor Contact Person"
+		},
+		{
+			"fieldname": "column_break_contractor",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "contractor_email",
+			"fieldtype": "Data",
+			"label": "Contractor Email",
+			"options": "Email"
+		},
+		{
+			"fieldname": "contractor_phone",
+			"fieldtype": "Data",
+			"label": "Contractor Phone",
+			"options": "Phone"
+		},
+		{
+			"fieldname": "section_progress",
+			"fieldtype": "Section Break",
+			"label": "Progress"
+		},
+		{
+			"default": "0",
+			"fieldname": "progress_percent",
+			"fieldtype": "Percent",
+			"in_list_view": 1,
+			"label": "Progress %"
+		},
+		{
+			"fieldname": "last_update_date",
+			"fieldtype": "Date",
+			"label": "Last Progress Update"
+		},
+		{
+			"fieldname": "column_break_progress",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "notes",
+			"fieldtype": "Small Text",
+			"label": "Progress Notes"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_documents",
+			"fieldtype": "Section Break",
+			"label": "Documents"
+		},
+		{
+			"fieldname": "architectural_plans",
+			"fieldtype": "Attach",
+			"label": "Architectural Plans"
+		},
+		{
+			"fieldname": "construction_contract",
+			"fieldtype": "Attach",
+			"label": "Construction Contract"
+		},
+		{
+			"fieldname": "column_break_documents",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "permits_folder",
+			"fieldtype": "Data",
+			"label": "Permits Folder URL"
+		},
+		{
+			"fieldname": "photos_folder",
+			"fieldtype": "Data",
+			"label": "Photos Folder URL"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_audit",
+			"fieldtype": "Section Break",
+			"label": "Audit Trail"
+		},
+		{
+			"default": "__user",
+			"fieldname": "created_by",
+			"fieldtype": "Link",
+			"label": "Created By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "created_at",
+			"fieldtype": "Datetime",
+			"label": "Created At",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_audit",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "modified_by_user",
+			"fieldtype": "Link",
+			"label": "Last Modified By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "modified_at",
+			"fieldtype": "Datetime",
+			"label": "Last Modified At",
+			"read_only": 1
+		}
+	],
+	"index_web_pages_for_search": 1,
+	"links": [
+		{
+			"link_doctype": "BEI Site Inspection",
+			"link_fieldname": "project"
+		},
+		{
+			"link_doctype": "BEI Project Bid",
+			"link_fieldname": "project"
+		},
+		{
+			"link_doctype": "BEI Project Permit",
+			"link_fieldname": "project"
+		},
+		{
+			"link_doctype": "BEI Project Milestone",
+			"link_fieldname": "project"
+		},
+		{
+			"link_doctype": "BEI Punchlist Item",
+			"link_fieldname": "project"
+		}
+	],
+	"modified": "2026-02-04 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "HR",
+	"name": "BEI Project",
+	"naming_rule": "Expression",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 0,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects User",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects Manager",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"read": 1,
+			"report": 1,
+			"role": "Employee"
+		}
+	],
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": [],
+	"title_field": "project_name",
+	"track_changes": 1
+}

--- a/hrms/hr/doctype/bei_project_bid/__init__.py
+++ b/hrms/hr/doctype/bei_project_bid/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt

--- a/hrms/hr/doctype/bei_project_bid/bei_project_bid.json
+++ b/hrms/hr/doctype/bei_project_bid/bei_project_bid.json
@@ -1,0 +1,305 @@
+{
+	"actions": [],
+	"allow_rename": 0,
+	"autoname": "format:BID-{YYYY}-{####}",
+	"creation": "2026-02-04 00:00:00.000000",
+	"default_view": "List",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"section_basic",
+		"project",
+		"project_name",
+		"contractor",
+		"contractor_name",
+		"column_break_basic",
+		"submission_date",
+		"status",
+		"section_amounts",
+		"base_amount",
+		"vat_amount",
+		"column_break_amounts",
+		"total_amount",
+		"final_amount",
+		"section_items",
+		"items",
+		"section_evaluation",
+		"technical_score",
+		"financial_score",
+		"overall_score",
+		"column_break_evaluation",
+		"evaluation_notes",
+		"section_award",
+		"is_awarded",
+		"award_date",
+		"award_notes",
+		"column_break_award",
+		"awarded_by",
+		"section_documents",
+		"bid_document",
+		"technical_proposal",
+		"column_break_documents",
+		"financial_proposal",
+		"section_audit",
+		"received_by",
+		"received_at"
+	],
+	"fields": [
+		{
+			"fieldname": "section_basic",
+			"fieldtype": "Section Break",
+			"label": "Bid Details"
+		},
+		{
+			"fieldname": "project",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Project",
+			"options": "BEI Project",
+			"reqd": 1
+		},
+		{
+			"fetch_from": "project.project_name",
+			"fieldname": "project_name",
+			"fieldtype": "Data",
+			"label": "Project Name",
+			"read_only": 1
+		},
+		{
+			"fieldname": "contractor",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Contractor",
+			"options": "BEI Supplier",
+			"reqd": 1
+		},
+		{
+			"fetch_from": "contractor.supplier_name",
+			"fieldname": "contractor_name",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Contractor Name",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_basic",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "Today",
+			"fieldname": "submission_date",
+			"fieldtype": "Date",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Submission Date",
+			"reqd": 1
+		},
+		{
+			"default": "Submitted",
+			"fieldname": "status",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Status",
+			"options": "Draft\nSubmitted\nUnder Review\nShortlisted\nAwarded\nNot Awarded\nWithdrawn"
+		},
+		{
+			"fieldname": "section_amounts",
+			"fieldtype": "Section Break",
+			"label": "Amounts"
+		},
+		{
+			"fieldname": "base_amount",
+			"fieldtype": "Currency",
+			"label": "Base Amount",
+			"precision": "2"
+		},
+		{
+			"fieldname": "vat_amount",
+			"fieldtype": "Currency",
+			"label": "VAT Amount",
+			"precision": "2"
+		},
+		{
+			"fieldname": "column_break_amounts",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "total_amount",
+			"fieldtype": "Currency",
+			"in_list_view": 1,
+			"label": "Total Amount",
+			"precision": "2"
+		},
+		{
+			"description": "Negotiated final amount after evaluation",
+			"fieldname": "final_amount",
+			"fieldtype": "Currency",
+			"label": "Final Amount",
+			"precision": "2"
+		},
+		{
+			"fieldname": "section_items",
+			"fieldtype": "Section Break",
+			"label": "Line Items"
+		},
+		{
+			"fieldname": "items",
+			"fieldtype": "Table",
+			"label": "Bid Items",
+			"options": "BEI Project Bid Item"
+		},
+		{
+			"fieldname": "section_evaluation",
+			"fieldtype": "Section Break",
+			"label": "Evaluation"
+		},
+		{
+			"fieldname": "technical_score",
+			"fieldtype": "Percent",
+			"label": "Technical Score"
+		},
+		{
+			"fieldname": "financial_score",
+			"fieldtype": "Percent",
+			"label": "Financial Score"
+		},
+		{
+			"fieldname": "overall_score",
+			"fieldtype": "Percent",
+			"label": "Overall Score",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_evaluation",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "evaluation_notes",
+			"fieldtype": "Text",
+			"label": "Evaluation Notes"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_award",
+			"fieldtype": "Section Break",
+			"label": "Award"
+		},
+		{
+			"default": "0",
+			"fieldname": "is_awarded",
+			"fieldtype": "Check",
+			"label": "Awarded",
+			"read_only": 1
+		},
+		{
+			"fieldname": "award_date",
+			"fieldtype": "Date",
+			"label": "Award Date",
+			"read_only": 1
+		},
+		{
+			"fieldname": "award_notes",
+			"fieldtype": "Small Text",
+			"label": "Award Notes"
+		},
+		{
+			"fieldname": "column_break_award",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "awarded_by",
+			"fieldtype": "Link",
+			"label": "Awarded By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_documents",
+			"fieldtype": "Section Break",
+			"label": "Documents"
+		},
+		{
+			"fieldname": "bid_document",
+			"fieldtype": "Attach",
+			"label": "Bid Document"
+		},
+		{
+			"fieldname": "technical_proposal",
+			"fieldtype": "Attach",
+			"label": "Technical Proposal"
+		},
+		{
+			"fieldname": "column_break_documents",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "financial_proposal",
+			"fieldtype": "Attach",
+			"label": "Financial Proposal"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_audit",
+			"fieldtype": "Section Break",
+			"label": "Audit Trail"
+		},
+		{
+			"default": "__user",
+			"fieldname": "received_by",
+			"fieldtype": "Link",
+			"label": "Received By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "received_at",
+			"fieldtype": "Datetime",
+			"label": "Received At",
+			"read_only": 1
+		}
+	],
+	"index_web_pages_for_search": 1,
+	"links": [],
+	"modified": "2026-02-04 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "HR",
+	"name": "BEI Project Bid",
+	"naming_rule": "Expression",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 0,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects User",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects Manager",
+			"share": 1,
+			"write": 1
+		}
+	],
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": [],
+	"title_field": "contractor_name",
+	"track_changes": 1
+}

--- a/hrms/hr/doctype/bei_project_bid_item/__init__.py
+++ b/hrms/hr/doctype/bei_project_bid_item/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt

--- a/hrms/hr/doctype/bei_project_bid_item/bei_project_bid_item.json
+++ b/hrms/hr/doctype/bei_project_bid_item/bei_project_bid_item.json
@@ -1,0 +1,63 @@
+{
+	"actions": [],
+	"creation": "2026-02-04 00:00:00.000000",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"item_description",
+		"quantity",
+		"unit",
+		"unit_price",
+		"amount"
+	],
+	"fields": [
+		{
+			"fieldname": "item_description",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Item Description",
+			"reqd": 1
+		},
+		{
+			"default": "1",
+			"fieldname": "quantity",
+			"fieldtype": "Float",
+			"in_list_view": 1,
+			"label": "Quantity"
+		},
+		{
+			"fieldname": "unit",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Unit"
+		},
+		{
+			"fieldname": "unit_price",
+			"fieldtype": "Currency",
+			"in_list_view": 1,
+			"label": "Unit Price",
+			"precision": "2"
+		},
+		{
+			"fieldname": "amount",
+			"fieldtype": "Currency",
+			"in_list_view": 1,
+			"label": "Amount",
+			"precision": "2",
+			"read_only": 1
+		}
+	],
+	"istable": 1,
+	"links": [],
+	"modified": "2026-02-04 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "HR",
+	"name": "BEI Project Bid Item",
+	"owner": "Administrator",
+	"permissions": [],
+	"sort_field": "creation",
+	"sort_order": "ASC",
+	"states": [],
+	"track_changes": 1
+}

--- a/hrms/hr/doctype/bei_project_milestone/__init__.py
+++ b/hrms/hr/doctype/bei_project_milestone/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt

--- a/hrms/hr/doctype/bei_project_milestone/bei_project_milestone.json
+++ b/hrms/hr/doctype/bei_project_milestone/bei_project_milestone.json
@@ -1,0 +1,282 @@
+{
+	"actions": [],
+	"allow_rename": 0,
+	"autoname": "format:MILE-{YYYY}-{####}",
+	"creation": "2026-02-04 00:00:00.000000",
+	"default_view": "List",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"section_basic",
+		"project",
+		"project_name",
+		"milestone_name",
+		"milestone_type",
+		"column_break_basic",
+		"status",
+		"completion_percentage",
+		"sequence",
+		"section_schedule",
+		"target_date",
+		"actual_date",
+		"column_break_schedule",
+		"days_variance",
+		"section_billing",
+		"billing_percentage",
+		"billing_amount",
+		"column_break_billing",
+		"payment_request",
+		"payment_status",
+		"section_deliverables",
+		"deliverables",
+		"acceptance_criteria",
+		"section_verification",
+		"verified",
+		"verified_by",
+		"column_break_verification",
+		"verification_date",
+		"verification_notes",
+		"section_audit",
+		"created_by",
+		"created_at"
+	],
+	"fields": [
+		{
+			"fieldname": "section_basic",
+			"fieldtype": "Section Break",
+			"label": "Milestone Details"
+		},
+		{
+			"fieldname": "project",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Project",
+			"options": "BEI Project",
+			"reqd": 1
+		},
+		{
+			"fetch_from": "project.project_name",
+			"fieldname": "project_name",
+			"fieldtype": "Data",
+			"label": "Project Name",
+			"read_only": 1
+		},
+		{
+			"fieldname": "milestone_name",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Milestone Name",
+			"reqd": 1
+		},
+		{
+			"fieldname": "milestone_type",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Milestone Type",
+			"options": "Downpayment\nMobilization\nFoundation\nStructural\nRough-in\nFinishing\nFinal Completion\nTurnover\nWarranty End\nOther",
+			"reqd": 1
+		},
+		{
+			"fieldname": "column_break_basic",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "Pending",
+			"fieldname": "status",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Status",
+			"options": "Pending\nIn Progress\nCompleted\nVerified\nDelayed\nCancelled"
+		},
+		{
+			"description": "Progress towards completion (0-100%)",
+			"fieldname": "completion_percentage",
+			"fieldtype": "Percent",
+			"in_list_view": 1,
+			"label": "Completion %"
+		},
+		{
+			"default": "1",
+			"description": "Order of milestone in project timeline",
+			"fieldname": "sequence",
+			"fieldtype": "Int",
+			"label": "Sequence"
+		},
+		{
+			"fieldname": "section_schedule",
+			"fieldtype": "Section Break",
+			"label": "Schedule"
+		},
+		{
+			"fieldname": "target_date",
+			"fieldtype": "Date",
+			"in_list_view": 1,
+			"label": "Target Date",
+			"reqd": 1
+		},
+		{
+			"fieldname": "actual_date",
+			"fieldtype": "Date",
+			"label": "Actual Date"
+		},
+		{
+			"fieldname": "column_break_schedule",
+			"fieldtype": "Column Break"
+		},
+		{
+			"description": "Negative = early, Positive = late",
+			"fieldname": "days_variance",
+			"fieldtype": "Int",
+			"label": "Days Variance",
+			"read_only": 1
+		},
+		{
+			"fieldname": "section_billing",
+			"fieldtype": "Section Break",
+			"label": "Billing"
+		},
+		{
+			"description": "Percentage of contract amount for this milestone",
+			"fieldname": "billing_percentage",
+			"fieldtype": "Percent",
+			"label": "Billing %"
+		},
+		{
+			"fieldname": "billing_amount",
+			"fieldtype": "Currency",
+			"in_list_view": 1,
+			"label": "Billing Amount",
+			"precision": "2"
+		},
+		{
+			"fieldname": "column_break_billing",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "payment_request",
+			"fieldtype": "Link",
+			"label": "Payment Request",
+			"options": "BEI Payment Request"
+		},
+		{
+			"default": "Not Billed",
+			"fieldname": "payment_status",
+			"fieldtype": "Select",
+			"label": "Payment Status",
+			"options": "Not Billed\nBilled\nPaid\nOn Hold"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_deliverables",
+			"fieldtype": "Section Break",
+			"label": "Deliverables"
+		},
+		{
+			"fieldname": "deliverables",
+			"fieldtype": "Text Editor",
+			"label": "Deliverables"
+		},
+		{
+			"fieldname": "acceptance_criteria",
+			"fieldtype": "Text Editor",
+			"label": "Acceptance Criteria"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_verification",
+			"fieldtype": "Section Break",
+			"label": "Verification"
+		},
+		{
+			"default": "0",
+			"fieldname": "verified",
+			"fieldtype": "Check",
+			"label": "Verified"
+		},
+		{
+			"fieldname": "verified_by",
+			"fieldtype": "Link",
+			"label": "Verified By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_verification",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "verification_date",
+			"fieldtype": "Date",
+			"label": "Verification Date",
+			"read_only": 1
+		},
+		{
+			"fieldname": "verification_notes",
+			"fieldtype": "Small Text",
+			"label": "Verification Notes"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_audit",
+			"fieldtype": "Section Break",
+			"label": "Audit Trail"
+		},
+		{
+			"default": "__user",
+			"fieldname": "created_by",
+			"fieldtype": "Link",
+			"label": "Created By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "created_at",
+			"fieldtype": "Datetime",
+			"label": "Created At",
+			"read_only": 1
+		}
+	],
+	"index_web_pages_for_search": 1,
+	"links": [],
+	"modified": "2026-02-04 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "HR",
+	"name": "BEI Project Milestone",
+	"naming_rule": "Expression",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 0,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects User",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects Manager",
+			"share": 1,
+			"write": 1
+		}
+	],
+	"sort_field": "sequence",
+	"sort_order": "ASC",
+	"states": [],
+	"title_field": "milestone_name",
+	"track_changes": 1
+}

--- a/hrms/hr/doctype/bei_project_permit/__init__.py
+++ b/hrms/hr/doctype/bei_project_permit/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt

--- a/hrms/hr/doctype/bei_project_permit/bei_project_permit.json
+++ b/hrms/hr/doctype/bei_project_permit/bei_project_permit.json
@@ -1,0 +1,268 @@
+{
+	"actions": [],
+	"allow_rename": 0,
+	"autoname": "format:PERMIT-{YYYY}-{####}",
+	"creation": "2026-02-04 00:00:00.000000",
+	"default_view": "List",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"section_basic",
+		"project",
+		"project_name",
+		"permit_type",
+		"permit_number",
+		"column_break_basic",
+		"status",
+		"issuing_authority",
+		"section_dates",
+		"application_date",
+		"approval_date",
+		"column_break_dates",
+		"expiry_date",
+		"renewal_date",
+		"section_fees",
+		"application_fee",
+		"permit_fee",
+		"column_break_fees",
+		"total_fees",
+		"receipt_number",
+		"section_requirements",
+		"requirements_checklist",
+		"section_documents",
+		"application_form",
+		"permit_document",
+		"column_break_documents",
+		"supporting_documents",
+		"section_notes",
+		"remarks",
+		"section_audit",
+		"processed_by",
+		"processed_at"
+	],
+	"fields": [
+		{
+			"fieldname": "section_basic",
+			"fieldtype": "Section Break",
+			"label": "Permit Details"
+		},
+		{
+			"fieldname": "project",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Project",
+			"options": "BEI Project",
+			"reqd": 1
+		},
+		{
+			"fetch_from": "project.project_name",
+			"fieldname": "project_name",
+			"fieldtype": "Data",
+			"label": "Project Name",
+			"read_only": 1
+		},
+		{
+			"fieldname": "permit_type",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Permit Type",
+			"options": "Building Permit\nOccupancy Permit\nFire Safety Inspection Certificate\nSanitary Permit\nBusiness Permit\nBrgy Clearance\nZoning Clearance\nLocational Clearance\nElectrical Permit\nMechanical Permit\nPlumbing Permit\nEnvironmental Compliance Certificate\nOther",
+			"reqd": 1
+		},
+		{
+			"fieldname": "permit_number",
+			"fieldtype": "Data",
+			"label": "Permit Number"
+		},
+		{
+			"fieldname": "column_break_basic",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "Pending",
+			"fieldname": "status",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Status",
+			"options": "Not Started\nIn Progress\nPending Requirements\nSubmitted\nApproved\nRejected\nExpired\nRenewed"
+		},
+		{
+			"fieldname": "issuing_authority",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Issuing Authority"
+		},
+		{
+			"fieldname": "section_dates",
+			"fieldtype": "Section Break",
+			"label": "Dates"
+		},
+		{
+			"fieldname": "application_date",
+			"fieldtype": "Date",
+			"label": "Application Date"
+		},
+		{
+			"fieldname": "approval_date",
+			"fieldtype": "Date",
+			"label": "Approval Date"
+		},
+		{
+			"fieldname": "column_break_dates",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "expiry_date",
+			"fieldtype": "Date",
+			"label": "Expiry Date"
+		},
+		{
+			"fieldname": "renewal_date",
+			"fieldtype": "Date",
+			"label": "Renewal Date"
+		},
+		{
+			"fieldname": "section_fees",
+			"fieldtype": "Section Break",
+			"label": "Fees"
+		},
+		{
+			"fieldname": "application_fee",
+			"fieldtype": "Currency",
+			"label": "Application Fee",
+			"precision": "2"
+		},
+		{
+			"fieldname": "permit_fee",
+			"fieldtype": "Currency",
+			"label": "Permit Fee",
+			"precision": "2"
+		},
+		{
+			"fieldname": "column_break_fees",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "total_fees",
+			"fieldtype": "Currency",
+			"label": "Total Fees",
+			"precision": "2",
+			"read_only": 1
+		},
+		{
+			"fieldname": "receipt_number",
+			"fieldtype": "Data",
+			"label": "Receipt Number"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_requirements",
+			"fieldtype": "Section Break",
+			"label": "Requirements"
+		},
+		{
+			"fieldname": "requirements_checklist",
+			"fieldtype": "Text Editor",
+			"label": "Requirements Checklist"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_documents",
+			"fieldtype": "Section Break",
+			"label": "Documents"
+		},
+		{
+			"fieldname": "application_form",
+			"fieldtype": "Attach",
+			"label": "Application Form"
+		},
+		{
+			"fieldname": "permit_document",
+			"fieldtype": "Attach",
+			"label": "Permit Document"
+		},
+		{
+			"fieldname": "column_break_documents",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "supporting_documents",
+			"fieldtype": "Attach",
+			"label": "Supporting Documents"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_notes",
+			"fieldtype": "Section Break",
+			"label": "Notes"
+		},
+		{
+			"fieldname": "remarks",
+			"fieldtype": "Text",
+			"label": "Remarks"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_audit",
+			"fieldtype": "Section Break",
+			"label": "Audit Trail"
+		},
+		{
+			"default": "__user",
+			"fieldname": "processed_by",
+			"fieldtype": "Link",
+			"label": "Processed By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "processed_at",
+			"fieldtype": "Datetime",
+			"label": "Processed At",
+			"read_only": 1
+		}
+	],
+	"index_web_pages_for_search": 1,
+	"links": [],
+	"modified": "2026-02-04 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "HR",
+	"name": "BEI Project Permit",
+	"naming_rule": "Expression",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 0,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects User",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects Manager",
+			"share": 1,
+			"write": 1
+		}
+	],
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": [],
+	"title_field": "permit_type",
+	"track_changes": 1
+}

--- a/hrms/hr/doctype/bei_punchlist_item/__init__.py
+++ b/hrms/hr/doctype/bei_punchlist_item/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt

--- a/hrms/hr/doctype/bei_punchlist_item/bei_punchlist_item.json
+++ b/hrms/hr/doctype/bei_punchlist_item/bei_punchlist_item.json
@@ -1,0 +1,293 @@
+{
+	"actions": [],
+	"allow_rename": 0,
+	"autoname": "format:PUNCH-{YYYY}-{#####}",
+	"creation": "2026-02-04 00:00:00.000000",
+	"default_view": "List",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"section_basic",
+		"project",
+		"project_name",
+		"store",
+		"store_code",
+		"column_break_basic",
+		"status",
+		"category",
+		"severity",
+		"section_issue",
+		"location",
+		"description",
+		"column_break_issue",
+		"photo",
+		"section_assignment",
+		"assigned_to",
+		"contractor",
+		"column_break_assignment",
+		"due_date",
+		"section_resolution",
+		"resolution_notes",
+		"resolved_date",
+		"column_break_resolution",
+		"resolved_by",
+		"after_photo",
+		"section_verification",
+		"verified",
+		"verified_by",
+		"column_break_verification",
+		"verification_date",
+		"section_audit",
+		"reported_by",
+		"reported_at"
+	],
+	"fields": [
+		{
+			"fieldname": "section_basic",
+			"fieldtype": "Section Break",
+			"label": "Punchlist Item"
+		},
+		{
+			"fieldname": "project",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Project",
+			"options": "BEI Project",
+			"reqd": 1
+		},
+		{
+			"fetch_from": "project.project_name",
+			"fieldname": "project_name",
+			"fieldtype": "Data",
+			"label": "Project Name",
+			"read_only": 1
+		},
+		{
+			"fetch_from": "project.store",
+			"fieldname": "store",
+			"fieldtype": "Link",
+			"label": "Store",
+			"options": "Warehouse",
+			"read_only": 1
+		},
+		{
+			"fetch_from": "project.store_code",
+			"fieldname": "store_code",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Store Code",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_basic",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "Open",
+			"fieldname": "status",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Status",
+			"options": "Open\nIn Progress\nResolved\nVerified\nClosed\nWaived"
+		},
+		{
+			"fieldname": "category",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Category",
+			"options": "Structural\nElectrical\nPlumbing\nHVAC\nFinishing\nPainting\nFlooring\nCeiling\nDoors & Windows\nFixtures\nSignage\nSafety\nCleaning\nOther",
+			"reqd": 1
+		},
+		{
+			"default": "Minor",
+			"fieldname": "severity",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Severity",
+			"options": "Critical\nMajor\nMinor\nCosmetic"
+		},
+		{
+			"fieldname": "section_issue",
+			"fieldtype": "Section Break",
+			"label": "Issue Details"
+		},
+		{
+			"fieldname": "location",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Location",
+			"reqd": 1
+		},
+		{
+			"fieldname": "description",
+			"fieldtype": "Text",
+			"label": "Description",
+			"reqd": 1
+		},
+		{
+			"fieldname": "column_break_issue",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "photo",
+			"fieldtype": "Attach Image",
+			"label": "Photo"
+		},
+		{
+			"fieldname": "section_assignment",
+			"fieldtype": "Section Break",
+			"label": "Assignment"
+		},
+		{
+			"fieldname": "assigned_to",
+			"fieldtype": "Link",
+			"label": "Assigned To",
+			"options": "User"
+		},
+		{
+			"fieldname": "contractor",
+			"fieldtype": "Link",
+			"label": "Contractor",
+			"options": "BEI Supplier"
+		},
+		{
+			"fieldname": "column_break_assignment",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "due_date",
+			"fieldtype": "Date",
+			"label": "Due Date"
+		},
+		{
+			"fieldname": "section_resolution",
+			"fieldtype": "Section Break",
+			"label": "Resolution"
+		},
+		{
+			"fieldname": "resolution_notes",
+			"fieldtype": "Text",
+			"label": "Resolution Notes"
+		},
+		{
+			"fieldname": "resolved_date",
+			"fieldtype": "Date",
+			"label": "Resolved Date"
+		},
+		{
+			"fieldname": "column_break_resolution",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "resolved_by",
+			"fieldtype": "Link",
+			"label": "Resolved By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "after_photo",
+			"fieldtype": "Attach Image",
+			"label": "After Photo"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_verification",
+			"fieldtype": "Section Break",
+			"label": "Verification"
+		},
+		{
+			"default": "0",
+			"fieldname": "verified",
+			"fieldtype": "Check",
+			"label": "Verified"
+		},
+		{
+			"fieldname": "verified_by",
+			"fieldtype": "Link",
+			"label": "Verified By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_verification",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "verification_date",
+			"fieldtype": "Date",
+			"label": "Verification Date",
+			"read_only": 1
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_audit",
+			"fieldtype": "Section Break",
+			"label": "Audit Trail"
+		},
+		{
+			"default": "__user",
+			"fieldname": "reported_by",
+			"fieldtype": "Link",
+			"label": "Reported By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "reported_at",
+			"fieldtype": "Datetime",
+			"label": "Reported At",
+			"read_only": 1
+		}
+	],
+	"index_web_pages_for_search": 1,
+	"links": [],
+	"modified": "2026-02-04 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "HR",
+	"name": "BEI Punchlist Item",
+	"naming_rule": "Expression",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 0,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects User",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects Manager",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"read": 1,
+			"write": 1,
+			"role": "Employee"
+		}
+	],
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": [],
+	"title_field": "location",
+	"track_changes": 1
+}

--- a/hrms/hr/doctype/bei_site_inspection/__init__.py
+++ b/hrms/hr/doctype/bei_site_inspection/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt

--- a/hrms/hr/doctype/bei_site_inspection/bei_site_inspection.json
+++ b/hrms/hr/doctype/bei_site_inspection/bei_site_inspection.json
@@ -1,0 +1,311 @@
+{
+	"actions": [],
+	"allow_rename": 0,
+	"autoname": "format:SITE-{YYYY}-{####}",
+	"creation": "2026-02-04 00:00:00.000000",
+	"default_view": "List",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"section_basic",
+		"project",
+		"project_name",
+		"store",
+		"store_code",
+		"column_break_basic",
+		"inspection_date",
+		"inspection_type",
+		"status",
+		"section_inspector",
+		"inspector",
+		"inspector_name",
+		"column_break_inspector",
+		"inspector_role",
+		"inspector_company",
+		"section_findings",
+		"overall_status",
+		"structural_score",
+		"electrical_score",
+		"plumbing_score",
+		"column_break_findings",
+		"hvac_score",
+		"finishing_score",
+		"safety_score",
+		"section_notes",
+		"findings",
+		"recommendations",
+		"section_photos",
+		"photos",
+		"section_approval",
+		"approved_by",
+		"approved_date",
+		"column_break_approval",
+		"rejection_reason",
+		"section_audit",
+		"submitted_by",
+		"submitted_at"
+	],
+	"fields": [
+		{
+			"fieldname": "section_basic",
+			"fieldtype": "Section Break",
+			"label": "Inspection Details"
+		},
+		{
+			"fieldname": "project",
+			"fieldtype": "Link",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Project",
+			"options": "BEI Project",
+			"reqd": 1
+		},
+		{
+			"fetch_from": "project.project_name",
+			"fieldname": "project_name",
+			"fieldtype": "Data",
+			"label": "Project Name",
+			"read_only": 1
+		},
+		{
+			"fetch_from": "project.store",
+			"fieldname": "store",
+			"fieldtype": "Link",
+			"label": "Store",
+			"options": "Warehouse",
+			"read_only": 1
+		},
+		{
+			"fetch_from": "project.store_code",
+			"fieldname": "store_code",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Store Code",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_basic",
+			"fieldtype": "Column Break"
+		},
+		{
+			"default": "Today",
+			"fieldname": "inspection_date",
+			"fieldtype": "Date",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Inspection Date",
+			"reqd": 1
+		},
+		{
+			"fieldname": "inspection_type",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Inspection Type",
+			"options": "Pre-Construction\nProgress\nPre-Opening\nFinal\nPunch List\nWarranty",
+			"reqd": 1
+		},
+		{
+			"default": "Draft",
+			"fieldname": "status",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"in_standard_filter": 1,
+			"label": "Status",
+			"options": "Draft\nSubmitted\nApproved\nRejected"
+		},
+		{
+			"fieldname": "section_inspector",
+			"fieldtype": "Section Break",
+			"label": "Inspector"
+		},
+		{
+			"fieldname": "inspector",
+			"fieldtype": "Link",
+			"label": "Inspector",
+			"options": "User"
+		},
+		{
+			"fieldname": "inspector_name",
+			"fieldtype": "Data",
+			"label": "Inspector Name",
+			"reqd": 1
+		},
+		{
+			"fieldname": "column_break_inspector",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "inspector_role",
+			"fieldtype": "Select",
+			"label": "Inspector Role",
+			"options": "Projects Team\nContractor\nThird Party\nGovernment Inspector"
+		},
+		{
+			"fieldname": "inspector_company",
+			"fieldtype": "Data",
+			"label": "Inspector Company"
+		},
+		{
+			"fieldname": "section_findings",
+			"fieldtype": "Section Break",
+			"label": "Scores & Findings"
+		},
+		{
+			"default": "Acceptable",
+			"fieldname": "overall_status",
+			"fieldtype": "Select",
+			"in_list_view": 1,
+			"label": "Overall Status",
+			"options": "Excellent\nAcceptable\nNeeds Work\nFailed"
+		},
+		{
+			"fieldname": "structural_score",
+			"fieldtype": "Rating",
+			"label": "Structural"
+		},
+		{
+			"fieldname": "electrical_score",
+			"fieldtype": "Rating",
+			"label": "Electrical"
+		},
+		{
+			"fieldname": "plumbing_score",
+			"fieldtype": "Rating",
+			"label": "Plumbing"
+		},
+		{
+			"fieldname": "column_break_findings",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "hvac_score",
+			"fieldtype": "Rating",
+			"label": "HVAC"
+		},
+		{
+			"fieldname": "finishing_score",
+			"fieldtype": "Rating",
+			"label": "Finishing"
+		},
+		{
+			"fieldname": "safety_score",
+			"fieldtype": "Rating",
+			"label": "Safety"
+		},
+		{
+			"fieldname": "section_notes",
+			"fieldtype": "Section Break",
+			"label": "Notes"
+		},
+		{
+			"fieldname": "findings",
+			"fieldtype": "Text Editor",
+			"label": "Findings"
+		},
+		{
+			"fieldname": "recommendations",
+			"fieldtype": "Text Editor",
+			"label": "Recommendations"
+		},
+		{
+			"fieldname": "section_photos",
+			"fieldtype": "Section Break",
+			"label": "Photos"
+		},
+		{
+			"fieldname": "photos",
+			"fieldtype": "Table",
+			"label": "Photos",
+			"options": "BEI Site Inspection Photo"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_approval",
+			"fieldtype": "Section Break",
+			"label": "Approval"
+		},
+		{
+			"fieldname": "approved_by",
+			"fieldtype": "Link",
+			"label": "Approved By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "approved_date",
+			"fieldtype": "Date",
+			"label": "Approved Date",
+			"read_only": 1
+		},
+		{
+			"fieldname": "column_break_approval",
+			"fieldtype": "Column Break"
+		},
+		{
+			"fieldname": "rejection_reason",
+			"fieldtype": "Small Text",
+			"label": "Rejection Reason"
+		},
+		{
+			"collapsible": 1,
+			"fieldname": "section_audit",
+			"fieldtype": "Section Break",
+			"label": "Audit Trail"
+		},
+		{
+			"default": "__user",
+			"fieldname": "submitted_by",
+			"fieldtype": "Link",
+			"label": "Submitted By",
+			"options": "User",
+			"read_only": 1
+		},
+		{
+			"fieldname": "submitted_at",
+			"fieldtype": "Datetime",
+			"label": "Submitted At",
+			"read_only": 1
+		}
+	],
+	"index_web_pages_for_search": 1,
+	"links": [],
+	"modified": "2026-02-04 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "HR",
+	"name": "BEI Site Inspection",
+	"naming_rule": "Expression",
+	"owner": "Administrator",
+	"permissions": [
+		{
+			"create": 1,
+			"delete": 0,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects User",
+			"share": 1,
+			"write": 1
+		},
+		{
+			"create": 1,
+			"delete": 1,
+			"email": 1,
+			"export": 1,
+			"print": 1,
+			"read": 1,
+			"report": 1,
+			"role": "Projects Manager",
+			"share": 1,
+			"write": 1
+		}
+	],
+	"sort_field": "modified",
+	"sort_order": "DESC",
+	"states": [],
+	"title_field": "project_name",
+	"track_changes": 1
+}

--- a/hrms/hr/doctype/bei_site_inspection_photo/__init__.py
+++ b/hrms/hr/doctype/bei_site_inspection_photo/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt

--- a/hrms/hr/doctype/bei_site_inspection_photo/bei_site_inspection_photo.json
+++ b/hrms/hr/doctype/bei_site_inspection_photo/bei_site_inspection_photo.json
@@ -1,0 +1,45 @@
+{
+	"actions": [],
+	"creation": "2026-02-04 00:00:00.000000",
+	"doctype": "DocType",
+	"editable_grid": 1,
+	"engine": "InnoDB",
+	"field_order": [
+		"photo",
+		"caption",
+		"area"
+	],
+	"fields": [
+		{
+			"fieldname": "photo",
+			"fieldtype": "Attach Image",
+			"in_list_view": 1,
+			"label": "Photo",
+			"reqd": 1
+		},
+		{
+			"fieldname": "caption",
+			"fieldtype": "Small Text",
+			"in_list_view": 1,
+			"label": "Caption"
+		},
+		{
+			"fieldname": "area",
+			"fieldtype": "Data",
+			"in_list_view": 1,
+			"label": "Area"
+		}
+	],
+	"istable": 1,
+	"links": [],
+	"modified": "2026-02-04 00:00:00.000000",
+	"modified_by": "Administrator",
+	"module": "HR",
+	"name": "BEI Site Inspection Photo",
+	"owner": "Administrator",
+	"permissions": [],
+	"sort_field": "creation",
+	"sort_order": "ASC",
+	"states": [],
+	"track_changes": 1
+}


### PR DESCRIPTION
## Summary

- Add complete Projects Module for construction and R&M lifecycle management
- Enhance R&M workflow with charging and cost tracking capabilities
- Create 9 new DocTypes for project management
- Add 30+ new API endpoints for project operations

## R&M Enhancements

- **Charging Workflow**: Add concern type classification and store charging mechanism
- **Cost Tracking**: Materials and labor cost tracking with auto-calculation
- **Bug Fix**: Fix BEI Maintenance Completion store link

## New DocTypes

| DocType | Purpose |
|---------|--------|
| BEI Project | Main project record with stages |
| BEI Site Inspection | Project inspections with scores |
| BEI Site Inspection Photo | Photo attachments for inspections |
| BEI Project Bid | Contractor bid tracking |
| BEI Project Bid Item | Line items for bids |
| BEI Project Permit | Permit lifecycle tracking |
| BEI Project Milestone | Progress milestones with billing |
| BEI Punchlist Item | Deficiency tracking |
| BEI Maintenance Material | Cost tracking child table |

## Test Plan

- [ ] Run bench migrate to create DocTypes
- [ ] Verify DocTypes visible in Frappe Desk
- [ ] Test R&M charging workflow via API
- [ ] Test project creation and stage transitions

 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large surface-area addition (new DocTypes and many whitelisted APIs) that changes maintenance request status/fields and writes financial amounts, increasing risk of workflow or data consistency issues despite being mostly additive.
> 
> **Overview**
> Adds a **Projects module** for construction/R&M lifecycle tracking by introducing new DocTypes for `BEI Project` plus related bids, permits, milestones, site inspections (with photo table), and punchlist items.
> 
> Extends the maintenance (R&M) workflow with a **charging + cost-tracking** flow: maintenance requests gain concern classification, store-charge fields and acknowledgement state, plus materials/labor cost rollups via a new `BEI Maintenance Material` child table; `projects.py` exposes new whitelisted endpoints to assess, charge/acknowledge, and update costs/materials, and adds APIs for project dashboard/detail, stage/progress updates, inspections approval, bid evaluation/award, milestone verification/billing, punchlist CRUD, and permit status updates.
> 
> Fixes a data model mismatch by changing `BEI Maintenance Completion.store` to link to `Warehouse` instead of `BEI Store`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41ce5cb7c3cd62112234110cdbe6b8da2ec3b2c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->