### PR TITLE
fix(store-ops): Sprint 2 Wave 1 - DocType permissions, fields, and APIs

### DIFF
--- a/hrms/api/coverage.py
+++ b/hrms/api/coverage.py
@@ -88,6 +88,7 @@ def request_coverage(store, coverage_date, shift, reason, absent_employee, notes
         doc.absent_employee = employee_id
         doc.requested_by = frappe.session.user
         doc.notes = notes
+        doc.status = "Open"
         doc.insert()
 
         return {"success": True, "name": doc.name}

--- a/hrms/api/inventory.py
+++ b/hrms/api/inventory.py
@@ -13,7 +13,7 @@ import json
 
 
 @frappe.whitelist()
-def submit_cycle_count(store, items):
+def submit_cycle_count(store, items, count_date=None):
     """Submit inventory cycle count."""
     if not store:
         frappe.throw(_("Store is required"))
@@ -21,9 +21,15 @@ def submit_cycle_count(store, items):
     if isinstance(items, str):
         items = json.loads(items)
 
+    # Validate no negative quantities
+    for item in items:
+        if flt(item.get("counted_qty", 0)) < 0:
+            frappe.throw(_("Counted quantity cannot be negative for item {0}").format(
+                item.get("item_code", "unknown")))
+
     doc = frappe.new_doc("BEI Cycle Count")
     doc.store = store
-    doc.count_date = nowdate()
+    doc.count_date = count_date or nowdate()
     doc.counted_by = frappe.session.user
 
     total_variance = 0

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -103,11 +103,102 @@ def resolve_warehouse(store_or_branch):
     frappe.throw(_("Could not find Store: {0}").format(store_or_branch))
 
 
+def _get_area_supervisor_for_store(warehouse):
+    """Get the area supervisor user for a given warehouse/store."""
+    # Check custom_area_supervisor field on Warehouse
+    supervisor = frappe.db.get_value("Warehouse", warehouse, "custom_area_supervisor")
+    if supervisor:
+        return supervisor
+
+    # Fallback: check parent warehouse
+    parent = frappe.db.get_value("Warehouse", warehouse, "parent_warehouse")
+    if parent:
+        supervisor = frappe.db.get_value("Warehouse", parent, "custom_area_supervisor")
+        if supervisor:
+            return supervisor
+
+    return None
+
+
+@frappe.whitelist()
+def get_user_store():
+    """
+    Resolve the current user's store(s) based on their role.
+
+    Store Staff / Store Supervisor: Returns store from Employee.branch
+    Area Supervisor: Returns all stores where Warehouse.custom_area_supervisor = user
+
+    Returns:
+        {
+            "stores": [{"name": "Store Name - BEI", "warehouse_name": "Store Name"}],
+            "default_store": "Store Name - BEI",
+            "is_multi_store": false,
+            "role": "Store Staff"
+        }
+    """
+    user = frappe.session.user
+    user_roles = frappe.get_roles(user)
+
+    stores = []
+    role = None
+
+    if "Area Supervisor" in user_roles:
+        # Area supervisors see all stores assigned to them
+        role = "Area Supervisor"
+        area_stores = frappe.get_all(
+            "Warehouse",
+            filters={
+                "custom_area_supervisor": user,
+                "is_group": 0
+            },
+            fields=["name", "warehouse_name"],
+            order_by="warehouse_name"
+        )
+        stores = area_stores
+
+    if not stores and ("Store Supervisor" in user_roles or "Store Staff" in user_roles
+                        or "Employee" in user_roles):
+        # Store staff/supervisors get their branch from Employee record
+        role = "Store Supervisor" if "Store Supervisor" in user_roles else "Store Staff"
+        employee = frappe.db.get_value(
+            "Employee",
+            {"user_id": user, "status": "Active"},
+            ["branch", "employee_name"],
+            as_dict=True
+        )
+        if employee and employee.branch:
+            warehouse = resolve_warehouse(employee.branch)
+            if warehouse:
+                warehouse_name = frappe.db.get_value("Warehouse", warehouse, "warehouse_name") or warehouse
+                stores = [{"name": warehouse, "warehouse_name": warehouse_name}]
+
+    # System Manager / HR User fallback - return all stores
+    if not stores and ("System Manager" in user_roles or "HR User" in user_roles):
+        role = "HR User"
+        stores = frappe.get_all(
+            "Warehouse",
+            filters={"is_group": 0, "disabled": 0},
+            fields=["name", "warehouse_name"],
+            order_by="warehouse_name",
+            limit=50
+        )
+
+    default_store = stores[0]["name"] if stores else None
+
+    return {
+        "stores": stores,
+        "default_store": default_store,
+        "is_multi_store": len(stores) > 1,
+        "role": role
+    }
+
+
 @frappe.whitelist()
 def get_orderable_items(store):
     """
     Get items available for ordering by this store.
-    Returns items filtered by warehouse/store with last order quantity.
+    Returns items sorted by order frequency (most ordered first),
+    with stock_uom and last order quantity.
     """
     if not store:
         frappe.throw(_("Store is required"))
@@ -115,17 +206,22 @@ def get_orderable_items(store):
     # Resolve branch name to warehouse name
     warehouse = resolve_warehouse(store)
 
-    # Get items that can be ordered by this store
-    # For now, return all stock items - can be filtered later by store config
-    items = frappe.get_all(
-        "Item",
-        filters={
-            "is_stock_item": 1,
-            "disabled": 0
-        },
-        fields=["name", "item_name", "item_group", "stock_uom", "image"],
-        order_by="item_group, item_name"
-    )
+    # Get items with order frequency for this store, sorted by most ordered first
+    items = frappe.db.sql("""
+        SELECT
+            i.name, i.item_name, i.item_group, i.stock_uom, i.image,
+            COALESCE(freq.order_count, 0) as order_count
+        FROM `tabItem` i
+        LEFT JOIN (
+            SELECT soi.item_code, COUNT(DISTINCT soi.parent) as order_count
+            FROM `tabBEI Store Order Item` soi
+            JOIN `tabBEI Store Order` so ON so.name = soi.parent
+            WHERE so.store = %s AND so.status != 'Draft'
+            GROUP BY soi.item_code
+        ) freq ON freq.item_code = i.name
+        WHERE i.is_stock_item = 1 AND i.disabled = 0
+        ORDER BY COALESCE(freq.order_count, 0) DESC, i.item_group, i.item_name
+    """, warehouse, as_dict=True)
 
     # Get last order quantities for each item
     for item in items:
@@ -181,6 +277,23 @@ def submit_order(store, items):
         })
 
     order.insert()
