### PR TITLE
fix: invoice variance approval match_status preserved

### DIFF
--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -58,6 +58,10 @@ class BEIInvoice(Document):
             self.match_status = "Pending"
             return
 
+        # Preserve approved variance status - don't recalculate after approval
+        if self.match_status == "Approved with Variance":
+            return
+
         # Calculate variances
         self.po_gr_variance = flt(self.po_amount, 2) - flt(self.gr_amount, 2)
         self.gr_inv_variance = flt(self.gr_amount, 2) - flt(self.grand_total, 2)


### PR DESCRIPTION
## Summary
- Fix perform_three_way_match() overwriting "Approved with Variance" on save
- Preserves match_status after variance has been explicitly approved
- Unblocks invoice verification -> payment request workflow

## Test Plan
- [x] Create invoice with variance > tolerance
- [x] Submit for verification -> Variance Pending Approval
- [x] Approve variance -> should stay Verified
- [x] Create payment request -> submit -> approve

---
E2E Round 3 fix (bug #23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)