### PR TITLE
fix(dispatch): unblock Sprint 03 runtime methods on production

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
-        with:
           fetch-depth: 200
       - uses: actions/setup-node@v2
         with:
@@ -32,6 +30,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.10
         uses: actions/setup-python@v2

--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -6,473 +6,660 @@ Dispatch Tracker API
 Handles warehouse dispatch, route tracking, and delivery confirmation for my.bebang.ph
 """
 
+from typing import Any
+
 import frappe
 from frappe import _
-from frappe.utils import nowdate, now_datetime, flt
+from frappe.utils import cint, flt, now_datetime, nowdate
 
-
-# P0-10: Import centralized RBAC role sets
-from hrms.utils.scm_roles import (
-    SCM_ADMIN_ROLES, SCM_DISPATCH_ROLES, SCM_STORE_ROLES,
-    check_scm_permission as _check_scm_permission
+from hrms.utils.delivery_billing_policy import (
+	DeliveryBillingPolicyError,
+	get_pre_delivery_exception_trace,
+	should_auto_create_billing_on_delivery,
 )
 
-
-@frappe.whitelist()
-def get_trips(date=None, status=None):
-    """Get dispatch trips for a date. Defaults to today if no date specified."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view dispatch trips")
-
-    filters = {"trip_date": date or nowdate()}
-
-    if status:
-        filters["status"] = status
-
-    trips = frappe.get_all(
-        "BEI Distribution Trip",
-        filters=filters,
-        fields=["name", "trip_date", "route_name", "driver", "vehicle", "vehicle_plate", "status", "departure_time"],
-        order_by="creation"
-    )
-
-    # Get stop counts and delivery progress
-    for trip in trips:
-        stops = frappe.get_all(
-            "BEI Trip Stop",
-            filters={"parent": trip.name},
-            fields=["status"]
-        )
-        trip["total_stops"] = len(stops)
-        trip["delivered_stops"] = sum(1 for s in stops if s.status == "Delivered")
-
-    return {"trips": trips}
+# P0-10: Import centralized RBAC role sets
+from hrms.utils.scm_roles import SCM_ADMIN_ROLES, SCM_DISPATCH_ROLES, SCM_STORE_ROLES
+from hrms.utils.scm_roles import check_scm_permission as _check_scm_permission
 
 
 @frappe.whitelist()
-def get_trip_detail(trip_name):
-    """Get full trip details including all stops."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view trip details")
+def get_trips(date: str | None = None, status: str | None = None):
+	"""Get dispatch trips for a date. Defaults to today if no date specified."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view dispatch trips")
 
-    trip = frappe.get_doc("BEI Distribution Trip", trip_name)
+	filters = {"trip_date": date or nowdate()}
 
-    return {
-        "trip": {
-            "name": trip.name,
-            "trip_date": trip.trip_date,
-            "route_name": trip.route_name,
-            "driver": trip.driver,
-            "vehicle": trip.vehicle,
-            "vehicle_plate": trip.vehicle_plate,
-            "status": trip.status,
-            "departure_time": trip.departure_time,
-            "departure_temp": trip.departure_temp,
-            "seal_number": trip.seal_number,
-            "stops": [
-                {
-                    "idx": s.idx,
-                    "store": s.store,
-                    "stop_order": s.stop_order,
-                    "items_count": s.items_count,
-                    "status": s.status,
-                    "arrival_time": s.arrival_time,
-                    "signed_by": s.signed_by,
-                    "exception_reason": s.exception_reason
-                }
-                for s in trip.stops
-            ]
-        }
-    }
+	if status:
+		filters["status"] = status
 
+	trips = frappe.get_all(
+		"BEI Distribution Trip",
+		filters=filters,
+		fields=[
+			"name",
+			"trip_date",
+			"route_name",
+			"driver",
+			"vehicle",
+			"vehicle_plate",
+			"status",
+			"departure_time",
+		],
+		order_by="creation",
+	)
 
-@frappe.whitelist()
-def confirm_departure(trip_name, driver=None, vehicle=None, vehicle_plate=None, temperature=None, seal_number=None):
-    """
-    Confirm trip departure with checklist.
-    Updates trip with departure details and sets status to In Transit.
-    """
-    _check_scm_permission(SCM_DISPATCH_ROLES, "confirm departure")
+	# Get stop counts and delivery progress
+	for trip in trips:
+		stops = frappe.get_all("BEI Trip Stop", filters={"parent": trip.name}, fields=["status"])
+		trip["total_stops"] = len(stops)
+		trip["delivered_stops"] = sum(1 for s in stops if s.status == "Delivered")
 
-    trip = frappe.get_doc("BEI Distribution Trip", trip_name)
-
-    if trip.status != "Preparing":
-        frappe.throw(_("Trip is not in Preparing status"))
-
-    if driver:
-        trip.driver = driver
-    if vehicle:
-        trip.vehicle = vehicle
-    if vehicle_plate:
-        trip.vehicle_plate = vehicle_plate
-    if temperature:
-        trip.departure_temp = float(temperature)
-    if seal_number:
-        trip.seal_number = seal_number
-
-    trip.departure_time = now_datetime()
-    trip.status = "In Transit"
-    trip.save()
-
-    return {
-        "success": True,
-        "message": f"Trip {trip_name} departed at {trip.departure_time}"
-    }
-
-
-def _get_stop(trip, stop_idx):
-    """Validate and return a trip stop by 1-based index."""
-    stop_idx = int(stop_idx)
-    if stop_idx < 1 or stop_idx > len(trip.stops):
-        frappe.throw(_("Invalid stop index"))
-    return trip.stops[stop_idx - 1]
-
-
-def _update_trip_status(trip, require_all_processed=False):
-    """Recalculate trip status based on stop statuses.
-
-    Args:
-        require_all_processed: If True, only update status when all stops are processed.
-            Used by report_exception to preserve "In Transit" until all stops are visited.
-
-    Returns (delivered_count, total_count) for use in response payloads.
-    """
-    total = len(trip.stops)
-    delivered = sum(1 for s in trip.stops if s.status == "Delivered")
-    processed = sum(1 for s in trip.stops if s.status != "Pending")
-
-    if processed == total:
-        trip.status = "Completed" if delivered == total else "Partial"
-    elif not require_all_processed and (delivered > 0 or processed > 0):
-        trip.status = "Partial"
-
-    return delivered, total
+	return {"trips": trips}
 
 
 @frappe.whitelist()
-def confirm_delivery(trip_name, stop_idx, signature=None, signed_by=None):
-    """Confirm delivery at a specific stop. stop_idx is 1-based."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "confirm delivery")
+def get_trip_detail(trip_name: str):
+	"""Get full trip details including all stops."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view trip details")
 
-    trip = frappe.get_doc("BEI Distribution Trip", trip_name)
+	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
 
-    if trip.status not in ["In Transit", "Partial"]:
-        frappe.throw(_("Trip is not in transit"))
-
-    stop = _get_stop(trip, stop_idx)
-    stop.status = "Delivered"
-    stop.arrival_time = now_datetime()
-    stop.signature = signature
-    stop.signed_by = signed_by
-
-    # Auto-generate delivery billing (async, feature-flagged)
-    if frappe.db.get_single_value("BEI Settings", "billing_auto_create_on_delivery"):
-        stop.billing_creation_status = "Pending"
-        frappe.enqueue(
-            "hrms.api.dispatch._create_delivery_billing",
-            queue="default",
-            trip_name=trip.name,
-            stop_idx=stop.idx,
-            enqueue_after_commit=True
-        )
-
-    delivered, total = _update_trip_status(trip)
-    trip.save()
-
-    # Update linked BEI Store Order status to "Delivered"
-    if hasattr(stop, "store_order") and stop.store_order:
-        _set_store_order_status(stop.store_order, "Delivered")
-
-    # PHASE 1A: Send "1 stop away" notification to next stop
-    # This runs AFTER save so delivery is confirmed even if notification fails
-    try:
-        current_stop_order = int(stop_idx)
-        next_stop = None
-        for s in trip.stops:
-            if s.stop_order == current_stop_order + 1 and s.status == "Pending":
-                next_stop = s
-                break
-
-        if next_stop and trip.departure_time:
-            from frappe.utils import add_to_date, format_time, get_datetime
-            # Calculate ETA for next stop
-            departure_dt = get_datetime(trip.departure_time)
-            scheduled_arrival = add_to_date(departure_dt, minutes=next_stop.stop_order * 20)
-            window_start = add_to_date(scheduled_arrival, minutes=-15)
-            window_end = add_to_date(scheduled_arrival, minutes=15)
-            eta_range = f"{format_time(window_start)} - {format_time(window_end)}"
-
-            _send_delivery_notification(trip.driver or "Driver", next_stop.store, eta_range)
-    except Exception as e:
-        # CRITICAL: Notification failures must not block delivery confirmation
-        frappe.log_error(
-            title="Next Stop Notification Failed",
-            message=f"Failed to notify next stop for {trip_name}: {str(e)}"
-        )
-
-    return {
-        "success": True,
-        "message": f"Delivery to {stop.store} confirmed",
-        "trip_status": trip.status,
-        "delivered": delivered,
-        "total": total
-    }
+	return {
+		"trip": {
+			"name": trip.name,
+			"trip_date": trip.trip_date,
+			"route_name": trip.route_name,
+			"driver": trip.driver,
+			"vehicle": trip.vehicle,
+			"vehicle_plate": trip.vehicle_plate,
+			"status": trip.status,
+			"departure_time": trip.departure_time,
+			"departure_temp": trip.departure_temp,
+			"seal_number": trip.seal_number,
+			"stops": [
+				{
+					"idx": s.idx,
+					"store": s.store,
+					"stop_order": s.stop_order,
+					"items_count": s.items_count,
+					"status": s.status,
+					"arrival_time": s.arrival_time,
+					"signed_by": s.signed_by,
+					"exception_reason": s.exception_reason,
+				}
+				for s in trip.stops
+			],
+		}
+	}
 
 
 @frappe.whitelist()
-def report_exception(trip_name, stop_idx, exception_type, reason=None, photo=None):
-    """Report an exception at a stop (store closed, refused, etc)."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "report exceptions")
+def confirm_departure(
+	trip_name: str,
+	driver: str | None = None,
+	vehicle: str | None = None,
+	vehicle_plate: str | None = None,
+	temperature: float | str | None = None,
+	seal_number: str | None = None,
+):
+	"""
+	Confirm trip departure with checklist.
+	Updates trip with departure details and sets status to In Transit.
+	"""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "confirm departure")
 
-    trip = frappe.get_doc("BEI Distribution Trip", trip_name)
+	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
 
-    stop = _get_stop(trip, stop_idx)
-    stop.status = exception_type
-    stop.arrival_time = now_datetime()
-    stop.exception_reason = reason
-    if photo:
-        stop.exception_photo = photo
+	if trip.status != "Preparing":
+		frappe.throw(_("Trip is not in Preparing status"))
 
-    _update_trip_status(trip, require_all_processed=True)
-    trip.save()
+	if driver:
+		trip.driver = driver
+	if vehicle:
+		trip.vehicle = vehicle
+	if vehicle_plate:
+		trip.vehicle_plate = vehicle_plate
+	if temperature:
+		trip.departure_temp = float(temperature)
+	if seal_number:
+		trip.seal_number = seal_number
 
-    return {
-        "success": True,
-        "message": f"Exception reported for {stop.store}: {exception_type}"
-    }
+	trip.departure_time = now_datetime()
+	trip.status = "In Transit"
+	trip.save()
 
-
-@frappe.whitelist()
-def get_route_progress(trip_name):
-    """Get current progress of a trip."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view route progress")
-
-    trip = frappe.get_doc("BEI Distribution Trip", trip_name)
-
-    stops = []
-    for stop in trip.stops:
-        stops.append({
-            "idx": stop.idx,
-            "store": stop.store,
-            "stop_order": stop.stop_order,
-            "items_count": stop.items_count,
-            "status": stop.status,
-            "arrival_time": str(stop.arrival_time) if stop.arrival_time else None,
-            "signed_by": stop.signed_by,
-            "exception_reason": stop.exception_reason
-        })
-
-    total = len(trip.stops)
-    delivered = sum(1 for s in trip.stops if s.status == "Delivered")
-    exceptions = sum(1 for s in trip.stops if s.status in ["Store Closed", "Refused"])
-    progress_pct = round((delivered / total * 100), 1) if total > 0 else 0
-
-    current_stop = None
-    next_stop = None
-    for i, stop in enumerate(stops):
-        if stop.get("status") not in ("Delivered", "Store Closed", "Refused"):
-            current_stop = stop.get("store") or stop.get("warehouse")
-            if i + 1 < total:
-                next_stop = stops[i + 1].get("store") or stops[i + 1].get("warehouse")
-            break
-
-    return {
-        "trip_name": trip.name,
-        "status": trip.status,
-        "departure_time": str(trip.departure_time) if trip.departure_time else None,
-        "total_stops": total,
-        "delivered": delivered,
-        "exceptions": exceptions,
-        "pending": total - delivered - exceptions,
-        "progress_pct": progress_pct,
-        "current_stop": current_stop,
-        "next_stop": next_stop,
-        "stops": stops
-    }
+	return {"success": True, "message": f"Trip {trip_name} departed at {trip.departure_time}"}
 
 
-def _build_trip_doc(trip_date, route_name, stops):
-    """Build a BEI Distribution Trip document with stops (not yet inserted)."""
-    trip = frappe.new_doc("BEI Distribution Trip")
-    trip.trip_date = trip_date or nowdate()
-    trip.route_name = route_name
-    trip.status = "Preparing"
+def _get_stop(trip: Any, stop_idx: int | str):
+	"""Validate and return a trip stop by 1-based index."""
+	stop_idx = int(stop_idx)
+	if stop_idx < 1 or stop_idx > len(trip.stops):
+		frappe.throw(_("Invalid stop index"))
+	return trip.stops[stop_idx - 1]
 
-    for idx, stop_data in enumerate(stops, 1):
-        trip.append("stops", {
-            "store": stop_data.get("store"),
-            "stop_order": idx,
-            "items_count": stop_data.get("items_count", 0),
-            "status": "Pending"
-        })
 
-    return trip
+def _update_trip_status(trip: Any, require_all_processed: bool = False):
+	"""Recalculate trip status based on stop statuses.
+
+	Args:
+	    require_all_processed: If True, only update status when all stops are processed.
+	        Used by report_exception to preserve "In Transit" until all stops are visited.
+
+	Returns (delivered_count, total_count) for use in response payloads.
+	"""
+	total = len(trip.stops)
+	delivered = sum(1 for s in trip.stops if s.status == "Delivered")
+	processed = sum(1 for s in trip.stops if s.status != "Pending")
+
+	if processed == total:
+		trip.status = "Completed" if delivered == total else "Partial"
+	elif not require_all_processed and (delivered > 0 or processed > 0):
+		trip.status = "Partial"
+
+	return delivered, total
 
 
 @frappe.whitelist()
