### PR TITLE
fix: dispatch naming series counter auto-recovery

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -244,7 +244,20 @@ def create_trip(trip_date, route_name, stops):
             "status": "Pending"
         })
 
-    trip.insert()
+    try:
+        trip.insert()
+    except frappe.DuplicateEntryError:
+        # Naming series counter out of sync - fix and retry
+        frappe.db.sql(
+            """UPDATE `tabSeries` SET current = (
+                SELECT IFNULL(MAX(CAST(SUBSTRING_INDEX(name, '-', -1) AS UNSIGNED)), 0)
+                FROM `tabBEI Distribution Trip`
+            ) WHERE name = %s""",
+            (trip.naming_series.replace('.YYYY.', str(nowdate()[:4])).replace('.#####', ''),)
+        )
+        frappe.db.commit()
+        trip.name = None
+        trip.insert()
 
     return {
         "success": True,


### PR DESCRIPTION
## Summary
- Handle DuplicateEntryError in create_trip() when naming series counter is out of sync
- Auto-resets counter from max existing record name and retries

## Test Plan
- [x] Create trip when counter stuck at 0 (was producing duplicate 00001)
- [x] Verify counter resets to current max and generates next number

---
E2E Round 3 fix (dispatch naming series)

🤖 Generated with [Claude Code](https://claude.com/claude-code)