+
+    # Create approval queue entry routed to area supervisor
+    try:
+        approver = _get_area_supervisor_for_store(warehouse)
+        if approver:
+            queue_entry = frappe.new_doc("BEI Approval Queue")
+            queue_entry.reference_doctype = "BEI Store Order"
+            queue_entry.reference_name = order.name
+            queue_entry.assigned_approver = approver
+            queue_entry.status = "Pending"
+            queue_entry.insert(ignore_permissions=True)
+    except Exception:
+        # Don't block order creation if approval queue fails
+        frappe.log_error(
+            f"Failed to create approval queue for order {order.name}",
+            "Approval Queue Error"
+        )
 
     return {
         "success": True,

--- a/hrms/hr/doctype/bei_bank_deposit/bei_bank_deposit.json
+++ b/hrms/hr/doctype/bei_bank_deposit/bei_bank_deposit.json
@@ -6,6 +6,7 @@
  "doctype": "DocType",
  "engine": "InnoDB",
  "field_order": [
+  "deposit_type",
   "store",
   "deposit_date",
   "bank",
@@ -21,6 +22,16 @@
   "notes"
  ],
  "fields": [
+  {
+   "default": "Bank Deposit",
+   "fieldname": "deposit_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Deposit Type",
+   "options": "Bank Deposit\nPickup",
+   "reqd": 1
+  },
   {
    "fieldname": "store",
    "fieldtype": "Link",

--- a/hrms/hr/doctype/bei_kudos/bei_kudos.json
+++ b/hrms/hr/doctype/bei_kudos/bei_kudos.json
@@ -114,7 +114,8 @@
   {
    "create": 1,
    "read": 1,
-   "role": "Employee"
+   "role": "Employee",
+   "write": 1
   }
  ],
  "sort_field": "creation",

--- a/hrms/hr/doctype/bei_pos_upload/bei_pos_upload.json
+++ b/hrms/hr/doctype/bei_pos_upload/bei_pos_upload.json
@@ -342,6 +342,12 @@
    "role": "Area Supervisor",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "role": "Employee",
+   "write": 1
   }
  ],
  "sort_field": "creation",

