### PR TITLE
fix(ci): repair broken linters workflow YAML

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
-        with:
           fetch-depth: 200
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## Why\nGitHub Actions had repeated false-failure runs for \\.github/workflows/linters.yml\\ due to invalid YAML (duplicate \\with\\ mapping under checkout step).\n\n## What\n- Remove the duplicate checkout \\with:\\ block\n- Keep only one \\etch-depth: 200\\\n\n## Scope\n- One file only: \\.github/workflows/linters.yml\\\n- No app/runtime code changes\n- No deployment triggered by this PR alone\n\n## Verification\n- Diff is exactly 2-line deletion in workflow file\n- Fix aligns with cleanup plan objective to eliminate CI noise