### PR TITLE
feat(transfer): derive branch from warehouse and filter non-BEI targets

### DIFF
--- a/hrms/api/transfer_requests.py
+++ b/hrms/api/transfer_requests.py
@@ -28,6 +28,7 @@ from hrms.utils.roving_employees import is_roving
 
 DOCTYPE_TRANSFER_REQUEST = "BEI Transfer Request"
 DOCTYPE_TRANSFER_DEVICE_COMMAND = "BEI Transfer Device Command"
+BEI_COMPANY_NAME = "Bebang Enterprise Inc."
 
 STAGE_PENDING_AREA = "Pending Area Approval"
 STAGE_PENDING_HR = "Pending HR Approval"
@@ -60,6 +61,14 @@ AREA_APPROVER_ROLES = {"Area Supervisor", "System Manager"}
 HR_APPROVER_ROLES = {"HR User", "HR Manager", "System Manager"}
 IT_APPROVER_ROLES = {"System Manager"}
 READ_ALL_ROLES = AREA_APPROVER_ROLES.union(HR_APPROVER_ROLES).union(IT_APPROVER_ROLES)
+TRANSFER_READ_ROLES = REQUESTER_ROLES.union(READ_ALL_ROLES)
+
+BLOCKED_WAREHOUSE_TERMS = (
+	"3PL",
+	"3RD PARTY",
+	"THIRD PARTY",
+	"3MD",
+)
 
 
 def _has_any_role(roles: set[str], user: str | None = None) -> bool:
@@ -124,8 +133,12 @@ def _notify_transfer_event(doc, event_title: str, details: str | None = None):
 def _require_store_warehouse_mapping(doc):
 	if not doc.store_warehouse:
 		frappe.throw(_("Missing Warehouse Mapping for target store"))
-	if not frappe.db.exists("Warehouse", doc.store_warehouse):
-		frappe.throw(_("Missing Warehouse Mapping for target store: {0}").format(doc.store_warehouse))
+	resolved = _validate_store_warehouse_for_transfer(
+		doc.store_warehouse,
+		expected_branch=getattr(doc, "to_branch", None),
+	)
+	if not getattr(doc, "to_branch", None):
+		doc.to_branch = resolved["branch"]
 
 
 def _split_roles(raw_roles: str | None) -> list[str]:
@@ -321,6 +334,159 @@ def _normalize_store_key(value: str | None) -> str:
 	v = v.replace("&", "AND")
 	v = re.sub(r"[^A-Z0-9]+", "", v)
 	return v
