### PR TITLE
fix(store): restructure closing report stages + fix 5 ops bugs

### DIFF
--- a/docs/plans/2026-02-12-closing-report-stage-restructure.md
+++ b/docs/plans/2026-02-12-closing-report-stage-restructure.md
@@ -1,0 +1,263 @@
+# Closing Report Stage Restructure
+
+**Date:** 2026-02-12
+**Priority:** HIGH — Do BEFORE bug fixes (changes the same functions)
+**Depends on:** None
+**Blocks:** `2026-02-12-closing-report-fix-and-ux-redesign.md` (bug fix plan must adapt to new structure)
+
+---
+
+## Problem
+
+The 3-stage closing report has fields in the wrong stages, redundant data collection, and dead code:
+
+| Issue | Impact |
+|-------|--------|
+| `variance_explanation` in Stage 3 instead of Stage 1 | Crew explains cash variance 2 pages after they see it — they forget why |
+| Equipment readings (Stage 2) split from equipment photos (Stage 3) | Crew reads thermometer AND photographs it at the same time — forced to enter in different steps |
+| 5 POS files re-collected in Stage 3 | Already collected via separate `BEI POS Upload` endpoint + DocType — double work for crew |
+| Old monolithic `submit_closing_report()` still exists | 75 lines of dead code that confuses maintenance |
+| Cash reconciliation fields not in any stage | `pos_total_sales`, `actual_cash_count`, `card_payments`, `gcash_total` exist in DocType but no stage collects them |
+| Maintenance fields not in any stage | 6 fields exist in DocType but nothing populates them |
+
+---
+
+## Changes
+
+### 1. Move `variance_explanation` from Stage 3 to Stage 1
+
+**File:** `hrms/api/store.py`
+
+**Stage 1** (`submit_closing_stage1_cash`, line 1307): Add `variance_explanation` parameter.
+
+```python
+def submit_closing_stage1_cash(report_name, petty_cash_fund=0, delivery_fund=0,
+                                change_fund=0, cash_notes=None, pos_down=False,
+                                pos_down_estimated_sales=None, pos_down_transaction_count=None,
+                                pos_down_notes=None, variance_explanation=None, **kwargs):
+    # ... existing code ...
+    doc.cash_notes = cash_notes
+    doc.variance_explanation = variance_explanation  # ADD — explain variance when you see it
+```
+
+**Stage 3** (`submit_closing_stage3_photos`, line 1419): Remove `variance_explanation` parameter.
+
+```python
+def submit_closing_stage3_photos(report_name, x_reading_opening_photo, x_reading_closing_photo,
+                                  z_reading_photo, store_photos=None,
+                                  notes=None):  # REMOVED: pos_files, variance_explanation
+```
+
+**Frontend** (`bei-tasks/app/dashboard/store-ops/closing/page.tsx`):
+- Move the variance explanation textarea from Stage 3 component to Stage 1 component
+- Show it conditionally when `cash_variance` (from API response) exceeds +/- 50 pesos
+- Stage 1 API response already returns `total_funds` — add `cash_variance` to response too
+
+**Stage 1 response change:**
+```python
+return {
+    "success": True,
+    "name": doc.name,
+    "stage_completed": doc.stage_completed,
+    "total_funds": doc.total_funds,
+    "cash_variance": doc.cash_variance  # ADD — so frontend can show variance explanation prompt
+}
+```
+
+### 2. Move equipment readings from Stage 2 to Stage 3
+
+**File:** `hrms/api/store.py`
+
+**Stage 2** (`submit_closing_stage2_checklist`, line 1353): Remove `equipment_status` parameter and lines 1396-1399.
+
+```python
+def submit_closing_stage2_checklist(report_name, inventory_items, checklist_items=None,
+                                     cashier_signoff=False, production_signoff=False,
+                                     supervisor_signoff=False):  # REMOVED: equipment_status
+    # ... existing code ...
+    # REMOVE lines 1374-1375 (isinstance check for equipment_status)
+    # REMOVE lines 1396-1399 (freezer_temp, chiller_temp, pos_closed_properly)
+```
+
+**Stage 3** (`submit_closing_stage3_photos`, line 1419): Add `equipment_status` parameter.
+
+```python
+def submit_closing_stage3_photos(report_name, x_reading_opening_photo, x_reading_closing_photo,
+                                  z_reading_photo, store_photos=None,
+                                  equipment_status=None, notes=None):
+    # ... after photo processing ...
+
+    # Equipment readings (entered alongside equipment photos)
+    if equipment_status:
+        if isinstance(equipment_status, str):
+            equipment_status = json.loads(equipment_status)
+        doc.freezer_temp = equipment_status.get("freezer_temp")
+        doc.chiller_temp = equipment_status.get("chiller_temp")
+        doc.pos_closed_properly = equipment_status.get("pos_closed_properly", 0)
+```
+
+**Frontend:**
+- Move freezer/chiller temp inputs from Stage 2 to Stage 3, next to the hygrometer and water meter photo capture fields
+- Group as "Equipment Readings + Photos" section in Stage 3 UI
+
+### 3. Remove POS files from Stage 3
+
+**File:** `hrms/api/store.py`
+
+**Stage 3** (`submit_closing_stage3_photos`, line 1419): Remove `pos_files` parameter and lines 1449-1456.
+
+```python
+def submit_closing_stage3_photos(report_name, x_reading_opening_photo, x_reading_closing_photo,
+                                  z_reading_photo, store_photos=None,
+                                  equipment_status=None, notes=None):
+    # REMOVED: pos_files parameter
+    # REMOVED: lines 1449-1456 (pos_files processing)
+```
+
+POS files are already handled by the separate `upload_pos_data()` endpoint (line 873) which creates a `BEI POS Upload` record. The closing report links to it via the `pos_upload` Link field.
+
+**Frontend:**
+- Remove POS file upload section from Stage 3 component
+- If POS Upload is required before closing, show a status badge: "POS Upload: Done" or "POS Upload: Pending"
+- Link to the POS Upload page if pending
+
+**DocType fields to keep (no schema change):** `pos_discount_report`, `pos_transaction_report`, `pos_product_mix`, `pos_daily_sales_revenue`, `pos_sales_summary` — these can be populated by a future auto-link from BEI POS Upload, or removed later. Not changing schema now.
+
+### 4. Delete old monolithic endpoint
+
+**File:** `hrms/api/store.py`
+
+Delete `submit_closing_report()` function (lines 643-717). This is the old single-endpoint version that the frontend no longer calls. The 3-stage pipeline (`get_or_create_closing_report` + `submit_closing_stage1_cash` + `submit_closing_stage2_checklist` + `submit_closing_stage3_photos`) replaces it completely.
+
+**Verify before deleting:**
+```bash
+# Search both repos for any remaining calls
+grep -r "submit_closing_report" hrms/ --include="*.py" --include="*.js"
+grep -r "submit_closing_report" ../bei-tasks/ --include="*.ts" --include="*.tsx"
+```
+
+If only the function definition is found (no callers), safe to delete.
+
+### 5. Add `actual_cash_count` to Stage 1 (conditional)
+
+**File:** `hrms/api/store.py`
+
+The `actual_cash_count` field is the physical cash count the crew does. It's used to compute `cash_variance = actual_cash_count - pos_total_sales - card_payments - gcash_total + ...`. Currently no stage collects it.
+
+Two scenarios:
+- **POS Upload done first:** `pos_total_sales`, `card_payments`, `gcash_total` auto-populate from POS extraction. Crew enters `actual_cash_count` in Stage 1 and variance is computed.
+- **POS Upload not done:** All POS fields are zero. `actual_cash_count` still captured but variance is meaningless.
+
+**Stage 1** (`submit_closing_stage1_cash`): Add `actual_cash_count` parameter.
+
+```python
+def submit_closing_stage1_cash(report_name, petty_cash_fund=0, delivery_fund=0,
+                                change_fund=0, cash_notes=None, pos_down=False,
+                                pos_down_estimated_sales=None, pos_down_transaction_count=None,
+                                pos_down_notes=None, variance_explanation=None,
+                                actual_cash_count=0, **kwargs):
+    # ... existing code ...
+    doc.actual_cash_count = float(actual_cash_count or 0)
+```
+
+**Frontend:**
+- Add "Actual Cash Count" input to Stage 1 below denomination breakdown
+- Show computed `cash_variance` after save (already returned in response)
+- If variance > +/- 50: show variance explanation textarea
+
+### 6. Maintenance fields — no stage, keep as-is
+
+The 6 maintenance fields (`has_maintenance_today`, `maintenance_verified`, etc.) are conditional — only relevant when a maintenance tech visited that day. This is better handled as a separate workflow (supervisor fills in after closing) rather than forcing every crew member through a maintenance section every night.
+
+**Decision: Leave as-is.** These fields can be populated via Frappe Desk or a future "Supervisor Review" flow. Not adding them to any stage.
+
+---
+
+## New Stage Structure (After Changes)
+
+### Stage 1: Cash Count & Reconciliation
+| Field | Type | Notes |
+|-------|------|-------|
+| petty_cash_fund | Currency | |
+| delivery_fund | Currency | |
+| change_fund | Currency | |
+| Denomination breakdowns (3x7) | Currency/Int | PCF, Delivery, Change Fund |
+| Voucher amounts (2) | Currency | PCF, Delivery |
+| actual_cash_count | Currency | **NEW** — physical cash count |
+| POS Down mode (4 fields) | Mixed | Conditional |
+| cash_notes | Text | |
+| variance_explanation | Text | **MOVED from Stage 3** — conditional on variance > 50 |
+
+**Saved data:** 30+ fields. Heavy data entry but all numerical — fast on mobile with number pads.
+
+### Stage 2: Checklist & Inventory
+| Field | Type | Notes |
+|-------|------|-------|
+| inventory_spot_check | Child Table | 12 items with expected/actual counts |
+| checklist_items | Child Table | End-of-day tasks |
+| cashier_signoff | Check | |
+| production_signoff | Check | |
+| supervisor_signoff | Check | |
+
+**Removed from Stage 2:** `equipment_status` (freezer_temp, chiller_temp, pos_closed_properly) — moved to Stage 3.
+
+**Saved data:** 2 child tables + 3 checkboxes. Checkbox-heavy — fast to complete.
+
+### Stage 3: Photos & Equipment
+| Field | Type | Notes |
+|-------|------|-------|
+| X-reading opening photo | Attach Image | Document scan |
+| X-reading closing photo | Attach Image | Document scan |
+| Z-reading photo | Attach Image | Document scan |
+| 10 store area photos | Attach Image | Standard camera |
+| Equipment readings | Mixed | **MOVED from Stage 2** — freezer_temp, chiller_temp, pos_closed_properly |
+| notes | Text | General notes |
+
+**Removed from Stage 3:** `pos_files` (5 fields) — handled by separate POS Upload. `variance_explanation` — moved to Stage 1.
+
+**Saved data:** 13 photos + 3 equipment fields + notes. Photo-heavy — slowest stage due to camera captures.
+
+---
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `hrms/api/store.py` | Move variance_explanation to stage1, move equipment to stage3, remove pos_files from stage3, add actual_cash_count to stage1, delete old submit_closing_report() |
+| `bei-tasks/app/dashboard/store-ops/closing/page.tsx` | Move variance explanation UI to Stage 1, move equipment inputs to Stage 3, remove POS file upload from Stage 3, add actual_cash_count input |
+
+No DocType schema changes needed — all fields already exist, we're just changing which API endpoint writes to them.
+
+---
+
+## Execution Order
+
+1. **Backend changes** (hrms/api/store.py) — all in one commit
+2. **Frontend changes** (bei-tasks closing page) — separate commit after backend deploys
+3. **Delete dead code** (old submit_closing_report) — only after verifying no callers remain
+
+This restructure should be done BEFORE the bug fix plan (`2026-02-12-closing-report-fix-and-ux-redesign.md`) since it changes the same functions. The bug fixes (save_base64_image, key mismatch, etc.) apply to the restructured code.
+
+---
+
+## Verification
+
+After restructure, verify:
+
+1. **Stage 1 saves variance_explanation** — submit with variance > 50, check explanation saved
+2. **Stage 2 no longer accepts equipment_status** — confirm parameter is ignored/removed
+3. **Stage 3 accepts equipment_status** — submit with freezer_temp=5, verify saved
+4. **Stage 3 no longer accepts pos_files** — confirm parameter is ignored/removed
+5. **Stage 1 saves actual_cash_count** — submit with count, verify cash_variance computed
+6. **Old endpoint deleted** — `POST submit_closing_report` returns 404/AttributeError
+7. **Full 3-stage flow** — complete all 3 stages, verify all fields populated correctly
+
+---
+
+## Related Plans
+
+| Plan | Relationship |
+|------|-------------|
+| `2026-02-12-closing-report-fix-and-ux-redesign.md` | Bug fixes (save_base64_image, key mismatch, permissions) — apply AFTER this restructure |
+| `2026-02-12-ops-bug-tracker.md` | Tracks all 22 ops bugs from feedback — BUG-002 is the closing report |
+| `2026-02-12-ops-5-bugs-fix-plan.md` | Original simpler bug fix plan — superseded by the comprehensive plan |

