### PR TITLE
fix: E2E Round 4 - closing report, store order qty, work order materials

### DIFF
--- a/hrms/api/commissary.py
+++ b/hrms/api/commissary.py
@@ -2462,6 +2462,36 @@ def create_work_order(item_code, qty, planned_start_date=None, remarks=None):
     if not bom:
         return {"success": False, "error": f"No active BOM found for item {item_code}"}
 
+    # Check material availability against BOM
+    shortages = []
+    bom_items = frappe.get_all(
+        "BOM Item",
+        filters={"parent": bom.name},
+        fields=["item_code", "item_name", "qty"]
+    )
+    for bi in bom_items:
+        required_qty = flt(bi.qty) * flt(qty) / flt(bom.quantity or 1)
+        available = flt(frappe.db.get_value(
+            "Bin",
+            {"item_code": bi.item_code, "warehouse": commissary_warehouse},
+            "actual_qty"
+        ))
+        if available < required_qty:
+            shortages.append({
+                "item_code": bi.item_code,
+                "item_name": bi.item_name,
+                "required": required_qty,
+                "available": available,
+                "short": required_qty - available
+            })
+
+    if shortages:
+        return {
+            "success": False,
+            "error": "Insufficient materials for production",
+            "shortages": shortages
+        }
+
     # Create Work Order
     wo = frappe.new_doc("Work Order")
     wo.production_item = item_code

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -8,7 +8,7 @@ Handles store ordering, receiving, and FQI reports for my.bebang.ph
 
 import frappe
 from frappe import _
-from frappe.utils import nowdate, add_days, now_datetime
+from frappe.utils import nowdate, add_days, now_datetime, flt
 import json
 import base64
 import hashlib
@@ -262,6 +262,17 @@ def submit_order(store, items):
 
     if not items:
         frappe.throw(_("At least one item is required"))
+
+    # Validate quantities - prevent unreasonable orders
+    MAX_ORDER_QTY = 10000
+    for item_data in items:
+        qty = flt(item_data.get("qty_requested", 0))
+        if qty <= 0:
+            frappe.throw(_("Quantity must be greater than zero for item {0}").format(
+                item_data.get("item_code")))
+        if qty > MAX_ORDER_QTY:
+            frappe.throw(_("Order quantity {0} exceeds maximum allowed ({1}) for item {2}").format(
+                qty, MAX_ORDER_QTY, item_data.get("item_code")))
 
     order = frappe.new_doc("BEI Store Order")
     order.store = warehouse

--- a/hrms/hr/doctype/bei_store_closing_report/bei_store_closing_report.py
+++ b/hrms/hr/doctype/bei_store_closing_report/bei_store_closing_report.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import now_datetime
+from frappe.utils import now_datetime, flt
 
 
 class BEIStoreClosingReport(Document):
@@ -24,6 +24,7 @@ class BEIStoreClosingReport(Document):
 		self.update_status()
 
 	def validate(self):
+		self.validate_photo_fields()
 		self.validate_variance_explanation()
 		self.validate_pos_down_mode()
 		self.validate_maintenance_fields()
@@ -111,14 +112,14 @@ class BEIStoreClosingReport(Document):
 			total_variance = 0
 			variance_count = 0
 			for item in self.inventory_spot_check:
-				# Compute variance inline (child before_save hasn't run yet during validate)
-				if item.expected_count is not None and item.actual_count is not None:
-					variance = float(item.actual_count) - float(item.expected_count)
-					item.variance = variance
-					total_variance += variance
-					if variance != 0:
-						variance_count += 1
-			self.inventory_variance_total = total_variance
+				actual = flt(item.actual_count)
+				expected = flt(item.expected_count)
+				variance = actual - expected
+				item.variance = variance
+				total_variance += variance
+				if abs(variance) > 0.001:
+					variance_count += 1
+			self.inventory_variance_total = flt(total_variance, 2)
 			self.inventory_variance_count = variance_count
 
 	def update_signoff_timestamps(self):
@@ -138,18 +139,19 @@ class BEIStoreClosingReport(Document):
 		)
 
 		# Check Stage 2: Checklist (inventory spot check + signoffs)
+		# Item count enforced at frontend (12 items); backend requires at least 1
 		stage2_complete = bool(
 			self.inventory_spot_check and
-			len(self.inventory_spot_check) >= 12 and
+			len(self.inventory_spot_check) >= 1 and
 			self.cashier_signoff and
 			self.production_signoff
 		)
 
-		# Check Stage 3: Photos & Files (required photos from DocType)
+		# Check Stage 3: Photos & Files (reject empty/whitespace-only strings)
 		stage3_complete = bool(
-			self.photo_zread and
-			self.photo_xread_opening and
-			self.photo_xread_closing
+			(self.photo_zread or "").strip() and
+			(self.photo_xread_opening or "").strip() and
+			(self.photo_xread_closing or "").strip()
 		)
 
 		# Set stage_completed based on progress (lowercase to match DocType options)
@@ -187,6 +189,20 @@ class BEIStoreClosingReport(Document):
 		# All good
 		if self.stage_completed == "complete":
 			self.status = "Submitted"
+
+	def validate_photo_fields(self):
+		"""Reject empty or whitespace-only photo strings."""
+		photo_fields = {
+			"photo_zread": "Z-Reading",
+			"photo_xread_opening": "X-Reading Opening",
+			"photo_xread_closing": "X-Reading Closing"
+		}
+		for field, label in photo_fields.items():
+			value = self.get(field)
+			if value is not None and isinstance(value, str) and not value.strip():
+				frappe.throw(
+					_("{0} photo cannot be empty. Please upload a valid photo.").format(label)
+				)
 
 	def validate_variance_explanation(self):
 		"""Require explanation if variance exceeds threshold."""


### PR DESCRIPTION
## Summary
- **E30**: Reject empty/whitespace photo strings in closing report
- **J6**: Use flt() for robust inventory variance calculation
- **J7**: Relax stage2 item threshold from 12 to 1
- **E27**: Cap store order qty at 10,000 per item
- **E29**: Block work order creation when BOM materials insufficient

## Files Changed
- bei_store_closing_report.py (E30, J6, J7)
- store.py (E27)
- commissary.py (E29)

## Test plan
- [ ] Closing report rejects empty string photos
- [ ] Inventory variance correctly calculates 50 vs 48
- [ ] Stage progresses past checklist with <12 items
- [ ] Store order rejects qty > 10,000
- [ ] Work order fails when materials insufficient