### PR TITLE
fix: non-blocking Frappe PI creation in invoice verification

### DIFF
--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -103,10 +103,16 @@ class BEIInvoice(Document):
             self.verified_date = now_datetime()
             self.save()
 
-            # Create Frappe Purchase Invoice
-            self.create_frappe_purchase_invoice()
+            # Create Frappe Purchase Invoice (best-effort - don't block verification)
+            pi_message = ""
+            try:
+                self.create_frappe_purchase_invoice()
+                pi_message = " Frappe Purchase Invoice created."
+            except Exception as e:
+                frappe.log_error(title="PI Creation Failed", message=str(e))
+                pi_message = f" Note: Frappe PI creation deferred ({str(e)[:100]})"
 
-            return {"success": True, "message": _("Invoice verified - 3-way match passed")}
+            return {"success": True, "message": _("Invoice verified - 3-way match passed") + pi_message}
 
         elif self.match_status == "Variance Detected":
             self.status = "Variance Pending Approval"
@@ -137,10 +143,16 @@ class BEIInvoice(Document):
         self.verified_date = now_datetime()
         self.save()
 
-        # Create Frappe Purchase Invoice
-        self.create_frappe_purchase_invoice()
+        # Create Frappe Purchase Invoice (best-effort - don't block variance approval)
+        pi_message = ""
+        try:
+            self.create_frappe_purchase_invoice()
+            pi_message = " Frappe Purchase Invoice created."
+        except Exception as e:
+            frappe.log_error(title="PI Creation Failed", message=str(e))
+            pi_message = f" Note: Frappe PI creation deferred ({str(e)[:100]})"
 
-        return {"success": True, "message": _("Variance approved - Invoice verified")}
+        return {"success": True, "message": _("Variance approved - Invoice verified") + pi_message}
 
     @frappe.whitelist()
     def reject_variance(self, reason):


### PR DESCRIPTION
## Summary
- Wrap create_frappe_purchase_invoice() in try/except in verify_match() and approve_variance()
- PI creation failure no longer rolls back the invoice verification transaction
- Includes match_status preservation fix from PR #23

## Root Cause
When approve_variance() called save() then create_frappe_purchase_invoice(), the PI creation would fail (missing Stock Received But Not Billed account) and the exception would cause Frappe to roll back the entire request transaction, including the save().

## Test Plan
- [x] Invoice with variance can be approved even when PI creation fails
- [x] Error is logged for manual PI creation later

---
E2E Round 3 fix (bug #23 continued)

🤖 Generated with [Claude Code](https://claude.com/claude-code)