-def create_trip(trip_date, route_name, stops):
-    """Create a new distribution trip. stops: list of {store, items_count}."""
-    _check_scm_permission(SCM_ADMIN_ROLES, "create trips")
+def confirm_delivery(
+	trip_name: str, stop_idx: int | str, signature: str | None = None, signed_by: str | None = None
+):
+	"""Confirm delivery at a specific stop. stop_idx is 1-based."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "confirm delivery")
 
-    if isinstance(stops, str):
-        stops = frappe.parse_json(stops)
+	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
 
-    if not stops:
-        frappe.throw(_("At least one stop is required"))
+	if trip.status not in ["In Transit", "Partial"]:
+		frappe.throw(_("Trip is not in transit"))
 
-    trip = _build_trip_doc(trip_date, route_name, stops)
+	stop = _get_stop(trip, stop_idx)
+	stop.status = "Delivered"
+	stop.arrival_time = now_datetime()
+	stop.signature = signature
+	stop.signed_by = signed_by
 
-    try:
-        trip.insert()
-    except frappe.DuplicateEntryError:
-        # Naming series counter out of sync - fix and retry with fresh doc
-        frappe.db.sql(
-            """UPDATE `tabSeries` SET current = (
+	# Auto-generate delivery billing (async, feature-flagged).
+	# GAP-092 policy: missing setting defaults to enabled.
+	auto_create_setting = frappe.db.get_single_value("BEI Settings", "billing_auto_create_on_delivery")
+	if should_auto_create_billing_on_delivery(auto_create_setting):
+		stop.billing_creation_status = "Pending"
+		frappe.enqueue(
+			"hrms.api.dispatch._create_delivery_billing",
+			queue="default",
+			trip_name=trip.name,
+			stop_idx=stop.idx,
+			enqueue_after_commit=True,
+		)
+
+	delivered, total = _update_trip_status(trip)
+	trip.save()
+
+	# Update linked BEI Store Order status to "Delivered"
+	if hasattr(stop, "store_order") and stop.store_order:
+		_set_store_order_status(stop.store_order, "Delivered")
+
+	# PHASE 1A: Send "1 stop away" notification to next stop
+	# This runs AFTER save so delivery is confirmed even if notification fails
+	try:
+		current_stop_order = int(stop_idx)
+		next_stop = None
+		for s in trip.stops:
+			if s.stop_order == current_stop_order + 1 and s.status == "Pending":
+				next_stop = s
+				break
+
+		if next_stop and trip.departure_time:
+			from frappe.utils import add_to_date, format_time, get_datetime
+
+			# Calculate ETA for next stop
+			departure_dt = get_datetime(trip.departure_time)
+			scheduled_arrival = add_to_date(departure_dt, minutes=next_stop.stop_order * 20)
+			window_start = add_to_date(scheduled_arrival, minutes=-15)
+			window_end = add_to_date(scheduled_arrival, minutes=15)
+			eta_range = f"{format_time(window_start)} - {format_time(window_end)}"
+
+			_send_delivery_notification(trip.driver or "Driver", next_stop.store, eta_range)
+	except Exception as e:
+		# CRITICAL: Notification failures must not block delivery confirmation
+		frappe.log_error(
+			title="Next Stop Notification Failed",
+			message=f"Failed to notify next stop for {trip_name}: {e!s}",
+		)
+
+	return {
+		"success": True,
+		"message": f"Delivery to {stop.store} confirmed",
+		"trip_status": trip.status,
+		"delivered": delivered,
+		"total": total,
+	}
+
+
+@frappe.whitelist()
+def report_exception(
+	trip_name: str,
+	stop_idx: int | str,
+	exception_type: str,
+	reason: str | None = None,
+	photo: str | None = None,
+):
+	"""Report an exception at a stop (store closed, refused, etc)."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "report exceptions")
+
+	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
+
+	stop = _get_stop(trip, stop_idx)
+	stop.status = exception_type
+	stop.arrival_time = now_datetime()
+	stop.exception_reason = reason
+	if photo:
+		stop.exception_photo = photo
+
+	_update_trip_status(trip, require_all_processed=True)
+	trip.save()
+
+	return {"success": True, "message": f"Exception reported for {stop.store}: {exception_type}"}
+
+
+@frappe.whitelist()
+def request_pre_delivery_billing_exception(
+	trip_name: str, stop_idx: int | str, reason: str, exception_type: str = "Delivery Pre-Billing"
+):
+	"""
+	Create a dual-approval exception request for pre-delivery billing.
+
+	GAP-092: routed through BEI Match Exception with CPO+CFO tier.
+	"""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "request pre-delivery billing exception")
+
+	if not trip_name:
+		frappe.throw(_("Trip name is required"))
+	stop_idx = cint(stop_idx)
+	if stop_idx <= 0:
+		frappe.throw(_("Stop index must be greater than 0"))
+	if not reason:
+		frappe.throw(_("Reason is required"))
+
+	from hrms.api.procurement import request_match_exception
+
+	return request_match_exception(
+		{
+			"reference_type": "BEI Distribution Trip",
+			"reference_name": trip_name,
+			"delivery_trip_reference": trip_name,
+			"delivery_stop_idx": stop_idx,
+			"reason": reason,
+			"exception_type": exception_type,
+		}
+	)
+
+
+@frappe.whitelist()
+def get_pre_delivery_billing_exception_status(trip_name: str, stop_idx: int | str):
+	"""Return latest pre-delivery billing exception status for one trip stop."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view pre-delivery billing exception status")
+
+	if not trip_name:
+		frappe.throw(_("Trip name is required"))
+	stop_idx = cint(stop_idx)
+	if stop_idx <= 0:
+		frappe.throw(_("Stop index must be greater than 0"))
+
+	exceptions = frappe.get_all(
+		"BEI Match Exception",
+		filters={
+			"reference_type": "BEI Distribution Trip",
+			"delivery_trip_reference": trip_name,
+			"delivery_stop_idx": stop_idx,
+		},
+		fields=[
+			"name",
+			"status",
+			"approval_tier",
+			"approver",
+			"approver_status",
+			"cpo_approved_by",
+			"cpo_approved_at",
+			"cfo_approved_by",
+			"cfo_approved_at",
+			"modified",
+		],
+		order_by="modified desc",
+		limit_page_length=5,
+	)
+
+	return {
+		"trip_name": trip_name,
+		"stop_idx": stop_idx,
+		"latest": exceptions[0] if exceptions else None,
+		"exceptions": exceptions,
+	}
+
+
+@frappe.whitelist()
+def create_pre_delivery_billing(trip_name: str, stop_idx: int | str, pre_delivery_exception: str):
+	"""
+	Create delivery billing before stop delivery only when dual approval exists.
+
+	Enforced by BEI Billing Schedule policy + exception trace validation.
+	"""
+	_check_scm_permission(SCM_ADMIN_ROLES, "create pre-delivery billing")
+
+	if not pre_delivery_exception:
+		frappe.throw(_("Pre-delivery billing requires an approved exception (Daymae/CPO + Butch/CFO)."))
+
+	_create_delivery_billing(
+		trip_name=trip_name,
+		stop_idx=stop_idx,
+		pre_delivery_exception=pre_delivery_exception,
+		require_pre_delivery_exception=True,
+	)
+
+	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
+	stop = _get_stop(trip, stop_idx)
+	if not stop.billing_reference:
+		frappe.throw(
+			_(
+				"Pre-delivery billing did not create a billing reference. Check trip stop status and exception trace."
+			)
+		)
+
+	return {
+		"success": True,
+		"trip_name": trip_name,
+		"stop_idx": cint(stop_idx),
+		"billing_reference": stop.billing_reference,
+		"billing_creation_status": stop.billing_creation_status,
+		"pre_delivery_exception": pre_delivery_exception,
+	}
+
+
+@frappe.whitelist()
+def get_route_progress(trip_name: str):
+	"""Get current progress of a trip."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view route progress")
+
+	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
+
+	stops = []
+	for stop in trip.stops:
+		stops.append(
+			{
+				"idx": stop.idx,
+				"store": stop.store,
+				"stop_order": stop.stop_order,
+				"items_count": stop.items_count,
+				"status": stop.status,
+				"arrival_time": str(stop.arrival_time) if stop.arrival_time else None,
+				"signed_by": stop.signed_by,
+				"exception_reason": stop.exception_reason,
+			}
+		)
+
+	total = len(trip.stops)
+	delivered = sum(1 for s in trip.stops if s.status == "Delivered")
+	exceptions = sum(1 for s in trip.stops if s.status in ["Store Closed", "Refused"])
+	progress_pct = round((delivered / total * 100), 1) if total > 0 else 0
+
+	current_stop = None
+	next_stop = None
+	for i, stop in enumerate(stops):
+		if stop.get("status") not in ("Delivered", "Store Closed", "Refused"):
+			current_stop = stop.get("store") or stop.get("warehouse")
+			if i + 1 < total:
+				next_stop = stops[i + 1].get("store") or stops[i + 1].get("warehouse")
+			break
+
+	return {
+		"trip_name": trip.name,
+		"status": trip.status,
+		"departure_time": str(trip.departure_time) if trip.departure_time else None,
+		"total_stops": total,
+		"delivered": delivered,
+		"exceptions": exceptions,
+		"pending": total - delivered - exceptions,
+		"progress_pct": progress_pct,
+		"current_stop": current_stop,
+		"next_stop": next_stop,
+		"stops": stops,
+	}
+
+
+def _build_trip_doc(trip_date: str | None, route_name: str, stops: list[dict[str, Any]]):
+	"""Build a BEI Distribution Trip document with stops (not yet inserted)."""
+	trip = frappe.new_doc("BEI Distribution Trip")
+	trip.trip_date = trip_date or nowdate()
+	trip.route_name = route_name
+	trip.status = "Preparing"
+
+	for idx, stop_data in enumerate(stops, 1):
+		trip.append(
+			"stops",
+			{
+				"store": stop_data.get("store"),
+				"stop_order": idx,
+				"items_count": stop_data.get("items_count", 0),
+				"status": "Pending",
+			},
+		)
+
+	return trip
+
+
+@frappe.whitelist()
+def create_trip(trip_date: str | None, route_name: str, stops: list[dict[str, Any]] | str):
+	"""Create a new distribution trip. stops: list of {store, items_count}."""
+	_check_scm_permission(SCM_ADMIN_ROLES, "create trips")
+
+	if isinstance(stops, str):
+		stops = frappe.parse_json(stops)
+
+	if not stops:
+		frappe.throw(_("At least one stop is required"))
+
+	trip = _build_trip_doc(trip_date, route_name, stops)
+
+	try:
+		trip.insert()
+	except frappe.DuplicateEntryError:
+		# Naming series counter out of sync - fix and retry with fresh doc
+		frappe.db.sql(
+			"""UPDATE `tabSeries` SET current = (
                 SELECT IFNULL(MAX(CAST(SUBSTRING_INDEX(name, '-', -1) AS UNSIGNED)), 0)
                 FROM `tabBEI Distribution Trip`
             ) WHERE name = %s""",
-            (trip.naming_series.replace('.YYYY.', str(nowdate()[:4])).replace('.#####', ''),)
-        )
-        frappe.db.commit()
-        trip = _build_trip_doc(trip_date, route_name, stops)
-        trip.insert()
+			(trip.naming_series.replace(".YYYY.", str(nowdate()[:4])).replace(".#####", ""),),
+		)
+		frappe.db.commit()
+		trip = _build_trip_doc(trip_date, route_name, stops)
+		trip.insert()
 
-    return {
-        "success": True,
-        "trip": trip.name,
-        "message": f"Trip {trip.name} created with {len(stops)} stops"
-    }
+	return {
+		"success": True,
+		"trip": trip.name,
+		"message": f"Trip {trip.name} created with {len(stops)} stops",
+	}
 
 
 FRANCHISE_STORE_TYPES = ("Full Franchise", "Managed Franchise")
 FRANCHISE_MARKUP = 1.08
 
 
-def _create_delivery_billing(trip_name, stop_idx):
-    """Create a BEI Billing Schedule for a delivery stop. Runs async via enqueue."""
-    # G-067: Feature flag — billing is enabled by default.
-    # Set BEI Settings.enable_delivery_billing = 0 to disable.
-    billing_enabled = frappe.db.get_single_value("BEI Settings", "enable_delivery_billing")
-    if billing_enabled is not None and not billing_enabled:
-        return
+def _create_delivery_billing(
+	trip_name: str,
+	stop_idx: int | str,
+	pre_delivery_exception: str | None = None,
+	require_pre_delivery_exception: bool = False,
+):
+	"""Create a BEI Billing Schedule for a delivery stop."""
+	# G-067: Feature flag — billing is enabled by default.
+	# Set BEI Settings.enable_delivery_billing = 0 to disable.
+	billing_enabled = frappe.db.get_single_value("BEI Settings", "enable_delivery_billing")
+	if billing_enabled is not None and not billing_enabled:
+		return
 
-    trip = frappe.get_doc("BEI Distribution Trip", trip_name)
-    stop = trip.stops[int(stop_idx) - 1]
+	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
+	stop = trip.stops[int(stop_idx) - 1]
 
-    try:
-        sp = frappe.db.savepoint("delivery_billing")
+	try:
+		sp = frappe.db.savepoint("delivery_billing")
 
-        # I-04 fix: Duplicate check before creating billing
-        existing = frappe.db.exists("BEI Billing Schedule", {
-            "trip_reference": trip.name,
-            "trip_stop_idx": stop.idx,
-            "billing_type": "Delivery",
-            "status": ["not in", ["Cancelled"]],
-        })
-        if existing:
-            stop.billing_reference = existing
-            stop.billing_creation_status = "Success"
-            trip.save(ignore_permissions=True)
-            frappe.db.release_savepoint(sp)
-            return
+		# I-04 fix: Duplicate check before creating billing
+		existing = frappe.db.exists(
+			"BEI Billing Schedule",
+			{
+				"trip_reference": trip.name,
+				"trip_stop_idx": stop.idx,
+				"billing_type": "Delivery",
+				"status": ["not in", ["Cancelled"]],
+			},
+		)
+		if existing:
+			stop.billing_reference = existing
+			stop.billing_creation_status = "Success"
+			trip.save(ignore_permissions=True)
+			frappe.db.release_savepoint(sp)
+			return
 
-        # Resolve store department, store type, and active rate -- bail on missing data
-        dept = frappe.db.get_value(
-            "BEI Warehouse Department Mapping",
-            {"warehouse": stop.store, "is_active": 1},
-            "department",
-        )
-        if not dept:
-            _fail_stop(trip, stop, sp, f"No warehouse->department mapping for {stop.store}", title="Missing Department Mapping")
-            return
+		exception_trace = None
+		if stop.status != "Delivered":
+			if not pre_delivery_exception:
+				if require_pre_delivery_exception:
+					raise DeliveryBillingPolicyError(
+						"Pre-delivery billing is blocked without approved dual-approval exception."
+					)
+				raise DeliveryBillingPolicyError(
+					"Trip stop is not delivered. Confirm delivery first or provide approved dual-approval exception."
+				)
 
-        store_type = frappe.db.get_value("BEI Store Type", {"store": dept}, "store_type")
+			exception_doc = frappe.get_doc("BEI Match Exception", pre_delivery_exception)
+			exception_trace = get_pre_delivery_exception_trace(
+				exception_doc,
+				trip_reference=trip.name,
+				trip_stop_idx=stop.idx,
+			)
 
-        rate = frappe.db.get_value(
-            "BEI Delivery Rate",
-            {"store": dept, "cargo_type": trip.cargo_type, "status": "Active"},
-            ["delivery_fee", "logistics_fee"],
-            as_dict=True,
-        )
-        if not rate:
-            _fail_stop(trip, stop, sp, f"No active {trip.cargo_type} rate for {dept}")
-            return
+		# Resolve store department, store type, and active rate -- bail on missing data
+		dept = frappe.db.get_value(
+			"BEI Warehouse Department Mapping",
+			{"warehouse": stop.store, "is_active": 1},
+			"department",
+		)
+		if not dept:
+			_fail_stop(
+				trip,
+				stop,
+				sp,
+				f"No warehouse->department mapping for {stop.store}",
+				title="Missing Department Mapping",
+			)
+			return
 
-        # Calculate goods value from store order
-        goods_value = _get_order_goods_value(stop.store_order)
+		store_type = frappe.db.get_value("BEI Store Type", {"store": dept}, "store_type")
 
-        # Apply 8% markup for franchise stores
-        is_franchise = store_type in FRANCHISE_STORE_TYPES
-        markup = FRANCHISE_MARKUP if is_franchise else 1.0
+		rate = frappe.db.get_value(
+			"BEI Delivery Rate",
+			{"store": dept, "cargo_type": trip.cargo_type, "status": "Active"},
+			["delivery_fee", "logistics_fee"],
+			as_dict=True,
+		)
+		if not rate:
+			_fail_stop(trip, stop, sp, f"No active {trip.cargo_type} rate for {dept}")
+			return
 
-        # Create billing record
-        billing = frappe.new_doc("BEI Billing Schedule")
-        billing.update({
-            "billing_type": "Delivery",
-            "store": dept,
-            "store_type": store_type or "",
-            "trip_reference": trip.name,
-            "trip_stop_idx": stop.idx,
-            "cargo_type": trip.cargo_type,
-            "delivery_fee": flt(rate.delivery_fee * markup, 2),
-            "logistics_fee": flt(rate.logistics_fee * markup, 2),
-            "goods_value": goods_value,
-            "handling_fee": flt(goods_value * 0.08, 2) if is_franchise else 0,
-            "status": "Pending",
-        })
-        billing.insert(ignore_permissions=True)
+		# Calculate goods value from store order
+		goods_value = _get_order_goods_value(stop.store_order)
 
-        # Update stop with billing reference
-        stop.billing_reference = billing.name
-        stop.delivery_value = goods_value
-        stop.billing_creation_status = "Success"
-        trip.save(ignore_permissions=True)
+		# Apply 8% markup for franchise stores
+		is_franchise = store_type in FRANCHISE_STORE_TYPES
+		markup = FRANCHISE_MARKUP if is_franchise else 1.0
 
-        # C-06 fix: No explicit commit inside enqueued job -- Frappe
-        # auto-commits when the enqueued function returns successfully.
-        frappe.db.release_savepoint(sp)
+		# Create billing record
+		billing = frappe.new_doc("BEI Billing Schedule")
+		billing.update(
+			{
+				"billing_type": "Delivery",
+				"store": dept,
+				"store_type": store_type or "",
+				"trip_reference": trip.name,
+				"trip_stop_idx": stop.idx,
+				"cargo_type": trip.cargo_type,
+				"delivery_fee": flt(rate.delivery_fee * markup, 2),
+				"logistics_fee": flt(rate.logistics_fee * markup, 2),
+				"goods_value": goods_value,
+				"handling_fee": flt(goods_value * 0.08, 2) if is_franchise else 0,
+				"status": "Pending",
+			}
+		)
+		if pre_delivery_exception:
+			billing.pre_delivery_exception = pre_delivery_exception
+		if exception_trace:
+			billing.exception_cpo_approved_by = exception_trace.get("cpo_approved_by")
+			billing.exception_cpo_approved_at = exception_trace.get("cpo_approved_at")
+			billing.exception_cfo_approved_by = exception_trace.get("cfo_approved_by")
+			billing.exception_cfo_approved_at = exception_trace.get("cfo_approved_at")
+			billing.exception_approval_audit_log = exception_trace.get("approval_audit_log")
+		billing.insert(ignore_permissions=True)
 
-    except Exception as e:
-        frappe.db.rollback(save_point=sp)
-        frappe.log_error(
-            f"Failed to create billing for {trip_name} stop {stop_idx}: {str(e)}",
-            "Billing Creation Error"
-        )
-        try:
-            trip.reload()
-            trip.stops[int(stop_idx) - 1].billing_creation_status = "Failed"
-            trip.save(ignore_permissions=True)
-        except Exception:
-            pass
+		# Update stop with billing reference
+		stop.billing_reference = billing.name
+		stop.delivery_value = goods_value
+		stop.billing_creation_status = "Success"
+		trip.save(ignore_permissions=True)
 
-        # G-101: Send Chat alert on billing failure
-        try:
-            from hrms.api.google_chat import send_message_to_space
-            from hrms.utils.bei_config import get_chat_space, SPACE_NOTIFICATIONS
-            send_message_to_space(
-                get_chat_space(SPACE_NOTIFICATIONS),
-                f"*Billing Creation Failed*\nTrip: {trip_name}\nStop: {stop_idx}\nError: {str(e)[:200]}"
-            )
-        except Exception:
-            pass  # notification failure must not cascade
+		# C-06 fix: No explicit commit inside enqueued job -- Frappe
+		# auto-commits when the enqueued function returns successfully.
+		frappe.db.release_savepoint(sp)
+
+	except Exception as e:
+		frappe.db.rollback(save_point=sp)
+		frappe.log_error(
+			f"Failed to create billing for {trip_name} stop {stop_idx}: {e!s}", "Billing Creation Error"
+		)
+		try:
+			trip.reload()
+			trip.stops[int(stop_idx) - 1].billing_creation_status = "Failed"
+			trip.save(ignore_permissions=True)
+		except Exception:
+			pass
+
+		# G-101: Send Chat alert on billing failure
+		try:
+			from hrms.api.google_chat import send_message_to_space
+			from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
+
+			send_message_to_space(
+				get_chat_space(SPACE_NOTIFICATIONS),
+				f"*Billing Creation Failed*\nTrip: {trip_name}\nStop: {stop_idx}\nError: {str(e)[:200]}",
+			)
+		except Exception:
+			pass  # notification failure must not cascade
 
 
-def _fail_stop(trip, stop, savepoint, error_message, title="Missing Delivery Rate"):
-    """Mark a stop as failed and log the error. Used during billing creation."""
-    frappe.log_error(error_message, title)
-    stop.billing_creation_status = "Failed"
-    trip.save(ignore_permissions=True)
-    frappe.db.release_savepoint(savepoint)
+def _fail_stop(
+	trip: Any, stop: Any, savepoint: Any, error_message: str, title: str = "Missing Delivery Rate"
+):
+	"""Mark a stop as failed and log the error. Used during billing creation."""
+	frappe.log_error(error_message, title)
+	stop.billing_creation_status = "Failed"
+	trip.save(ignore_permissions=True)
+	frappe.db.release_savepoint(savepoint)
 
 
-def _get_order_goods_value(store_order):
-    """Calculate the total goods value from a store order's line items."""
-    if not store_order:
-        return 0
-    result = frappe.db.sql("""
+def _get_order_goods_value(store_order: str | None):
+	"""Calculate the total goods value from a store order's line items."""
+	if not store_order:
+		return 0
+	result = frappe.db.sql(
+		"""
         SELECT COALESCE(SUM(qty * unit_price), 0)
         FROM `tabBEI Store Order Item`
         WHERE parent = %s
-    """, store_order)
-    return result[0][0] if result else 0
+    """,
+		store_order,
+	)
+	return result[0][0] if result else 0
 
 
 # ============================================================================
@@ -481,646 +668,699 @@ def _get_order_goods_value(store_order):
 
 
 def _get_user_warehouse():
-    """
-    Get the warehouse/store for the current user.
-    Returns warehouse name or None if user has no assigned store.
-    """
-    user = frappe.session.user
+	"""
+	Get the warehouse/store for the current user.
+	Returns warehouse name or None if user has no assigned store.
+	"""
+	user = frappe.session.user
 
-    # Get warehouse from Employee.branch
-    employee = frappe.db.get_value(
-        "Employee",
-        {"user_id": user, "status": "Active"},
-        ["branch"],
-        as_dict=True
-    )
+	# Get warehouse from Employee.branch
+	employee = frappe.db.get_value(
+		"Employee", {"user_id": user, "status": "Active"}, ["branch"], as_dict=True
+	)
 
-    if not employee or not employee.branch:
-        return None
+	if not employee or not employee.branch:
+		return None
 
-    # Resolve branch to full warehouse name
-    branch = employee.branch
+	# Resolve branch to full warehouse name
+	branch = employee.branch
 
-    # Check if the exact warehouse exists
-    if frappe.db.exists("Warehouse", branch):
-        return branch
+	# Check if the exact warehouse exists
+	if frappe.db.exists("Warehouse", branch):
+		return branch
 
-    # Try appending company abbreviation
-    warehouse_with_company = f"{branch} - BEI"
-    if frappe.db.exists("Warehouse", warehouse_with_company):
-        return warehouse_with_company
+	# Try appending company abbreviation
+	warehouse_with_company = f"{branch} - BEI"
+	if frappe.db.exists("Warehouse", warehouse_with_company):
+		return warehouse_with_company
 
-    # Try to find warehouse by warehouse_name
-    warehouse = frappe.db.get_value("Warehouse", {"warehouse_name": branch}, "name")
-    return warehouse
+	# Try to find warehouse by warehouse_name
+	warehouse = frappe.db.get_value("Warehouse", {"warehouse_name": branch}, "name")
+	return warehouse
 
 
-def _calculate_eta(trip, my_stop_order):
-    """
-    Calculate ETA for a delivery stop.
+def _calculate_eta(trip: Any, my_stop_order: int):
+	"""
+	Calculate ETA for a delivery stop.
 
-    Returns:
-        dict: {
-            "eta_minutes": int or None,
-            "eta_window": {"min": "HH:MM", "max": "HH:MM"} or None
-        }
-    """
-    from frappe.utils import get_datetime, add_to_date, format_time
+	Returns:
+	    dict: {
+	        "eta_minutes": int or None,
+	        "eta_window": {"min": "HH:MM", "max": "HH:MM"} or None
+	    }
+	"""
+	from frappe.utils import add_to_date, format_time, get_datetime
 
-    if not trip.departure_time:
-        return {"eta_minutes": None, "eta_window": None}
+	if not trip.departure_time:
+		return {"eta_minutes": None, "eta_window": None}
 
-    # Find last delivered stop
-    last_delivered = 0
-    for stop in trip.stops:
-        if stop.status == "Delivered" and stop.stop_order > last_delivered:
-            last_delivered = stop.stop_order
+	# Find last delivered stop
+	last_delivered = 0
+	for stop in trip.stops:
+		if stop.status == "Delivered" and stop.stop_order > last_delivered:
+			last_delivered = stop.stop_order
 
-    # Calculate stops remaining
-    stops_remaining = my_stop_order - last_delivered
-    if stops_remaining < 0:
-        stops_remaining = 0
+	# Calculate stops remaining
+	stops_remaining = my_stop_order - last_delivered
+	if stops_remaining < 0:
+		stops_remaining = 0
 
-    # G-003/G-073: Use per-stop estimated_minutes if available, fallback to 20 min/stop
-    DEFAULT_MINUTES_PER_STOP = 20
-    eta_minutes = 0
-    cumulative_minutes = 0  # for scheduled arrival calculation
-    for stop in sorted(trip.stops, key=lambda s: s.stop_order):
-        stop_time = getattr(stop, "estimated_minutes", None) or DEFAULT_MINUTES_PER_STOP
-        if stop.stop_order > last_delivered and stop.stop_order <= my_stop_order:
-            eta_minutes += stop_time
-        if stop.stop_order <= my_stop_order:
-            cumulative_minutes += stop_time
+	# G-003/G-073: Use per-stop estimated_minutes if available, fallback to 20 min/stop
+	DEFAULT_MINUTES_PER_STOP = 20
+	eta_minutes = 0
+	cumulative_minutes = 0  # for scheduled arrival calculation
+	for stop in sorted(trip.stops, key=lambda s: s.stop_order):
+		stop_time = getattr(stop, "estimated_minutes", None) or DEFAULT_MINUTES_PER_STOP
+		if stop.stop_order > last_delivered and stop.stop_order <= my_stop_order:
+			eta_minutes += stop_time
+		if stop.stop_order <= my_stop_order:
+			cumulative_minutes += stop_time
 
-    # Calculate arrival window (±15 minutes from scheduled time)
-    departure_dt = get_datetime(trip.departure_time)
-    scheduled_arrival = add_to_date(departure_dt, minutes=cumulative_minutes)
-    window_start = add_to_date(scheduled_arrival, minutes=-15)
-    window_end = add_to_date(scheduled_arrival, minutes=15)
+	# Calculate arrival window (±15 minutes from scheduled time)
+	departure_dt = get_datetime(trip.departure_time)
+	scheduled_arrival = add_to_date(departure_dt, minutes=cumulative_minutes)
+	window_start = add_to_date(scheduled_arrival, minutes=-15)
+	window_end = add_to_date(scheduled_arrival, minutes=15)
 
-    return {
-        "eta_minutes": eta_minutes,
-        "eta_window": {
-            "min": format_time(window_start),
-            "max": format_time(window_end)
-        }
-    }
+	return {
+		"eta_minutes": eta_minutes,
+		"eta_window": {"min": format_time(window_start), "max": format_time(window_end)},
+	}
 
 
-def _get_items_preview(store_order):
-    """
-    Get preview of items from a store order.
-    Returns list of up to 10 items, with overflow indicator.
-    """
-    if not store_order:
-        return []
+def _get_items_preview(store_order: str | None):
+	"""
+	Get preview of items from a store order.
+	Returns list of up to 10 items, with overflow indicator.
+	"""
+	if not store_order:
+		return []
 
-    items = frappe.get_all(
-        "BEI Store Order Item",
-        filters={"parent": store_order},
-        fields=["item_code", "item_name", "qty_requested as qty", "uom"],
-        order_by="idx",
-        limit=11  # Get 11 to check if there's overflow
-    )
+	items = frappe.get_all(
+		"BEI Store Order Item",
+		filters={"parent": store_order},
+		fields=["item_code", "item_name", "qty_requested as qty", "uom"],
+		order_by="idx",
+		limit=11,  # Get 11 to check if there's overflow
+	)
 
-    if len(items) > 10:
-        overflow_count = len(frappe.get_all(
-            "BEI Store Order Item",
-            filters={"parent": store_order}
-        )) - 10
-        items = items[:10]
-        items.append({
-            "item_code": "MORE",
-            "item_name": f"... and {overflow_count} more items",
-            "qty": 0,
-            "uom": ""
-        })
+	if len(items) > 10:
+		overflow_count = len(frappe.get_all("BEI Store Order Item", filters={"parent": store_order})) - 10
+		items = items[:10]
+		items.append(
+			{"item_code": "MORE", "item_name": f"... and {overflow_count} more items", "qty": 0, "uom": ""}
+		)
 
-    return items
+	return items
 
 
-def _send_delivery_notification(driver, store, eta_range):
-    """
-    Send Google Chat notification for "1 stop away" alert.
-    G-003: Routes to per-store Chat space first, falls back to global.
-    MUST NOT block delivery confirmation if it fails.
-    """
-    from hrms.api.google_chat import send_message_to_space
-    from hrms.utils.bei_config import get_chat_space, SPACE_NOTIFICATIONS
+def _send_delivery_notification(driver: str, store: str, eta_range: str):
+	"""
+	Send Google Chat notification for "1 stop away" alert.
+	G-003: Routes to per-store Chat space first, falls back to global.
+	MUST NOT block delivery confirmation if it fails.
+	"""
+	from hrms.api.google_chat import send_message_to_space
+	from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
 
-    # G-003: Try per-store Chat space first, fall back to global
-    store_space = frappe.db.get_value("Warehouse", store, "custom_gchat_space")
-    space = store_space or get_chat_space(SPACE_NOTIFICATIONS)
+	# G-003: Try per-store Chat space first, fall back to global
+	store_space = frappe.db.get_value("Warehouse", store, "custom_gchat_space")
+	space = store_space or get_chat_space(SPACE_NOTIFICATIONS)
 
-    message = (
-        f"*Delivery Update*\n\n"
-        f"Driver *{driver}* is 1 stop away from *{store}*.\n"
-        f"ETA: {eta_range}\n\n"
-        f"Please prepare receiving area."
-    )
+	message = (
+		f"*Delivery Update*\n\n"
+		f"Driver *{driver}* is 1 stop away from *{store}*.\n"
+		f"ETA: {eta_range}\n\n"
+		f"Please prepare receiving area."
+	)
 
-    send_message_to_space(space, message)
-
-
-def _set_store_order_status(store_order_name, status):
-    """
-    Update a single BEI Store Order status. Silently skips if order not found.
-    Used to keep store orders in sync with trip/delivery progress.
-    """
-    try:
-        if frappe.db.exists("BEI Store Order", store_order_name):
-            frappe.db.set_value("BEI Store Order", store_order_name, "status", status)
-    except Exception as e:
-        frappe.log_error(
-            title="Store Order Status Update Failed",
-            message=f"Failed to set {store_order_name} to {status}: {str(e)}"
-        )
+	send_message_to_space(space, message)
 
 
-def _set_store_orders_in_transit(stops):
-    """
-    After a trip is created, set all linked BEI Store Orders to "In Transit".
-    Only affects orders that were in "Ready for Dispatch" status.
-    """
-    try:
-        for stop_data in stops:
-            store_order = stop_data.get("store_order")
-            if store_order:
-                current_status = frappe.db.get_value("BEI Store Order", store_order, "status")
-                if current_status in ("Approved", "Ready for Dispatch", "Partially Fulfilled"):
-                    frappe.db.set_value("BEI Store Order", store_order, "status", "In Transit")
-    except Exception as e:
-        frappe.log_error(
-            title="Store Orders In Transit Update Failed",
-            message=f"Failed to set store orders to In Transit: {str(e)}"
-        )
+def _set_store_order_status(store_order_name: str, status: str):
+	"""
+	Update a single BEI Store Order status. Silently skips if order not found.
+	Used to keep store orders in sync with trip/delivery progress.
+	"""
+	try:
+		if frappe.db.exists("BEI Store Order", store_order_name):
+			frappe.db.set_value("BEI Store Order", store_order_name, "status", status)
+	except Exception as e:
+		frappe.log_error(
+			title="Store Order Status Update Failed",
+			message=f"Failed to set {store_order_name} to {status}: {e!s}",
+		)
+
+
+def _set_store_orders_in_transit(stops: list[dict[str, Any]]):
+	"""
+	After a trip is created, set all linked BEI Store Orders to "In Transit".
+	Only affects orders that were in "Ready for Dispatch" status.
+	"""
+	try:
+		for stop_data in stops:
+			store_order = stop_data.get("store_order")
+			if store_order:
+				current_status = frappe.db.get_value("BEI Store Order", store_order, "status")
+				if current_status in ("Approved", "Ready for Dispatch", "Partially Fulfilled"):
+					frappe.db.set_value("BEI Store Order", store_order, "status", "In Transit")
+	except Exception as e:
+		frappe.log_error(
+			title="Store Orders In Transit Update Failed",
+			message=f"Failed to set store orders to In Transit: {e!s}",
+		)
 
 
 @frappe.whitelist()
-def get_my_delivery(date=None):
-    """
-    Get delivery trip for the current user's store.
+def get_my_delivery(date: str | None = None):
+	"""
+	Get delivery trip for the current user's store.
 
-    Args:
-        date: Trip date (defaults to today)
+	Args:
+	    date: Trip date (defaults to today)
 
-    Returns:
-        {
-            "ok": true,
-            "trip": {
-                "name": "TRIP-001",
-                "driver": "Juan Dela Cruz",
-                "vehicle_plate": "ABC 123",
-                "departure_time": "2026-02-16 08:00:00",
-                "status": "In Transit",
-                "my_stop": {
-                    "stop_order": 3,
-                    "eta_minutes": 40,
-                    "eta_window": {"min": "09:25", "max": "09:55"},
-                    "items_preview": [...],
-                    "status": "Pending"
-                }
-            },
-            "cs_phone": "0917-123-4567"
-        }
+	Returns:
+	    {
+	        "ok": true,
+	        "trip": {
+	            "name": "TRIP-001",
+	            "driver": "Juan Dela Cruz",
+	            "vehicle_plate": "ABC 123",
+	            "departure_time": "2026-02-16 08:00:00",
+	            "status": "In Transit",
+	            "my_stop": {
+	                "stop_order": 3,
+	                "eta_minutes": 40,
+	                "eta_window": {"min": "09:25", "max": "09:55"},
+	                "items_preview": [...],
+	                "status": "Pending"
+	            }
+	        },
+	        "cs_phone": "0917-123-4567"
+	    }
 
-        OR {"ok": false, "message": "No delivery scheduled"} if no trip found
-    """
-    from frappe.utils import today
+	    OR {"ok": false, "message": "No delivery scheduled"} if no trip found
+	"""
+	from frappe.utils import today
 
-    # RBAC: Only store staff, supervisors, area supervisors, and warehouse users
-    allowed_roles = {"Store Staff", "Store Supervisor", "Area Supervisor", "Warehouse User", "System Manager"}
-    user_roles = set(frappe.get_roles(frappe.session.user))
-    if not user_roles.intersection(allowed_roles):
-        frappe.throw("You do not have permission to view delivery information", frappe.PermissionError)
+	# RBAC: Only store staff, supervisors, area supervisors, and warehouse users
+	allowed_roles = {"Store Staff", "Store Supervisor", "Area Supervisor", "Warehouse User", "System Manager"}
+	user_roles = set(frappe.get_roles(frappe.session.user))
+	if not user_roles.intersection(allowed_roles):
+		frappe.throw("You do not have permission to view delivery information", frappe.PermissionError)
 
-    trip_date = date or today()
-    user_warehouse = _get_user_warehouse()
+	trip_date = date or today()
+	user_warehouse = _get_user_warehouse()
 
-    if not user_warehouse:
-        return {"ok": False, "message": "No store assigned to your account"}
+	if not user_warehouse:
+		return {"ok": False, "message": "No store assigned to your account"}
 
-    # Find trip with a stop at user's warehouse
-    trips = frappe.get_all(
-        "BEI Distribution Trip",
-        filters={"trip_date": trip_date, "status": ["in", ["Preparing", "In Transit", "Partial"]]},
-        fields=["name"]
-    )
+	# Find trip with a stop at user's warehouse
+	trips = frappe.get_all(
+		"BEI Distribution Trip",
+		filters={"trip_date": trip_date, "status": ["in", ["Preparing", "In Transit", "Partial"]]},
+		fields=["name"],
+	)
 
-    for trip_name in trips:
-        trip = frappe.get_doc("BEI Distribution Trip", trip_name.name)
+	for trip_name in trips:
+		trip = frappe.get_doc("BEI Distribution Trip", trip_name.name)
 
-        # Find my stop
-        my_stop = None
-        for stop in trip.stops:
-            if stop.store == user_warehouse:
-                my_stop = stop
-                break
+		# Find my stop
+		my_stop = None
+		for stop in trip.stops:
+			if stop.store == user_warehouse:
+				my_stop = stop
+				break
 
-        if my_stop:
-            # Calculate ETA
-            eta_data = _calculate_eta(trip, my_stop.stop_order)
+		if my_stop:
+			# Calculate ETA
+			eta_data = _calculate_eta(trip, my_stop.stop_order)
 
-            # Get items preview
-            items_preview = _get_items_preview(my_stop.store_order)
+			# Get items preview
+			items_preview = _get_items_preview(my_stop.store_order)
 
-            # Get customer service phone
-            cs_phone = frappe.db.get_single_value("BEI Settings", "customer_service_phone") or ""
+			# Get customer service phone
+			cs_phone = frappe.db.get_single_value("BEI Settings", "customer_service_phone") or ""
 
-            return {
-                "ok": True,
-                "trip": {
-                    "name": trip.name,
-                    "driver": trip.driver or "TBA",
-                    "vehicle_plate": trip.vehicle_plate or "TBA",
-                    "departure_time": str(trip.departure_time) if trip.departure_time else None,
-                    "status": trip.status,
-                    "my_stop": {
-                        "stop_order": my_stop.stop_order,
-                        "eta_minutes": eta_data["eta_minutes"],
-                        "eta_window": eta_data["eta_window"],
-                        "items_preview": items_preview,
-                        "status": my_stop.status
-                    }
-                },
-                "cs_phone": cs_phone
-            }
+			return {
+				"ok": True,
+				"trip": {
+					"name": trip.name,
+					"driver": trip.driver or "TBA",
+					"vehicle_plate": trip.vehicle_plate or "TBA",
+					"departure_time": str(trip.departure_time) if trip.departure_time else None,
+					"status": trip.status,
+					"my_stop": {
+						"stop_order": my_stop.stop_order,
+						"eta_minutes": eta_data["eta_minutes"],
+						"eta_window": eta_data["eta_window"],
+						"items_preview": items_preview,
+						"status": my_stop.status,
+					},
+				},
+				"cs_phone": cs_phone,
+			}
 
-    return {"ok": False, "message": "No delivery scheduled"}
+	return {"ok": False, "message": "No delivery scheduled"}
 
 
 # ============================================================================
 # PHASE 1C: ROUTE MANAGEMENT & TRIP CREATION
 # ============================================================================
 
-@frappe.whitelist()
-def get_routes(cargo_type=None, active_only=True):
-    """Get all route masters, optionally filtered."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view routes")
-
-    filters = {}
-    if cargo_type:
-        filters["cargo_type"] = cargo_type
-    if active_only:
-        filters["active"] = 1
-
-    routes = frappe.get_all(
-        "BEI Route",
-        filters=filters,
-        fields=["name", "route_name", "cargo_type", "source_warehouse", "default_vehicle", "default_driver", "estimated_duration_hrs", "active"],
-        order_by="route_name"
-    )
-
-    for route in routes:
-        stops = frappe.get_all(
-            "BEI Route Stop",
-            filters={"parent": route.name},
-            fields=["store", "stop_order", "estimated_minutes"],
-            order_by="stop_order"
-        )
-        route["stops"] = stops
-        route["stop_count"] = len(stops)
-
-    return {"routes": routes}
-
 
 @frappe.whitelist()
