### PR TITLE
fix(dispatch): handle missing BEI Settings billing flag in runtime

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -503,8 +503,13 @@ def _create_delivery_billing(
 	"""Create a BEI Billing Schedule for a delivery stop."""
 	# G-067: Feature flag — billing is enabled by default.
 	# Set BEI Settings.enable_delivery_billing = 0 to disable.
-	billing_enabled = frappe.db.get_single_value("BEI Settings", "enable_delivery_billing")
-	if billing_enabled is not None and not billing_enabled:
+	# Some runtime tenants may not have this field yet; treat missing as enabled.
+	try:
+		billing_setting = frappe.db.get_single_value("BEI Settings", "enable_delivery_billing")
+	except Exception:
+		billing_setting = None
+
+	if not should_auto_create_billing_on_delivery(billing_setting):
 		return
 
 	trip = frappe.get_doc("BEI Distribution Trip", trip_name)


### PR DESCRIPTION
## Summary\n- avoid hard failure when BEI Settings.enable_delivery_billing is absent in tenant schema\n- default behavior remains enabled (consistent with G-067 policy)\n\n## Validation\n- pre-commit run --files hrms/api/dispatch.py hrms/hr/doctype/bei_match_exception/bei_match_exception.py\n- python -m pytest hrms/tests/test_dispatch_pre_delivery.py -q