--- a/hrms/hr/doctype/bei_store_closing_report/bei_store_closing_report.json
+++ b/hrms/hr/doctype/bei_store_closing_report/bei_store_closing_report.json
@@ -47,6 +47,40 @@
   "denom_20",
   "denom_coins",
   "denom_total",
+  "section_pcf_denomination",
+  "pcf_denom_1000",
+  "pcf_denom_500",
+  "pcf_denom_200",
+  "pcf_denom_100",
+  "column_break_pcf_denom",
+  "pcf_denom_50",
+  "pcf_denom_20",
+  "pcf_denom_coins",
+  "pcf_denom_total",
+  "section_del_denomination",
+  "del_denom_1000",
+  "del_denom_500",
+  "del_denom_200",
+  "del_denom_100",
+  "column_break_del_denom",
+  "del_denom_50",
+  "del_denom_20",
+  "del_denom_coins",
+  "del_denom_total",
+  "section_chg_denomination",
+  "chg_denom_1000",
+  "chg_denom_500",
+  "chg_denom_200",
+  "chg_denom_100",
+  "column_break_chg_denom",
+  "chg_denom_50",
+  "chg_denom_20",
+  "chg_denom_coins",
+  "chg_denom_total",
+  "section_vouchers",
+  "pcf_voucher_amount",
+  "column_break_vouchers",
+  "delivery_voucher_amount",
   "section_cash",
   "pos_total_sales",
   "actual_cash_count",
@@ -378,6 +412,206 @@
    "fieldtype": "Currency",
    "label": "Denomination Total",
    "read_only": 1
