### PR TITLE
fix: force manual pre-delivery billing path when auto toggle is off

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -387,6 +387,7 @@ def create_pre_delivery_billing(trip_name: str, stop_idx: int | str, pre_deliver
 		stop_idx=stop_idx,
 		pre_delivery_exception=pre_delivery_exception,
 		require_pre_delivery_exception=True,
+		force_create=True,
 	)
 
 	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
@@ -524,6 +525,7 @@ def _create_delivery_billing(
 	stop_idx: int | str,
 	pre_delivery_exception: str | None = None,
 	require_pre_delivery_exception: bool = False,
+	force_create: bool = False,
 ):
 	"""Create a BEI Billing Schedule for a delivery stop."""
 	# G-067: Feature flag — billing is enabled by default.
@@ -531,7 +533,7 @@ def _create_delivery_billing(
 	# Some runtime tenants may not have this field yet; treat missing as enabled.
 	billing_setting = _safe_single_value("BEI Settings", "enable_delivery_billing")
 
-	if not should_auto_create_billing_on_delivery(billing_setting):
+	if not force_create and not should_auto_create_billing_on_delivery(billing_setting):
 		return
 
 	trip = frappe.get_doc("BEI Distribution Trip", trip_name)

--- a/hrms/tests/test_dispatch_pre_delivery.py
+++ b/hrms/tests/test_dispatch_pre_delivery.py
@@ -205,6 +205,7 @@ class TestDispatchPreDelivery(unittest.TestCase):
 			stop_idx=1,
 			pre_delivery_exception="BEI-EXC-0003",
 			require_pre_delivery_exception=True,
+			force_create=True,
 		)
 		self.assertEqual(result["billing_reference"], "BILL-0001")
 


### PR DESCRIPTION
## Summary
- add orce_create support in _create_delivery_billing
- call manual create_pre_delivery_billing with orce_create=True
- keep global auto-billing toggle behavior unchanged for non-manual paths
- update dispatch pre-delivery unit test expectation

## Validation
- python -m pytest hrms/tests/test_dispatch_pre_delivery.py hrms/tests/test_delivery_billing_policy.py -q

## Why
Sprint 03 integrated S03-092 still blocked after approval fix because LFG has auto billing disabled and manual pre-delivery billing endpoint reused that toggle.