--- a/hrms/api/payroll.py
+++ b/hrms/api/payroll.py
@@ -530,6 +530,32 @@ def get_salary_slip_list(from_date, to_date, department=None, page=1, page_size=
 
 
 @frappe.whitelist()
+def get_my_payslips(limit=12):
+    """Get current employee's own salary slips (self-service).
+
+    No HR permission check needed — returns only the logged-in user's payslips.
+
+    Args:
+        limit: Max number of slips to return (default 12 = 1 year)
+
+    Returns:
+        dict: {success, payslips} or {success, error}
+    """
+    employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
+    if not employee:
+        return {"success": False, "error": "No employee record found for your account"}
+
+    slips = frappe.get_all("Salary Slip",
+        filters={"employee": employee, "docstatus": 1},
+        fields=["name", "posting_date", "start_date", "end_date",
+                "gross_pay", "total_deduction", "net_pay", "status"],
+        order_by="posting_date desc",
+        limit=int(limit)
+    )
+    return {"success": True, "payslips": slips}
+
+
+@frappe.whitelist()
 def get_payroll_dashboard(from_date=None, to_date=None):
     """Get combined payroll dashboard data.
 

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -640,84 +640,6 @@ def get_opening_reports(store=None, date_from=None, date_to=None, limit=20):
 
 
 @frappe.whitelist()
-def submit_closing_report(store, checklist_items=None, report_time=None,
-                          pos_total_sales=0, actual_cash_count=0,
-                          card_payments=0, gcash_total=0,
-                          variance_explanation=None, notes=None,
-                          photo_xread_opening=None, photo_xread_closing=None,
-                          photo_zread=None, photo_closing_reports=None,
-                          photo_dashboard_report=None, photo_logo_signage=None,
-                          photo_hygrometer=None, photo_water_meter=None,
-                          photo_backup_area_clean=None, photo_frozen_milk_clean=None,
-                          photo_toppings_clean=None, photo_dispatch_clean=None,
-                          photo_cold_storage_close=None, photo_cashier_clean=None,
-                          photo_rollup_closed=None):
-    """Submit daily closing report with cash reconciliation and 15 required photos.
-
-    Bug fixes (C2):
-    - report_time made optional (defaults to current time)
-    - checklist_items made optional (allows partial submission)
-    - Cash fields default to 0 to avoid float(None) errors
-    - insert with ignore_permissions=True for Employee Self Service role
-    - Returns user-friendly error instead of raw traceback
-    """
-    try:
-        if not store:
-            frappe.throw(_("Store is required"))
-
-        if isinstance(checklist_items, str):
-            checklist_items = json.loads(checklist_items)
-
-        # Resolve branch name to warehouse name
-        warehouse = resolve_warehouse(store)
-
-        doc = frappe.new_doc("BEI Store Closing Report")
-        doc.store = warehouse
-        doc.report_date = nowdate()
-        doc.report_time = report_time or now_datetime().strftime("%H:%M:%S")
-        doc.submitted_by = frappe.session.user
-        doc.pos_total_sales = float(pos_total_sales or 0)
-        doc.actual_cash_count = float(actual_cash_count or 0)
-        doc.card_payments = float(card_payments or 0)
-        doc.gcash_total = float(gcash_total or 0)
-        doc.variance_explanation = variance_explanation
-        doc.notes = notes
-
-        # Photos - convert base64 to file URLs if needed
-        doctype_name = "BEI Store Closing Report"
-        doc.photo_xread_opening = save_base64_image(photo_xread_opening, doctype_name, fieldname="photo_xread_opening")
-        doc.photo_xread_closing = save_base64_image(photo_xread_closing, doctype_name, fieldname="photo_xread_closing")
-        doc.photo_zread = save_base64_image(photo_zread, doctype_name, fieldname="photo_zread")
-        doc.photo_closing_reports = save_base64_image(photo_closing_reports, doctype_name, fieldname="photo_closing_reports")
-        doc.photo_dashboard_report = save_base64_image(photo_dashboard_report, doctype_name, fieldname="photo_dashboard_report")
-        doc.photo_logo_signage = save_base64_image(photo_logo_signage, doctype_name, fieldname="photo_logo_signage")
-        doc.photo_hygrometer = save_base64_image(photo_hygrometer, doctype_name, fieldname="photo_hygrometer")
-        doc.photo_water_meter = save_base64_image(photo_water_meter, doctype_name, fieldname="photo_water_meter")
-        doc.photo_backup_area_clean = save_base64_image(photo_backup_area_clean, doctype_name, fieldname="photo_backup_area_clean")
-        doc.photo_frozen_milk_clean = save_base64_image(photo_frozen_milk_clean, doctype_name, fieldname="photo_frozen_milk_clean")
-        doc.photo_toppings_clean = save_base64_image(photo_toppings_clean, doctype_name, fieldname="photo_toppings_clean")
-        doc.photo_dispatch_clean = save_base64_image(photo_dispatch_clean, doctype_name, fieldname="photo_dispatch_clean")
-        doc.photo_cold_storage_close = save_base64_image(photo_cold_storage_close, doctype_name, fieldname="photo_cold_storage_close")
-        doc.photo_cashier_clean = save_base64_image(photo_cashier_clean, doctype_name, fieldname="photo_cashier_clean")
-        doc.photo_rollup_closed = save_base64_image(photo_rollup_closed, doctype_name, fieldname="photo_rollup_closed")
-
-        if checklist_items:
-            for item in checklist_items:
-                doc.append("checklist_items", item)
-
-        doc.flags.ignore_mandatory = True
-        doc.insert(ignore_permissions=True)
-        return {"success": True, "name": doc.name, "variance": doc.cash_variance}
-
-    except Exception as e:
-        frappe.log_error(
-            f"Closing Report Error for store {store}: {str(e)}\n\n{frappe.get_traceback()}",
-            "Closing Report Submission Error"
-        )
-        return {"success": False, "error": _("Failed to submit closing report. Please try again or contact support.")}
-
-
-@frappe.whitelist()
 def get_closing_reports(store=None, date_from=None, date_to=None, limit=20):
     """Get closing report history."""
     filters = {}
@@ -937,18 +859,26 @@ def upload_pos_data(store, pos_date, pos_system, discount_report, transaction_re
     # Resolve branch name to warehouse name (C6 fix)
     warehouse = resolve_warehouse(store)
 
+    # Case-insensitive POS system matching (e.g., "Mosaic" -> "MOSAIC")
+    if pos_system:
+        pos_system = pos_system.strip().upper()
+
     doc = frappe.new_doc("BEI POS Upload")
     doc.store = warehouse
     doc.pos_date = pos_date
     doc.uploaded_by = frappe.session.user
     doc.pos_system = pos_system
-    doc.discount_report = discount_report
-    doc.transaction_report = transaction_report
-    doc.product_mix = product_mix
-    doc.daily_sales_revenue = daily_sales_revenue
-    doc.sales_summary = sales_summary
     doc.notes = notes
     doc.insert()
+
+    # Save report files as Frappe File records (not raw base64)
+    doctype_name = "BEI POS Upload"
+    doc.discount_report = save_base64_image(discount_report, doctype_name, docname=doc.name, fieldname="discount_report")
+    doc.transaction_report = save_base64_image(transaction_report, doctype_name, docname=doc.name, fieldname="transaction_report")
+    doc.product_mix = save_base64_image(product_mix, doctype_name, docname=doc.name, fieldname="product_mix")
+    doc.daily_sales_revenue = save_base64_image(daily_sales_revenue, doctype_name, docname=doc.name, fieldname="daily_sales_revenue")
+    doc.sales_summary = save_base64_image(sales_summary, doctype_name, docname=doc.name, fieldname="sales_summary")
+    doc.save()
 
     result = {"success": True, "name": doc.name}
     if date_mismatch_warning:
@@ -1307,13 +1237,16 @@ def get_or_create_closing_report(store):
 def submit_closing_stage1_cash(report_name, petty_cash_fund=0, delivery_fund=0,
                                 change_fund=0, cash_notes=None, pos_down=False,
                                 pos_down_estimated_sales=None, pos_down_transaction_count=None,
-                                pos_down_notes=None, **kwargs):
+                                pos_down_notes=None, variance_explanation=None,
+                                actual_cash_count=0, **kwargs):
     """
-    Submit Stage 1: Cash Count
+    Submit Stage 1: Cash Count & Reconciliation
 
     Note: Cash Sales Fund stays in POS only - not entered here.
     Only Petty Cash, Delivery Fund, and Change Fund are entered in this stage.
     Denomination breakdown and voucher amounts are passed via kwargs.
+    actual_cash_count: Physical cash count by crew.
+    variance_explanation: Required when cash_variance > ±50 (explain while you see the number).
     """
     validate_store_ops_role()
     doc = frappe.get_doc("BEI Store Closing Report", report_name)
@@ -1322,6 +1255,8 @@ def submit_closing_stage1_cash(report_name, petty_cash_fund=0, delivery_fund=0,
     doc.delivery_fund = float(delivery_fund or 0)
     doc.change_fund = float(change_fund or 0)
     doc.cash_notes = cash_notes
+    doc.actual_cash_count = float(actual_cash_count or 0)
+    doc.variance_explanation = variance_explanation
 
     # POS Down mode
     doc.pos_down = 1 if pos_down else 0
@@ -1345,22 +1280,26 @@ def submit_closing_stage1_cash(report_name, petty_cash_fund=0, delivery_fund=0,
         "success": True,
         "name": doc.name,
         "stage_completed": doc.stage_completed,
-        "total_funds": doc.total_funds
+        "total_funds": doc.total_funds,
+        "cash_variance": doc.cash_variance
     }
 
 
 @frappe.whitelist()
 def submit_closing_stage2_checklist(report_name, inventory_items, checklist_items=None,
                                      cashier_signoff=False, production_signoff=False,
-                                     supervisor_signoff=False, equipment_status=None):
+                                     supervisor_signoff=False):
     """
     Submit Stage 2: Checklist & Inventory Spot Check
 
     inventory_items: List of {item_name, expected_count, actual_count}
     - 12 specific items categorized by: Highest Cost, Single Count Variances,
       Shortest Shelf Life, Most Used Items
+    - Accepts both item_name and item_description keys (frontend compatibility)
 
     checklist_items: General end-of-day tasks
+
+    Note: equipment_status moved to Stage 3 (entered alongside equipment photos).
     """
     validate_store_ops_role()
     doc = frappe.get_doc("BEI Store Closing Report", report_name)
@@ -1371,16 +1310,13 @@ def submit_closing_stage2_checklist(report_name, inventory_items, checklist_item
     if isinstance(checklist_items, str):
         checklist_items = json.loads(checklist_items)
 
-    if isinstance(equipment_status, str):
-        equipment_status = json.loads(equipment_status)
-
     # Clear existing inventory items
     doc.inventory_spot_check = []
 
     # Add inventory spot check items (12 items)
     for item in inventory_items:
         doc.append("inventory_spot_check", {
-            "item_name": item.get("item_name"),
+            "item_name": item.get("item_name") or item.get("item_description") or item.get("name", ""),
             "category": item.get("category"),
             "expected_count": float(item.get("expected_count", 0)),
             "actual_count": float(item.get("actual_count", 0))
@@ -1391,12 +1327,6 @@ def submit_closing_stage2_checklist(report_name, inventory_items, checklist_item
         doc.checklist_items = []
         for item in checklist_items:
             doc.append("checklist_items", item)
-
-    # Equipment status
-    if equipment_status:
-        doc.freezer_temp = equipment_status.get("freezer_temp")
-        doc.chiller_temp = equipment_status.get("chiller_temp")
-        doc.pos_closed_properly = equipment_status.get("pos_closed_properly", 0)
 
     # Staff signoffs
     doc.cashier_signoff = 1 if cashier_signoff else 0
@@ -1417,23 +1347,28 @@ def submit_closing_stage2_checklist(report_name, inventory_items, checklist_item
 
 @frappe.whitelist()
 def submit_closing_stage3_photos(report_name, x_reading_opening_photo, x_reading_closing_photo,
-                                  z_reading_photo, pos_files=None, store_photos=None,
-                                  variance_explanation=None, notes=None):
+                                  z_reading_photo, store_photos=None,
+                                  equipment_status=None, notes=None):
     """
-    Submit Stage 3: Photos & Files
+    Submit Stage 3: Photos & Equipment
 
     Document Scanner Photos (with edge detection):
     - x_reading_opening_photo: X-Reading from opening shift
     - x_reading_closing_photo: X-Reading from closing shift
     - z_reading_photo: Z-Reading (end of day)
 
-    pos_files: List of 5 POS export files
-    store_photos: Dict of store area photos (logo_signage, hygrometer, etc.)
+    store_photos: Dict of store area photos (accepts both photo_* and short key formats)
+    equipment_status: Dict with freezer_temp, chiller_temp, pos_closed_properly
+                      (moved from Stage 2 — entered alongside equipment photos)
+
+    Removed: pos_files (handled by separate BEI POS Upload endpoint),
+             variance_explanation (moved to Stage 1 — explain when you see the number)
     """
     validate_store_ops_role()
     doc = frappe.get_doc("BEI Store Closing Report", report_name)
+    doctype_name = "BEI Store Closing Report"
 
-    # Document scanner photos (required)
+    # Document scanner photos (required) — save as files, not raw base64
     if not x_reading_opening_photo or not str(x_reading_opening_photo).strip():
         frappe.throw(_("X-Reading Opening photo is required"), title=_("Missing Photo"))
     if not x_reading_closing_photo or not str(x_reading_closing_photo).strip():
@@ -1441,38 +1376,54 @@ def submit_closing_stage3_photos(report_name, x_reading_opening_photo, x_reading
     if not z_reading_photo or not str(z_reading_photo).strip():
         frappe.throw(_("Z-Reading photo is required"), title=_("Missing Photo"))
 
-    doc.photo_xread_opening = str(x_reading_opening_photo).strip()
-    doc.photo_xread_closing = str(x_reading_closing_photo).strip()
-    doc.photo_zread = str(z_reading_photo).strip()
+    doc.photo_xread_opening = save_base64_image(
+        str(x_reading_opening_photo).strip(), doctype_name,
+        docname=doc.name, fieldname="photo_xread_opening"
+    )
+    doc.photo_xread_closing = save_base64_image(
+        str(x_reading_closing_photo).strip(), doctype_name,
+        docname=doc.name, fieldname="photo_xread_closing"
+    )
+    doc.photo_zread = save_base64_image(
+        str(z_reading_photo).strip(), doctype_name,
+        docname=doc.name, fieldname="photo_zread"
+    )
 
-    # POS files (5 required)
-    if pos_files:
-        if isinstance(pos_files, str):
-            pos_files = json.loads(pos_files)
-        doc.pos_discount_report = pos_files.get("discount_report")
-        doc.pos_transaction_report = pos_files.get("transaction_report")
-        doc.pos_product_mix = pos_files.get("product_mix")
-        doc.pos_daily_sales_revenue = pos_files.get("daily_sales_revenue")
-        doc.pos_sales_summary = pos_files.get("sales_summary")
-
-    # Store area photos (standard camera)
+    # Store area photos — normalize keys (accept both photo_* and short format)
     if store_photos:
         if isinstance(store_photos, str):
             store_photos = json.loads(store_photos)
-        doc.photo_logo_signage = store_photos.get("logo_signage")
-        doc.photo_hygrometer = store_photos.get("hygrometer")
-        doc.photo_water_meter = store_photos.get("water_meter")
-        doc.photo_backup_area_clean = store_photos.get("backup_area")
-        doc.photo_frozen_milk_clean = store_photos.get("frozen_milk")
-        doc.photo_toppings_clean = store_photos.get("toppings")
-        doc.photo_dispatch_clean = store_photos.get("dispatch")
-        doc.photo_cold_storage_close = store_photos.get("cold_storage")
-        doc.photo_cashier_clean = store_photos.get("cashier")
-        doc.photo_rollup_closed = store_photos.get("rollup_door")
+        if isinstance(store_photos, list):
+            store_photos = {p.get("field", ""): p.get("data", p.get("url", "")) for p in store_photos if isinstance(p, dict)}
 
-    # Variance explanation (required if variance > ±50)
-    if variance_explanation:
-        doc.variance_explanation = variance_explanation
+        photo_map = {
+            "photo_logo_signage": ["photo_logo_signage", "logo_signage"],
+            "photo_hygrometer": ["photo_hygrometer", "hygrometer"],
+            "photo_water_meter": ["photo_water_meter", "water_meter"],
+            "photo_backup_area_clean": ["photo_backup_area_clean", "backup_area"],
+            "photo_frozen_milk_clean": ["photo_frozen_milk_clean", "frozen_milk"],
+            "photo_toppings_clean": ["photo_toppings_clean", "toppings"],
+            "photo_dispatch_clean": ["photo_dispatch_clean", "dispatch"],
+            "photo_cold_storage_close": ["photo_cold_storage_close", "cold_storage"],
+            "photo_cashier_clean": ["photo_cashier_clean", "cashier"],
+            "photo_rollup_closed": ["photo_rollup_closed", "rollup_door"],
+        }
+        for doc_field, accepted_keys in photo_map.items():
+            for key in accepted_keys:
+                value = store_photos.get(key)
+                if value:
+                    saved_url = save_base64_image(value, doctype_name, docname=doc.name, fieldname=doc_field)
+                    if saved_url:
+                        doc.set(doc_field, saved_url)
+                    break
+
+    # Equipment readings (moved from Stage 2 — entered alongside equipment photos)
+    if equipment_status:
+        if isinstance(equipment_status, str):
+            equipment_status = json.loads(equipment_status)
+        doc.freezer_temp = equipment_status.get("freezer_temp")
+        doc.chiller_temp = equipment_status.get("chiller_temp")
+        doc.pos_closed_properly = equipment_status.get("pos_closed_properly", 0)
 
     doc.notes = notes
     doc.report_time = now_datetime().strftime("%H:%M:%S")

--- a/hrms/hr/doctype/bei_approval_queue/bei_approval_queue.json
+++ b/hrms/hr/doctype/bei_approval_queue/bei_approval_queue.json
@@ -148,6 +148,11 @@
    "role": "HR User",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Store Supervisor",
+   "write": 1
   }
  ],
  "sort_field": "creation",


### PR DESCRIPTION
## Summary

- **Stage restructure:** Move variance_explanation to Stage 1, equipment to Stage 3, remove POS files from Stage 3, add actual_cash_count, delete dead monolithic endpoint
- **BUG-002:** Closing report Stage 2 field mapping + Stage 3 save_base64_image for all photos + store_photos key normalization
- **BUG-006:** POS Upload save_base64_image for 5 report files + case-insensitive POS system matching
- **BUG-015:** Store Supervisor read+write permission on BEI Approval Queue
- **BUG-017:** New get_my_payslips() self-service endpoint for employees

## Test plan
- [ ] Stage 1: Submit with actual_cash_count + variance_explanation
- [ ] Stage 2: Submit with item_description key
- [ ] Stage 3: Submit with 150KB photos via save_base64_image
- [ ] Stage 3: Submit with equipment_status
- [ ] POS Upload: Submit with 150KB files + Mosaic POS system
- [ ] Approval Queue: Supervisor can read/write
- [ ] Payslips: Employee gets own salary slips
- [ ] Full 3-stage flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)