### PR TITLE
fix(dispatch): unblock trip pre-billing exception without PO

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -2785,6 +2785,7 @@ def request_match_exception(data):
     if reference_type == "BEI Distribution Trip":
         trip_name = data.get("delivery_trip_reference") or data.get("reference_name")
         stop_idx = cint(data.get("delivery_stop_idx"))
+        trip_purchase_order = data.get("purchase_order")
         if not trip_name:
             frappe.throw(_("Delivery Trip Reference is required"))
         if stop_idx <= 0:
@@ -2805,7 +2806,7 @@ def request_match_exception(data):
                 )
             )
 
-        exception = frappe.get_doc({
+        exception_payload = {
             "doctype": "BEI Match Exception",
             "reference_type": "BEI Distribution Trip",
             "reference_name": trip_name,
@@ -2814,7 +2815,13 @@ def request_match_exception(data):
             "approval_tier": "CPO+CFO",
             "reason": reason,
             "exception_type": exception_type,
-        })
+        }
+        # Keep backward compatibility: attach PO only when valid, otherwise bypass mandatory PO on trip flow.
+        if trip_purchase_order and frappe.db.exists("BEI Purchase Order", trip_purchase_order):
+            exception_payload["purchase_order"] = trip_purchase_order
+        exception = frappe.get_doc(exception_payload)
+        if "purchase_order" not in exception_payload:
+            exception.flags.ignore_mandatory = True
     else:
         purchase_order = data.get("purchase_order")
         if not purchase_order:


### PR DESCRIPTION
## Summary\n- allow equest_match_exception trip flow to bypass mandatory purchase_order when not applicable\n- attach purchase_order only when a valid BEI Purchase Order is provided\n- keeps PO-required validation unchanged for non-trip exception flow\n\n## Why\nSprint-03 integrated L4 evidence is blocked on GAP-092 because BEI Match Exception enforces mandatory purchase_order even for eference_type=BEI Distribution Trip.