### PR TITLE
fix(procurement): Strip invalid UOM from GR items to prevent LinkValidationError

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -726,6 +726,9 @@ def create_goods_receipt(data):
         for item in data["items"]:
             if "rate" in item and "unit_cost" not in item:
                 item["unit_cost"] = item.pop("rate")
+            # Strip invalid UOM to avoid LinkValidationError
+            if item.get("uom") and not frappe.db.exists("UOM", item["uom"]):
+                item.pop("uom")
 
     gr = frappe.get_doc({
         "doctype": "BEI Goods Receipt",


### PR DESCRIPTION
## Summary
- Strip invalid UOM values from GR items before Frappe insert
- Prevents HTTP 417 LinkValidationError when PO items have UOM values (e.g. Bag, Can) not in Frappe UOM master
- Defense-in-depth: frontend already strips UOM (b574e15), this adds server-side protection

## Test Plan
- [x] GR-2026-00063 created successfully via UI after frontend fix
- [ ] Backend UOM stripping verified after deployment

---
Generated with Claude Code