### PR TITLE
fix(commissary): remove remarks column from get_my_requisitions

### DIFF
--- a/hrms/api/commissary.py
+++ b/hrms/api/commissary.py
@@ -2059,7 +2059,7 @@ def get_my_requisitions(status=None, limit=50):
         filters=filters,
         fields=[
             "name", "transaction_date", "schedule_date",
-            "status", "owner", "remarks", "docstatus"
+            "status", "owner", "docstatus"
         ],
         order_by="transaction_date desc",
         limit=int(limit)


### PR DESCRIPTION
## Summary
- Remove non-existent `remarks` column from Material Request query in `get_my_requisitions()`
- Fixes HTTP 500 "Unknown column remarks" error for commissary users

## Test plan
- [ ] Call `get_my_requisitions` - should return list without 500 error

---
Generated with Claude Code