### PR TITLE
fix(transfer): normalize warehouse keys for device mapping

### DIFF
--- a/hrms/api/transfer_requests.py
+++ b/hrms/api/transfer_requests.py
@@ -314,6 +314,10 @@ def _normalize_store_key(value: str | None) -> str:
 		return ""
 	v = value.strip().upper()
 	v = re.sub(r"\s*-\s*BEI$", "", v)
+	v = re.sub(r"\s*-\s*BEBANG\s+ENTERPRISE(?:\s+INC\.?)?$", "", v)
+	# Warehouse labels often follow "<store> - <company>".
+	if " - " in v:
+		v = v.split(" - ", 1)[0].strip()
 	v = v.replace("&", "AND")
 	v = re.sub(r"[^A-Z0-9]+", "", v)
 	return v

--- a/hrms/tests/test_transfer_requests.py
+++ b/hrms/tests/test_transfer_requests.py
@@ -95,6 +95,10 @@ class TestTransferRequests(FrappeTestCase):
 			"BRITTANYOFFICE",
 		)
 		self.assertEqual(
+			transfer_requests._normalize_store_key("SM Grand Central - Bebang Enterprise Inc."),
+			"SMGRANDCENTRAL",
+		)
+		self.assertEqual(
 			transfer_requests._normalize_store_key("SM MOA"),
 			"SMMOA",
 		)
@@ -115,7 +119,7 @@ class TestTransferRequests(FrappeTestCase):
 	def test_compute_transfer_device_plan_for_standard_employee_targets_new_store(self):
 		doc = frappe._dict(
 			{
-				"store_warehouse": "BRITTANY OFFICE - BEI",
+				"store_warehouse": "Brittany Office - Bebang Enterprise Inc.",
 				"to_branch": "BRITTANY OFFICE",
 				"from_branch": "SM MOA",
 			}


### PR DESCRIPTION
## Summary\n- normalize transfer store keys for warehouse labels that include full company suffixes (e.g. - Bebang Enterprise Inc.)\n- preserve existing - BEI normalization behavior\n- add regression assertions in transfer unit tests\n\n## Production issue addressed\nudit_transfer_store_mappings reported warehouse_exists=true but device_count=0 for valid warehouses because the normalized key still contained company suffix text.\n\n## Verification\n- python -m compileall hrms/api/transfer_requests.py hrms/tests/test_transfer_requests.py\n- live checks will be rerun after deploy