### PR TITLE
fix(ci): harden production deploy guard and require build

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -54,6 +54,11 @@ jobs:
             echo "   This workflow only deploys production and cannot run from feature branches."
             exit 1
           fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.skip_build }}" = "true" ]; then
+            echo "❌ skip_build=true is blocked."
+            echo "   Production deployments must build from current production source."
+            exit 1
+          fi
           echo "✅ Branch guard passed."
 
   build:
@@ -134,6 +139,7 @@ jobs:
     name: Deploy to AWS EC2
     runs-on: ubuntu-latest
     needs: [guard, build]
+    environment: production-deploy
     if: always() && (needs.build.result == 'success' || github.event.inputs.skip_build == 'true')
 
     steps:
@@ -449,6 +455,7 @@ jobs:
     name: Archive old images & cleanup
     runs-on: ubuntu-latest
     needs: [deploy]
+    environment: production-deploy
     if: needs.deploy.result == 'success'
 
     steps:


### PR DESCRIPTION
## Summary\n- keep production-only guard\n- block workflow_dispatch with skip_build=true\n- attach deploy/cleanup jobs to production-deploy environment\n\n## Why\nPrevents stale-tag deploys and prepares branch-restricted secret hardening for deploy credentials.