-def get_route_detail(route_name):
-    """Get full route details including all stops."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view route details")
+def get_routes(cargo_type: str | None = None, active_only: bool = True):
+	"""Get all route masters, optionally filtered."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view routes")
 
-    route = frappe.get_doc("BEI Route", route_name)
-    return {
-        "route": {
-            "name": route.name,
-            "route_name": route.route_name,
-            "cargo_type": route.cargo_type,
-            "source_warehouse": route.source_warehouse,
-            "default_vehicle": route.default_vehicle,
-            "default_driver": route.default_driver,
-            "estimated_duration_hrs": route.estimated_duration_hrs,
-            "active": route.active,
-            "notes": route.notes,
-            "stops": [
-                {
-                    "idx": s.idx,
-                    "store": s.store,
-                    "stop_order": s.stop_order,
-                    "estimated_minutes": s.estimated_minutes,
-                    "special_instructions": s.special_instructions,
-                    "mall_permit_required": s.mall_permit_required
-                }
-                for s in route.stops
-            ]
-        }
-    }
+	filters = {}
+	if cargo_type:
+		filters["cargo_type"] = cargo_type
+	if active_only:
+		filters["active"] = 1
+
+	routes = frappe.get_all(
+		"BEI Route",
+		filters=filters,
+		fields=[
+			"name",
+			"route_name",
+			"cargo_type",
+			"source_warehouse",
+			"default_vehicle",
+			"default_driver",
+			"estimated_duration_hrs",
+			"active",
+		],
+		order_by="route_name",
+	)
+
+	for route in routes:
+		stops = frappe.get_all(
+			"BEI Route Stop",
+			filters={"parent": route.name},
+			fields=["store", "stop_order", "estimated_minutes"],
+			order_by="stop_order",
+		)
+		route["stops"] = stops
+		route["stop_count"] = len(stops)
+
+	return {"routes": routes}
 
 
 @frappe.whitelist()
-def create_route(route_name, cargo_type, source_warehouse, stops=None, default_vehicle=None, default_driver=None, notes=None):
-    """Create a new route master."""
-    _check_scm_permission(SCM_ADMIN_ROLES, "create routes")
+def get_route_detail(route_name: str):
+	"""Get full route details including all stops."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view route details")
 
-    if isinstance(stops, str):
-        stops = frappe.parse_json(stops)
-
-    route = frappe.new_doc("BEI Route")
-    route.route_name = route_name
-    route.cargo_type = cargo_type
-    route.source_warehouse = source_warehouse
-    route.default_vehicle = default_vehicle
-    route.default_driver = default_driver
-    route.notes = notes
-    route.active = 1
-
-    if stops:
-        for idx, stop_data in enumerate(stops, 1):
-            route.append("stops", {
-                "store": stop_data.get("store"),
-                "stop_order": idx,
-                "estimated_minutes": stop_data.get("estimated_minutes", 20),
-                "special_instructions": stop_data.get("special_instructions", ""),
-                "mall_permit_required": stop_data.get("mall_permit_required", 0)
-            })
-
-    route.insert()
-    return {"success": True, "route": route.name}
-
-
-@frappe.whitelist()
-def update_route(route_name, updates=None):
-    """Update a route master. Accepts partial updates."""
-    _check_scm_permission(SCM_ADMIN_ROLES, "update routes")
-
-    if isinstance(updates, str):
-        updates = frappe.parse_json(updates)
-
-    route = frappe.get_doc("BEI Route", route_name)
-
-    simple_fields = ["route_name", "cargo_type", "source_warehouse", "default_vehicle", "default_driver", "estimated_duration_hrs", "notes", "active"]
-    for field in simple_fields:
-        if field in updates:
-            setattr(route, field, updates[field])
-
-    if "stops" in updates:
-        route.stops = []
-        for idx, stop_data in enumerate(updates["stops"], 1):
-            route.append("stops", {
-                "store": stop_data.get("store"),
-                "stop_order": idx,
-                "estimated_minutes": stop_data.get("estimated_minutes", 20),
-                "special_instructions": stop_data.get("special_instructions", ""),
-                "mall_permit_required": stop_data.get("mall_permit_required", 0)
-            })
-
-    route.save()
-    return {"success": True, "route": route.name}
+	route = frappe.get_doc("BEI Route", route_name)
+	return {
+		"route": {
+			"name": route.name,
+			"route_name": route.route_name,
+			"cargo_type": route.cargo_type,
+			"source_warehouse": route.source_warehouse,
+			"default_vehicle": route.default_vehicle,
+			"default_driver": route.default_driver,
+			"estimated_duration_hrs": route.estimated_duration_hrs,
+			"active": route.active,
+			"notes": route.notes,
+			"stops": [
+				{
+					"idx": s.idx,
+					"store": s.store,
+					"stop_order": s.stop_order,
+					"estimated_minutes": s.estimated_minutes,
+					"special_instructions": s.special_instructions,
+					"mall_permit_required": s.mall_permit_required,
+				}
+				for s in route.stops
+			],
+		}
+	}
 
 
 @frappe.whitelist()
-def delete_route(route_name):
-    """Soft-delete a route (set active=0)."""
-    _check_scm_permission(SCM_ADMIN_ROLES, "delete routes")
+def create_route(
+	route_name: str,
+	cargo_type: str,
+	source_warehouse: str,
+	stops: list[dict[str, Any]] | str | None = None,
+	default_vehicle: str | None = None,
+	default_driver: str | None = None,
+	notes: str | None = None,
+):
+	"""Create a new route master."""
+	_check_scm_permission(SCM_ADMIN_ROLES, "create routes")
 
-    route = frappe.get_doc("BEI Route", route_name)
-    route.active = 0
-    route.save()
-    return {"success": True, "message": f"Route {route_name} deactivated"}
+	if isinstance(stops, str):
+		stops = frappe.parse_json(stops)
+
+	route = frappe.new_doc("BEI Route")
+	route.route_name = route_name
+	route.cargo_type = cargo_type
+	route.source_warehouse = source_warehouse
+	route.default_vehicle = default_vehicle
+	route.default_driver = default_driver
+	route.notes = notes
+	route.active = 1
+
+	if stops:
+		for idx, stop_data in enumerate(stops, 1):
+			route.append(
+				"stops",
+				{
+					"store": stop_data.get("store"),
+					"stop_order": idx,
+					"estimated_minutes": stop_data.get("estimated_minutes", 20),
+					"special_instructions": stop_data.get("special_instructions", ""),
+					"mall_permit_required": stop_data.get("mall_permit_required", 0),
+				},
+			)
+
+	route.insert()
+	return {"success": True, "route": route.name}
 
 
 @frappe.whitelist()
-def get_vehicles(status=None, owner_type=None):
-    """List vehicles with optional filters."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view vehicles")
+def update_route(route_name: str, updates: dict[str, Any] | str | None = None):
+	"""Update a route master. Accepts partial updates."""
+	_check_scm_permission(SCM_ADMIN_ROLES, "update routes")
 
-    filters = {}
-    if status:
-        filters["status"] = status
-    if owner_type:
-        filters["owner_type"] = owner_type
+	if isinstance(updates, str):
+		updates = frappe.parse_json(updates)
 
-    vehicles = frappe.get_all(
-        "BEI Vehicle",
-        filters=filters,
-        fields=["name", "vehicle_plate", "vehicle_type", "capacity_kg", "capacity_cbm", "owner_type", "threepl_partner", "status"],
-        order_by="vehicle_plate"
-    )
-    return {"vehicles": vehicles}
+	route = frappe.get_doc("BEI Route", route_name)
+
+	simple_fields = [
+		"route_name",
+		"cargo_type",
+		"source_warehouse",
+		"default_vehicle",
+		"default_driver",
+		"estimated_duration_hrs",
+		"notes",
+		"active",
+	]
+	for field in simple_fields:
+		if field in updates:
+			setattr(route, field, updates[field])
+
+	if "stops" in updates:
+		route.stops = []
+		for idx, stop_data in enumerate(updates["stops"], 1):
+			route.append(
+				"stops",
+				{
+					"store": stop_data.get("store"),
+					"stop_order": idx,
+					"estimated_minutes": stop_data.get("estimated_minutes", 20),
+					"special_instructions": stop_data.get("special_instructions", ""),
+					"mall_permit_required": stop_data.get("mall_permit_required", 0),
+				},
+			)
+
+	route.save()
+	return {"success": True, "route": route.name}
 
 
-def _build_stop_preview(route, trip_date):
-    """Shared helper: build stop list with pending order info using bulk queries."""
-    store_list = [s.store for s in route.stops]
+@frappe.whitelist()
+def delete_route(route_name: str):
+	"""Soft-delete a route (set active=0)."""
+	_check_scm_permission(SCM_ADMIN_ROLES, "delete routes")
 
-    orders = frappe.db.get_all("BEI Store Order",
-        filters={"store": ["in", store_list], "delivery_date": trip_date, "status": "Approved"},
-        fields=["name", "store"])
-    order_map = {o.store: o.name for o in orders}
+	route = frappe.get_doc("BEI Route", route_name)
+	route.active = 0
+	route.save()
+	return {"success": True, "message": f"Route {route_name} deactivated"}
 
