### PR TITLE
fix(foodpanda): prevent FP SUMMARY truncation in sync

### DIFF
--- a/scripts/sync_foodpanda_to_supabase.py
+++ b/scripts/sync_foodpanda_to_supabase.py
@@ -228,8 +228,8 @@ def extract_foodpanda_orders(target_date: Optional[date] = None) -> List[Dict[st
     store_mapping = fetch_store_mapping()
 
     # Read all data from FP SUMMARY sheet (row 2 = headers, row 3+ = data)
-    # Extend range to handle large datasets (up to row 10000)
-    range_name = "'FP SUMMARY'!A2:Z10000"
+    # Use open-ended range to avoid truncating newly appended rows
+    range_name = "'FP SUMMARY'!A2:Z"
 
     result = service.spreadsheets().values().get(
         spreadsheetId=SPREADSHEET_ID,


### PR DESCRIPTION
## What
Use an open-ended Sheets range for `FP SUMMARY` in `sync_foodpanda_to_supabase.py` so new rows are always included.

## Why
The previous hard cap (`A2:Z10000`) truncated recent rows once the sheet exceeded 10k rows, causing zero extracted orders for newer dates.

## Change
- `range_name`: `'FP SUMMARY'!A2:Z10000` -> `'FP SUMMARY'!A2:Z`
- Updated inline comment accordingly.

## Validation
- Reproduced truncation: `A2:Z10000` max date = 2026-02-21
- Verified full range: `A2:Z50000` max date = 2026-02-24
- Confirmed FP SUMMARY contains 2026-02-23/24 rows via Sheets API.