+
+
+def _contains_blocked_warehouse_term(value: str | None) -> bool:
+	if not value:
+		return False
+	upper_value = str(value).upper()
+	return any(term in upper_value for term in BLOCKED_WAREHOUSE_TERMS)
+
+
+def _get_branch_index() -> dict[str, str]:
+	rows = frappe.get_all("Branch", fields=["name"], limit_page_length=0)
+	index: dict[str, str] = {}
+	for row in rows:
+		branch_name = (row.get("name") or "").strip()
+		if not branch_name:
+			continue
+		index[_normalize_store_key(branch_name)] = branch_name
+	return index
+
+
+def _resolve_branch_from_store_warehouse(store_warehouse: str | None, branch_index: dict[str, str] | None = None) -> str | None:
+	if not store_warehouse:
+		return None
+
+	candidates = [str(store_warehouse).strip()]
+	if " - " in candidates[0]:
+		candidates.append(candidates[0].split(" - ", 1)[0].strip())
+
+	for candidate in candidates:
+		if candidate and frappe.db.exists("Branch", candidate):
+			return candidate
+
+	normalized_index = branch_index or _get_branch_index()
+	for candidate in candidates:
+		norm = _normalize_store_key(candidate)
+		if norm and norm in normalized_index:
+			return normalized_index[norm]
+
+	return None
+
+
+def _validate_store_warehouse_for_transfer(store_warehouse: str | None, expected_branch: str | None = None) -> dict[str, Any]:
+	warehouse_name = (store_warehouse or "").strip()
+	if not warehouse_name:
+		frappe.throw(_("Missing Warehouse Mapping for target store"))
+	if not frappe.db.exists("Warehouse", warehouse_name):
+		frappe.throw(_("Invalid warehouse mapping: {0}").format(warehouse_name))
+
+	if _contains_blocked_warehouse_term(warehouse_name):
+		frappe.throw(_("Warehouse is blocked for employee transfer routing: {0}").format(warehouse_name))
+
+	warehouse_doc = frappe.get_doc("Warehouse", warehouse_name)
+	warehouse_company = (getattr(warehouse_doc, "company", None) or "").strip()
+	if warehouse_company and warehouse_company != BEI_COMPANY_NAME:
+		frappe.throw(
+			_("Warehouse company mismatch. Expected {0}, got {1}").format(BEI_COMPANY_NAME, warehouse_company)
+		)
+
+	if cint(getattr(warehouse_doc, "is_group", 0)):
+		frappe.throw(_("Warehouse cannot be a group node for transfer routing: {0}").format(warehouse_name))
+
+	warehouse_label = (getattr(warehouse_doc, "warehouse_name", None) or warehouse_name).strip()
+	if _contains_blocked_warehouse_term(warehouse_label):
+		frappe.throw(_("Warehouse is blocked for employee transfer routing: {0}").format(warehouse_name))
+
+	branch_index = _get_branch_index()
+	branch_name = (getattr(warehouse_doc, "branch", None) or "").strip()
+	if branch_name and not frappe.db.exists("Branch", branch_name):
+		branch_name = ""
+
+	if not branch_name:
+		branch_name = _resolve_branch_from_store_warehouse(warehouse_name, branch_index=branch_index) or ""
+
+	if not branch_name:
+		frappe.throw(_("Unable to derive target branch from warehouse {0}").format(warehouse_name))
+
+	if expected_branch:
+		expected_key = _normalize_store_key(expected_branch)
+		branch_key = _normalize_store_key(branch_name)
+		if expected_key and branch_key and expected_key != branch_key:
+			frappe.throw(
+				_(
+					"Target branch {0} does not match warehouse {1} (derived branch: {2})"
+				).format(expected_branch, warehouse_name, branch_name)
+			)
+
+	return {
+		"warehouse": warehouse_name,
+		"branch": branch_name,
+		"company": warehouse_company or BEI_COMPANY_NAME,
+		"warehouse_label": warehouse_label,
+	}
+
+
+def _list_transfer_store_warehouse_options(search_text: str | None = None, limit: int = 100) -> list[dict[str, str]]:
+	branch_index = _get_branch_index()
+	search_lower = (search_text or "").strip().lower()
+	limit = max(1, min(500, cint(limit) or 100))
+
+	filters: dict[str, Any] = {}
+	warehouse_meta = frappe.get_meta("Warehouse")
+	fields = ["name"]
+	for field in ("warehouse_name", "company", "is_group", "disabled", "branch"):
+		if warehouse_meta.has_field(field):
+			fields.append(field)
+
+	if warehouse_meta.has_field("is_group"):
+		filters["is_group"] = 0
+	if warehouse_meta.has_field("disabled"):
+		filters["disabled"] = 0
+	if warehouse_meta.has_field("company"):
+		filters["company"] = BEI_COMPANY_NAME
+
+	rows = frappe.get_all(
+		"Warehouse",
+		filters=filters,
+		fields=fields,
+		order_by="name asc",
+		limit_page_length=max(limit * 5, 200),
+	)
+
+	options: list[dict[str, str]] = []
+	for row in rows:
+		warehouse_name = (row.get("name") or "").strip()
+		warehouse_label = (row.get("warehouse_name") or warehouse_name).strip()
+		if not warehouse_name:
+			continue
+		if _contains_blocked_warehouse_term(warehouse_name) or _contains_blocked_warehouse_term(warehouse_label):
+			continue
+
+		branch_name = (row.get("branch") or "").strip()
+		if branch_name and not frappe.db.exists("Branch", branch_name):
+			branch_name = ""
+		if not branch_name:
+			branch_name = _resolve_branch_from_store_warehouse(warehouse_name, branch_index=branch_index) or ""
+		if not branch_name:
+			continue
+
+		if search_lower:
+			haystack = f"{warehouse_name} {warehouse_label} {branch_name}".lower()
+			if search_lower not in haystack:
+				continue
+
+		options.append(
+			{
+				"warehouse": warehouse_name,
+				"warehouse_label": warehouse_label,
+				"branch": branch_name,
+				"company": (row.get("company") or BEI_COMPANY_NAME).strip(),
+			}
+		)
+
+	return options[:limit]
 
 
 def _get_employee_bio_id(employee_id: str) -> str:
@@ -877,7 +1043,7 @@ def create_transfer_request(
 	employee,
 	effective_date,
 	reason,
-	to_branch,
+	to_branch=None,
 	to_department=None,
 	to_designation=None,
 	to_reports_to=None,
@@ -885,12 +1051,15 @@ def create_transfer_request(
 ):
 	_require_any_role(REQUESTER_ROLES, "You do not have permission to create transfer requests")
 
-	if not all([employee, effective_date, reason, to_branch, store_warehouse]):
-		frappe.throw(_("Required fields: employee, effective_date, reason, to_branch, store_warehouse"))
+	if not all([employee, effective_date, reason, store_warehouse]):
+		frappe.throw(_("Required fields: employee, effective_date, reason, store_warehouse"))
 	if not frappe.db.exists("Employee", employee):
 		frappe.throw(_("Employee not found"), frappe.DoesNotExistError)
-	if not frappe.db.exists("Warehouse", store_warehouse):
-		frappe.throw(_("Invalid warehouse mapping: {0}").format(store_warehouse))
+	warehouse_meta = _validate_store_warehouse_for_transfer(
+		store_warehouse,
+		expected_branch=to_branch,
+	)
+	to_branch = to_branch or warehouse_meta["branch"]
 
 	employee_doc = frappe.get_doc("Employee", employee)
 	doc = frappe.get_doc(
@@ -922,6 +1091,17 @@ def create_transfer_request(
 		"success": True,
 		"name": doc.name,
 		"current_stage": doc.current_stage,
+	}
+
+
+@frappe.whitelist()
+def get_transfer_form_options(search_text=None, limit=100):
+	"""Return filtered BEI store-warehouse options for transfer request forms."""
+	_require_any_role(TRANSFER_READ_ROLES, "You do not have permission to view transfer form options")
+	options = _list_transfer_store_warehouse_options(search_text=search_text, limit=limit)
+	return {
+		"warehouses": options,
+		"total": len(options),
 	}
 
 

--- a/hrms/tests/test_transfer_requests.py
+++ b/hrms/tests/test_transfer_requests.py
@@ -1,6 +1,7 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, getdate, now_datetime, nowdate
+from unittest.mock import patch
 
 from hrms.api import transfer_requests
 
@@ -102,6 +103,32 @@ class TestTransferRequests(FrappeTestCase):
 			transfer_requests._normalize_store_key("SM MOA"),
 			"SMMOA",
 		)
+
+	def test_contains_blocked_warehouse_term_detects_3pl_terms(self):
+		self.assertTrue(transfer_requests._contains_blocked_warehouse_term("3PL Mega Hub"))
+		self.assertTrue(transfer_requests._contains_blocked_warehouse_term("3MD Warehouse"))
+		self.assertFalse(transfer_requests._contains_blocked_warehouse_term("Brittany Office - BEI"))
+
+	def test_resolve_branch_from_store_warehouse_uses_normalized_branch_index(self):
+		with patch("frappe.db.exists", return_value=False):
+			branch = transfer_requests._resolve_branch_from_store_warehouse(
+				"Ayala Evo - Bebang Enterprise Inc.",
+				branch_index={"AYALAEVO": "AYALA EVO"},
+			)
+		self.assertEqual(branch, "AYALA EVO")
+
+	def test_validate_store_warehouse_for_transfer_blocks_non_bei_company(self):
+		class _FakeWarehouse:
+			company = "Other Company"
+			is_group = 0
+			warehouse_name = "AYALA EVO"
+			branch = "AYALA EVO"
+
+		with patch("frappe.db.exists", side_effect=lambda doctype, name: True), patch(
+			"frappe.get_doc", return_value=_FakeWarehouse()
+		), patch("hrms.api.transfer_requests._get_branch_index", return_value={"AYALAEVO": "AYALA EVO"}):
+			with self.assertRaises(frappe.ValidationError):
+				transfer_requests._validate_store_warehouse_for_transfer("AYALA EVO - BEI")
 
 	def test_compute_transfer_device_plan_for_roving_employee_targets_all_devices(self):
 		doc = frappe._dict(

--- a/hrms/tests/test_transfer_requests_l4.py
+++ b/hrms/tests/test_transfer_requests_l4.py
@@ -75,6 +75,45 @@ class TestTransferRequestsL4(unittest.TestCase):
 		self.assertEqual(insert_holder["doc"].store_warehouse, "BRITTANY OFFICE - BEI")
 		self.assertEqual(insert_holder["doc"].to_branch, "BRITTANY OFFICE")
 
+	def test_create_transfer_request_derives_to_branch_from_warehouse_when_missing(self):
+		employee_doc = _FakeEmployeeDoc(
+			name="EMP-0009",
+			branch="SM MOA",
+			department="Operations - BEI",
+			designation="Store Supervisor",
+			reports_to="EMP-AREA-001",
+		)
+		insert_holder = {}
+
+		def _fake_get_doc(*args, **kwargs):
+			if len(args) == 2 and args[0] == "Employee":
+				return employee_doc
+			if args and isinstance(args[0], dict):
+				doc = _FakeInsertDoc(**args[0])
+				insert_holder["doc"] = doc
+				return doc
+			raise AssertionError(f"Unexpected get_doc call: args={args}, kwargs={kwargs}")
+
+		with patch.object(frappe, "session", SimpleNamespace(user="test.supervisor@bebang.ph")), patch(
+			"hrms.api.transfer_requests._require_any_role"
+		), patch("hrms.api.transfer_requests._notify_transfer_event"), patch(
+			"frappe.db.exists", return_value=True
+		), patch(
+			"frappe.get_doc", side_effect=_fake_get_doc
+		), patch(
+			"hrms.api.transfer_requests._validate_store_warehouse_for_transfer",
+			return_value={"warehouse": "BRITTANY OFFICE - BEI", "branch": "BRITTANY OFFICE", "company": "Bebang Enterprise Inc."},
+		):
+			result = transfer_requests.create_transfer_request(
+				employee="EMP-0009",
+				effective_date=nowdate(),
+				reason="Warehouse-driven branch derive",
+				store_warehouse="BRITTANY OFFICE - BEI",
+			)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(insert_holder["doc"].to_branch, "BRITTANY OFFICE")
+
 	def test_approve_transfer_stage_moves_hr_to_it_and_creates_employee_transfer(self):
 		doc = _FakeTransferDoc(
 			name="BEI-TRF-2026-00001",
@@ -253,3 +292,24 @@ class TestTransferRequestsL4(unittest.TestCase):
 		self.assertEqual(result["ok"], 1)
 		self.assertEqual(result["blocked"], 1)
 		self.assertIn("UNKNOWN STORE - BEI", result["missing_warehouse"])
+
+	def test_get_transfer_form_options_returns_filtered_warehouse_rows(self):
+		expected = [
+			{
+				"warehouse": "AYALA EVO - BEI",
+				"warehouse_label": "AYALA EVO",
+				"branch": "AYALA EVO",
+				"company": "Bebang Enterprise Inc.",
+			}
+		]
+
+		with patch.object(frappe, "session", SimpleNamespace(user="test.supervisor@bebang.ph")), patch(
+			"hrms.api.transfer_requests._require_any_role"
+		), patch(
+			"hrms.api.transfer_requests._list_transfer_store_warehouse_options",
+			return_value=expected,
+		):
+			result = transfer_requests.get_transfer_form_options(search_text="ayala", limit=20)
+
+		self.assertEqual(result["total"], 1)
+		self.assertEqual(result["warehouses"][0]["branch"], "AYALA EVO")

--- a/hrms/tests/test_transfer_requests_l4.py
+++ b/hrms/tests/test_transfer_requests_l4.py
@@ -61,6 +61,9 @@ class TestTransferRequestsL4(unittest.TestCase):
 			"frappe.db.exists", return_value=True
 		), patch(
 			"frappe.get_doc", side_effect=_fake_get_doc
+		), patch(
+			"hrms.api.transfer_requests._validate_store_warehouse_for_transfer",
+			return_value={"warehouse": "BRITTANY OFFICE - BEI", "branch": "BRITTANY OFFICE", "company": "Bebang Enterprise Inc."},
 		):
 			result = transfer_requests.create_transfer_request(
 				employee="EMP-0001",


### PR DESCRIPTION
## Scope\n- add get_transfer_form_options API for transfer request forms\n- derive 	o_branch from selected store warehouse when omitted\n- enforce warehouse/company/branch validation and block non-BEI/3PL-like locations\n\n## Safety\n- cherry-picked single scoped commit (442c7aae8) onto production base\n- python -m py_compile passed for touched modules/tests\n\n## Why\nFixes transfer form redundancy and prevents invalid warehouse targets from entering transfer workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transfer-request creation and routing validation, which could block previously-accepted warehouse/branch combinations and affect production transfer workflows. New warehouse filtering/derivation logic depends on `Warehouse`/`Branch` metadata correctness.
> 
> **Overview**
> Improves transfer request creation by **validating target `store_warehouse`** (must exist, be non-group, BEI-owned, and not match blocked 3PL-like terms) and by **deriving `to_branch` from the selected warehouse** when omitted (and rejecting mismatches when provided).
> 
> Adds a new whitelisted endpoint, `get_transfer_form_options`, to return a filtered list of valid BEI warehouse targets for the transfer form, with updated role gating (`TRANSFER_READ_ROLES`). Tests were expanded to cover the new validation, branch derivation, and options listing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8082b4d3a707c8ad7cbedb35c2bcc0edef9641e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->