-    order_names = [o.name for o in orders]
-    item_counts = {}
-    if order_names:
-        counts = frappe.db.sql("""
+
+@frappe.whitelist()
+def get_vehicles(status: str | None = None, owner_type: str | None = None):
+	"""List vehicles with optional filters."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view vehicles")
+
+	filters = {}
+	if status:
+		filters["status"] = status
+	if owner_type:
+		filters["owner_type"] = owner_type
+
+	vehicles = frappe.get_all(
+		"BEI Vehicle",
+		filters=filters,
+		fields=[
+			"name",
+			"vehicle_plate",
+			"vehicle_type",
+			"capacity_kg",
+			"capacity_cbm",
+			"owner_type",
+			"threepl_partner",
+			"status",
+		],
+		order_by="vehicle_plate",
+	)
+	return {"vehicles": vehicles}
+
+
+def _build_stop_preview(route: Any, trip_date: str):
+	"""Shared helper: build stop list with pending order info using bulk queries."""
+	store_list = [s.store for s in route.stops]
+
+	orders = frappe.db.get_all(
+		"BEI Store Order",
+		filters={"store": ["in", store_list], "delivery_date": trip_date, "status": "Approved"},
+		fields=["name", "store"],
+	)
+	order_map = {o.store: o.name for o in orders}
+
+	order_names = [o.name for o in orders]
+	item_counts = {}
+	if order_names:
+		counts = frappe.db.sql(
+			"""
             SELECT parent, COUNT(*) as cnt FROM `tabBEI Store Order Item`
             WHERE parent IN %(names)s GROUP BY parent
-        """, {"names": order_names}, as_dict=True)
-        item_counts = {c.parent: c.cnt for c in counts}
+        """,
+			{"names": order_names},
+			as_dict=True,
+		)
+		item_counts = {c.parent: c.cnt for c in counts}
 
-    stops = []
-    for s in route.stops:
-        order = order_map.get(s.store)
-        stops.append({
-            "store": s.store,
-            "stop_order": getattr(s, "stop_order", 0),
-            "estimated_minutes": getattr(s, "estimated_minutes", 0),
-            "store_order": order or "",
-            "items_count": item_counts.get(order, 0) if order else 0,
-        })
-    return stops
-
-
-@frappe.whitelist()
-def preview_trip_stops(route_name, trip_date=None):
-    """Preview stops and pending store orders for a proposed trip."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "preview trip stops")
-    route = frappe.get_doc("BEI Route", route_name)
-
-    if not route.active:
-        frappe.throw(_("Route is not active"))
-
-    trip_date = trip_date or nowdate()
-    stops = _build_stop_preview(route, trip_date)
-    return {"route_name": route_name, "trip_date": trip_date, "stops": stops}
+	stops = []
+	for s in route.stops:
+		order = order_map.get(s.store)
+		stops.append(
+			{
+				"store": s.store,
+				"stop_order": getattr(s, "stop_order", 0),
+				"estimated_minutes": getattr(s, "estimated_minutes", 0),
+				"store_order": order or "",
+				"items_count": item_counts.get(order, 0) if order else 0,
+			}
+		)
+	return stops
 
 
 @frappe.whitelist()
-def create_trip_from_route(route_name, trip_date=None, vehicle=None, driver=None, selected_stops=None):
-    """One-click trip creation from a route template.
+def preview_trip_stops(route_name: str, trip_date: str | None = None):
+	"""Preview stops and pending store orders for a proposed trip."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "preview trip stops")
+	route = frappe.get_doc("BEI Route", route_name)
 
-    1. Loads route + stops
-    2. Creates BEI Distribution Trip
-    3. Copies stops, links approved store orders
-    4. Returns trip name
-    """
-    _check_scm_permission(SCM_DISPATCH_ROLES, "create trips from routes")
+	if not route.active:
+		frappe.throw(_("Route is not active"))
 
-    route = frappe.get_doc("BEI Route", route_name)
+	trip_date = trip_date or nowdate()
+	stops = _build_stop_preview(route, trip_date)
+	return {"route_name": route_name, "trip_date": trip_date, "stops": stops}
 
-    if not route.active:
-        frappe.throw(_("Route is not active"))
 
-    trip_date = trip_date or nowdate()
+@frappe.whitelist()
+def create_trip_from_route(
+	route_name: str,
+	trip_date: str | None = None,
+	vehicle: str | None = None,
+	driver: str | None = None,
+	selected_stops: list[dict[str, Any]] | str | None = None,
+):
+	"""One-click trip creation from a route template.
 
-    # G-069: UX pre-check for duplicate trip (DB constraint is the real guard)
-    existing_trip = frappe.db.get_value(
-        "BEI Distribution Trip",
-        {"route_name": route_name, "trip_date": trip_date},
-        "name"
-    )
-    if existing_trip:
-        frappe.throw(
-            _("A trip already exists for route '{0}' on {1}: {2}").format(
-                route_name, trip_date, existing_trip
-            )
-        )
+	1. Loads route + stops
+	2. Creates BEI Distribution Trip
+	3. Copies stops, links approved store orders
+	4. Returns trip name
+	"""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "create trips from routes")
 
-    # Resolve vehicle details
-    vehicle_plate = None
-    if vehicle:
-        vehicle_plate = frappe.db.get_value("BEI Vehicle", vehicle, "vehicle_plate")
-    elif route.default_vehicle:
-        vehicle = route.default_vehicle
-        vehicle_plate = frappe.db.get_value("BEI Vehicle", route.default_vehicle, "vehicle_plate")
+	route = frappe.get_doc("BEI Route", route_name)
 
-    if selected_stops:
-        if isinstance(selected_stops, str):
-            selected_stops = frappe.parse_json(selected_stops)
+	if not route.active:
+		frappe.throw(_("Route is not active"))
 
-        # Validate all selected stores exist in route's zone pool
-        zone_stores = {s.store for s in route.stops}
-        for sel in selected_stops:
-            if sel.get("store") not in zone_stores:
-                frappe.throw(_(f"Store {sel.get('store')} is not in zone {route.route_name}"))
+	trip_date = trip_date or nowdate()
 
-        # Build stops from selection using bulk queries
-        sel_stores = [sel.get("store") for sel in selected_stops]
-        orders = frappe.db.get_all("BEI Store Order",
-            filters={"store": ["in", sel_stores], "delivery_date": trip_date, "status": "Approved"},
-            fields=["name", "store"])
-        order_map = {o.store: o.name for o in orders}
+	# G-069: UX pre-check for duplicate trip (DB constraint is the real guard)
+	existing_trip = frappe.db.get_value(
+		"BEI Distribution Trip", {"route_name": route_name, "trip_date": trip_date}, "name"
+	)
+	if existing_trip:
+		frappe.throw(
+			_("A trip already exists for route '{0}' on {1}: {2}").format(
+				route_name, trip_date, existing_trip
+			)
+		)
 
-        order_names = [o.name for o in orders]
-        item_counts = {}
-        if order_names:
-            counts = frappe.db.sql("""
+	# Resolve vehicle details
+	vehicle_plate = None
+	if vehicle:
+		vehicle_plate = frappe.db.get_value("BEI Vehicle", vehicle, "vehicle_plate")
+	elif route.default_vehicle:
+		vehicle = route.default_vehicle
+		vehicle_plate = frappe.db.get_value("BEI Vehicle", route.default_vehicle, "vehicle_plate")
+
+	if selected_stops:
+		if isinstance(selected_stops, str):
+			selected_stops = frappe.parse_json(selected_stops)
+
+		# Validate all selected stores exist in route's zone pool
+		zone_stores = {s.store for s in route.stops}
+		for sel in selected_stops:
+			if sel.get("store") not in zone_stores:
+				frappe.throw(_(f"Store {sel.get('store')} is not in zone {route.route_name}"))
+
+		# Build stops from selection using bulk queries
+		sel_stores = [sel.get("store") for sel in selected_stops]
+		orders = frappe.db.get_all(
+			"BEI Store Order",
+			filters={"store": ["in", sel_stores], "delivery_date": trip_date, "status": "Approved"},
+			fields=["name", "store"],
+		)
+		order_map = {o.store: o.name for o in orders}
+
+		order_names = [o.name for o in orders]
+		item_counts = {}
+		if order_names:
+			counts = frappe.db.sql(
+				"""
                 SELECT parent, COUNT(*) as cnt FROM `tabBEI Store Order Item`
                 WHERE parent IN %(names)s GROUP BY parent
-            """, {"names": order_names}, as_dict=True)
-            item_counts = {c.parent: c.cnt for c in counts}
+            """,
+				{"names": order_names},
+				as_dict=True,
+			)
+			item_counts = {c.parent: c.cnt for c in counts}
 
-        stops = []
-        for sel in selected_stops:
-            store = sel.get("store")
-            order = order_map.get(store)
-            stops.append({
-                "store": store,
-                "items_count": item_counts.get(order, 0) if order else 0,
-                "store_order": order or ""
-            })
-    else:
-        # Original behavior: use all route stops (via shared helper)
-        stops = _build_stop_preview(route, trip_date)
+		stops = []
+		for sel in selected_stops:
+			store = sel.get("store")
+			order = order_map.get(store)
+			stops.append(
+				{
+					"store": store,
+					"items_count": item_counts.get(order, 0) if order else 0,
+					"store_order": order or "",
+				}
+			)
+	else:
+		# Original behavior: use all route stops (via shared helper)
+		stops = _build_stop_preview(route, trip_date)
 
-    # Use existing trip creation logic
-    trip = _build_trip_doc(trip_date, route.route_name, stops)
-    trip.driver = driver or route.default_driver
-    trip.vehicle = vehicle
-    trip.vehicle_plate = vehicle_plate
-    trip.cargo_type = route.cargo_type
+	# Use existing trip creation logic
+	trip = _build_trip_doc(trip_date, route.route_name, stops)
+	trip.driver = driver or route.default_driver
+	trip.vehicle = vehicle
+	trip.vehicle_plate = vehicle_plate
+	trip.cargo_type = route.cargo_type
 
-    # Link store orders to stops
-    for idx, stop_data in enumerate(stops):
-        if stop_data.get("store_order"):
-            trip.stops[idx].store_order = stop_data["store_order"]
+	# Link store orders to stops
+	for idx, stop_data in enumerate(stops):
+		if stop_data.get("store_order"):
+			trip.stops[idx].store_order = stop_data["store_order"]
 
-    trip.insert()
+	trip.insert()
 
-    # Update linked BEI Store Orders to "In Transit"
-    _set_store_orders_in_transit(stops)
+	# Update linked BEI Store Orders to "In Transit"
+	_set_store_orders_in_transit(stops)
 
-    return {
-        "success": True,
-        "trip": trip.name,
-        "message": f"Trip {trip.name} created from route {route.route_name} with {len(stops)} stops"
-    }
-
-
-@frappe.whitelist()
-def duplicate_route(route_name, new_name):
-    """Clone a route with a new name."""
-    _check_scm_permission(SCM_ADMIN_ROLES, "duplicate routes")
-
-    source = frappe.get_doc("BEI Route", route_name)
-
-    new_route = frappe.new_doc("BEI Route")
-    new_route.route_name = new_name
-    new_route.cargo_type = source.cargo_type
-    new_route.source_warehouse = source.source_warehouse
-    new_route.default_vehicle = source.default_vehicle
-    new_route.default_driver = source.default_driver
-    new_route.estimated_duration_hrs = source.estimated_duration_hrs
-    new_route.notes = source.notes
-    new_route.active = 1
-
-    for stop in source.stops:
-        new_route.append("stops", {
-            "store": stop.store,
-            "stop_order": stop.stop_order,
-            "estimated_minutes": stop.estimated_minutes,
-            "special_instructions": stop.special_instructions,
-            "mall_permit_required": stop.mall_permit_required
-        })
-
-    new_route.insert()
-    return {"success": True, "route": new_route.name}
+	return {
+		"success": True,
+		"trip": trip.name,
+		"message": f"Trip {trip.name} created from route {route.route_name} with {len(stops)} stops",
+	}
 
 
 @frappe.whitelist()
-def reorder_stops(route_name, stop_order_map):
-    """Reorder stops in a route. stop_order_map: {store: new_order}"""
-    _check_scm_permission(SCM_ADMIN_ROLES, "reorder stops")
+def duplicate_route(route_name: str, new_name: str):
+	"""Clone a route with a new name."""
+	_check_scm_permission(SCM_ADMIN_ROLES, "duplicate routes")
 
-    if isinstance(stop_order_map, str):
-        stop_order_map = frappe.parse_json(stop_order_map)
+	source = frappe.get_doc("BEI Route", route_name)
 
-    route = frappe.get_doc("BEI Route", route_name)
+	new_route = frappe.new_doc("BEI Route")
+	new_route.route_name = new_name
+	new_route.cargo_type = source.cargo_type
+	new_route.source_warehouse = source.source_warehouse
+	new_route.default_vehicle = source.default_vehicle
+	new_route.default_driver = source.default_driver
+	new_route.estimated_duration_hrs = source.estimated_duration_hrs
+	new_route.notes = source.notes
+	new_route.active = 1
 
-    for stop in route.stops:
-        if stop.store in stop_order_map:
-            stop.stop_order = int(stop_order_map[stop.store])
+	for stop in source.stops:
+		new_route.append(
+			"stops",
+			{
+				"store": stop.store,
+				"stop_order": stop.stop_order,
+				"estimated_minutes": stop.estimated_minutes,
+				"special_instructions": stop.special_instructions,
+				"mall_permit_required": stop.mall_permit_required,
+			},
+		)
 
-    # Re-sort stops by new order
-    route.stops.sort(key=lambda s: s.stop_order)
-    for idx, stop in enumerate(route.stops, 1):
-        stop.idx = idx
-        stop.stop_order = idx
+	new_route.insert()
+	return {"success": True, "route": new_route.name}
 
-    route.save()
-    return {"success": True, "route": route.name}
+
+@frappe.whitelist()
+def reorder_stops(route_name: str, stop_order_map: dict[str, int] | str):
+	"""Reorder stops in a route. stop_order_map: {store: new_order}"""
+	_check_scm_permission(SCM_ADMIN_ROLES, "reorder stops")
+
+	if isinstance(stop_order_map, str):
+		stop_order_map = frappe.parse_json(stop_order_map)
+
+	route = frappe.get_doc("BEI Route", route_name)
+
+	for stop in route.stops:
+		if stop.store in stop_order_map:
+			stop.stop_order = int(stop_order_map[stop.store])
+
+	# Re-sort stops by new order
+	route.stops.sort(key=lambda s: s.stop_order)
+	for idx, stop in enumerate(route.stops, 1):
+		stop.idx = idx
+		stop.stop_order = idx
+
+	route.save()
+	return {"success": True, "route": route.name}
 
 
 @frappe.whitelist()
 def get_driver_list():
-    """Get list of available drivers (employees with driver designation)."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view driver list")
+	"""Get list of available drivers (employees with driver designation)."""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view driver list")
 
-    drivers = frappe.get_all(
-        "Employee",
-        filters={"status": "Active", "designation": ["in", ["Driver", "Delivery Driver", "Truck Driver"]]},
-        fields=["name", "employee_name", "cell_phone"],
-        order_by="employee_name"
-    )
-    return {"drivers": drivers}
+	drivers = frappe.get_all(
+		"Employee",
+		filters={"status": "Active", "designation": ["in", ["Driver", "Delivery Driver", "Truck Driver"]]},
+		fields=["name", "employee_name", "cell_phone"],
+		order_by="employee_name",
+	)
+	return {"drivers": drivers}
 
 
 # ============================================================================
@@ -1131,264 +1371,432 @@ DRIVER_DESIGNATIONS = ["Driver", "Helper", "Relief Driver", "Delivery Driver", "
 
 
 @frappe.whitelist()
-def get_available_drivers(date=None):
-    """
-    Get all drivers with their assignment status for a given date.
+def get_available_drivers(date: str | None = None):
+	"""
+	Get all drivers with their assignment status for a given date.
 
-    Returns each driver with:
-      - status: "Available" | "Assigned" | "Off-Duty"
-      - trip: trip details if assigned (trip_name, route_name, departure_time, vehicle_plate)
+	Returns each driver with:
+	  - status: "Available" | "Assigned" | "Off-Duty"
+	  - trip: trip details if assigned (trip_name, route_name, departure_time, vehicle_plate)
 
-    Args:
-        date: ISO date string (defaults to today)
+	Args:
+	    date: ISO date string (defaults to today)
 
-    Returns:
-        {"drivers": [DriverStatus, ...]}
-    """
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view available drivers")
+	Returns:
+	    {"drivers": [DriverStatus, ...]}
+	"""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view available drivers")
 
-    trip_date = date or nowdate()
+	trip_date = date or nowdate()
 
-    # All active employees with driver designations
-    all_drivers = frappe.get_all(
-        "Employee",
-        filters={"status": "Active", "designation": ["in", DRIVER_DESIGNATIONS]},
-        fields=["name", "employee_name", "designation", "cell_phone", "status"],
-        order_by="employee_name"
-    )
+	# All active employees with driver designations
+	all_drivers = frappe.get_all(
+		"Employee",
+		filters={"status": "Active", "designation": ["in", DRIVER_DESIGNATIONS]},
+		fields=["name", "employee_name", "designation", "cell_phone", "status"],
+		order_by="employee_name",
+	)
 
-    # Build a map of employee -> trip for the date
-    trips_on_date = frappe.get_all(
-        "BEI Distribution Trip",
-        filters={"trip_date": trip_date},
-        fields=["name", "driver", "route_name", "departure_time", "vehicle_plate", "status"]
-    )
+	# Build a map of employee -> trip for the date
+	trips_on_date = frappe.get_all(
+		"BEI Distribution Trip",
+		filters={"trip_date": trip_date},
+		fields=["name", "driver", "route_name", "departure_time", "vehicle_plate", "status"],
+	)
 
-    assigned_map = {}
-    for trip in trips_on_date:
-        if trip.driver:
-            assigned_map[trip.driver] = trip
+	assigned_map = {}
+	for trip in trips_on_date:
+		if trip.driver:
+			assigned_map[trip.driver] = trip
 
-    result = []
-    for driver in all_drivers:
-        assigned_trip = assigned_map.get(driver.name)
-        driver_status = "Assigned" if assigned_trip else "Available"
+	result = []
+	for driver in all_drivers:
+		assigned_trip = assigned_map.get(driver.name)
+		driver_status = "Assigned" if assigned_trip else "Available"
 
-        entry = {
-            "employee": driver.name,
-            "employee_name": driver.employee_name,
-            "designation": driver.designation,
-            "cell_phone": driver.cell_phone or "",
-            "status": driver_status,
-            "trip": None,
-        }
+		entry = {
+			"employee": driver.name,
+			"employee_name": driver.employee_name,
+			"designation": driver.designation,
+			"cell_phone": driver.cell_phone or "",
+			"status": driver_status,
+			"trip": None,
+		}
 
-        if assigned_trip:
-            entry["trip"] = {
-                "name": assigned_trip.name,
-                "route_name": assigned_trip.route_name,
-                "departure_time": str(assigned_trip.departure_time) if assigned_trip.departure_time else None,
-                "vehicle_plate": assigned_trip.vehicle_plate or "",
-                "status": assigned_trip.status,
-            }
+		if assigned_trip:
+			entry["trip"] = {
+				"name": assigned_trip.name,
+				"route_name": assigned_trip.route_name,
+				"departure_time": str(assigned_trip.departure_time) if assigned_trip.departure_time else None,
+				"vehicle_plate": assigned_trip.vehicle_plate or "",
+				"status": assigned_trip.status,
+			}
 
-        result.append(entry)
+		result.append(entry)
 
-    # Count summary
-    available_count = sum(1 for d in result if d["status"] == "Available")
-    assigned_count = sum(1 for d in result if d["status"] == "Assigned")
+	# Count summary
+	available_count = sum(1 for d in result if d["status"] == "Available")
+	assigned_count = sum(1 for d in result if d["status"] == "Assigned")
 
-    return {
-        "drivers": result,
-        "summary": {
-            "total": len(result),
-            "available": available_count,
-            "assigned": assigned_count,
-        }
-    }
-
-
-@frappe.whitelist()
-def assign_driver(trip_name, employee, vehicle=None):
-    """
-    Assign a driver (or helper) to an existing trip.
-    Only valid for trips in "Preparing" status.
-
-    Args:
-        trip_name: BEI Distribution Trip name
-        employee:  Employee name (Link field)
-        vehicle:   Optional BEI Vehicle name — updates vehicle_plate automatically
-
-    Returns:
-        {"success": True, "trip": trip_name, "driver": employee_name}
-    """
-    _check_scm_permission(SCM_DISPATCH_ROLES, "assign drivers to trips")
-
-    # Validate employee exists and has a driver designation
-    emp = frappe.db.get_value(
-        "Employee",
-        {"name": employee, "status": "Active"},
-        ["name", "employee_name", "designation"],
-        as_dict=True
-    )
-    if not emp:
-        frappe.throw(_("Employee {0} not found or not active").format(employee))
-
-    if emp.designation not in DRIVER_DESIGNATIONS:
-        frappe.throw(
-            _("Employee {0} does not have a driver designation ({1})").format(
-                emp.employee_name, emp.designation
-            )
-        )
-
-    trip = frappe.get_doc("BEI Distribution Trip", trip_name)
-
-    if trip.status not in ("Preparing", "In Transit"):
-        frappe.throw(
-            _("Cannot reassign driver: trip {0} is in status '{1}'").format(trip_name, trip.status)
-        )
-
-    trip.driver = employee
-
-    if vehicle:
-        vehicle_plate = frappe.db.get_value("BEI Vehicle", vehicle, "vehicle_plate")
-        trip.vehicle = vehicle
-        trip.vehicle_plate = vehicle_plate or ""
-
-    trip.save()
-
-    return {
-        "success": True,
-        "trip": trip.name,
-        "driver": emp.employee_name,
-        "vehicle_plate": trip.vehicle_plate or "",
-    }
+	return {
+		"drivers": result,
+		"summary": {
+			"total": len(result),
+			"available": available_count,
+			"assigned": assigned_count,
+		},
+	}
 
 
 @frappe.whitelist()
-def get_driver_schedule(employee, date_from=None, date_to=None):
-    """
-    Get a specific driver's schedule over a date range.
+def assign_driver(trip_name: str, employee: str, vehicle: str | None = None):
+	"""
+	Assign a driver (or helper) to an existing trip.
+	Only valid for trips in "Preparing" status.
 
-    Args:
-        employee:  Employee name
-        date_from: Start date (defaults to Monday of current week)
-        date_to:   End date (defaults to Sunday of current week)
+	Args:
+	    trip_name: BEI Distribution Trip name
+	    employee:  Employee name (Link field)
+	    vehicle:   Optional BEI Vehicle name — updates vehicle_plate automatically
 
-    Returns:
-        {
-            "employee": {...},
-            "days": [
-                {
-                    "date": "2026-02-17",
-                    "status": "Available" | "Assigned" | "Off-Duty",
-                    "trip": {...} or null
-                },
-                ...
-            ]
-        }
-    """
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view driver schedules")
+	Returns:
+	    {"success": True, "trip": trip_name, "driver": employee_name}
+	"""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "assign drivers to trips")
 
