### PR TITLE
fix(procurement): map rate to unit_cost in PO creation API

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -506,6 +506,15 @@ def create_purchase_order(data):
                 )
             )
 
+    # Map 'rate' to 'unit_cost' in items if needed (frontend sends 'rate')
+    if "items" in data:
+        for item in data["items"]:
+            if "rate" in item and "unit_cost" not in item:
+                item["unit_cost"] = item.pop("rate")
+            # Strip invalid UOM to avoid LinkValidationError
+            if item.get("uom") and not frappe.db.exists("UOM", item["uom"]):
+                item.pop("uom")
+
     po = frappe.get_doc({
         "doctype": "BEI Purchase Order",
         **_sanitize_doc_data(data)


### PR DESCRIPTION
## Summary
- Maps frontend `rate` field to `unit_cost` in `create_purchase_order()` — the BEI Purchase Order DocType expects `unit_cost` but the frontend sends `rate`
- Strips invalid UOM values to prevent `LinkValidationError` when UOM doesn't exist in Frappe

## Changes
- `hrms/api/procurement.py`: Added rate→unit_cost mapping and UOM validation in `create_purchase_order()`

## Test plan
- [ ] Create PO via my.bebang.ph with items that have `rate` field
- [ ] Verify PO items have `unit_cost` populated correctly
- [ ] Verify invalid UOM values are stripped without error

---
Generated with [Claude Code](https://claude.com/claude-code)