### PR TITLE
fix(billing): initialize balance_due in calculate_totals()

### DIFF
--- a/hrms/hr/doctype/bei_billing_schedule/bei_billing_schedule.py
+++ b/hrms/hr/doctype/bei_billing_schedule/bei_billing_schedule.py
@@ -130,6 +130,7 @@ class BEIBillingSchedule(Document):
 
 		self.vat_amount = vat_amount
 		self.total_amount = self.subtotal + self.vat_amount
+		self.balance_due = flt(self.total_amount - flt(self.amount_paid or 0), 2)
 
 	def send_to_store(self):
 		"""Generate and send Statement of Account to store via email."""


### PR DESCRIPTION
## Summary
- New billings had balance_due=0 even when total_amount was correctly calculated
- Added balance_due = total_amount - amount_paid in calculate_totals()
- Prevents payment validation from rejecting valid payments

## Test Plan
- [x] Verified payment flow works on billings with correct total_amount
- [x] 5/5 finance L3 scenarios pass
- [x] 13/13 L1 smoke tests pass

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)