-    from frappe.utils import getdate, add_days, get_first_day_of_week
+	# Validate employee exists and has a driver designation
+	emp = frappe.db.get_value(
+		"Employee",
+		{"name": employee, "status": "Active"},
+		["name", "employee_name", "designation"],
+		as_dict=True,
+	)
+	if not emp:
+		frappe.throw(_("Employee {0} not found or not active").format(employee))
 
-    today = getdate(nowdate())
+	if emp.designation not in DRIVER_DESIGNATIONS:
+		frappe.throw(
+			_("Employee {0} does not have a driver designation ({1})").format(
+				emp.employee_name, emp.designation
+			)
+		)
 
-    if date_from:
-        start = getdate(date_from)
-    else:
-        # Default to Monday of current week
-        weekday = today.weekday()  # Monday=0
-        start = add_days(today, -weekday)
+	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
 
-    if date_to:
-        end = getdate(date_to)
-    else:
-        # Default to Sunday of current week
-        end = add_days(start, 6)
+	if trip.status not in ("Preparing", "In Transit"):
+		frappe.throw(_("Cannot reassign driver: trip {0} is in status '{1}'").format(trip_name, trip.status))
 
-    # Validate employee
-    emp = frappe.db.get_value(
-        "Employee",
-        employee,
-        ["name", "employee_name", "designation", "status", "cell_phone"],
-        as_dict=True
-    )
-    if not emp:
-        frappe.throw(_("Employee {0} not found").format(employee))
+	trip.driver = employee
 
-    # Get all trips assigned to this driver in range
-    trips = frappe.get_all(
-        "BEI Distribution Trip",
-        filters={
-            "driver": employee,
-            "trip_date": ["between", [str(start), str(end)]]
-        },
-        fields=["name", "trip_date", "route_name", "departure_time", "vehicle_plate", "status"]
-    )
+	if vehicle:
+		vehicle_plate = frappe.db.get_value("BEI Vehicle", vehicle, "vehicle_plate")
+		trip.vehicle = vehicle
+		trip.vehicle_plate = vehicle_plate or ""
 
-    trip_by_date = {str(t.trip_date): t for t in trips}
+	trip.save()
 
-    # Build day-by-day schedule
-    days = []
-    current = start
-    while current <= end:
-        date_str = str(current)
-        trip = trip_by_date.get(date_str)
+	return {
+		"success": True,
+		"trip": trip.name,
+		"driver": emp.employee_name,
+		"vehicle_plate": trip.vehicle_plate or "",
+	}
 
-        if emp.status != "Active":
-            day_status = "Off-Duty"
-        elif trip:
-            day_status = "Assigned"
-        else:
-            day_status = "Available"
 
-        day_entry = {
-            "date": date_str,
-            "status": day_status,
-            "trip": {
-                "name": trip.name,
-                "route_name": trip.route_name,
-                "departure_time": str(trip.departure_time) if trip.departure_time else None,
-                "vehicle_plate": trip.vehicle_plate or "",
-                "status": trip.status,
-            } if trip else None
-        }
-        days.append(day_entry)
-        current = add_days(current, 1)
+@frappe.whitelist()
+def get_driver_schedule(employee: str, date_from: str | None = None, date_to: str | None = None):
+	"""
+	Get a specific driver's schedule over a date range.
 
-    return {
-        "employee": {
-            "name": emp.name,
-            "employee_name": emp.employee_name,
-            "designation": emp.designation,
-            "status": emp.status,
-            "cell_phone": emp.cell_phone or "",
-        },
-        "date_from": str(start),
-        "date_to": str(end),
-        "days": days,
-    }
+	Args:
+	    employee:  Employee name
+	    date_from: Start date (defaults to Monday of current week)
+	    date_to:   End date (defaults to Sunday of current week)
+
+	Returns:
+	    {
+	        "employee": {...},
+	        "days": [
+	            {
+	                "date": "2026-02-17",
+	                "status": "Available" | "Assigned" | "Off-Duty",
+	                "trip": {...} or null
+	            },
+	            ...
+	        ]
+	    }
+	"""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view driver schedules")
+
+	from frappe.utils import add_days, get_first_day_of_week, getdate
+
+	today = getdate(nowdate())
+
+	if date_from:
+		start = getdate(date_from)
+	else:
+		# Default to Monday of current week
+		weekday = today.weekday()  # Monday=0
+		start = add_days(today, -weekday)
+
+	if date_to:
+		end = getdate(date_to)
+	else:
+		# Default to Sunday of current week
+		end = add_days(start, 6)
+
+	# Validate employee
+	emp = frappe.db.get_value(
+		"Employee", employee, ["name", "employee_name", "designation", "status", "cell_phone"], as_dict=True
+	)
+	if not emp:
+		frappe.throw(_("Employee {0} not found").format(employee))
+
+	# Get all trips assigned to this driver in range
+	trips = frappe.get_all(
+		"BEI Distribution Trip",
+		filters={"driver": employee, "trip_date": ["between", [str(start), str(end)]]},
+		fields=["name", "trip_date", "route_name", "departure_time", "vehicle_plate", "status"],
+	)
+
+	trip_by_date = {str(t.trip_date): t for t in trips}
+
+	# Build day-by-day schedule
+	days = []
+	current = start
+	while current <= end:
+		date_str = str(current)
+		trip = trip_by_date.get(date_str)
+
+		if emp.status != "Active":
+			day_status = "Off-Duty"
+		elif trip:
+			day_status = "Assigned"
+		else:
+			day_status = "Available"
+
+		day_entry = {
+			"date": date_str,
+			"status": day_status,
+			"trip": {
+				"name": trip.name,
+				"route_name": trip.route_name,
+				"departure_time": str(trip.departure_time) if trip.departure_time else None,
+				"vehicle_plate": trip.vehicle_plate or "",
+				"status": trip.status,
+			}
+			if trip
+			else None,
+		}
+		days.append(day_entry)
+		current = add_days(current, 1)
+
+	return {
+		"employee": {
+			"name": emp.name,
+			"employee_name": emp.employee_name,
+			"designation": emp.designation,
+			"status": emp.status,
+			"cell_phone": emp.cell_phone or "",
+		},
+		"date_from": str(start),
+		"date_to": str(end),
+		"days": days,
+	}
 
 
 @frappe.whitelist()
 def get_warehouses():
-    """Get warehouses that have active department mappings (valid for trip stops)."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view warehouses")
-    return frappe.get_all(
-        "BEI Warehouse Department Mapping",
-        filters={"is_active": 1},
-        fields=["warehouse as name", "warehouse as warehouse_name", "department"],
-        order_by="warehouse"
-    )
+	"""Get warehouses valid for trip routes/stops.
+
+	Primary source: active `BEI Warehouse Department Mapping`.
+	Fallback: leaf warehouses in `Warehouse` when mapping data is incomplete.
+	"""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view warehouses")
+	mapped = frappe.get_all(
+		"BEI Warehouse Department Mapping",
+		filters={"is_active": 1},
+		fields=["warehouse as name", "warehouse as warehouse_name", "department"],
+		order_by="warehouse",
+	)
+
+	resolved_mapped = []
+	seen = set()
+	for row in mapped:
+		resolved_name = _resolve_store_to_warehouse_name(row.name)
+		if not resolved_name or resolved_name in seen:
+			continue
+		seen.add(resolved_name)
+		resolved_mapped.append(
+			{
+				"name": resolved_name,
+				"warehouse_name": frappe.db.get_value("Warehouse", resolved_name, "warehouse_name")
+				or resolved_name,
+				"department": row.department,
+			}
+		)
+
+	if resolved_mapped:
+		return resolved_mapped
+
+	fallback = frappe.get_all(
+		"Warehouse", filters={"is_group": 0}, fields=["name", "warehouse_name"], order_by="name"
+	)
+	return [
+		{
+			"name": row.name,
+			"warehouse_name": row.warehouse_name or row.name,
+			"department": None,
+		}
+		for row in fallback
+	]
+
+
+def _canonical_store_key(value: Any):
+	"""Normalize store labels for resilient matching across naming variants."""
+	if not value:
+		return ""
+	return "".join(ch for ch in str(value).strip().lower() if ch.isalnum())
+
+
+def _strip_legacy_company_suffix(store_name: str | None):
+	"""Strip common company suffixes from legacy store labels."""
+	if not store_name:
+		return ""
+	text = str(store_name).strip()
+	upper = text.upper()
+	suffixes = (
+		" - BEI",
+		"- BEI",
+		" - BK",
+		"- BK",
+		" - BEBANG ENTERPRISE INC.",
+		"- BEBANG ENTERPRISE INC.",
+		" - BEBANG KITCHEN INC.",
+		"- BEBANG KITCHEN INC.",
+	)
+	for suffix in suffixes:
+		if upper.endswith(suffix):
+			return text[: len(text) - len(suffix)].strip(" -")
+	return text
+
+
+def _resolve_store_to_warehouse_name(store_name: str | None):
+	"""Resolve a store label from BEI Store Type to a valid Warehouse name."""
+	if not store_name:
+		return None
+
+	raw = str(store_name).strip()
+
+	# 1) exact warehouse docname
+	if frappe.db.exists("Warehouse", raw):
+		return raw
+
+	# 2) exact docname, case-insensitive
+	exact_ci = frappe.db.sql(
+		"""
+        SELECT name
+        FROM `tabWarehouse`
+        WHERE LOWER(name) = LOWER(%s)
+        LIMIT 1
+        """,
+		(raw,),
+		as_dict=True,
+	)
+	if exact_ci:
+		return exact_ci[0].name
+
+	# 3) common explicit suffix candidates based on stripped base label
+	base = _strip_legacy_company_suffix(raw)
+	candidates = (
+		base,
+		f"{base} - BEI" if base else "",
+		f"{base} - BK" if base else "",
+		f"{base} - Bebang Enterprise Inc." if base else "",
+		f"{base} - Bebang Kitchen Inc." if base else "",
+	)
+	for candidate in candidates:
+		if candidate and frappe.db.exists("Warehouse", candidate):
+			return candidate
+
+	# 4) warehouse_name exact/case-insensitive match
+	by_warehouse_name = frappe.db.sql(
+		"""
+        SELECT name
+        FROM `tabWarehouse`
+        WHERE is_group = 0
+          AND LOWER(warehouse_name) = LOWER(%s)
+        LIMIT 1
+        """,
+		(base or raw,),
+		as_dict=True,
+	)
+	if by_warehouse_name:
+		return by_warehouse_name[0].name
+
+	# 5) canonical fallback (handles punctuation/case/suffix differences)
+	target_keys = {k for k in (_canonical_store_key(raw), _canonical_store_key(base)) if k}
+	if target_keys:
+		for row in frappe.get_all(
+			"Warehouse",
+			filters={"is_group": 0},
+			fields=["name", "warehouse_name"],
+			order_by="name",
+		):
+			if _canonical_store_key(row.name) in target_keys:
+				return row.name
+			if _canonical_store_key(row.warehouse_name or "") in target_keys:
+				return row.name
+
+	# 6) legacy fallback for old behavior
+	if frappe.db.exists("Warehouse", store_name):
+		return store_name
+
+	# common BEI suffix
+	with_bei = f"{store_name} - BEI"
+	if frappe.db.exists("Warehouse", with_bei):
+		return with_bei
+
+	# warehouse_name match
+	return frappe.db.get_value("Warehouse", {"warehouse_name": store_name, "is_group": 0}, "name")
 
 
 @frappe.whitelist()
 def get_stores():
-    """Get list of stores for route stop selection."""
-    _check_scm_permission(SCM_DISPATCH_ROLES, "view stores")
-    return frappe.get_all(
-        "BEI Store Type",
-        fields=["store as name", "store", "store_type"],
-        order_by="store"
-    )
+	"""Get route-stop candidates as valid Warehouse link values.
+
+	`BEI Route Stop.store` links to `Warehouse`. `BEI Store Type.store` is a
+	Department-style label, so we resolve each entry to an actual warehouse docname.
+	"""
+	_check_scm_permission(SCM_DISPATCH_ROLES, "view stores")
+	rows = frappe.get_all("BEI Store Type", fields=["store", "store_type"], order_by="store")
+
+	stores = []
+	seen = set()
+	for row in rows:
+		warehouse_name = _resolve_store_to_warehouse_name(row.store)
+		if not warehouse_name or warehouse_name in seen:
+			continue
+		seen.add(warehouse_name)
+		stores.append(
+			{
+				"name": warehouse_name,
+				"store": warehouse_name,
+				"store_type": row.store_type,
+				"store_label": row.store,
+			}
+		)
+
+	if stores:
+		return stores
+
+	# Hard fallback to avoid empty selector when Store Type to Warehouse mapping is stale.
+	return [
+		{
+			"name": row["name"],
+			"store": row["name"],
+			"store_type": "Unknown",
+			"store_label": row.get("warehouse_name") or row["name"],
+		}
+		for row in get_warehouses()
+	]

--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -5,340 +5,1015 @@ These endpoints receive data from the Sheets Receiver service
 and sync it to ERPNext DocTypes.
 """
 
+import hashlib
+import json
+from typing import Any
+
 import frappe
 from frappe import _
-from frappe.utils import now_datetime, flt, cint
-from typing import List, Dict, Any
-import json
+from frappe.utils import cint, flt, getdate, now_datetime, nowdate
+
+_FIELD_CACHE: dict[tuple, bool] = {}
+ROOT_TYPES = {"Asset", "Liability", "Equity", "Income", "Expense"}
+AP_OPENING_ITEM_CODE = "ERP-SYNC-AP-OPENING"
+SYNC_ALLOWED_ROLES = {
+	"System Manager",
+	"Accounts Manager",
+	"Accounts User",
+	"HR Manager",
+}
+
+
+def _parse_rows(data: Any) -> list[dict[str, Any]]:
+	if isinstance(data, str):
+		parsed = json.loads(data)
+		return parsed if isinstance(parsed, list) else []
+	if isinstance(data, list):
+		return data
+	return []
+
+
+def _init_results(rows_processed: int) -> dict[str, Any]:
+	return {
+		"rows_processed": rows_processed,
+		"rows_created": 0,
+		"rows_updated": 0,
+		"rows_failed": 0,
+		"errors": [],
+	}
+
+
+def _first_non_empty(row: dict[str, Any], *keys: str) -> Any | None:
+	for key in keys:
+		value = row.get(key)
+		if value is None:
+			continue
+		if isinstance(value, str) and not value.strip():
+			continue
+		return value
+	return None
+
+
+def _safe_date(value: Any) -> str | None:
+	if value in (None, ""):
+		return None
+	try:
+		return str(getdate(value))
+	except Exception:
+		return None
+
+
+def _is_duplicate_error(exc: Exception) -> bool:
+	duplicate_cls = getattr(frappe, "DuplicateEntryError", None)
+	if duplicate_cls and isinstance(exc, duplicate_cls):
+		return True
+	message = str(exc).lower()
+	return "duplicate" in message and "entry" in message
+
+
+def _sync_ref(prefix: str, sheet_name: str, checksum: str, row_key: str) -> str:
+	digest = hashlib.sha1(f"{sheet_name}|{checksum}|{row_key}".encode()).hexdigest()[:16]
+	return f"{prefix}:{digest}"
+
+
+def _make_savepoint(prefix: str, row_key: str) -> str:
+	digest = hashlib.sha1(f"{prefix}|{row_key}".encode()).hexdigest()[:12]
+	return f"{prefix}_{digest}"
+
+
+def _release_savepoint(name: str) -> None:
+	try:
+		frappe.db.release_savepoint(name)
+	except Exception:
+		# Savepoint release availability differs by backend/version; rollback still works.
+		pass
+
+
+def _assert_sync_authorized() -> None:
+	user = frappe.session.user or "Guest"
+	if user == "Guest":
+		frappe.throw(_("Authentication is required for ERP sync endpoints"), frappe.PermissionError)
+
+	if user == "Administrator":
+		return
+
+	user_roles = set(frappe.get_roles(user))
+	if user_roles.intersection(SYNC_ALLOWED_ROLES):
+		return
+
+	frappe.throw(_("You are not allowed to execute ERP sync endpoints"), frappe.PermissionError)
+
+
+def _doctype_has_field(doctype: str, fieldname: str) -> bool:
+	cache_key = (doctype, fieldname)
+	if cache_key in _FIELD_CACHE:
+		return _FIELD_CACHE[cache_key]
+
+	has_field = False
+	try:
+		has_field = bool(frappe.get_meta(doctype).has_field(fieldname))
+	except Exception:
+		has_field = False
+
+	_FIELD_CACHE[cache_key] = has_field
+	return has_field
+
+
+def _first_available_field(doctype: str, candidates: list[str]) -> str | None:
+	for fieldname in candidates:
+		if _doctype_has_field(doctype, fieldname):
+			return fieldname
+	return None
+
+
+def _normalize_company(company: str | None = None) -> str:
+	if company and frappe.db.exists("Company", company):
+		return company
+
+	default_company = None
+	try:
+		default_company = frappe.defaults.get_global_default("company")
+	except Exception:
+		default_company = None
+
+	if default_company and frappe.db.exists("Company", default_company):
+		return default_company
+
+	try:
+		companies = frappe.get_all("Company", pluck="name", limit=1)
+	except Exception:
+		companies = []
+
+	if companies:
+		return companies[0]
+
+	frappe.throw(_("Default company is required for ERP sync writes"))
+
+
+def _resolve_warehouse(raw_value: str | None) -> str | None:
+	value = (raw_value or "").strip()
+	if not value:
+		if frappe.db.exists("Warehouse", "Stores - BEI"):
+			return "Stores - BEI"
+		return frappe.db.get_value("Warehouse", {"is_group": 0}, "name")
+
+	if frappe.db.exists("Warehouse", value):
+		return value
+
+	if not value.endswith(" - BEI"):
+		candidate = f"{value} - BEI"
+		if frappe.db.exists("Warehouse", candidate):
+			return candidate
+
+	return None
+
+
+def _resolve_root_type(account_type: str | None, gl_code: str | None, row: dict[str, Any]) -> str:
+	explicit = _first_non_empty(row, "root_type")
+	if explicit in ROOT_TYPES:
+		return explicit
+
+	normalized = (account_type or "").strip().lower()
+	if any(token in normalized for token in ("asset", "receivable", "bank", "cash")):
+		return "Asset"
+	if any(token in normalized for token in ("liability", "payable")):
+		return "Liability"
+	if "equity" in normalized:
+		return "Equity"
+	if any(token in normalized for token in ("income", "revenue", "sale")):
+		return "Income"
+	if any(token in normalized for token in ("expense", "cost", "cogs")):
+		return "Expense"
+
+	leading = str(gl_code or "")[:1]
+	if leading == "1":
+		return "Asset"
+	if leading == "2":
+		return "Liability"
+	if leading == "3":
+		return "Equity"
+	if leading == "4":
+		return "Income"
+	if leading in {"5", "6", "7", "8", "9"}:
+		return "Expense"
+	return "Asset"
+
+
+def _resolve_parent_account(row: dict[str, Any], company: str, root_type: str) -> str | None:
+	parent_name = _first_non_empty(row, "parent_account", "parent")
+	if parent_name and frappe.db.exists("Account", parent_name):
+		return parent_name
+
+	parent_code = _first_non_empty(row, "parent_gl_code", "parent_account_code")
+	if parent_code:
+		parent = frappe.db.get_value(
+			"Account",
+			{"company": company, "account_number": parent_code},
+			"name",
+		)
+		if parent:
+			return parent
+
+	return frappe.db.get_value(
+		"Account",
+		{"company": company, "root_type": root_type, "is_group": 1},
+		"name",
+	)
+
+
+def _report_type_for(root_type: str) -> str:
+	if root_type in {"Income", "Expense"}:
+		return "Profit and Loss"
+	return "Balance Sheet"
+
+
+def _ensure_bank(bank_name: str | None) -> str | None:
+	if not bank_name:
+		return None
+
+	normalized = str(bank_name).strip()
+	if not normalized:
+		return None
+
+	if frappe.db.exists("Bank", normalized):
+		return normalized
+
+	existing = frappe.db.get_value("Bank", {"bank_name": normalized}, "name")
+	if existing:
+		return existing
+
+	bank = frappe.get_doc({"doctype": "Bank", "bank_name": normalized})
+	try:
+		bank.insert(ignore_permissions=True)
+		return bank.name
+	except Exception as exc:
+		if _is_duplicate_error(exc):
+			return frappe.db.get_value("Bank", {"bank_name": normalized}, "name")
+		raise
+
+
+def _ensure_supplier(supplier_name: str) -> str:
+	if frappe.db.exists("Supplier", supplier_name):
+		return supplier_name
+
+	existing = frappe.db.get_value("Supplier", {"supplier_name": supplier_name}, "name")
+	if existing:
+		return existing
+
+	supplier_group = frappe.db.get_value("Supplier Group", {"is_group": 0}, "name") or "All Supplier Groups"
+	supplier = frappe.get_doc(
+		{
+			"doctype": "Supplier",
+			"supplier_name": supplier_name,
+			"supplier_group": supplier_group,
+			"supplier_type": "Company",
+		}
+	)
+	try:
+		supplier.insert(ignore_permissions=True)
+		return supplier.name
+	except Exception as exc:
+		if _is_duplicate_error(exc):
+			return frappe.db.get_value("Supplier", {"supplier_name": supplier_name}, "name")
+		raise
+
+
+def _default_expense_account(company: str) -> str | None:
+	return frappe.db.get_value(
+		"Account",
+		{"company": company, "root_type": "Expense", "is_group": 0},
+		"name",
+	) or frappe.db.get_value(
+		"Account",
+		{"company": company, "account_type": "Expense Account", "is_group": 0},
+		"name",
+	)
+
+
+def _default_payable_account(company: str) -> str | None:
+	return frappe.db.get_value(
+		"Account",
+		{"company": company, "account_type": "Payable", "is_group": 0},
+		"name",
+	) or frappe.db.get_value(
+		"Account",
+		{"company": company, "root_type": "Liability", "is_group": 0},
+		"name",
+	)
+
+
+def _default_cost_center(company: str) -> str | None:
+	return frappe.db.get_value("Company", company, "cost_center") or frappe.db.get_value(
+		"Cost Center", {"company": company, "is_group": 0}, "name"
+	)
+
+
+def _ensure_ap_opening_item() -> str:
+	if frappe.db.exists("Item", AP_OPENING_ITEM_CODE):
+		return AP_OPENING_ITEM_CODE
+
+	item_group = frappe.db.get_value("Item Group", {"is_group": 0}, "name") or "All Item Groups"
+	item = frappe.get_doc(
+		{
+			"doctype": "Item",
+			"item_code": AP_OPENING_ITEM_CODE,
+			"item_name": "AP Opening Balance Sync Item",
+			"item_group": item_group,
+			"stock_uom": "Nos",
+			"is_stock_item": 0,
+			"is_purchase_item": 1,
+			"is_sales_item": 0,
+		}
+	)
+	try:
+		item.insert(ignore_permissions=True)
+		return item.name
+	except Exception as exc:
+		if _is_duplicate_error(exc):
+			return AP_OPENING_ITEM_CODE
+		raise
 
 
 @frappe.whitelist()
