### PR TITLE
fix: complete_work_order Manufacture Stock Entry warehouse

### DIFF
--- a/hrms/api/commissary.py
+++ b/hrms/api/commissary.py
@@ -2636,6 +2636,9 @@ def complete_work_order(work_order_name, qty_produced=None):
     se.bom_no = wo.bom_no
     se.fg_completed_qty = qty
     se.company = wo.company
+    # Set warehouses before get_items() so ERPNext populates items correctly
+    se.from_warehouse = wo.wip_warehouse or commissary_warehouse
+    se.to_warehouse = wo.fg_warehouse or commissary_warehouse
 
     se.get_items()
 


### PR DESCRIPTION
## Summary
- Set from_warehouse and to_warehouse before get_items() in complete_work_order()
- ERPNext requires these to populate the finished good row in Manufacture entries
- Fixes FinishedGoodError found during K3 retest

## Test Plan
- [ ] Call complete_work_order on active Work Order
- [ ] Verify Manufacture Stock Entry created with finished good item

---
PR #29 - E2E Round 5 follow-up