### PR TITLE
feat(geo-attendance): map support with dual coordinate audit trail

### DIFF
--- a/hrms/api/official_business.py
+++ b/hrms/api/official_business.py
@@ -6,6 +6,7 @@ from frappe.utils import now_datetime
 from frappe.rate_limiter import rate_limit
 from frappe.query_builder import DocType
 from hrms.utils.aws_location import AWSLocationService
+from hrms.utils.geo import calculate_haversine_distance
 
 
 NO_EMPLOYEE_MSG = "Your account is not linked to an employee record. Please contact HR to set up your employee profile."
@@ -73,24 +74,32 @@ def checkout(
     longitude: float,
     accuracy: float,
     selfie_base64: str,
-    expected_return: str = None
+    expected_return: str = None,
+    gps_latitude: float = None,
+    gps_longitude: float = None
 ):
     """Create OB checkout record
 
     Args:
         destination: Where employee is going
         purpose: Reason for OB
-        latitude: GPS latitude
-        longitude: GPS longitude
+        latitude: Submitted latitude (adjusted pin position, or raw GPS if no map)
+        longitude: Submitted longitude (adjusted pin position, or raw GPS if no map)
         accuracy: GPS accuracy in meters
         selfie_base64: Base64-encoded selfie image
         expected_return: Optional expected return time
+        gps_latitude: Raw GPS latitude from device (optional, for audit trail)
+        gps_longitude: Raw GPS longitude from device (optional, for audit trail)
 
     Returns:
         Dict with OB record name and status
     """
     # Get current employee
     employee = _get_employee_or_throw()
+
+    # Raw GPS coordinates: use provided values or fall back to submitted coords
+    raw_gps_lat = float(gps_latitude) if gps_latitude is not None else float(latitude)
+    raw_gps_lng = float(gps_longitude) if gps_longitude is not None else float(longitude)
 
     # Enforce selfie requirement
     if not selfie_base64:
