### PR TITLE
fix(transfer): resolve dispatch sync 500 from underscore shadowing

### DIFF
--- a/hrms/api/transfer_requests.py
+++ b/hrms/api/transfer_requests.py
@@ -1024,7 +1024,7 @@ def _dispatch_transfer_sync(
 	remove_devices = plan["remove_devices"]
 	all_devices = sorted(set(target_devices + remove_devices))
 
-	_, invalid_devices = validate_device_batch(all_devices)
+	valid_devices, invalid_devices = validate_device_batch(all_devices)
 	if invalid_devices:
 		frappe.throw(_("Invalid device mapping: {0}").format(", ".join(invalid_devices)))
 


### PR DESCRIPTION
## Problem\nManual transfer sync dispatch (dispatch_transfer_sync) returns HTTP 500 with TypeError: 'list' object is not callable.\n\n## Root cause\nInside _dispatch_transfer_sync, tuple unpacking used _ as a local variable:\n- _, invalid_devices = validate_device_batch(all_devices)\n\nThat shadows Frappe i18n function _ in function scope, so later _('...') crashes.\n\n## Fix\nRename local binding to avoid shadowing:\n- alid_devices, invalid_devices = validate_device_batch(all_devices)\n\n## Verification\n- python -m py_compile hrms/api/transfer_requests.py\n- Live transfer flow reproduced pre-fix and captured error evidence under output/l3/runs/*.\n\nAfter merge/deploy I will rerun live L1-L4 transfer flow and attach GO evidence.