### PR TITLE
feat: Official Receipt (OR) Tracking

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -2164,3 +2164,395 @@ def get_finance_analytics():
         "po_trend": get_monthly_po_trend(months=6),
         "suppliers": get_supplier_performance()
     }
+
+
+# =============================================================================
+# Official Receipt (OR) Tracking (Feature B)
+# =============================================================================
+
+@frappe.whitelist()
+def upload_official_receipt(name, or_number, or_date, or_amount, or_attachment=None):
+    """Upload OR for a payment request. Closes the transaction if amount matches within 5%.
+    If mismatch > 5%, still accepts but flags for review.
+
+    Args:
+        name: BEI Payment Request name (e.g. PAY-2026-00001)
+        or_number: Official Receipt number from supplier
+        or_date: Date on the OR
+        or_amount: Amount on the OR
+        or_attachment: Attach field value (file URL)
+
+    Returns:
+        dict with success, message, amount_match, variance_pct
+    """
+    from frappe.utils import now_datetime as _now_dt
+
+    pay_req = frappe.get_doc("BEI Payment Request", name)
+
+    if pay_req.status not in ("Paid - Awaiting OR", "Paid"):
+        frappe.throw(
+            _("Cannot upload OR for payment with status '{0}'. "
+              "Expected 'Paid - Awaiting OR'.").format(pay_req.status)
+        )
+
+    if pay_req.or_status == "OR Received":
+        frappe.throw(_("OR has already been uploaded for this payment request"))
+
+    or_amount = flt(or_amount, 2)
+    payment_amount = flt(pay_req.payment_amount, 2)
+
+    # Calculate variance
+    variance_pct = 0
+    amount_match = True
+    if payment_amount > 0:
+        variance_pct = abs(or_amount - payment_amount) / payment_amount * 100
+        amount_match = variance_pct <= 5
+
+    # Update OR fields
+    pay_req.or_number = or_number
+    pay_req.or_date = or_date
+    pay_req.or_amount = or_amount
+    pay_req.or_attachment = or_attachment
+    pay_req.or_uploaded_by = frappe.session.user
+    pay_req.or_uploaded_date = _now_dt()
+    pay_req.or_status = "OR Received"
+    pay_req.status = "Closed"
+    pay_req.save(ignore_permissions=True)
+
+    msg = _("Official Receipt uploaded successfully. Transaction closed.")
+    if not amount_match:
+        msg = _(
+            "Official Receipt uploaded. Amount mismatch of {0:.1f}% detected "
+            "(Payment: {1:,.2f}, OR: {2:,.2f}). Transaction closed but flagged for review."
+        ).format(variance_pct, payment_amount, or_amount)
+
+    return {
+        "success": True,
+        "message": msg,
+        "amount_match": amount_match,
+        "variance_pct": round(variance_pct, 2),
+        "status": pay_req.status,
+        "or_status": pay_req.or_status,
+    }
+
+
+@frappe.whitelist()
+def get_awaiting_or_list(page=1, page_size=20, status=None, supplier=None, overdue_only=False):
+    """Get list of payments awaiting OR. Used by Butch's OR dashboard.
+
+    Args:
+        page: Page number (1-indexed)
+        page_size: Items per page
+        status: Filter by or_status (e.g. "Awaiting OR", "Overdue")
+        supplier: Filter by supplier name
+        overdue_only: If true, only show overdue items
+
+    Returns:
+        dict with data list, total count, pagination info
+    """
+    from frappe.utils import getdate as _getdate, date_diff
+
+    page = int(page)
+    page_size = min(int(page_size), 100)
+    offset = (page - 1) * page_size
+
+    conditions = ["pr.status = 'Paid - Awaiting OR'"]
+    params = {}
+
+    if status:
+        conditions.append("pr.or_status = %(or_status)s")
+        params["or_status"] = status
+
+    if supplier:
+        conditions.append("pr.supplier = %(supplier)s")
+        params["supplier"] = supplier
+
+    if overdue_only == "true" or overdue_only is True:
+        conditions.append("pr.or_status = 'Overdue'")
+
+    where = " AND ".join(conditions)
+
+    total = frappe.db.sql(
+        f"SELECT COUNT(*) FROM `tabBEI Payment Request` pr WHERE {where}",
+        params
+    )[0][0]
+
+    data = frappe.db.sql(
+        f"""SELECT
+            pr.name,
+            pr.payment_request_no,
+            pr.supplier,
+            pr.supplier_name,
+            pr.payment_amount,
+            pr.payment_date,
+            pr.or_status,
+            pr.or_due_date,
+            pr.or_follow_up_count,
+            pr.or_last_follow_up,
+            pr.purchase_order,
+            pr.invoice
+        FROM `tabBEI Payment Request` pr
+        WHERE {where}
+        ORDER BY pr.or_due_date ASC, pr.payment_date ASC
+        LIMIT %(limit)s OFFSET %(offset)s""",
+        {**params, "limit": page_size, "offset": offset},
+        as_dict=True,
+    )
+
+    today = _getdate()
+    for row in data:
+        paid_date = _getdate(row.payment_date) if row.payment_date else today
+        row["days_waiting"] = date_diff(today, paid_date)
+
+    return {
+        "data": data,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+        "total_pages": -(-total // page_size) if total else 0,
+    }
+
+
+@frappe.whitelist()
+def get_or_aging_summary():
+    """Get OR aging summary by bracket.
+
+    Returns:
+        dict with counts for: 0-7d, 8-14d, 15-30d, 31-60d, 60+d
+        Also returns total_awaiting, total_overdue, avg_days_outstanding
+    """
+    from frappe.utils import getdate as _getdate, date_diff
+
+    today = _getdate()
+
+    rows = frappe.db.sql(
+        """SELECT
+            pr.name,
+            pr.payment_date,
+            pr.payment_amount,
+            pr.or_status,
+            pr.or_due_date
+        FROM `tabBEI Payment Request` pr
+        WHERE pr.status = 'Paid - Awaiting OR'""",
+        as_dict=True,
+    )
+
+    brackets = {
+        "0_7_days": {"count": 0, "amount": 0},
+        "8_14_days": {"count": 0, "amount": 0},
+        "15_30_days": {"count": 0, "amount": 0},
+        "31_60_days": {"count": 0, "amount": 0},
+        "over_60_days": {"count": 0, "amount": 0},
+    }
+
+    total_awaiting = 0
+    total_overdue = 0
+    total_days = 0
+    total_amount_awaiting = 0
+    total_amount_overdue = 0
+
+    for row in rows:
+        paid_date = _getdate(row.payment_date) if row.payment_date else today
+        days = date_diff(today, paid_date)
+        amount = flt(row.payment_amount, 2)
+
+        total_awaiting += 1
+        total_amount_awaiting += amount
+        total_days += days
+
+        if row.or_status == "Overdue":
+            total_overdue += 1
+            total_amount_overdue += amount
+
+        if days <= 7:
+            brackets["0_7_days"]["count"] += 1
+            brackets["0_7_days"]["amount"] += amount
+        elif days <= 14:
+            brackets["8_14_days"]["count"] += 1
+            brackets["8_14_days"]["amount"] += amount
+        elif days <= 30:
+            brackets["15_30_days"]["count"] += 1
+            brackets["15_30_days"]["amount"] += amount
+        elif days <= 60:
+            brackets["31_60_days"]["count"] += 1
+            brackets["31_60_days"]["amount"] += amount
+        else:
+            brackets["over_60_days"]["count"] += 1
+            brackets["over_60_days"]["amount"] += amount
+
+    avg_days = round(total_days / total_awaiting, 1) if total_awaiting else 0
+
+    return {
+        "brackets": brackets,
+        "total_awaiting": total_awaiting,
+        "total_amount_awaiting": total_amount_awaiting,
+        "total_overdue": total_overdue,
+        "total_amount_overdue": total_amount_overdue,
+        "avg_days_outstanding": avg_days,
+    }
+
+
+@frappe.whitelist()
+def mark_or_not_required(name, reason=None):
+    """Mark a payment as not requiring OR. Sets status to Closed.
+    Requires reason for audit trail.
+
+    Args:
+        name: BEI Payment Request name
+        reason: Reason why OR is not required (mandatory)
+
+    Returns:
+        dict with success, message
+    """
+    if not reason:
+        frappe.throw(_("Please provide a reason for marking OR as not required"))
+
+    pay_req = frappe.get_doc("BEI Payment Request", name)
+
+    if pay_req.status not in ("Paid - Awaiting OR", "Paid"):
+        frappe.throw(
+            _("Cannot modify OR status for payment with status '{0}'").format(pay_req.status)
+        )
+
+    pay_req.or_required = 0
+    pay_req.or_status = "Not Required"
+    pay_req.status = "Closed"
+    pay_req.save(ignore_permissions=True)
+
+    # Add comment for audit trail
+    frappe.get_doc({
+        "doctype": "Comment",
+        "comment_type": "Info",
+        "reference_doctype": "BEI Payment Request",
+        "reference_name": name,
+        "content": _("OR marked as not required by {0}. Reason: {1}").format(
+            frappe.session.user, reason
+        ),
+    }).insert(ignore_permissions=True)
+
+    return {
+        "success": True,
+        "message": _("OR marked as not required. Transaction closed."),
+        "status": pay_req.status,
+        "or_status": pay_req.or_status,
+    }
+
+
+@frappe.whitelist()
+def send_or_follow_up(name):
+    """Send follow-up to supplier for missing OR.
+    Increments follow_up_count, records last_follow_up timestamp.
+
+    Args:
+        name: BEI Payment Request name
+
+    Returns:
+        dict with success, message, follow_up_count
+    """
+    from frappe.utils import now_datetime as _now_dt
+
+    pay_req = frappe.get_doc("BEI Payment Request", name)
+
+    if pay_req.status != "Paid - Awaiting OR":
+        frappe.throw(
+            _("Cannot send follow-up for payment with status '{0}'").format(pay_req.status)
+        )
+
+    pay_req.or_follow_up_count = (pay_req.or_follow_up_count or 0) + 1
+    pay_req.or_last_follow_up = _now_dt()
+    pay_req.save(ignore_permissions=True)
+
+    # Add comment for audit trail
+    frappe.get_doc({
+        "doctype": "Comment",
+        "comment_type": "Info",
+        "reference_doctype": "BEI Payment Request",
+        "reference_name": name,
+        "content": _("OR follow-up #{0} sent by {1}").format(
+            pay_req.or_follow_up_count, frappe.session.user
+        ),
+    }).insert(ignore_permissions=True)
+
+    return {
+        "success": True,
+        "message": _("Follow-up #{0} recorded for {1}").format(
+            pay_req.or_follow_up_count, pay_req.supplier_name or pay_req.supplier
+        ),
+        "follow_up_count": pay_req.or_follow_up_count,
+    }
+
+
+def check_overdue_or():
+    """Daily scheduler: check for overdue OR and escalate.
+    7 days past due: or_status -> 'Overdue', nudge procurement user
+    14 days past due: escalate to Mae (CPO) via notification
+    30 days past due: escalate to Butch (CFO) via notification
+    """
+    from frappe.utils import getdate as _getdate, date_diff
+
+    today = _getdate()
+
+    overdue_payments = frappe.db.sql(
+        """SELECT name, supplier_name, payment_amount, or_due_date,
+                  or_follow_up_count, or_status
+        FROM `tabBEI Payment Request`
+        WHERE status = 'Paid - Awaiting OR'
+          AND or_due_date IS NOT NULL
+          AND or_due_date < %(today)s""",
+        {"today": today},
+        as_dict=True,
+    )
+
+    for pay in overdue_payments:
+        days_overdue = date_diff(today, _getdate(pay.or_due_date))
+
+        # Mark as Overdue if not already
+        if pay.or_status != "Overdue":
+            frappe.db.set_value(
+                "BEI Payment Request", pay.name, "or_status", "Overdue",
+                update_modified=False
+            )
+
+        # Escalation tiers
+        if days_overdue >= 30:
+            # Escalate to CFO (Butch)
+            _create_or_escalation_notification(
+                pay, "CFO", "butch@bebang.ph", days_overdue
+            )
+        elif days_overdue >= 14:
+            # Escalate to CPO (Mae)
+            _create_or_escalation_notification(
+                pay, "CPO", "mae@bebang.ph", days_overdue
+            )
+
+    frappe.db.commit()
+
+
+def _create_or_escalation_notification(payment, role_label, recipient, days_overdue):
+    """Create a system notification for OR escalation.
+
+    Args:
+        payment: dict with name, supplier_name, payment_amount
+        role_label: "CPO" or "CFO"
+        recipient: email of the recipient
+        days_overdue: number of days past OR due date
+    """
+    subject = _("OR Overdue ({0} days): {1} - PHP {2:,.2f}").format(
+        days_overdue, payment.supplier_name, flt(payment.payment_amount, 2)
+    )
+
+    try:
+        notification = frappe.get_doc({
+            "doctype": "Notification Log",
+            "for_user": recipient,
+            "type": "Alert",
+            "document_type": "BEI Payment Request",
+            "document_name": payment.name,
+            "subject": subject,
+        })
+        notification.insert(ignore_permissions=True)
+    except Exception:
+        frappe.log_error(
+            f"Failed to create OR escalation notification for {payment.name}",
+            "OR Escalation Error"
+        )

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -261,6 +261,7 @@ scheduler_events = {
 		"hrms.hr.doctype.interview.interview.send_daily_feedback_reminder",
 		"hrms.hr.doctype.job_opening.job_opening.close_expired_job_openings",
 		"hrms.api.pcf.check_month_end_auto_submit",
+		"hrms.api.procurement.check_overdue_or",
 	],
 	"daily_long": [
 		"hrms.hr.doctype.leave_ledger_entry.leave_ledger_entry.process_expired_allocation",

--- a/hrms/hr/doctype/bei_payment_request/bei_payment_request.json
+++ b/hrms/hr/doctype/bei_payment_request/bei_payment_request.json
@@ -70,7 +70,23 @@
     "transaction_reference",
     "payment_proof",
     "integration_section",
-    "frappe_payment_entry"
+    "frappe_payment_entry",
+    "or_tracking_section",
+    "or_status",
+    "or_required",
+    "or_due_date",
+    "column_break_or1",
+    "or_number",
+    "or_date",
+    "or_amount",
+    "or_attachment_section",
+    "or_attachment",
+    "or_uploaded_by",
+    "column_break_or2",
+    "or_uploaded_date",
+    "or_follow_up_section",
+    "or_follow_up_count",
+    "or_last_follow_up"
   ],
   "fields": [
     {
@@ -100,7 +116,7 @@
       "in_list_view": 1,
       "in_standard_filter": 1,
       "label": "Status",
-      "options": "Draft\nPending Review\nPending Budget Approval\nPending CFO Approval\nPending CEO Approval\nApproved\nProcessing\nPaid\nRejected\nCancelled"
+      "options": "Draft\nPending Review\nPending Budget Approval\nPending CFO Approval\nPending CEO Approval\nApproved\nProcessing\nPaid\nPaid - Awaiting OR\nClosed\nRejected\nCancelled"
     },
     {
       "fieldname": "column_break_header",
@@ -474,6 +490,98 @@
       "fieldtype": "Link",
       "label": "Frappe Payment Entry",
       "options": "Payment Entry",
+      "read_only": 1
+    },
+    {
+      "fieldname": "or_tracking_section",
+      "fieldtype": "Section Break",
+      "label": "Official Receipt Tracking"
+    },
+    {
+      "default": "Not Required",
+      "fieldname": "or_status",
+      "fieldtype": "Select",
+      "in_standard_filter": 1,
+      "label": "OR Status",
+      "options": "Not Required\nAwaiting OR\nOR Received\nOverdue",
+      "read_only": 1
+    },
+    {
+      "default": "1",
+      "description": "Most payments require an Official Receipt from the supplier",
+      "fieldname": "or_required",
+      "fieldtype": "Check",
+      "label": "OR Required"
+    },
+    {
+      "description": "Expected date for OR (payment date + supplier payment terms)",
+      "fieldname": "or_due_date",
+      "fieldtype": "Date",
+      "label": "OR Due Date",
+      "read_only": 1
+    },
+    {
+      "fieldname": "column_break_or1",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "or_number",
+      "fieldtype": "Data",
+      "label": "OR Number"
+    },
+    {
+      "fieldname": "or_date",
+      "fieldtype": "Date",
+      "label": "OR Date"
+    },
+    {
+      "fieldname": "or_amount",
+      "fieldtype": "Currency",
+      "label": "OR Amount"
+    },
+    {
+      "fieldname": "or_attachment_section",
+      "fieldtype": "Section Break",
+      "label": "OR Document"
+    },
+    {
+      "fieldname": "or_attachment",
+      "fieldtype": "Attach",
+      "label": "OR Attachment"
+    },
+    {
+      "fieldname": "or_uploaded_by",
+      "fieldtype": "Data",
+      "label": "OR Uploaded By",
+      "read_only": 1
+    },
+    {
+      "fieldname": "column_break_or2",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "or_uploaded_date",
+      "fieldtype": "Datetime",
+      "label": "OR Uploaded Date",
+      "read_only": 1
+    },
+    {
+      "collapsible": 1,
+      "fieldname": "or_follow_up_section",
+      "fieldtype": "Section Break",
+      "label": "OR Follow-Up"
+    },
+    {
+      "default": "0",
+      "fieldname": "or_follow_up_count",
+      "fieldtype": "Int",
+      "label": "Follow-Up Count",
+      "read_only": 1
+    },
+    {
+      "fieldname": "or_last_follow_up",
+      "fieldtype": "Datetime",
+      "label": "Last Follow-Up",
       "read_only": 1
     }
   ],

--- a/hrms/hr/doctype/bei_payment_request/bei_payment_request.py
+++ b/hrms/hr/doctype/bei_payment_request/bei_payment_request.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt, now_datetime
+from frappe.utils import flt, now_datetime, nowdate, add_days
 
 
 # CEO approval threshold
@@ -503,46 +503,56 @@ class BEIPaymentRequest(Document):
         self.save()
 
         # Create Frappe Payment Entry
+        pe_name = None
+        pe_warning = None
         try:
             pe_name = self.create_frappe_payment_entry()
-
-            if pe_name:
-                # Update status to Paid
-                self.status = "Paid"
-                self.save()
-
-                return {
-                    "success": True,
-                    "message": _("Payment completed. Frappe Payment Entry: {0}").format(pe_name),
-                    "payment_entry": pe_name
-                }
-            else:
-                # PE creation didn't return name, but might have succeeded
-                self.status = "Paid"
-                self.save()
-
-                return {
-                    "success": True,
-                    "message": _("Payment marked as completed")
-                }
-
         except Exception as e:
             # Log error but don't fail - payment was made in reality
             frappe.log_error(
                 f"Payment Entry creation failed for {self.name}: {e}",
                 "BEI Payment Entry Error"
             )
+            pe_warning = str(e)
 
-            # Still mark as paid since the actual payment happened
-            self.status = "Paid"
-            self.save()
+        # Route based on OR requirement
+        self._route_after_payment()
+        self.save()
 
-            return {
-                "success": True,
-                "message": _("Payment marked as completed. Note: Frappe Payment Entry "
-                           "creation failed - manual entry may be required."),
-                "warning": str(e)
-            }
+        msg = _("Payment completed")
+        if pe_name:
+            msg = _("Payment completed. Frappe Payment Entry: {0}").format(pe_name)
+
+        result = {
+            "success": True,
+            "message": msg,
+            "status": self.status,
+            "or_status": self.or_status,
+        }
+        if pe_name:
+            result["payment_entry"] = pe_name
+        if pe_warning:
+            result["warning"] = _("Frappe Payment Entry creation failed - "
+                                  "manual entry may be required. {0}").format(pe_warning)
+        return result
+
+    def _route_after_payment(self):
+        """Route payment to OR tracking or close based on or_required flag."""
+        if self.or_required:
+            self.status = "Paid - Awaiting OR"
+            self.or_status = "Awaiting OR"
+            # Calculate OR due date from supplier's payment terms
+            payment_terms_days = 30  # default
+            if self.supplier:
+                supplier_terms = frappe.db.get_value(
+                    "BEI Supplier", self.supplier, "payment_terms_days"
+                )
+                if supplier_terms:
+                    payment_terms_days = int(supplier_terms)
+            self.or_due_date = add_days(nowdate(), payment_terms_days)
+        else:
+            self.status = "Closed"
+            self.or_status = "Not Required"
 
     @frappe.whitelist()
     def get_approval_status(self):

--- a/hrms/hr/doctype/bei_supplier/bei_supplier.json
+++ b/hrms/hr/doctype/bei_supplier/bei_supplier.json
@@ -28,6 +28,7 @@
     "column_break_bank",
     "bank_account_number",
     "payment_terms",
+    "payment_terms_days",
     "metrics_section",
     "total_po_count",
     "total_po_value",
@@ -162,6 +163,13 @@
       "fieldtype": "Link",
       "label": "Default Payment Terms",
       "options": "Payment Terms Template"
+    },
+    {
+      "default": "30",
+      "description": "Number of days supplier typically takes to provide Official Receipt after payment",
+      "fieldname": "payment_terms_days",
+      "fieldtype": "Int",
+      "label": "Payment Terms (Days)"
     },
     {
       "collapsible": 1,

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -38,3 +38,4 @@ hrms.patches.v16_0.create_custom_field_for_employee_advance_in_employee_master
 hrms.patches.v16_0.bei_task_notification_email_templates #2025-12-17
 hrms.patches.v16_0.add_employee_enrichment_fields #2026-01-16
 hrms.patches.v16_0.seed_bei_separation_data #2026-01-22
+hrms.patches.v16_0.migrate_paid_to_awaiting_or #2026-02-09

--- a/hrms/patches/v16_0/migrate_paid_to_awaiting_or.py
+++ b/hrms/patches/v16_0/migrate_paid_to_awaiting_or.py
@@ -1,0 +1,42 @@
+"""Migrate existing 'Paid' BEI Payment Requests to 'Paid - Awaiting OR'.
+
+All existing BEI Payment Requests with status 'Paid' should be migrated to
+'Paid - Awaiting OR' so they appear in the OR tracking dashboard.
+
+Sets:
+  - status = 'Paid - Awaiting OR'
+  - or_status = 'Awaiting OR'
+  - or_required = 1
+  - or_due_date = modified + 30 days (best estimate since we don't know actual payment date)
+"""
+
+import frappe
+
+
+def execute():
+    if not frappe.db.table_exists("tabBEI Payment Request"):
+        return
+
+    # Check if the or_status column exists (added by model sync)
+    columns = frappe.db.get_table_columns("tabBEI Payment Request")
+    if "or_status" not in columns:
+        return
+
+    count = frappe.db.sql(
+        "SELECT COUNT(*) FROM `tabBEI Payment Request` WHERE status = 'Paid'"
+    )[0][0]
+
+    if count == 0:
+        return
+
+    frappe.db.sql("""
+        UPDATE `tabBEI Payment Request`
+        SET status = 'Paid - Awaiting OR',
+            or_status = 'Awaiting OR',
+            or_required = 1,
+            or_due_date = DATE_ADD(COALESCE(payment_date, modified), INTERVAL 30 DAY)
+        WHERE status = 'Paid'
+    """)
+
+    frappe.db.commit()
+    frappe.msgprint(f"Migrated {count} 'Paid' payment requests to 'Paid - Awaiting OR'")


### PR DESCRIPTION
## Summary

Feature B of Procurement Sprint: Official Receipt (OR) Tracking.

After payment, transactions stay open (Paid - Awaiting OR) until supplier OR arrives.

### Changes
- 11 OR fields on BEI Payment Request
- 2 new statuses: Paid - Awaiting OR, Closed
- mark_as_paid() routes to OR tracking
- 5 new API endpoints
- Daily scheduler for overdue escalation (7/14/30 days)
- payment_terms_days on BEI Supplier
- Migration patch for existing Paid records

Merge order: feat/match-exception FIRST, then this PR rebases.