@@ -99,6 +108,17 @@ def checkout(
     # Reject poor GPS signal
     if float(accuracy) > 100:
         frappe.throw(_("GPS accuracy too low ({0}m). Please move to an open area with clear sky view for better signal.".format(int(float(accuracy)))))
+
+    # Validate adjusted position is within 300m of raw GPS (anti-spoofing)
+    adjustment_distance = calculate_haversine_distance(
+        raw_gps_lat, raw_gps_lng, float(latitude), float(longitude)
+    )
+    if adjustment_distance > 300:
+        frappe.throw(
+            _("Adjusted location is {0}m from GPS position. Maximum 300m allowed.").format(
+                int(adjustment_distance)
+            )
+        )
 
     # Check if employee already has active OB (with row-level lock to prevent race condition)
     BEIOfficialBusiness = DocType("BEI Official Business")
@@ -121,7 +141,7 @@ def checkout(
     # Find nearest OB location
     nearest = aws_location.find_nearest_ob_location(float(latitude), float(longitude))
 
-    # Create OB record
+    # Create OB record (stores both raw GPS and adjusted pin position)
     ob_doc = frappe.get_doc({
         "doctype": "BEI Official Business",
         "employee": employee,
@@ -131,6 +151,9 @@ def checkout(
         "checkout_latitude": float(latitude),
         "checkout_longitude": float(longitude),
         "checkout_accuracy": float(accuracy),
+        "checkout_gps_latitude": raw_gps_lat,
+        "checkout_gps_longitude": raw_gps_lng,
+        "checkout_adjustment_distance": round(adjustment_distance, 1),
         "checkout_address": address or f"{latitude}, {longitude}",
         "expected_return": expected_return,
         "status": "Out"

--- a/hrms/api/shift_tracking.py
+++ b/hrms/api/shift_tracking.py
@@ -19,6 +19,7 @@ from frappe.utils import now_datetime, cint
 
 from hrms.api.official_business import validate_image_upload
 from hrms.utils.aws_location import AWSLocationService
+from hrms.utils.geo import calculate_haversine_distance
 
 
 # ---------------------------------------------------------------------------
@@ -60,14 +61,17 @@ def _get_subordinates(manager_employee_id: str) -> list[str]:
 
 @frappe.whitelist()
 @rate_limit(limit=10, seconds=60)
-def punch_in(latitude: float, longitude: float, accuracy: float, selfie_base64: str):
+def punch_in(latitude: float, longitude: float, accuracy: float, selfie_base64: str,
+             gps_latitude: float = None, gps_longitude: float = None):
     """Punch in with GPS + selfie. Uses row-level lock to prevent duplicate punches.
 
     Args:
-        latitude:  GPS latitude  (degrees)
-        longitude: GPS longitude (degrees)
-        accuracy:  GPS accuracy  (meters)
+        latitude:      Submitted latitude (adjusted pin position, or raw GPS if no map)
+        longitude:     Submitted longitude (adjusted pin position, or raw GPS if no map)
+        accuracy:      GPS accuracy (meters)
         selfie_base64: Base64-encoded selfie image (data URL or raw)
+        gps_latitude:  Raw GPS latitude from device (optional, for audit trail)
+        gps_longitude: Raw GPS longitude from device (optional, for audit trail)
 
     Returns:
         dict with shift record name, address, status
@@ -78,11 +82,26 @@ def punch_in(latitude: float, longitude: float, accuracy: float, selfie_base64: 
     longitude = float(longitude)
     accuracy = float(accuracy)
 
+    # Raw GPS coordinates: use provided values or fall back to submitted coords
+    raw_gps_lat = float(gps_latitude) if gps_latitude is not None else latitude
+    raw_gps_lng = float(gps_longitude) if gps_longitude is not None else longitude
+
     # Reject poor GPS signal
     if accuracy > 100:
         frappe.throw(_("GPS accuracy too low ({0}m). Please move to an open area.").format(
             int(accuracy)
         ))
+
+    # Validate adjusted position is within 300m of raw GPS (anti-spoofing)
+    adjustment_distance = calculate_haversine_distance(
+        raw_gps_lat, raw_gps_lng, latitude, longitude
+    )
+    if adjustment_distance > 300:
+        frappe.throw(
+            _("Adjusted location is {0}m from GPS position. Maximum 300m allowed.").format(
+                int(adjustment_distance)
+            )
+        )
 
     # ---- Row-level lock: prevent duplicate punch-in (race condition guard) ----
     active_shift = frappe.db.sql(
@@ -110,7 +129,7 @@ def punch_in(latitude: float, longitude: float, accuracy: float, selfie_base64: 
     aws_location = AWSLocationService()
     address = aws_location.reverse_geocode(latitude, longitude)
 
-    # Create shift record
+    # Create shift record (stores both raw GPS and adjusted pin position)
     shift_doc = frappe.get_doc({
         "doctype": "BEI Shift Record",
         "employee": employee,
@@ -118,6 +137,9 @@ def punch_in(latitude: float, longitude: float, accuracy: float, selfie_base64: 
         "punch_in_latitude": latitude,
         "punch_in_longitude": longitude,
         "punch_in_accuracy": accuracy,
+        "punch_in_gps_latitude": raw_gps_lat,
+        "punch_in_gps_longitude": raw_gps_lng,
+        "punch_in_adjustment_distance": round(adjustment_distance, 1),
         "punch_in_address": address or f"{latitude}, {longitude}",
         "status": "In Progress",
         "verification_status": "Pending",
@@ -482,3 +504,28 @@ def bulk_verify_punches(shift_ids, verification_status: str, notes: str = None):
         "updated_count": updated_count,
         "message": _("{0} punches {1}").format(updated_count, verification_status.lower()),
     }
+
+
+# ---------------------------------------------------------------------------
+# 8. Reverse Geocode Location
+# ---------------------------------------------------------------------------
+
+@frappe.whitelist()  # Requires login (no allow_guest)
+@rate_limit(limit=20, seconds=60)
+def reverse_geocode_location(latitude, longitude):
+    """Return human-readable address for given coordinates.
+
+    Used by the LocationMap component to show live address as the user
+    drags the pin. Rate limited to 20 calls/min per user to prevent
+    AWS Location Service cost abuse.
+
+    Args:
+        latitude:  GPS latitude (degrees)
+        longitude: GPS longitude (degrees)
+
+    Returns:
+        dict with address string
+    """
+    aws_location = AWSLocationService()
+    address = aws_location.reverse_geocode(float(latitude), float(longitude))
+    return {"address": address or "Unknown location"}

--- a/hrms/hr/doctype/bei_official_business/bei_official_business.json
+++ b/hrms/hr/doctype/bei_official_business/bei_official_business.json
@@ -16,6 +16,9 @@
   "checkout_latitude",
   "checkout_longitude",
   "checkout_accuracy",
+  "checkout_gps_latitude",
+  "checkout_gps_longitude",
+  "checkout_adjustment_distance",
   "checkout_address",
   "checkout_selfie",
   "column_break_checkout",
@@ -112,6 +115,29 @@
    "fieldtype": "Float",
    "label": "GPS Accuracy (meters)",
    "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "checkout_gps_latitude",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "GPS Raw Latitude",
+   "precision": "8",
+   "read_only": 1
+  },
+  {
+   "fieldname": "checkout_gps_longitude",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "GPS Raw Longitude",
+   "precision": "8",
+   "read_only": 1
+  },
+  {
+   "fieldname": "checkout_adjustment_distance",
+   "fieldtype": "Float",
+   "label": "Pin Adjustment (meters)",
+   "precision": "1",
    "read_only": 1
   },
   {
@@ -275,7 +301,7 @@
   }
  ],
  "is_submittable": 0,
- "modified": "2026-02-05 12:00:00.000000",
+ "modified": "2026-02-10 18:00:00.000000",
  "module": "HR",
  "name": "BEI Official Business",
  "permissions": [

--- a/hrms/hr/doctype/bei_shift_record/bei_shift_record.json
+++ b/hrms/hr/doctype/bei_shift_record/bei_shift_record.json
@@ -15,6 +15,9 @@
   "punch_in_latitude",
   "punch_in_longitude",
   "punch_in_accuracy",
+  "punch_in_gps_latitude",
+  "punch_in_gps_longitude",
+  "punch_in_adjustment_distance",
   "column_break_punch_in",
   "punch_in_address",
   "punch_in_photo",
@@ -110,6 +113,29 @@
    "fieldtype": "Float",
    "label": "GPS Accuracy (meters)",
    "precision": "2",
+   "read_only": 1
+  },
+  {
+   "fieldname": "punch_in_gps_latitude",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "GPS Raw Latitude",
+   "precision": "8",
+   "read_only": 1
+  },
+  {
+   "fieldname": "punch_in_gps_longitude",
+   "fieldtype": "Float",
+   "hidden": 1,
+   "label": "GPS Raw Longitude",
+   "precision": "8",
+   "read_only": 1
+  },
+  {
+   "fieldname": "punch_in_adjustment_distance",
+   "fieldtype": "Float",
+   "label": "Pin Adjustment (meters)",
+   "precision": "1",
    "read_only": 1
   },
   {
@@ -278,7 +304,7 @@
  ],
  "is_submittable": 0,
  "links": [],
- "modified": "2026-02-06 12:00:00.000000",
+ "modified": "2026-02-10 18:00:00.000000",
  "module": "HR",
  "name": "BEI Shift Record",
  "naming_rule": "Expression",


### PR DESCRIPTION
## Summary

Sprint 3 backend for Geotagged Attendance map feature:

- **New endpoint:** reverse_geocode_location - returns human-readable address, rate-limited 20/min
- **Server-side 300m validation:** Both punch_in and checkout validate adjusted pin within 300m of raw GPS
- **Audit trail:** Both DocTypes store raw GPS coords alongside adjusted pin position + adjustment_distance
- **Backward compatible:** New gps_latitude/gps_longitude params are optional

## Test plan
- [ ] Existing punch-in/checkout works without gps_* params
- [ ] New gps_* params stored correctly
- [ ] Server rejects adjusted position > 300m from raw GPS
- [ ] reverse_geocode_location returns address
- [ ] DocType migration adds new fields

Generated with [Claude Code](https://claude.com/claude-code)