-def sync_ar_aging(sheet_name: str, data: List[Dict], checksum: str, **kwargs) -> Dict:
-    """
-    Sync AR Aging data from Google Sheets.
+def sync_ar_aging(sheet_name: str, data: list[dict], checksum: str, **kwargs) -> dict:
+	"""
+	Sync AR Aging data from Google Sheets.
 
-    Creates/updates Sales Invoice outstanding amounts.
-    """
-    if isinstance(data, str):
-        data = json.loads(data)
+	Creates/updates Sales Invoice outstanding amounts.
+	"""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	results = _init_results(len(rows))
+	seen_invoice_keys: set[str] = set()
 
-    results = {
-        'rows_processed': len(data),
-        'rows_created': 0,
-        'rows_updated': 0,
-        'rows_failed': 0,
-        'errors': []
-    }
+	outstanding_field = _first_available_field(
+		"Sales Invoice",
+		[
+			"outstanding_amount",
+			"custom_external_outstanding",
+			"custom_ar_outstanding",
+			"custom_sheet_outstanding",
+		],
+	)
+	base_outstanding_field = _first_available_field(
+		"Sales Invoice",
+		[
+			"base_outstanding_amount",
+			"custom_base_external_outstanding",
+		],
+	)
+	days_overdue_field = _first_available_field(
+		"Sales Invoice",
+		[
+			"custom_days_overdue",
+			"custom_ar_days_overdue",
+		],
+	)
 
-    for row in data:
-        try:
-            # Map sheet columns to ERPNext fields
-            invoice_no = row.get('invoice_no') or row.get('invoice_number')
-            customer = row.get('customer') or row.get('customer_name')
-            outstanding = flt(row.get('outstanding') or row.get('balance') or 0)
-            due_date = row.get('due_date')
+	for row in rows:
+		invoice_no = str(_first_non_empty(row, "invoice_no", "invoice_number", "name") or "").strip()
+		if invoice_no and invoice_no in seen_invoice_keys:
+			results["rows_updated"] += 1
+			continue
+		if invoice_no:
+			seen_invoice_keys.add(invoice_no)
 
-            if not invoice_no:
-                continue
+		savepoint = _make_savepoint("sync_ar", f"{sheet_name}|{checksum}|{invoice_no or 'unknown'}")
+		frappe.db.savepoint(savepoint)
+		try:
+			outstanding = flt(_first_non_empty(row, "outstanding", "balance", "outstanding_amount") or 0)
+			due_date = _safe_date(_first_non_empty(row, "due_date"))
+			days_overdue = cint(_first_non_empty(row, "days_overdue", "overdue_days") or 0)
 
-            # Check if invoice exists
-            if frappe.db.exists('Sales Invoice', invoice_no):
-                # Update outstanding tracking (custom doctype or field)
-                # For now, just log it
-                frappe.log_error(
-                    message=f"AR Aging Update: {invoice_no} = {outstanding}",
-                    title="AR Sync"
-                )
-                results['rows_updated'] += 1
-            else:
-                # Log missing invoices
-                frappe.log_error(
-                    message=f"Invoice not found: {invoice_no}",
-                    title="AR Sync - Missing"
-                )
-                results['rows_failed'] += 1
+			if not invoice_no:
+				results["rows_failed"] += 1
+				results["errors"].append("Missing invoice_no in AR row")
+				_release_savepoint(savepoint)
+				continue
 
-        except Exception as e:
-            results['errors'].append(f"{row.get('invoice_no', 'unknown')}: {str(e)}")
-            results['rows_failed'] += 1
+			invoice_name = frappe.db.exists("Sales Invoice", invoice_no)
+			if not invoice_name:
+				invoice_name = frappe.db.get_value("Sales Invoice", {"name": invoice_no}, "name")
 
-    # Log sync completion
-    frappe.logger().info(f"AR Aging sync complete: {results}")
+			if not invoice_name:
+				results["rows_failed"] += 1
+				results["errors"].append(f"Invoice not found: {invoice_no}")
+				_release_savepoint(savepoint)
+				continue
 
-    return results
+			updates: dict[str, Any] = {}
+			if outstanding_field:
+				updates[outstanding_field] = outstanding
 
+			if base_outstanding_field:
+				conversion_rate = flt(
+					frappe.db.get_value("Sales Invoice", invoice_name, "conversion_rate") or 1
+				)
+				updates[base_outstanding_field] = outstanding * conversion_rate
 
-@frappe.whitelist()
-def sync_inventory(sheet_name: str, data: List[Dict], checksum: str, **kwargs) -> Dict:
-    """
-    Sync Inventory data from Google Sheets.
+			if due_date and _doctype_has_field("Sales Invoice", "due_date"):
+				updates["due_date"] = due_date
 
-    Updates stock levels via Stock Reconciliation.
-    """
-    if isinstance(data, str):
-        data = json.loads(data)
+			if days_overdue_field:
+				updates[days_overdue_field] = days_overdue
 
-    results = {
-        'rows_processed': len(data),
-        'rows_created': 0,
-        'rows_updated': 0,
-        'rows_failed': 0,
-        'errors': []
-    }
+			sync_token_field = _first_available_field(
+				"Sales Invoice",
+				["custom_ar_sync_ref", "custom_last_sync_checksum"],
+			)
+			if sync_token_field:
+				sync_ref = _sync_ref("AR", sheet_name, checksum, str(invoice_no))
+				existing_sync_ref = frappe.db.get_value("Sales Invoice", invoice_name, sync_token_field)
+				if existing_sync_ref == sync_ref:
+					results["rows_updated"] += 1
+					_release_savepoint(savepoint)
+					continue
+				updates[sync_token_field] = sync_ref
 
-    # Group by warehouse for efficient processing
-    items_by_warehouse = {}
+			if updates:
+				frappe.db.set_value("Sales Invoice", invoice_name, updates, update_modified=False)
 
-    for row in data:
-        try:
-            item_code = row.get('item_code') or row.get('sku')
-            warehouse = row.get('warehouse') or row.get('location') or 'Stores - BEI'
-            qty = flt(row.get('qty') or row.get('quantity') or row.get('stock') or 0)
+			results["rows_updated"] += 1
+			_release_savepoint(savepoint)
 
-            if not item_code:
-                continue
+		except Exception as e:
+			frappe.db.rollback(save_point=savepoint)
+			results["errors"].append(f"{row.get('invoice_no', 'unknown')}: {e!s}")
+			results["rows_failed"] += 1
 
-            if warehouse not in items_by_warehouse:
-                items_by_warehouse[warehouse] = []
-
-            items_by_warehouse[warehouse].append({
-                'item_code': item_code,
-                'warehouse': warehouse,
-                'qty': qty
-            })
-
-        except Exception as e:
-            results['errors'].append(str(e))
-            results['rows_failed'] += 1
-
-    # Create stock reconciliation for each warehouse
-    for warehouse, items in items_by_warehouse.items():
-        try:
-            # For now, log the data (actual reconciliation needs careful handling)
-            frappe.log_error(
-                message=f"Inventory sync for {warehouse}: {len(items)} items",
-                title="Inventory Sync"
-            )
-            results['rows_updated'] += len(items)
-
-        except Exception as e:
-            results['errors'].append(f"{warehouse}: {str(e)}")
-            results['rows_failed'] += len(items)
-
-    return results
+	frappe.logger().info(f"AR Aging sync complete: {results}")
+	return results
 
 
 @frappe.whitelist()
-def sync_coa(sheet_name: str, data: List[Dict], checksum: str, **kwargs) -> Dict:
-    """
-    Sync Chart of Accounts from Google Sheets.
+def sync_inventory(sheet_name: str, data: list[dict], checksum: str, **kwargs) -> dict:
+	"""
+	Sync Inventory data from Google Sheets.
 
-    Creates/updates Account DocType.
-    """
-    if isinstance(data, str):
-        data = json.loads(data)
+	Updates stock levels via Stock Reconciliation.
+	"""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	results = _init_results(len(rows))
 
-    results = {
-        'rows_processed': len(data),
-        'rows_created': 0,
-        'rows_updated': 0,
-        'rows_failed': 0,
-        'errors': []
-    }
+	items_by_warehouse: dict[str, dict[str, dict[str, Any]]] = {}
 
-    for row in data:
-        try:
-            gl_code = row.get('gl_code') or row.get('account_code')
-            account_name = row.get('gl_description') or row.get('account_name')
-            account_type = row.get('accounttype') or row.get('account_type')
+	for row in rows:
+		try:
+			item_code = _first_non_empty(row, "item_code", "sku")
+			warehouse = _resolve_warehouse(_first_non_empty(row, "warehouse", "location", "store"))
+			qty = flt(_first_non_empty(row, "qty", "quantity", "stock") or 0)
 
-            if not gl_code or not account_name:
-                continue
+			if not item_code:
+				results["rows_failed"] += 1
+				results["errors"].append("Missing item_code in inventory row")
+				continue
 
-            # Check if account exists
-            existing = frappe.db.get_value(
-                'Account',
-                {'account_number': gl_code},
-                'name'
-            )
+			if not frappe.db.exists("Item", item_code):
+				results["rows_failed"] += 1
+				results["errors"].append(f"Item not found: {item_code}")
+				continue
 
-            if existing:
-                # Account exists - could update if needed
-                results['rows_updated'] += 1
-            else:
-                # Log new accounts (actual creation needs parent account logic)
-                frappe.log_error(
-                    message=f"New account needed: {gl_code} - {account_name}",
-                    title="COA Sync - New Account"
-                )
-                results['rows_created'] += 1
+			if not warehouse:
+				results["rows_failed"] += 1
+				results["errors"].append(f"Warehouse not found for item {item_code}")
+				continue
 
-        except Exception as e:
-            results['errors'].append(f"{row.get('gl_code', 'unknown')}: {str(e)}")
-            results['rows_failed'] += 1
+			if warehouse not in items_by_warehouse:
+				items_by_warehouse[warehouse] = {}
 
-    return results
+			# Last row wins for repeated item+warehouse rows in same payload.
+			items_by_warehouse[warehouse][item_code] = {
+				"item_code": item_code,
+				"warehouse": warehouse,
+				"qty": qty,
+			}
+
+		except Exception as e:
+			results["errors"].append(str(e))
+			results["rows_failed"] += 1
+
+	for warehouse, items_map in items_by_warehouse.items():
+		items = list(items_map.values())
+		sync_ref = _sync_ref("INV", sheet_name, checksum, warehouse)
+		savepoint = _make_savepoint("sync_inv", f"{sheet_name}|{checksum}|{warehouse}")
+		frappe.db.savepoint(savepoint)
+		try:
+			existing = frappe.db.get_value(
+				"Stock Reconciliation",
+				{"remarks": ["like", f"%{sync_ref}%"], "docstatus": ["<", 2]},
+				"name",
+			)
+
+			if existing:
+				results["rows_updated"] += len(items)
+				_release_savepoint(savepoint)
+				continue
+
+			sr = frappe.new_doc("Stock Reconciliation")
+			sr.purpose = "Stock Reconciliation"
+			sr.posting_date = nowdate()
+			sr.posting_time = now_datetime().strftime("%H:%M:%S")
+			sr.company = _normalize_company()
+			sr.remarks = (
+				f"ERP Inventory Sync ({sync_ref}) "
+				f"sheet={sheet_name} warehouse={warehouse} rows={len(items)}"
+			)
+
+			for item in items:
+				sr.append(
+					"items",
+					{
+						"item_code": item["item_code"],
+						"warehouse": warehouse,
+						"qty": item["qty"],
+					},
+				)
+
+			sr.insert(ignore_permissions=True)
+			sr.submit()
+			results["rows_created"] += len(items)
+			_release_savepoint(savepoint)
+
+		except Exception as exc:
+			frappe.db.rollback(save_point=savepoint)
+			if _is_duplicate_error(exc):
+				existing = frappe.db.get_value(
+					"Stock Reconciliation",
+					{"remarks": ["like", f"%{sync_ref}%"]},
+					"name",
+				)
+				if existing:
+					results["rows_updated"] += len(items)
+					continue
+			results["errors"].append(f"{warehouse}: {exc!s}")
+			results["rows_failed"] += len(items)
+
+	return results
 
 
 @frappe.whitelist()
-def sync_bank_accounts(sheet_name: str, data: List[Dict], checksum: str, **kwargs) -> Dict:
-    """
-    Sync Bank Directory from Google Sheets.
+def sync_coa(sheet_name: str, data: list[dict], checksum: str, **kwargs) -> dict:
+	"""
+	Sync Chart of Accounts from Google Sheets.
 
-    Creates/updates Bank Account DocType.
-    """
-    if isinstance(data, str):
-        data = json.loads(data)
+	Creates/updates Account DocType.
+	"""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	results = _init_results(len(rows))
+	seen_account_keys: set[str] = set()
 
-    results = {
-        'rows_processed': len(data),
-        'rows_created': 0,
-        'rows_updated': 0,
-        'rows_failed': 0,
-        'errors': []
-    }
+	for row in rows:
+		savepoint: str | None = None
+		try:
+			gl_code = _first_non_empty(row, "gl_code", "account_code")
+			account_name = _first_non_empty(row, "gl_description", "account_name")
+			account_type = _first_non_empty(row, "accounttype", "account_type")
+			company = _normalize_company(_first_non_empty(row, "company"))
+			dedupe_key = f"{company}|{gl_code}"
+			if gl_code and dedupe_key in seen_account_keys:
+				results["rows_updated"] += 1
+				continue
+			if gl_code:
+				seen_account_keys.add(dedupe_key)
 
-    for row in data:
-        try:
-            account_number = row.get('account_number') or row.get('account_no')
-            account_name = row.get('account_name')
-            bank_name = row.get('bank_name') or row.get('bank')
-            branch = row.get('branch_name') or row.get('branch')
+			savepoint = _make_savepoint("sync_coa", f"{sheet_name}|{checksum}|{dedupe_key}")
+			frappe.db.savepoint(savepoint)
 
-            if not account_number:
-                continue
+			root_type = _resolve_root_type(str(account_type or ""), str(gl_code or ""), row)
+			parent_account = _resolve_parent_account(row, company, root_type)
+			report_type = _report_type_for(root_type)
+			is_group = cint(_first_non_empty(row, "is_group", "group") or 0)
 
-            # Check if bank account exists
-            existing = frappe.db.get_value(
-                'Bank Account',
-                {'bank_account_no': account_number},
-                'name'
-            )
+			if not gl_code or not account_name:
+				results["rows_failed"] += 1
+				results["errors"].append("Missing gl_code or account_name in COA row")
+				_release_savepoint(savepoint)
+				continue
 
-            if existing:
-                results['rows_updated'] += 1
-            else:
-                frappe.log_error(
-                    message=f"New bank account: {account_number} - {bank_name}",
-                    title="Bank Sync - New Account"
-                )
-                results['rows_created'] += 1
+			existing = frappe.db.get_value(
+				"Account",
+				{"company": company, "account_number": gl_code},
+				"name",
+			)
 
-        except Exception as e:
-            results['errors'].append(f"{row.get('account_number', 'unknown')}: {str(e)}")
-            results['rows_failed'] += 1
+			if existing:
+				sync_token_field = _first_available_field(
+					"Account", ["custom_sync_ref", "custom_last_sync_checksum"]
+				)
+				sync_ref = _sync_ref("COA", sheet_name, checksum, str(gl_code))
+				if sync_token_field:
+					existing_sync_ref = frappe.db.get_value("Account", existing, sync_token_field)
+					if existing_sync_ref == sync_ref:
+						results["rows_updated"] += 1
+						_release_savepoint(savepoint)
+						continue
 
-    return results
+				updates: dict[str, Any] = {
+					"account_name": account_name,
+					"root_type": root_type,
+					"report_type": report_type,
+					"is_group": is_group,
+				}
+				if account_type and _doctype_has_field("Account", "account_type"):
+					updates["account_type"] = account_type
+				if parent_account:
+					updates["parent_account"] = parent_account
+				if sync_token_field:
+					updates[sync_token_field] = sync_ref
+				frappe.db.set_value("Account", existing, updates, update_modified=False)
+				results["rows_updated"] += 1
+				_release_savepoint(savepoint)
+			else:
+				if not parent_account:
+					raise ValueError(f"Unable to resolve parent account for {gl_code}")
+
+				account = frappe.new_doc("Account")
+				account.account_name = account_name
+				account.account_number = gl_code
+				account.company = company
+				account.parent_account = parent_account
+				account.root_type = root_type
+				account.report_type = report_type
+				account.is_group = is_group
+				if account_type and _doctype_has_field("Account", "account_type"):
+					account.account_type = account_type
+				sync_token_field = _first_available_field(
+					"Account", ["custom_sync_ref", "custom_last_sync_checksum"]
+				)
+				if sync_token_field:
+					setattr(account, sync_token_field, _sync_ref("COA", sheet_name, checksum, str(gl_code)))
+
+				try:
+					account.insert(ignore_permissions=True)
+					results["rows_created"] += 1
+					_release_savepoint(savepoint)
+				except Exception as exc:
+					if _is_duplicate_error(exc):
+						results["rows_updated"] += 1
+						_release_savepoint(savepoint)
+					else:
+						raise
+
+		except Exception as e:
+			if savepoint:
+				frappe.db.rollback(save_point=savepoint)
+			results["errors"].append(f"{row.get('gl_code', 'unknown')}: {e!s}")
+			results["rows_failed"] += 1
+
+	return results
 
 
 @frappe.whitelist()
-def sync_ap_opening(sheet_name: str, data: List[Dict], checksum: str, **kwargs) -> Dict:
-    """
-    Sync AP Opening Balance (Supplier SOA) from Google Sheets.
+def sync_bank_accounts(sheet_name: str, data: list[dict], checksum: str, **kwargs) -> dict:
+	"""
+	Sync Bank Directory from Google Sheets.
 
-    Creates/updates Purchase Invoice entries for opening balances.
-    """
-    if isinstance(data, str):
-        data = json.loads(data)
+	Creates/updates Bank Account DocType.
+	"""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	results = _init_results(len(rows))
+	seen_account_numbers: set[str] = set()
 
-    results = {
-        'rows_processed': len(data),
-        'rows_created': 0,
-        'rows_updated': 0,
-        'rows_failed': 0,
-        'errors': []
-    }
+	for row in rows:
+		savepoint: str | None = None
+		try:
+			account_number = _first_non_empty(row, "account_number", "account_no", "bank_account_no")
+			account_name = _first_non_empty(row, "account_name", "account_holder")
+			bank_name = _first_non_empty(row, "bank_name", "bank")
+			branch = _first_non_empty(row, "branch_name", "branch")
+			company = _normalize_company(_first_non_empty(row, "company"))
+			gl_code = _first_non_empty(row, "gl_code", "account_code", "coa_code")
+			linked_account = None
 
-    for row in data:
-        try:
-            supplier = row.get('supplier') or row.get('supplier_name')
-            invoice_no = row.get('invoice_no') or row.get('reference')
-            amount = flt(row.get('amount') or row.get('balance') or row.get('outstanding') or 0)
+			if not account_number:
+				results["rows_failed"] += 1
+				results["errors"].append("Missing account_number in bank directory row")
+				continue
 
-            if not supplier or not invoice_no:
-                continue
+			account_number = str(account_number).strip()
+			if account_number in seen_account_numbers:
+				results["rows_updated"] += 1
+				continue
+			seen_account_numbers.add(account_number)
 
