### PR TITLE
fix: add pandas dependency for POS data upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "google-generativeai>=0.3.0",
     "scikit-learn>=1.3.0",
     "openai>=1.0.0",
+    "pandas>=2.0.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- Add pandas>=2.0.0 to pyproject.toml dependencies
- Required by POS upload (pos_parser.py), expense classifier, and sheets receiver
- Fixes J4 test failure (ModuleNotFoundError: pandas)

## Test Plan
- [ ] Docker build includes pandas
- [ ] POS upload endpoint works

---
 Generated with Claude Code