### PR TITLE
fix(rbac): add permission checks to maintenance assign + completion endpoints

### DIFF
--- a/hrms/api/projects.py
+++ b/hrms/api/projects.py
@@ -352,6 +352,12 @@ def assign_maintenance_request(
             "request": {...}
         }
     """
+    # RBAC: Only Projects User/Manager can assign requests
+    user_roles = frappe.get_roles(frappe.session.user)
+    allowed_roles = ["Projects User", "Projects Manager", "System Manager", "Administrator"]
+    if not any(role in user_roles for role in allowed_roles):
+        frappe.throw(_("You do not have permission to assign maintenance requests"), frappe.PermissionError)
+
     if not request_id:
         frappe.throw(_("Request ID is required"))
 
@@ -537,6 +543,12 @@ def record_maintenance_completion(
             "completion": {...}
         }
     """
+    # RBAC: Only Projects User/Manager can record completions
+    user_roles = frappe.get_roles(frappe.session.user)
+    allowed_roles = ["Projects User", "Projects Manager", "System Manager", "Administrator"]
+    if not any(role in user_roles for role in allowed_roles):
+        frappe.throw(_("You do not have permission to record maintenance completions"), frappe.PermissionError)
+
     if not request_id:
         frappe.throw(_("Request ID is required"))
 


### PR DESCRIPTION
## Summary
- Add RBAC checks to `assign_maintenance_request` and `record_maintenance_completion` endpoints
- Only Projects User/Manager/System Manager/Administrator roles can call these endpoints
- Matches existing pattern from `update_maintenance_status`

## Test plan
- [ ] MAINT-012: Crew user gets 403 on assign attempt
- [ ] MAINT-011: Staff user gets 403 on status update (existing, should still pass)
- [ ] MAINT-003: Projects head can still assign (should still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)