### PR TITLE
fix(geo-attendance): 305m server tolerance for Haversine float precision

### DIFF
--- a/hrms/api/official_business.py
+++ b/hrms/api/official_business.py
@@ -110,10 +110,11 @@ def checkout(
         frappe.throw(_("GPS accuracy too low ({0}m). Please move to an open area with clear sky view for better signal.".format(int(float(accuracy)))))
 
     # Validate adjusted position is within 300m of raw GPS (anti-spoofing)
+    # 305m server tolerance for floating-point diff between frontend/backend Haversine
     adjustment_distance = calculate_haversine_distance(
         raw_gps_lat, raw_gps_lng, float(latitude), float(longitude)
     )
-    if adjustment_distance > 300:
+    if adjustment_distance > 305:
         frappe.throw(
             _("Adjusted location is {0}m from GPS position. Maximum 300m allowed.").format(
                 int(adjustment_distance)

--- a/hrms/api/shift_tracking.py
+++ b/hrms/api/shift_tracking.py
@@ -93,10 +93,11 @@ def punch_in(latitude: float, longitude: float, accuracy: float, selfie_base64: 
         ))
 
     # Validate adjusted position is within 300m of raw GPS (anti-spoofing)
+    # 305m server tolerance for floating-point diff between frontend/backend Haversine
     adjustment_distance = calculate_haversine_distance(
         raw_gps_lat, raw_gps_lng, latitude, longitude
     )
-    if adjustment_distance > 300:
+    if adjustment_distance > 305:
         frappe.throw(
             _("Adjusted location is {0}m from GPS position. Maximum 300m allowed.").format(
                 int(adjustment_distance)


### PR DESCRIPTION
Code review fix: frontend atan2 vs backend asin Haversine variants can differ at 300m boundary. 5m tolerance prevents false rejections.

Generated with [Claude Code](https://claude.com/claude-code)