### PR TITLE
fix(dispatch): unblock trip-based pre-delivery exception flow

### DIFF
--- a/hrms/hr/doctype/bei_match_exception/bei_match_exception.json
+++ b/hrms/hr/doctype/bei_match_exception/bei_match_exception.json
@@ -13,6 +13,13 @@
   "po_amount",
   "approval_tier",
   "status",
+  "delivery_trip_reference",
+  "delivery_stop_idx",
+  "cpo_approved_by",
+  "cpo_approved_at",
+  "cfo_approved_by",
+  "cfo_approved_at",
+  "approval_audit_log",
   "section_reason",
   "reason",
   "exception_type",
@@ -35,7 +42,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Reference Type",
-   "options": "BEI Invoice\nBEI Payment Request",
+   "options": "BEI Invoice\nBEI Payment Request\nBEI Distribution Trip",
    "reqd": 1
   },
   {
@@ -71,7 +78,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Approval Tier",
-   "options": "\nCPO\nCFO\nCEO",
+   "options": "\nCPO\nCPO+CFO\nCPO+CEO\nCFO\nCEO",
    "read_only": 1
   },
   {
@@ -82,6 +89,56 @@
    "in_standard_filter": 1,
    "label": "Status",
    "options": "Pending CPO\nPending CFO\nPending CEO\nApproved\nRejected"
+  },
+  {
+   "fieldname": "delivery_trip_reference",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Delivery Trip Reference",
+   "options": "BEI Distribution Trip",
+   "read_only": 1
+  },
+  {
+   "fieldname": "delivery_stop_idx",
+   "fieldtype": "Int",
+   "hidden": 1,
+   "label": "Delivery Stop Index",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cpo_approved_by",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "CPO Approved By",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cpo_approved_at",
+   "fieldtype": "Datetime",
+   "hidden": 1,
+   "label": "CPO Approved At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cfo_approved_by",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "CFO Approved By",
+   "read_only": 1
+  },
+  {
+   "fieldname": "cfo_approved_at",
+   "fieldtype": "Datetime",
+   "hidden": 1,
+   "label": "CFO Approved At",
+   "read_only": 1
+  },
+  {
+   "fieldname": "approval_audit_log",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Approval Audit Log",
+   "read_only": 1
   },
   {
    "fieldname": "section_reason",
@@ -99,7 +156,7 @@
    "fieldtype": "Select",
    "in_standard_filter": 1,
    "label": "Exception Type",
-   "options": "Service PO\nAdvance Payment\nEmergency\nUtility\nOther",
+   "options": "Service PO\nAdvance Payment\nEmergency\nUtility\nDelivery Pre-Billing\nOther",
    "reqd": 1
   },
   {

--- a/hrms/hr/doctype/bei_match_exception/bei_match_exception.py
+++ b/hrms/hr/doctype/bei_match_exception/bei_match_exception.py
@@ -41,6 +41,9 @@ def get_approval_tier(po_amount):
 
 def get_tier_status(tier):
     """Return the pending status string for a given tier."""
+    # Dual-tier flows always start with CPO review before escalation.
+    if tier in {"CPO+CFO", "CPO+CEO"}:
+        return "Pending CPO"
     return f"Pending {tier}"
 
 

--- a/hrms/hr/doctype/bei_match_exception/bei_match_exception.py
+++ b/hrms/hr/doctype/bei_match_exception/bei_match_exception.py
@@ -5,69 +5,66 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import flt, now_datetime
 
-
 # Configurable approver mapping by tier
 EXCEPTION_APPROVERS = {
-    "CPO": "mae@bebang.ph",
-    "CPO+CFO": "mae@bebang.ph",
-    "CPO+CEO": "mae@bebang.ph",
-    "CFO": "butch@bebang.ph",
-    "CEO": "sam@bebang.ph",
+	"CPO": "mae@bebang.ph",
+	"CPO+CFO": "mae@bebang.ph",
+	"CPO+CEO": "mae@bebang.ph",
+	"CFO": "butch@bebang.ph",
+	"CEO": "sam@bebang.ph",
 }
 
 # Amount thresholds for tier assignment (PHP)
 TIER_THRESHOLDS = {
-    "CPO": 500000,      # < 500K
-    "CFO": 1000000,     # 500K to < 1M
-    # CEO: >= 1M
+	"CPO": 500000,  # < 500K
+	"CFO": 1000000,  # 500K to < 1M
+	# CEO: >= 1M
 }
 
 
 def get_approval_tier(po_amount):
-    """Determine approval tier based on PO amount.
+	"""Determine approval tier based on PO amount.
 
-    < 500K -> CPO (Mae)
-    500K to < 1M -> CPO+CFO
-    >= 1M -> CPO+CEO
-    """
-    amount = flt(po_amount)
-    if amount < TIER_THRESHOLDS["CPO"]:
-        return "CPO"
-    elif amount < TIER_THRESHOLDS["CFO"]:
-        return "CPO+CFO"
-    else:
-        return "CPO+CEO"
+	< 500K -> CPO (Mae)
+	500K to < 1M -> CPO+CFO
+	>= 1M -> CPO+CEO
+	"""
+	amount = flt(po_amount)
+	if amount < TIER_THRESHOLDS["CPO"]:
+		return "CPO"
+	elif amount < TIER_THRESHOLDS["CFO"]:
+		return "CPO+CFO"
+	else:
+		return "CPO+CEO"
 
 
 def get_tier_status(tier):
-    """Return the pending status string for a given tier."""
-    # Dual-tier flows always start with CPO review before escalation.
-    if tier in {"CPO+CFO", "CPO+CEO"}:
-        return "Pending CPO"
-    return f"Pending {tier}"
+	"""Return the pending status string for a given tier."""
+	# Dual-tier flows always start with CPO review before escalation.
+	if tier in {"CPO+CFO", "CPO+CEO"}:
+		return "Pending CPO"
+	return f"Pending {tier}"
 
 
 class BEIMatchException(Document):
-    def before_insert(self):
-        # Auto-set tier and approver based on PO amount
-        if self.purchase_order and not self.approval_tier:
-            po_amount = frappe.db.get_value(
-                "BEI Purchase Order", self.purchase_order, "grand_total"
-            )
-            self.po_amount = flt(po_amount)
-            self.approval_tier = get_approval_tier(self.po_amount)
+	def before_insert(self):
+		# Auto-set tier and approver based on PO amount
+		if self.purchase_order and not self.approval_tier:
+			po_amount = frappe.db.get_value("BEI Purchase Order", self.purchase_order, "grand_total")
+			self.po_amount = flt(po_amount)
+			self.approval_tier = get_approval_tier(self.po_amount)
 
-        if self.approval_tier and not self.approver:
-            self.approver = EXCEPTION_APPROVERS.get(self.approval_tier)
+		if self.approval_tier and not self.approver:
+			self.approver = EXCEPTION_APPROVERS.get(self.approval_tier)
 
-        if not self.status:
-            self.status = get_tier_status(self.approval_tier or "CPO")
+		if not self.status:
+			self.status = get_tier_status(self.approval_tier or "CPO")
 
-        if not self.requested_by:
-            self.requested_by = frappe.session.user
+		if not self.requested_by:
+			self.requested_by = frappe.session.user
 
-        if not self.requested_date:
-            self.requested_date = now_datetime()
+		if not self.requested_date:
+			self.requested_date = now_datetime()
 
-        if not self.approver_status:
-            self.approver_status = "Pending"
+		if not self.approver_status:
+			self.approver_status = "Pending"


### PR DESCRIPTION
## Summary\n- allow BEI Match Exception reference_type to include BEI Distribution Trip\n- add dual-tier options needed by GAP-092 (CPO+CFO/CPO+CEO)\n- normalize dual-tier initial status to Pending CPO\n- add Delivery Pre-Billing exception type and explicit trace fields in DocType schema\n\n## Validation\n- python -m pytest hrms/tests/test_dispatch_pre_delivery.py -q\n- rerun Sprint 03 integrated evidence after deploy