-            # Log AP data (actual invoice creation is complex)
-            frappe.log_error(
-                message=f"AP Opening: {supplier} - {invoice_no} = {amount}",
-                title="AP Sync"
-            )
-            results['rows_updated'] += 1
+			savepoint = _make_savepoint("sync_bank", f"{sheet_name}|{checksum}|{account_number}")
+			frappe.db.savepoint(savepoint)
 
-        except Exception as e:
-            results['errors'].append(str(e))
-            results['rows_failed'] += 1
+			if gl_code:
+				linked_account = frappe.db.get_value(
+					"Account",
+					{"company": company, "account_number": gl_code},
+					"name",
+				) or (gl_code if frappe.db.exists("Account", gl_code) else None)
 
-    return results
+			bank = _ensure_bank(str(bank_name)) if bank_name else None
+
+			existing = frappe.db.get_value(
+				"Bank Account",
+				{"bank_account_no": account_number},
+				"name",
+			)
+
+			if existing:
+				updates: dict[str, Any] = {}
+				sync_token_field = _first_available_field(
+					"Bank Account",
+					["custom_sync_ref", "custom_last_sync_checksum"],
+				)
+				sync_ref = _sync_ref("BANK", sheet_name, checksum, account_number)
+				if sync_token_field:
+					existing_sync_ref = frappe.db.get_value("Bank Account", existing, sync_token_field)
+					if existing_sync_ref == sync_ref:
+						results["rows_updated"] += 1
+						_release_savepoint(savepoint)
+						continue
+				if account_name:
+					updates["account_name"] = account_name
+				if bank:
+					updates["bank"] = bank
+				if branch:
+					if _doctype_has_field("Bank Account", "branch"):
+						updates["branch"] = branch
+					elif _doctype_has_field("Bank Account", "branch_code"):
+						updates["branch_code"] = branch
+				if linked_account and _doctype_has_field("Bank Account", "account"):
+					updates["account"] = linked_account
+				if _doctype_has_field("Bank Account", "is_company_account"):
+					updates["is_company_account"] = 1
+				if _doctype_has_field("Bank Account", "party_type"):
+					updates["party_type"] = "Company"
+				if _doctype_has_field("Bank Account", "party"):
+					updates["party"] = company
+				if sync_token_field:
+					updates[sync_token_field] = sync_ref
+				if updates:
+					frappe.db.set_value("Bank Account", existing, updates, update_modified=False)
+				results["rows_updated"] += 1
+				_release_savepoint(savepoint)
+			else:
+				bank_account = frappe.new_doc("Bank Account")
+				bank_account.bank_account_no = account_number
+				bank_account.account_name = str(account_name or account_number)
+				if bank:
+					bank_account.bank = bank
+				if branch:
+					if _doctype_has_field("Bank Account", "branch"):
+						bank_account.branch = branch
+					elif _doctype_has_field("Bank Account", "branch_code"):
+						bank_account.branch_code = branch
+				if _doctype_has_field("Bank Account", "is_company_account"):
+					bank_account.is_company_account = 1
+				if _doctype_has_field("Bank Account", "party_type"):
+					bank_account.party_type = "Company"
+				if _doctype_has_field("Bank Account", "party"):
+					bank_account.party = company
+				if linked_account and _doctype_has_field("Bank Account", "account"):
+					bank_account.account = linked_account
+				sync_token_field = _first_available_field(
+					"Bank Account",
+					["custom_sync_ref", "custom_last_sync_checksum"],
+				)
+				if sync_token_field:
+					setattr(
+						bank_account,
+						sync_token_field,
+						_sync_ref("BANK", sheet_name, checksum, account_number),
+					)
+
+				try:
+					bank_account.insert(ignore_permissions=True)
+					results["rows_created"] += 1
+					_release_savepoint(savepoint)
+				except Exception as exc:
+					if _is_duplicate_error(exc):
+						results["rows_updated"] += 1
+						_release_savepoint(savepoint)
+					else:
+						raise
+
+		except Exception as e:
+			if savepoint:
+				frappe.db.rollback(save_point=savepoint)
+			results["errors"].append(f"{row.get('account_number', 'unknown')}: {e!s}")
+			results["rows_failed"] += 1
+
+	return results
 
 
-@frappe.whitelist(allow_guest=True, methods=['POST'])
+@frappe.whitelist()
+def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) -> dict:
+	"""
+	Sync AP Opening Balance (Supplier SOA) from Google Sheets.
+
+	Creates/updates Purchase Invoice entries for opening balances.
+	"""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	results = _init_results(len(rows))
+	opening_item = _ensure_ap_opening_item()
+	seen_supplier_invoice_keys: set[str] = set()
+
+	for row in rows:
+		savepoint: str | None = None
+		try:
+			supplier_input = _first_non_empty(row, "supplier", "supplier_name")
+			invoice_no = _first_non_empty(row, "invoice_no", "reference", "bill_no")
+			amount = flt(_first_non_empty(row, "amount", "balance", "outstanding") or 0)
+			company = _normalize_company(_first_non_empty(row, "company"))
+			dedupe_key = f"{company}|{supplier_input}|{invoice_no}"
+			if supplier_input and invoice_no and dedupe_key in seen_supplier_invoice_keys:
+				results["rows_updated"] += 1
+				continue
+			if supplier_input and invoice_no:
+				seen_supplier_invoice_keys.add(dedupe_key)
+
+			savepoint = _make_savepoint("sync_ap", f"{sheet_name}|{checksum}|{dedupe_key}")
+			frappe.db.savepoint(savepoint)
+
+			posting_date = (
+				_safe_date(_first_non_empty(row, "posting_date", "invoice_date", "date")) or nowdate()
+			)
+			due_date = _safe_date(_first_non_empty(row, "due_date")) or posting_date
+
+			if not supplier_input or not invoice_no:
+				results["rows_failed"] += 1
+				results["errors"].append("Missing supplier or invoice_no in AP opening row")
+				_release_savepoint(savepoint)
+				continue
+
+			supplier = _ensure_supplier(str(supplier_input))
+			existing = frappe.db.get_value(
+				"Purchase Invoice",
+				{
+					"supplier": supplier,
+					"bill_no": invoice_no,
+					"company": company,
+					"docstatus": ["<", 2],
+				},
+				"name",
+			)
+
+			if existing:
+				updates: dict[str, Any] = {}
+				if _doctype_has_field("Purchase Invoice", "due_date"):
+					updates["due_date"] = due_date
+				if _doctype_has_field("Purchase Invoice", "bill_date"):
+					updates["bill_date"] = posting_date
+				sync_ref = _sync_ref("AP", sheet_name, checksum, f"{supplier}|{invoice_no}")
+				if _doctype_has_field("Purchase Invoice", "remarks"):
+					current_remarks = frappe.db.get_value("Purchase Invoice", existing, "remarks") or ""
+					if sync_ref not in current_remarks:
+						sync_note = f"[{sync_ref}] amount={amount}"
+						updates["remarks"] = f"{current_remarks}\n{sync_note}".strip()
+				if updates:
+					frappe.db.set_value("Purchase Invoice", existing, updates, update_modified=False)
+				results["rows_updated"] += 1
+				_release_savepoint(savepoint)
+				continue
+
+			expense_account = _first_non_empty(row, "expense_account") or _default_expense_account(company)
+			payable_account = _first_non_empty(
+				row, "credit_to", "payable_account"
+			) or _default_payable_account(company)
+			cost_center = _first_non_empty(row, "cost_center") or _default_cost_center(company)
+
+			if not expense_account:
+				raise ValueError(f"No expense account available for company {company}")
+			if not payable_account:
+				raise ValueError(f"No payable account available for company {company}")
+
+			sync_ref = _sync_ref("AP", sheet_name, checksum, f"{supplier}|{invoice_no}")
+			pi = frappe.new_doc("Purchase Invoice")
+			pi.company = company
+			pi.supplier = supplier
+			pi.bill_no = invoice_no
+			pi.bill_date = posting_date
+			pi.posting_date = posting_date
+			pi.due_date = due_date
+			pi.set_posting_time = 1
+			if _doctype_has_field("Purchase Invoice", "is_opening"):
+				pi.is_opening = "Yes"
+			if _doctype_has_field("Purchase Invoice", "credit_to"):
+				pi.credit_to = payable_account
+			if _doctype_has_field("Purchase Invoice", "remarks"):
+				pi.remarks = f"ERP AP Opening Sync [{sync_ref}]"
+
+			item_row = {
+				"item_code": opening_item,
+				"qty": 1,
+				"rate": amount,
+				"expense_account": expense_account,
+				"description": f"Opening balance sync for {invoice_no}",
+			}
+			if cost_center:
+				item_row["cost_center"] = cost_center
+			pi.append("items", item_row)
+
+			try:
+				pi.insert(ignore_permissions=True)
+				try:
+					pi.submit()
+				except Exception:
+					frappe.log_error(
+						message=f"AP opening sync created draft PI {pi.name}; submit failed: {frappe.get_traceback()}",
+						title="AP Opening Sync Submit Warning",
+					)
+				results["rows_created"] += 1
+				_release_savepoint(savepoint)
+			except Exception as exc:
+				if _is_duplicate_error(exc):
+					results["rows_updated"] += 1
+					_release_savepoint(savepoint)
+				else:
+					raise
+
+		except Exception as e:
+			if savepoint:
+				frappe.db.rollback(save_point=savepoint)
+			results["errors"].append(str(e))
+			results["rows_failed"] += 1
+
+	return results
+
+
+@frappe.whitelist()
+def sync_supplier_soa(sheet_name: str, data: list[dict], checksum: str, **kwargs) -> dict:
+	"""
+	Backward-compatible alias for supplier_soa route.
+
+	Source config still points to this method name.
+	"""
+	return sync_ap_opening(sheet_name=sheet_name, data=data, checksum=checksum, **kwargs)
+
+
+# nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method
+@frappe.whitelist(allow_guest=True, methods=["POST"])
 def webhook():
-    """
-    Proxy webhook endpoint for Sheets Receiver.
+	"""
+	Proxy webhook endpoint for Sheets Receiver.
 
-    This allows the webhook to come through Frappe's URL
-    and be forwarded to the Sheets Receiver service.
+	This allows the webhook to come through Frappe's URL
+	and be forwarded to the Sheets Receiver service.
 
-    Google sends webhooks to:
-    https://hq.bebang.ph/api/method/hrms.api.sheets_receiver.webhook
+	Google sends webhooks to:
+	https://hq.bebang.ph/api/method/hrms.api.sheets_receiver.webhook
 
-    We forward to:
-    http://sheets-receiver:8765/webhook/sheets
-    """
-    import requests
+	We forward to:
+	http://sheets-receiver:8765/webhook/sheets
+	"""
+	import requests
 
-    # Get headers from Google
-    headers = {
-        'X-Goog-Channel-ID': frappe.request.headers.get('X-Goog-Channel-ID'),
-        'X-Goog-Resource-ID': frappe.request.headers.get('X-Goog-Resource-ID'),
-        'X-Goog-Resource-State': frappe.request.headers.get('X-Goog-Resource-State'),
-        'X-Goog-Changed': frappe.request.headers.get('X-Goog-Changed'),
-        'X-Goog-Message-Number': frappe.request.headers.get('X-Goog-Message-Number'),
-        'Content-Type': 'application/json'
-    }
+	headers = {
+		"X-Goog-Channel-ID": frappe.request.headers.get("X-Goog-Channel-ID"),
+		"X-Goog-Resource-ID": frappe.request.headers.get("X-Goog-Resource-ID"),
+		"X-Goog-Resource-State": frappe.request.headers.get("X-Goog-Resource-State"),
+		"X-Goog-Changed": frappe.request.headers.get("X-Goog-Changed"),
+		"X-Goog-Message-Number": frappe.request.headers.get("X-Goog-Message-Number"),
+		"Content-Type": "application/json",
+	}
 
-    # Forward to Sheets Receiver service
-    try:
-        response = requests.post(
-            'http://sheets-receiver:8765/webhook/sheets',
-            headers=headers,
-            data=frappe.request.data,
-            timeout=5
-        )
-        return response.json()
-    except Exception as e:
-        frappe.log_error(f"Failed to forward webhook: {e}", "Sheets Webhook Error")
-        return {'status': 'error', 'message': str(e)}
+	try:
+		response = requests.post(
+			"http://sheets-receiver:8765/webhook/sheets",
+			headers=headers,
+			data=frappe.request.data,
+			timeout=5,
+		)
+		return response.json()
+	except Exception as e:
+		frappe.log_error(f"Failed to forward webhook: {e}", "Sheets Webhook Error")
+		return {"status": "error", "message": str(e)}
 
 
 @frappe.whitelist()
 def get_sync_status():
-    """Get sync status from Sheets Receiver service."""
-    import requests
+	"""Get sync status from Sheets Receiver service."""
+	_assert_sync_authorized()
+	import requests
 
-    try:
-        response = requests.get(
-            'http://sheets-receiver:8765/api/status',
-            timeout=10
-        )
-        return response.json()
-    except Exception as e:
-        return {'status': 'error', 'message': str(e)}
+	try:
+		response = requests.get("http://sheets-receiver:8765/api/status", timeout=10)
+		return response.json()
+	except Exception as e:
+		return {"status": "error", "message": str(e)}
 
 
 @frappe.whitelist()
-def trigger_sync(sheet_key: str = None, force: bool = False):
-    """Trigger manual sync via Sheets Receiver service."""
-    import requests
+def trigger_sync(sheet_key: str | None = None, force: bool = False):
+	"""Trigger manual sync via Sheets Receiver service."""
+	_assert_sync_authorized()
+	import requests
 
-    try:
-        if sheet_key:
-            url = f'http://sheets-receiver:8765/api/sync/{sheet_key}?force={force}'
-        else:
-            url = f'http://sheets-receiver:8765/api/sync-all?force={force}'
+	try:
+		if sheet_key:
+			url = f"http://sheets-receiver:8765/api/sync/{sheet_key}?force={force}"
+		else:
+			url = f"http://sheets-receiver:8765/api/sync-all?force={force}"
 
-        response = requests.post(url, timeout=10)
-        return response.json()
-    except Exception as e:
-        return {'status': 'error', 'message': str(e)}
+		response = requests.post(url, timeout=10)
+		return response.json()
+	except Exception as e:
+		return {"status": "error", "message": str(e)}

--- a/hrms/tests/test_dispatch_pre_delivery.py
+++ b/hrms/tests/test_dispatch_pre_delivery.py
@@ -1,0 +1,213 @@
+import datetime
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_frappe_and_dependencies():
+	if "frappe" not in sys.modules:
+		frappe = types.ModuleType("frappe")
+		utils = types.ModuleType("frappe.utils")
+
+		def whitelist(*args, **kwargs):
+			def decorator(fn):
+				return fn
+
+			return decorator
+
+		def _throw(message, exc=None):
+			if isinstance(exc, type) and issubclass(exc, Exception):
+				raise exc(message)
+			raise Exception(message)
+
+		frappe.whitelist = whitelist
+		frappe._ = lambda text: text
+		frappe.throw = _throw
+		frappe.PermissionError = type("PermissionError", (Exception,), {})
+		frappe.DuplicateEntryError = type("DuplicateEntryError", (Exception,), {})
+		frappe.log_error = lambda *args, **kwargs: None
+		frappe.logger = lambda: types.SimpleNamespace(info=lambda *args, **kwargs: None)
+		frappe.get_traceback = lambda: "traceback"
+		frappe.enqueue = lambda *args, **kwargs: None
+		frappe.parse_json = json.loads
+		frappe.__dict__["session"] = types.SimpleNamespace(user="Administrator")
+
+		frappe.__dict__["db"] = types.SimpleNamespace(
+			get_single_value=lambda *args, **kwargs: 1,
+			exists=lambda *args, **kwargs: None,
+			get_value=lambda *args, **kwargs: None,
+			sql=lambda *args, **kwargs: [(0,)],
+			savepoint=lambda name: name,
+			release_savepoint=lambda name: None,
+			rollback=lambda **kwargs: None,
+			commit=lambda: None,
+		)
+		frappe.get_doc = lambda *args, **kwargs: types.SimpleNamespace(
+			name="DOC-0001",
+			stops=[],
+			save=lambda **kw: None,
+			reload=lambda: None,
+		)
+		frappe.get_all = lambda *args, **kwargs: []
+		frappe.new_doc = lambda *args, **kwargs: types.SimpleNamespace(
+			update=lambda *a, **k: None,
+			insert=lambda **k: None,
+			name="DOC-0001",
+		)
+
+		utils.nowdate = lambda: "2026-02-26"
+		utils.now_datetime = lambda: datetime.datetime(2026, 2, 26, 10, 0, 0)
+		utils.flt = lambda value, precision=None: float(value or 0)
+		utils.cint = lambda value: int(float(value or 0))
+
+		sys.modules["frappe"] = frappe
+		sys.modules["frappe.utils"] = utils
+
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.utils" not in sys.modules:
+		hrms_utils_pkg = types.ModuleType("hrms.utils")
+		hrms_utils_pkg.__path__ = []
+		sys.modules["hrms.utils"] = hrms_utils_pkg
+
+	if "hrms.api" not in sys.modules:
+		hrms_api_pkg = types.ModuleType("hrms.api")
+		hrms_api_pkg.__path__ = []
+		sys.modules["hrms.api"] = hrms_api_pkg
+
+	if "hrms.utils.delivery_billing_policy" not in sys.modules:
+		policy_mod = types.ModuleType("hrms.utils.delivery_billing_policy")
+
+		class DeliveryBillingPolicyError(Exception):
+			pass
+
+		policy_mod.DeliveryBillingPolicyError = DeliveryBillingPolicyError
+		policy_mod.should_auto_create_billing_on_delivery = lambda setting: True
+		policy_mod.get_pre_delivery_exception_trace = lambda exception_doc, trip_reference, trip_stop_idx: {
+			"exception_name": exception_doc.get("name") if isinstance(exception_doc, dict) else "EXC-0001",
+			"cpo_approved_by": "mae@bebang.ph",
+			"cpo_approved_at": "2026-02-26 10:00:00",
+			"cfo_approved_by": "butch@bebang.ph",
+			"cfo_approved_at": "2026-02-26 11:00:00",
+			"approval_audit_log": "dual approval complete",
+		}
+		sys.modules["hrms.utils.delivery_billing_policy"] = policy_mod
+
+	if "hrms.utils.scm_roles" not in sys.modules:
+		scm_roles_mod = types.ModuleType("hrms.utils.scm_roles")
+		scm_roles_mod.SCM_ADMIN_ROLES = ["System Manager"]
+		scm_roles_mod.SCM_DISPATCH_ROLES = ["System Manager"]
+		scm_roles_mod.SCM_STORE_ROLES = ["Store User"]
+		scm_roles_mod.check_scm_permission = lambda roles, action: None
+		sys.modules["hrms.utils.scm_roles"] = scm_roles_mod
+
+	if "hrms.api.procurement" not in sys.modules:
+		procurement_mod = types.ModuleType("hrms.api.procurement")
+		procurement_mod.request_match_exception = lambda payload: {
+			"success": True,
+			"name": "BEI-EXC-0001",
+			"payload": payload,
+		}
+		sys.modules["hrms.api.procurement"] = procurement_mod
+
+
+_install_fake_frappe_and_dependencies()
+dispatch_spec = importlib.util.spec_from_file_location(
+	"dispatch_under_test",
+	ROOT / "hrms" / "api" / "dispatch.py",
+)
+dispatch = importlib.util.module_from_spec(dispatch_spec)
+dispatch_spec.loader.exec_module(dispatch)
+
+
+class _Stop:
+	def __init__(self, idx=1, status="Pending", billing_reference=None, billing_creation_status=None):
+		self.idx = idx
+		self.status = status
+		self.billing_reference = billing_reference
+		self.billing_creation_status = billing_creation_status
+
+
+class _Trip:
+	def __init__(self, stop):
+		self.name = "TRIP-0001"
+		self.stops = [stop]
+
+	def save(self, **kwargs):
+		return None
+
+
+class TestDispatchPreDelivery(unittest.TestCase):
+	def test_request_pre_delivery_billing_exception_requires_reason(self):
+		with self.assertRaises(Exception):
+			dispatch.request_pre_delivery_billing_exception("TRIP-0001", 1, "")
+
+	def test_request_pre_delivery_billing_exception_calls_procurement_api(self):
+		with patch(
+			"hrms.api.procurement.request_match_exception",
+			return_value={"success": True, "name": "BEI-EXC-0092"},
+		) as request_match:
+			result = dispatch.request_pre_delivery_billing_exception(
+				trip_name="TRIP-0001",
+				stop_idx=2,
+				reason="Store requested advance billing before receipt",
+			)
+
+		request_match.assert_called_once()
+		payload = request_match.call_args.args[0]
+		self.assertEqual(payload["delivery_trip_reference"], "TRIP-0001")
+		self.assertEqual(payload["delivery_stop_idx"], 2)
+		self.assertEqual(result["name"], "BEI-EXC-0092")
+
+	def test_get_pre_delivery_billing_exception_status_returns_latest(self):
+		exceptions = [
+			{"name": "BEI-EXC-0003", "status": "Approved", "modified": "2026-02-26 12:00:00"},
+			{"name": "BEI-EXC-0002", "status": "Pending CFO", "modified": "2026-02-26 11:00:00"},
+		]
+		dispatch.frappe.get_all = MagicMock(return_value=exceptions)
+
+		result = dispatch.get_pre_delivery_billing_exception_status("TRIP-0001", 3)
+
+		self.assertEqual(result["latest"]["name"], "BEI-EXC-0003")
+		self.assertEqual(len(result["exceptions"]), 2)
+
+	def test_create_pre_delivery_billing_requires_exception_name(self):
+		with self.assertRaises(Exception):
+			dispatch.create_pre_delivery_billing("TRIP-0001", 1, "")
+
+	def test_create_pre_delivery_billing_calls_internal_guarded_path(self):
+		stop = _Stop(
+			idx=1, status="Pending", billing_reference="BILL-0001", billing_creation_status="Success"
+		)
+		trip = _Trip(stop)
+		dispatch.frappe.get_doc = MagicMock(return_value=trip)
+
+		with patch.object(dispatch, "_create_delivery_billing") as create_billing:
+			result = dispatch.create_pre_delivery_billing(
+				trip_name="TRIP-0001",
+				stop_idx=1,
+				pre_delivery_exception="BEI-EXC-0003",
+			)
+
+		create_billing.assert_called_once_with(
+			trip_name="TRIP-0001",
+			stop_idx=1,
+			pre_delivery_exception="BEI-EXC-0003",
+			require_pre_delivery_exception=True,
+		)
+		self.assertEqual(result["billing_reference"], "BILL-0001")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -47,7 +47,7 @@ def _install_fake_frappe():
 	frappe.defaults = types.SimpleNamespace(get_global_default=lambda key: None)
 	frappe.__dict__["session"] = types.SimpleNamespace(user="Administrator")
 	frappe.get_roles = lambda user=None: ["System Manager"] if user and user != "Guest" else []