+  },
+  {
+   "description": "Petty Cash Fund denomination breakdown",
+   "fieldname": "section_pcf_denomination",
+   "fieldtype": "Section Break",
+   "label": "PCF Denomination Breakdown"
+  },
+  {
+   "default": "0",
+   "fieldname": "pcf_denom_1000",
+   "fieldtype": "Currency",
+   "label": "PCF - PHP 1000"
+  },
+  {
+   "default": "0",
+   "fieldname": "pcf_denom_500",
+   "fieldtype": "Currency",
+   "label": "PCF - PHP 500"
+  },
+  {
+   "default": "0",
+   "fieldname": "pcf_denom_200",
+   "fieldtype": "Currency",
+   "label": "PCF - PHP 200"
+  },
+  {
+   "default": "0",
+   "fieldname": "pcf_denom_100",
+   "fieldtype": "Currency",
+   "label": "PCF - PHP 100"
+  },
+  {
+   "fieldname": "column_break_pcf_denom",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "pcf_denom_50",
+   "fieldtype": "Currency",
+   "label": "PCF - PHP 50"
+  },
+  {
+   "default": "0",
+   "fieldname": "pcf_denom_20",
+   "fieldtype": "Currency",
+   "label": "PCF - PHP 20"
+  },
+  {
+   "default": "0",
+   "fieldname": "pcf_denom_coins",
+   "fieldtype": "Currency",
+   "label": "PCF - Coins"
+  },
+  {
+   "description": "Auto-calculated: Sum of PCF denominations",
+   "fieldname": "pcf_denom_total",
+   "fieldtype": "Currency",
+   "label": "PCF Denomination Total",
+   "read_only": 1
+  },
+  {
+   "description": "Delivery Fund denomination breakdown",
+   "fieldname": "section_del_denomination",
+   "fieldtype": "Section Break",
+   "label": "Delivery Fund Denomination Breakdown"
+  },
+  {
+   "default": "0",
+   "fieldname": "del_denom_1000",
+   "fieldtype": "Currency",
+   "label": "Delivery - PHP 1000"
+  },
+  {
+   "default": "0",
+   "fieldname": "del_denom_500",
+   "fieldtype": "Currency",
+   "label": "Delivery - PHP 500"
+  },
+  {
+   "default": "0",
+   "fieldname": "del_denom_200",
+   "fieldtype": "Currency",
+   "label": "Delivery - PHP 200"
+  },
+  {
+   "default": "0",
+   "fieldname": "del_denom_100",
+   "fieldtype": "Currency",
+   "label": "Delivery - PHP 100"
+  },
+  {
+   "fieldname": "column_break_del_denom",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "del_denom_50",
+   "fieldtype": "Currency",
+   "label": "Delivery - PHP 50"
+  },
+  {
+   "default": "0",
+   "fieldname": "del_denom_20",
+   "fieldtype": "Currency",
+   "label": "Delivery - PHP 20"
+  },
+  {
+   "default": "0",
+   "fieldname": "del_denom_coins",
+   "fieldtype": "Currency",
+   "label": "Delivery - Coins"
+  },
+  {
+   "description": "Auto-calculated: Sum of Delivery denominations",
+   "fieldname": "del_denom_total",
+   "fieldtype": "Currency",
+   "label": "Delivery Denomination Total",
+   "read_only": 1
+  },
+  {
+   "description": "Change Fund denomination breakdown",
+   "fieldname": "section_chg_denomination",
+   "fieldtype": "Section Break",
+   "label": "Change Fund Denomination Breakdown"
+  },
+  {
+   "default": "0",
+   "fieldname": "chg_denom_1000",
+   "fieldtype": "Currency",
+   "label": "Change Fund - PHP 1000"
+  },
+  {
+   "default": "0",
+   "fieldname": "chg_denom_500",
+   "fieldtype": "Currency",
+   "label": "Change Fund - PHP 500"
+  },
+  {
+   "default": "0",
+   "fieldname": "chg_denom_200",
+   "fieldtype": "Currency",
+   "label": "Change Fund - PHP 200"
+  },
+  {
+   "default": "0",
+   "fieldname": "chg_denom_100",
+   "fieldtype": "Currency",
+   "label": "Change Fund - PHP 100"
+  },
+  {
+   "fieldname": "column_break_chg_denom",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "chg_denom_50",
+   "fieldtype": "Currency",
+   "label": "Change Fund - PHP 50"
+  },
+  {
+   "default": "0",
+   "fieldname": "chg_denom_20",
+   "fieldtype": "Currency",
+   "label": "Change Fund - PHP 20"
+  },
+  {
+   "default": "0",
+   "fieldname": "chg_denom_coins",
+   "fieldtype": "Currency",
+   "label": "Change Fund - Coins"
+  },
+  {
+   "description": "Auto-calculated: Sum of Change Fund denominations",
+   "fieldname": "chg_denom_total",
+   "fieldtype": "Currency",
+   "label": "Change Fund Denomination Total",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_vouchers",
+   "fieldtype": "Section Break",
+   "label": "Voucher Amounts"
+  },
+  {
+   "default": "0",
+   "description": "Total PCF voucher amount for the day",
+   "fieldname": "pcf_voucher_amount",
+   "fieldtype": "Currency",
+   "label": "PCF Voucher Amount"
+  },
+  {
+   "fieldname": "column_break_vouchers",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "Total delivery voucher amount for the day",
+   "fieldname": "delivery_voucher_amount",
+   "fieldtype": "Currency",
+   "label": "Delivery Voucher Amount"
   },
   {
    "fieldname": "section_cash",

--- a/hrms/hr/doctype/bei_store_visit_report/bei_store_visit_report.json
+++ b/hrms/hr/doctype/bei_store_visit_report/bei_store_visit_report.json
@@ -214,6 +214,16 @@
    "role": "HR User",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "read": 1,
+   "role": "Area Supervisor",
+   "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Employee"
   }
  ],
  "sort_field": "creation",


### PR DESCRIPTION
## Summary
- Fix DocType permissions for POS Upload, Kudos, Store Visit Report (Employee + Area Supervisor roles)
- Add 30+ denomination fields, deposit type, voucher amounts to DocTypes
- Add store resolution endpoint, approval queue creation, cycle count validation APIs

## Commits (3)
- 86cf40d fix(doctype): add Employee/Area Supervisor permissions
- 39158b9 feat(doctype): add denomination fields, voucher amounts, deposit type
- f73be6d feat(api): add store resolution, approval queue, cycle count validation

## Test Plan
- [x] Backend quality checkpoint passed (Python syntax + JSON validity)
- [ ] E2E browser test after deploy

---
Created via store-ops-sprint2 team