### PR TITLE
fix: C5 cycle count status + C8 return request column check (Round 2)

### DIFF
--- a/hrms/api/inventory.py
+++ b/hrms/api/inventory.py
@@ -100,7 +100,7 @@ def approve_cycle_count(count_name):
     if doc.status not in ["Submitted", "Resubmitted"]:
         frappe.throw(_("Only submitted cycle counts can be approved"))
 
-    doc.status = "Approved"
+    doc.status = "Verified"
     doc.approved_by = frappe.session.user
     doc.approved_at = nowdate()
     doc.save()
@@ -418,9 +418,11 @@ def submit_return_request(store, items, photo=None):
 def get_return_requests(store=None, status=None, limit=20):
     """Get return request history for a store."""
     limit = min(int(limit or 20), 500)
-    filters = {"custom_return_request": 1}
+    filters = {}
 
-    # Bug fix C8: Check if custom_return_from_store column exists before filtering
+    # Bug fix C8: Check if custom columns exist before filtering
+    if frappe.db.has_column("Stock Entry", "custom_return_request"):
+        filters["custom_return_request"] = 1
     if store:
         warehouse = _resolve_warehouse(store)
         if warehouse and frappe.db.has_column("Stock Entry", "custom_return_from_store"):


### PR DESCRIPTION
## Summary
- **C5**: approve_cycle_count sets status to "Verified" (was "Approved" which is not in DocType options)
- **C8**: get_return_requests wraps custom_return_request filter in has_column check

## Test Plan
- [ ] C5: Call approve_cycle_count - should set status to Verified without error
- [ ] C8: Call get_return_requests - should not crash on missing column

---
Round 2 of E2E bug fix cycle.

🤖 Created via /pr-deploy