-	frappe.request = types.SimpleNamespace(headers={}, data=b"")
+	frappe.__dict__["request"] = types.SimpleNamespace(headers={}, data=b"")
 	frappe.__dict__["db"] = types.SimpleNamespace(
 		exists=lambda *args, **kwargs: None,
 		get_value=lambda *args, **kwargs: None,

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -1,0 +1,411 @@
+import datetime
+import importlib.util
+import re
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_frappe():
+	if "frappe" in sys.modules:
+		return
+
+	frappe = types.ModuleType("frappe")
+	utils = types.ModuleType("frappe.utils")
+
+	def whitelist(*args, **kwargs):
+		def decorator(fn):
+			return fn
+
+		return decorator
+
+	class DuplicateEntryError(Exception):
+		pass
+
+	class PermissionError(Exception):
+		pass
+
+	def _throw(message, exc=None):
+		if isinstance(exc, type) and issubclass(exc, Exception):
+			raise exc(message)
+		raise Exception(message)
+
+	frappe.whitelist = whitelist
+	frappe._ = lambda text: text
+	frappe.throw = _throw
+	frappe.DuplicateEntryError = DuplicateEntryError
+	frappe.PermissionError = PermissionError
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.logger = lambda: types.SimpleNamespace(info=lambda *args, **kwargs: None)
+	frappe.get_traceback = lambda: "traceback"
+	frappe.defaults = types.SimpleNamespace(get_global_default=lambda key: None)
+	frappe.__dict__["session"] = types.SimpleNamespace(user="Administrator")
+	frappe.get_roles = lambda user=None: ["System Manager"] if user and user != "Guest" else []
+	frappe.request = types.SimpleNamespace(headers={}, data=b"")
+	frappe.__dict__["db"] = types.SimpleNamespace(
+		exists=lambda *args, **kwargs: None,
+		get_value=lambda *args, **kwargs: None,
+		set_value=lambda *args, **kwargs: None,
+		savepoint=lambda *args, **kwargs: None,
+		release_savepoint=lambda *args, **kwargs: None,
+		rollback=lambda *args, **kwargs: None,
+	)
+	frappe.get_all = lambda *args, **kwargs: []
+	frappe.get_meta = lambda *args, **kwargs: types.SimpleNamespace(has_field=lambda *_: True)
+	frappe.get_doc = lambda *args, **kwargs: types.SimpleNamespace(insert=lambda **_: None, name="DOC-0001")
+	frappe.new_doc = lambda *args, **kwargs: types.SimpleNamespace(
+		append=lambda *a, **k: None,
+		insert=lambda **k: None,
+		submit=lambda: None,
+	)
+
+	utils.now_datetime = lambda: datetime.datetime(2026, 1, 1, 8, 0, 0)
+	utils.nowdate = lambda: "2026-01-01"
+	utils.flt = lambda value: float(value or 0)
+	utils.cint = lambda value: int(float(value or 0))
+	utils.getdate = (
+		lambda value=None: datetime.date.fromisoformat(str(value)) if value else datetime.date(2026, 1, 1)
+	)
+
+	sys.modules["frappe"] = frappe
+	sys.modules["frappe.utils"] = utils
+
+
+_install_fake_frappe()
+erp_sync_spec = importlib.util.spec_from_file_location(
+	"erp_sync_under_test",
+	ROOT / "hrms" / "api" / "erp_sync.py",
+)
+erp_sync = importlib.util.module_from_spec(erp_sync_spec)
+erp_sync_spec.loader.exec_module(erp_sync)
+
+
+class _FakeDoc:
+	def __init__(self, doctype, on_insert=None):
+		self.doctype = doctype
+		self.name = None
+		self.items = []
+		self.remarks = ""
+		self._on_insert = on_insert
+		self.insert_calls = 0
+		self.submit_calls = 0
+
+	def append(self, table, row):
+		if table == "items":
+			self.items.append(row)
+
+	def insert(self, ignore_permissions=False):
+		self.insert_calls += 1
+		if self._on_insert:
+			self._on_insert(self)
+		if not self.name:
+			self.name = f"{self.doctype}-0001"
+		return self
+
+	def submit(self):
+		self.submit_calls += 1
+
+
+class TestErpSync(unittest.TestCase):
+	def setUp(self):
+		erp_sync._FIELD_CACHE.clear()
+		erp_sync.frappe.__dict__["session"] = types.SimpleNamespace(user="Administrator")
+		erp_sync.frappe.get_roles = MagicMock(return_value=["System Manager"])
+		erp_sync.frappe.db.savepoint = MagicMock(return_value=None)
+		erp_sync.frappe.db.release_savepoint = MagicMock()
+		erp_sync.frappe.db.rollback = MagicMock()
+
+	def test_sync_ar_aging_writes_sales_invoice_fields(self):
+		erp_sync.frappe.db.exists = MagicMock(return_value="SINV-0001")
+		erp_sync.frappe.db.get_value = MagicMock(return_value=1)
+		erp_sync.frappe.db.set_value = MagicMock()
+		erp_sync.frappe.logger = MagicMock(return_value=types.SimpleNamespace(info=MagicMock()))
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		result = erp_sync.sync_ar_aging(
+			sheet_name="AR Aging",
+			data=[{"invoice_no": "SINV-0001", "outstanding": 1200, "due_date": "2026-01-31"}],
+			checksum="chk-ar-1",
+		)
+
+		self.assertEqual(result["rows_updated"], 1)
+		self.assertEqual(result["rows_failed"], 0)
+		erp_sync.frappe.db.set_value.assert_called_once()
+		args = erp_sync.frappe.db.set_value.call_args[0]
+		self.assertEqual(args[0], "Sales Invoice")
+		self.assertEqual(args[1], "SINV-0001")
+		self.assertIn("outstanding_amount", args[2])
+
+	def test_sync_inventory_is_idempotent_by_sync_reference(self):
+		created_sync_refs = set()
+		created_docs = []
+
+		def db_exists(doctype, name=None):
+			if doctype in ("Item", "Warehouse", "Company"):
+				return name or True
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "Stock Reconciliation" and isinstance(filters, dict) and "remarks" in filters:
+				like_value = filters["remarks"][1]
+				for sync_ref in created_sync_refs:
+					if sync_ref in like_value:
+						return "SR-0001"
+				return None
+			return None
+
+		def new_doc(doctype):
+			if doctype != "Stock Reconciliation":
+				return _FakeDoc(doctype)
+
+			def on_insert(doc):
+				doc.name = f"SR-{len(created_docs) + 1:04d}"
+				created_docs.append(doc)
+				match = re.search(r"\((INV:[^)]+)\)", doc.remarks or "")
+				if match:
+					created_sync_refs.add(match.group(1))
+
+			return _FakeDoc(doctype, on_insert=on_insert)
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		with patch.object(erp_sync, "_normalize_company", return_value="BEI"):
+			first = erp_sync.sync_inventory(
+				sheet_name="Inventory",
+				data=[
+					{"item_code": "ITM-001", "warehouse": "Stores - BEI", "qty": 5},
+					{"item_code": "ITM-002", "warehouse": "Stores - BEI", "qty": 8},
+				],
+				checksum="chk-inv-1",
+			)
+			second = erp_sync.sync_inventory(
+				sheet_name="Inventory",
+				data=[
+					{"item_code": "ITM-001", "warehouse": "Stores - BEI", "qty": 5},
+					{"item_code": "ITM-002", "warehouse": "Stores - BEI", "qty": 8},
+				],
+				checksum="chk-inv-1",
+			)
+
+		self.assertEqual(first["rows_created"], 2)
+		self.assertEqual(second["rows_updated"], 2)
+		self.assertEqual(len(created_docs), 1)
+
+	def test_sync_coa_creates_then_updates_same_account(self):
+		created_accounts = {}
+		created_docs = []
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "Account" and isinstance(filters, dict):
+				account_number = filters.get("account_number")
+				if account_number:
+					return created_accounts.get(account_number)
+				if filters.get("is_group") == 1:
+					return "Assets - BEI"
+			return None
+
+		def new_doc(doctype):
+			if doctype != "Account":
+				return _FakeDoc(doctype)
+
+			def on_insert(doc):
+				doc.name = f"ACC-{len(created_docs) + 1:04d}"
+				created_docs.append(doc)
+				created_accounts[doc.account_number] = doc.name
+
+			return _FakeDoc(doctype, on_insert=on_insert)
+
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.db.set_value = MagicMock()
+		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		row = {"gl_code": "1010", "account_name": "Cash On Hand", "account_type": "Cash", "company": "BEI"}
+
+		with (
+			patch.object(erp_sync, "_normalize_company", return_value="BEI"),
+			patch.object(erp_sync, "_resolve_parent_account", return_value="Assets - BEI"),
+		):
+			first = erp_sync.sync_coa("COA", [row], "chk-coa-1")
+			second = erp_sync.sync_coa("COA", [row], "chk-coa-1")
+
+		self.assertEqual(first["rows_created"], 1)
+		self.assertEqual(second["rows_updated"], 1)
+		self.assertEqual(len(created_docs), 1)
+		erp_sync.frappe.db.set_value.assert_called_once()
+
+	def test_sync_bank_accounts_creates_then_updates_by_account_number(self):
+		created_bank_accounts = {}
+		created_docs = []
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "Bank Account" and isinstance(filters, dict):
+				account_no = filters.get("bank_account_no")
+				if account_no:
+					return created_bank_accounts.get(account_no)
+			if doctype == "Account" and isinstance(filters, dict):
+				if filters.get("account_number") == "1010":
+					return "Bank GL - BEI"
+			return None
+
+		def new_doc(doctype):
+			if doctype != "Bank Account":
+				return _FakeDoc(doctype)
+
+			def on_insert(doc):
+				doc.name = f"BANK-ACC-{len(created_docs) + 1:04d}"
+				created_docs.append(doc)
+				created_bank_accounts[doc.bank_account_no] = doc.name
+
+			return _FakeDoc(doctype, on_insert=on_insert)
+
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.db.set_value = MagicMock()
+		erp_sync.frappe.db.exists = MagicMock(return_value=True)
+		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		row = {
+			"account_number": "1234567890",
+			"account_name": "Main Operating",
+			"bank_name": "BDO",
+			"gl_code": "1010",
+		}
+
+		with (
+			patch.object(erp_sync, "_normalize_company", return_value="BEI"),
+			patch.object(erp_sync, "_ensure_bank", return_value="BDO"),
+		):
+			first = erp_sync.sync_bank_accounts("Bank Directory", [row], "chk-bank-1")
+			second = erp_sync.sync_bank_accounts("Bank Directory", [row], "chk-bank-1")
+
+		self.assertEqual(first["rows_created"], 1)
+		self.assertEqual(second["rows_updated"], 1)
+		self.assertEqual(len(created_docs), 1)
+		erp_sync.frappe.db.set_value.assert_called_once()
+
+	def test_sync_ap_opening_creates_then_updates_existing_invoice(self):
+		created_purchase_invoices = {}
+		created_docs = []
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "Purchase Invoice" and isinstance(filters, dict):
+				key = (filters.get("supplier"), filters.get("bill_no"), filters.get("company"))
+				if key in created_purchase_invoices:
+					return created_purchase_invoices[key]
+				return None
+			if doctype == "Purchase Invoice" and isinstance(filters, str) and fieldname == "remarks":
+				return "existing remarks"
+			return None
+
+		def new_doc(doctype):
+			if doctype != "Purchase Invoice":
+				return _FakeDoc(doctype)
+
+			def on_insert(doc):
+				doc.name = f"PI-{len(created_docs) + 1:04d}"
+				created_docs.append(doc)
+				key = (doc.supplier, doc.bill_no, doc.company)
+				created_purchase_invoices[key] = doc.name
+
+			return _FakeDoc(doctype, on_insert=on_insert)
+
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.db.set_value = MagicMock()
+		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
+		erp_sync.frappe.log_error = MagicMock()
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		row = {
+			"supplier": "Acme Supply",
+			"invoice_no": "INV-001",
+			"amount": 24500.0,
+			"due_date": "2026-02-15",
+		}
+
+		with (
+			patch.object(erp_sync, "_ensure_ap_opening_item", return_value="ERP-SYNC-AP-OPENING"),
+			patch.object(erp_sync, "_normalize_company", return_value="BEI"),
+			patch.object(erp_sync, "_ensure_supplier", return_value="SUP-0001"),
+			patch.object(erp_sync, "_default_expense_account", return_value="Expense - BEI"),
+			patch.object(erp_sync, "_default_payable_account", return_value="Payable - BEI"),
+			patch.object(erp_sync, "_default_cost_center", return_value="Main - BEI"),
+			patch.object(erp_sync, "_doctype_has_field", return_value=True),
+		):
+			first = erp_sync.sync_ap_opening("AP Opening", [row], "chk-ap-1")
+			second = erp_sync.sync_ap_opening("AP Opening", [row], "chk-ap-1")
+
+		self.assertEqual(first["rows_created"], 1)
+		self.assertEqual(second["rows_updated"], 1)
+		self.assertEqual(len(created_docs), 1)
+		erp_sync.frappe.db.set_value.assert_called_once()
+
+	def test_sync_supplier_soa_aliases_sync_ap_opening(self):
+		rows = [{"supplier": "Acme Supply", "invoice_no": "INV-001"}]
+		expected = {"rows_processed": 1, "rows_created": 1, "rows_updated": 0, "rows_failed": 0, "errors": []}
+		with patch.object(erp_sync, "sync_ap_opening", return_value=expected) as sync_ap_opening:
+			result = erp_sync.sync_supplier_soa("Supplier SOA", rows, "chk-supplier-1")
+
+		sync_ap_opening.assert_called_once_with(
+			sheet_name="Supplier SOA",
+			data=rows,
+			checksum="chk-supplier-1",
+		)
+		self.assertEqual(result, expected)
+
+	def test_sync_authorization_blocks_guest(self):
+		erp_sync.frappe.session.user = "Guest"
+		erp_sync.frappe.get_roles = MagicMock(return_value=[])
+
+		with self.assertRaises(erp_sync.frappe.PermissionError):
+			erp_sync._assert_sync_authorized()
+
+	def test_sync_authorization_blocks_unscoped_role(self):
+		erp_sync.frappe.session.user = "viewer@bebang.ph"
+		erp_sync.frappe.get_roles = MagicMock(return_value=["Employee"])
+
+		with self.assertRaises(erp_sync.frappe.PermissionError):
+			erp_sync._assert_sync_authorized()
+
+	def test_sync_authorization_allows_scoped_role(self):
+		erp_sync.frappe.session.user = "finance@bebang.ph"
+		erp_sync.frappe.get_roles = MagicMock(return_value=["Accounts Manager"])
+
+		# Should not raise
+		erp_sync._assert_sync_authorized()
+
+	def test_sync_ar_aging_rolls_back_on_row_error(self):
+		captured_savepoints = []
+
+		def _capture_savepoint(name):
+			captured_savepoints.append(name)
+			return None
+
+		erp_sync.frappe.db.savepoint = MagicMock(side_effect=_capture_savepoint)
+		erp_sync.frappe.db.rollback = MagicMock()
+		erp_sync.frappe.db.release_savepoint = MagicMock()
+		erp_sync.frappe.db.exists = MagicMock(side_effect=RuntimeError("db offline"))
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		result = erp_sync.sync_ar_aging(
+			sheet_name="AR Aging",
+			data=[{"invoice_no": "SINV-ERR", "outstanding": 100}],
+			checksum="chk-ar-rollback",
+		)
+
+		self.assertEqual(result["rows_failed"], 1)
+		self.assertEqual(len(captured_savepoints), 1)
+		erp_sync.frappe.db.rollback.assert_called_once_with(save_point=captured_savepoints[0])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/hrms/utils/delivery_billing_policy.py
+++ b/hrms/utils/delivery_billing_policy.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2026, Bebang Enterprise Inc.
+# For license information, please see license.txt
+
+from collections.abc import Mapping
+from datetime import datetime
+
+CPO_APPROVER_EMAIL = "mae@bebang.ph"
+CFO_APPROVER_EMAIL = "butch@bebang.ph"
+DUAL_APPROVAL_TIER = "CPO+CFO"
+
+
+class DeliveryBillingPolicyError(ValueError):
+	"""Raised when a pre-delivery billing request violates policy."""
+
+
+def should_auto_create_billing_on_delivery(setting_value):
+	"""Treat missing setting as enabled; explicit falsey values disable automation."""
+	if setting_value is None:
+		return True
+
+	if isinstance(setting_value, bool):
+		return setting_value
+
+	if isinstance(setting_value, int | float):
+		return int(setting_value) == 1
+
+	text = str(setting_value).strip().lower()
+	if text in {"1", "true", "yes", "y", "on"}:
+		return True
+	if text in {"0", "false", "no", "n", "off", ""}:
+		return False
+
+	return bool(setting_value)
+
+
+def append_approval_audit_log(existing_log, action, approver, approved_at, comment=None):
+	"""Append one structured approval line to the audit log text field."""
+	if isinstance(approved_at, datetime):
+		timestamp = approved_at.isoformat(sep=" ", timespec="seconds")
+	else:
+		timestamp = str(approved_at)
+
+	entry = f"[{timestamp}] {action} by {approver}"
+	cleaned_comment = (comment or "").strip()
+	if cleaned_comment:
+		entry = f"{entry} | Comment: {cleaned_comment}"
+
+	if not existing_log:
+		return entry
+	return f"{existing_log}\n{entry}"
+
+
+def _value(doc_or_dict, key, default=None):
+	if isinstance(doc_or_dict, Mapping):
+		return doc_or_dict.get(key, default)
+	return getattr(doc_or_dict, key, default)
+
+
+def get_pre_delivery_exception_trace(exception_doc, trip_reference, trip_stop_idx):
+	"""Validate exception against delivery policy and return normalized audit trace."""
+	approval_tier = _value(exception_doc, "approval_tier")
+	if approval_tier != DUAL_APPROVAL_TIER:
+		raise DeliveryBillingPolicyError(
+			"Pre-delivery billing requires an exception approved under CPO+CFO dual approval."
+		)
+
+	status = _value(exception_doc, "status")
+	if status != "Approved":
+		raise DeliveryBillingPolicyError("Pre-delivery billing exception is not fully approved yet.")
+
+	exception_trip = _value(exception_doc, "delivery_trip_reference")
+	if exception_trip != trip_reference:
+		raise DeliveryBillingPolicyError(
+			f"Exception trip reference mismatch: expected {trip_reference}, got {exception_trip or 'empty'}."
+		)
+
+	try:
+		exception_stop_idx = int(_value(exception_doc, "delivery_stop_idx") or 0)
+		target_stop_idx = int(trip_stop_idx or 0)
+	except (TypeError, ValueError):
+		raise DeliveryBillingPolicyError("Invalid delivery stop index on exception or billing.")
+
+	if exception_stop_idx != target_stop_idx:
+		raise DeliveryBillingPolicyError(
+			f"Exception stop mismatch: expected stop {target_stop_idx}, got {exception_stop_idx}."
+		)
+
+	cpo_approved_by = _value(exception_doc, "cpo_approved_by")
+	cpo_approved_at = _value(exception_doc, "cpo_approved_at")
+	cfo_approved_by = _value(exception_doc, "cfo_approved_by")
+	cfo_approved_at = _value(exception_doc, "cfo_approved_at")
+
+	if cpo_approved_by != CPO_APPROVER_EMAIL or not cpo_approved_at:
+		raise DeliveryBillingPolicyError("Pre-delivery billing requires explicit Daymae/CPO approval trace.")
+
+	if cfo_approved_by != CFO_APPROVER_EMAIL or not cfo_approved_at:
+		raise DeliveryBillingPolicyError("Pre-delivery billing requires explicit Butch/CFO approval trace.")
+
+	return {
+		"exception_name": _value(exception_doc, "name"),
+		"cpo_approved_by": cpo_approved_by,
+		"cpo_approved_at": cpo_approved_at,
+		"cfo_approved_by": cfo_approved_by,
+		"cfo_approved_at": cfo_approved_at,
+		"approval_audit_log": _value(exception_doc, "approval_audit_log"),
+	}


### PR DESCRIPTION
## Scope\n- Bring Sprint 03 runtime methods to production:\n  - hrms.api.dispatch.request_pre_delivery_billing_exception\n  - hrms.api.dispatch.create_pre_delivery_billing\n  - hrms.api.erp_sync.sync_supplier_soa\n- Add hrms/utils/delivery_billing_policy.py dependency\n- Include dispatch/erp_sync test coverage\n- Repair linters.yml checkout depth issue for PR checks\n\n## Why\nRuntime probes on lfg/hq show these methods missing in deployed target, keeping Sprint 03 gate in NO-GO.\n\n## Validation done locally\n- pre-commit on changed files\n- python hrms/tests/test_dispatch_pre_delivery.py\n- python hrms/tests/test_erp_sync.py\n