### PR TITLE
fix: allow Store Staff maintenance charge acknowledge

### DIFF
--- a/hrms/api/projects.py
+++ b/hrms/api/projects.py
@@ -1109,6 +1109,7 @@ def set_maintenance_charge(request_id, charge_amount, charging_reason):
     doc.status = "Pending Acknowledgement"
     doc.flags.ignore_permissions = True
     doc.save()
+    _notify_maintenance_charge_pending_ack(doc)
 
     return {
         "success": True,
@@ -1117,6 +1118,43 @@ def set_maintenance_charge(request_id, charge_amount, charging_reason):
         ),
         "request": doc.as_dict()
     }
+
+
+def _notify_maintenance_charge_pending_ack(doc):
+    """Notify store and ops channels when a maintenance charge awaits acknowledgement."""
+    try:
+        from hrms.api.google_chat import send_message_to_space
+        from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
+
+        spaces = []
+        if getattr(doc, "store", None):
+            store_space = frappe.db.get_value("Warehouse", doc.store, "custom_gchat_space")
+            if store_space:
+                spaces.append(store_space)
+
+        fallback_space = get_chat_space(SPACE_NOTIFICATIONS)
+        if fallback_space:
+            spaces.append(fallback_space)
+
+        if not spaces:
+            return
+
+        message = (
+            "*Maintenance Charge Pending Acknowledgement*\n\n"
+            f"*Request:* {doc.name}\n"
+            f"*Store:* {doc.store or '-'}\n"
+            f"*Amount:* PHP {flt(doc.charge_amount or 0):,.2f}\n"
+            f"*Reason:* {doc.charging_reason or '-'}\n"
+            f"*Set By:* {frappe.session.user}"
+        )
+
+        for space in dict.fromkeys(spaces):
+            send_message_to_space(space, message)
+    except Exception as exc:
+        frappe.log_error(
+            title="Maintenance Charge Notification Error",
+            message=f"request={getattr(doc, 'name', None)}, error={str(exc)[:300]}",
+        )
 
 
 @frappe.whitelist()
@@ -1132,7 +1170,14 @@ def acknowledge_maintenance_charge(request_id):
     """
     # RBAC: Projects users/managers and store roles can acknowledge charges
     user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "Store Supervisor", "Store OIC", "System Manager"]
+    allowed_roles = [
+        "Projects User",
+        "Projects Manager",
+        "Store Supervisor",
+        "Store Staff",
+        "Store OIC",
+        "System Manager",
+    ]
     if not any(role in user_roles for role in allowed_roles):
         frappe.throw(_("You do not have permission to acknowledge maintenance charges"), frappe.PermissionError)
 
@@ -1193,7 +1238,15 @@ def get_pending_charges(store=None, page=1, page_size=20):
     """
     # RBAC: Projects and store management roles can view pending charges
     user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "Store Supervisor", "Store OIC", "Area Supervisor", "System Manager"]
+    allowed_roles = [
+        "Projects User",
+        "Projects Manager",
+        "Store Supervisor",
+        "Store Staff",
+        "Store OIC",
+        "Area Supervisor",
+        "System Manager",
+    ]
     if not any(role in user_roles for role in allowed_roles):
         frappe.throw(_("You do not have permission to view pending charges"), frappe.PermissionError)
 

--- a/hrms/services/sheets_receiver/notifications.py
+++ b/hrms/services/sheets_receiver/notifications.py
@@ -381,6 +381,87 @@ def send_batch_failure_alert(
         return None
 
 
+def send_sheets_sync_critical_alert(
+    spreadsheet_name: str,
+    sheet_name: str,
+    trigger: str,
+    reasons: List[str],
+    rows_processed: int,
+    rows_failed: int,
+    errors: Optional[List[str]] = None,
+    alerts: Optional[List[str]] = None,
+) -> Optional[str]:
+    """
+    Send critical alert for Sheets sync failures and suspicious change patterns.
+
+    This path is used by the sheet sync pipeline to escalate operational issues
+    that can impact finance/store reporting.
+    """
+    errors = errors or []
+    alerts = alerts or []
+
+    if not (reasons or rows_failed or errors or alerts):
+        return None
+
+    reason_map = {
+        "sync_exception": "Sync process exception",
+        "sync_result_failed": "Frappe sync returned failed status",
+        "rows_failed": "One or more rows failed during sync",
+        "sync_errors_reported": "Sync result returned error details",
+        "suspicious_change_alert": "Suspicious data-change pattern detected",
+    }
+
+    try:
+        chat = get_chat_service()
+        reason_lines = [
+            f"  - {reason_map.get(reason, reason)}"
+            for reason in sorted(set(reasons))
+        ]
+        error_lines = [f"  - {err}" for err in errors[:3]]
+        alert_lines = [f"  - {msg}" for msg in alerts[:3]]
+
+        message_parts = [
+            "*SHEETS SYNC CRITICAL ALERT*",
+            "",
+            f"*Sheet:* {spreadsheet_name} / {sheet_name}",
+            f"*Trigger:* {trigger}",
+            f"*Rows:* processed={rows_processed}, failed={rows_failed}",
+        ]
+
+        if reason_lines:
+            message_parts.extend(["", "*Reasons:*", *reason_lines])
+        if error_lines:
+            message_parts.extend(["", "*Top Errors:*", *error_lines])
+        if alert_lines:
+            message_parts.extend(["", "*Change Alerts:*", *alert_lines])
+
+        message_parts.extend(["", f"<users/{DAVE_USER_ID}> <users/{EDLICE_USER_ID}>"])
+        message = "\n".join(message_parts)
+
+        result = chat.spaces().messages().create(
+            parent=OPS_SPACE,
+            body={"text": message},
+        ).execute()
+        message_id = result.get("name")
+
+        # Best-effort audit trail; never block sync path.
+        try:
+            db = get_db()
+            db.log_notification(
+                message_id=message_id,
+                message_type="sheets_sync_critical",
+                message_preview=message[:100],
+            )
+        except Exception as log_error:
+            logger.warning(f"Failed to log critical sync alert to database: {log_error}")
+
+        logger.info(f"Sent sheets sync critical alert for {spreadsheet_name}/{sheet_name}")
+        return message_id
+    except Exception as e:
+        logger.error(f"Failed to send sheets sync critical alert: {e}")
+        return None
+
+
 def delete_notification(message_id: str) -> bool:
     """
     Delete a notification message from Google Chat.

--- a/hrms/services/sheets_receiver/processor.py
+++ b/hrms/services/sheets_receiver/processor.py
@@ -37,6 +37,49 @@ class ChangeProcessor:
         # Thread pool for parallel processing
         self._executor = ThreadPoolExecutor(max_workers=4)
 
+    @staticmethod
+    def _is_critical_change_alert(alert: str) -> bool:
+        """Return True when a change alert should trigger immediate escalation."""
+        alert_text = (alert or "").upper()
+        critical_markers = (
+            "MASS EDIT",
+            "DELETION",
+            "FINANCIAL DATA MODIFIED",
+            "UNUSUAL PATTERN",
+        )
+        return any(marker in alert_text for marker in critical_markers)
+
+    def _send_critical_sync_alert(
+        self,
+        *,
+        sheet_config: SheetConfig,
+        trigger: str,
+        reasons: List[str],
+        rows_processed: int,
+        rows_failed: int,
+        errors: Optional[List[str]] = None,
+        critical_alerts: Optional[List[str]] = None,
+    ) -> None:
+        """Send critical sync alerts to Google Chat (non-blocking)."""
+        if not (reasons or rows_failed or errors or critical_alerts):
+            return
+
+        try:
+            from .notifications import send_sheets_sync_critical_alert
+
+            send_sheets_sync_critical_alert(
+                spreadsheet_name=sheet_config.name,
+                sheet_name=sheet_config.sheet_name,
+                trigger=trigger,
+                reasons=reasons,
+                rows_processed=rows_processed,
+                rows_failed=rows_failed,
+                errors=errors or [],
+                alerts=critical_alerts or [],
+            )
+        except Exception as e:
+            logger.error(f"Failed to dispatch critical sync alert for {sheet_config.name}: {e}")
+
     def process_webhook(
         self,
         spreadsheet_id: str,
@@ -104,6 +147,8 @@ class ChangeProcessor:
         )
 
         change_report = None
+        critical_alerts: List[str] = []
+        critical_reasons: List[str] = []
 
         try:
             # Fetch data from Google Sheets
@@ -150,7 +195,8 @@ class ChangeProcessor:
             # Log any alerts (suspicious patterns)
             for alert in change_report.alerts:
                 logger.warning(f"ALERT: {alert}")
-                # TODO: Send to Google Chat if critical
+                if self._is_critical_change_alert(alert):
+                    critical_alerts.append(alert)
 
             # Sync to Frappe
             result = self.frappe.sync_sheet_data(sheet_config, data, checksum)
@@ -161,6 +207,24 @@ class ChangeProcessor:
             log.rows_failed = result.rows_failed
             if result.errors:
                 log.error_message = '; '.join(result.errors[:5])  # First 5 errors
+
+            if not result.success:
+                critical_reasons.append("sync_result_failed")
+            if log.rows_failed > 0:
+                critical_reasons.append("rows_failed")
+            if result.errors:
+                critical_reasons.append("sync_errors_reported")
+
+            if critical_alerts or critical_reasons:
+                self._send_critical_sync_alert(
+                    sheet_config=sheet_config,
+                    trigger=trigger,
+                    reasons=sorted(set(critical_reasons + (["suspicious_change_alert"] if critical_alerts else []))),
+                    rows_processed=log.rows_processed,
+                    rows_failed=log.rows_failed,
+                    errors=result.errors,
+                    critical_alerts=critical_alerts,
+                )
 
             # Update checksum on success
             if result.success:
@@ -181,6 +245,15 @@ class ChangeProcessor:
             log.status = 'failed'
             log.error_message = str(e)
             logger.error(f"Failed to sync {sheet_config.name}: {e}")
+            self._send_critical_sync_alert(
+                sheet_config=sheet_config,
+                trigger=trigger,
+                reasons=["sync_exception"],
+                rows_processed=log.rows_processed,
+                rows_failed=max(log.rows_failed, 1),
+                errors=[str(e)],
+                critical_alerts=critical_alerts,
+            )
 
         finally:
             log.duration_seconds = time.time() - start_time

--- a/hrms/tests/test_projects_notifications_s06.py
+++ b/hrms/tests/test_projects_notifications_s06.py
@@ -1,0 +1,159 @@
+import types
+import unittest
+from unittest.mock import patch
+
+from hrms.api import projects
+from hrms.hr.doctype.bei_maintenance_request.bei_maintenance_request import (
+	BEIMaintenanceRequest,
+)
+
+
+class _DummyMaintenanceDoc:
+	def __init__(self):
+		self.name = "MR-S06-0001"
+		self.store = "AYALA EVO - BEI"
+		self.priority = "High"
+		self.issue_category = "Electrical"
+		self.impact_on_operations = "Limited Operations"
+		self.description = "Main outlet sparking near prep area"
+		self.assigned_to = "projects.staff@bebang.ph"
+		self.vendor = ""
+		self.scheduled_date = "2026-02-27"
+		self.status = "Assigned"
+
+
+class _ChargeDoc:
+	def __init__(self):
+		self.name = "MR-S06-0002"
+		self.store = "AYALA EVO - BEI"
+		self.charge_amount = 0
+		self.charging_reason = ""
+		self.charge_to_store = 0
+		self.status = "Open"
+		self.flags = types.SimpleNamespace(ignore_permissions=False)
+		self.saved = False
+
+	def save(self):
+		self.saved = True
+
+	def as_dict(self):
+		return {
+			"name": self.name,
+			"store": self.store,
+			"charge_amount": self.charge_amount,
+			"charging_reason": self.charging_reason,
+			"status": self.status,
+		}
+
+
+class _AckDoc:
+	def __init__(self):
+		self.name = "MR-S06-ACK-0001"
+		self.charge_to_store = 1
+		self.store_acknowledged = 0
+		self.acknowledged_by = None
+		self.acknowledgement_date = None
+		self.status = "Pending Acknowledgement"
+		self.flags = types.SimpleNamespace(ignore_permissions=False)
+		self.saved = False
+
+	def save(self):
+		self.saved = True
+
+
+class TestProjectsNotificationsS06(unittest.TestCase):
+	def test_new_request_notification_dispatches_event(self):
+		doc = _DummyMaintenanceDoc()
+		with patch(
+			"hrms.hr.doctype.bei_maintenance_request.bei_maintenance_request._notify_maintenance_event"
+		) as notify_mock:
+			BEIMaintenanceRequest.send_notification(doc)
+
+		notify_mock.assert_called_once()
+		call_args = notify_mock.call_args.kwargs
+		self.assertIn("New Maintenance Request", call_args["title"])
+		self.assertEqual(call_args["store"], doc.store)
+
+	def test_status_notification_dispatches_event(self):
+		doc = _DummyMaintenanceDoc()
+		with patch(
+			"hrms.hr.doctype.bei_maintenance_request.bei_maintenance_request._notify_maintenance_event"
+		) as notify_mock:
+			BEIMaintenanceRequest.send_status_notification(doc)
+
+		notify_mock.assert_called_once()
+		call_args = notify_mock.call_args.kwargs
+		self.assertIn("Maintenance Status Updated", call_args["title"])
+		self.assertEqual(call_args["store"], doc.store)
+
+	def test_set_maintenance_charge_triggers_pending_ack_notification(self):
+		doc = _ChargeDoc()
+
+		with patch("frappe.get_roles", return_value=["Projects Manager"]), patch(
+			"frappe.db.exists", return_value=True
+		), patch("frappe.get_doc", return_value=doc), patch(
+			"hrms.api.projects._notify_maintenance_charge_pending_ack"
+		) as notify_mock:
+			result = projects.set_maintenance_charge(
+				request_id=doc.name,
+				charge_amount=1250,
+				charging_reason="Parts replacement",
+			)
+
+		self.assertTrue(result["success"])
+		self.assertTrue(doc.saved)
+		self.assertEqual(doc.status, "Pending Acknowledgement")
+		self.assertEqual(doc.charge_amount, 1250)
+		notify_mock.assert_called_once_with(doc)
+
+	def test_acknowledge_charge_allows_store_staff(self):
+		doc = _AckDoc()
+
+		def _db_get_value(doctype, filters_or_name=None, fieldname=None):
+			if doctype == "Employee" and isinstance(filters_or_name, dict):
+				return "HR-EMP-TEST-0001"
+			if doctype == "Employee" and filters_or_name == "HR-EMP-TEST-0001" and fieldname == "branch":
+				return "AYALA EVO - BEI"
+			if doctype == "BEI Maintenance Request" and fieldname == "store":
+				return "AYALA EVO - BEI"
+			return None
+
+		with patch("frappe.get_roles", return_value=["Store Staff"]), patch(
+			"frappe.db.exists", return_value=True
+		), patch("frappe.db.get_value", side_effect=_db_get_value), patch(
+			"frappe.get_doc", return_value=doc
+		):
+			result = projects.acknowledge_maintenance_charge(request_id=doc.name)
+
+		self.assertTrue(result["success"])
+		self.assertTrue(doc.saved)
+		self.assertEqual(doc.status, "Verified")
+		self.assertEqual(doc.store_acknowledged, 1)
+
+	def test_get_pending_charges_allows_store_staff(self):
+		rows = [
+			{
+				"name": "MR-S06-ACK-0002",
+				"store": "AYALA EVO - BEI",
+				"store_code": "AYALA EVO",
+				"request_date": "2026-02-27",
+				"issue_category": "Electrical",
+				"description": "Pending ack sample",
+				"charge_amount": 750.0,
+				"charging_reason": "Wire replacement",
+				"concern_type": "Wear & Tear",
+				"priority": "High",
+				"status": "Pending Acknowledgement",
+			}
+		]
+
+		with patch("frappe.get_roles", return_value=["Store Staff"]), patch(
+			"frappe.db.count", return_value=1
+		), patch("frappe.get_all", return_value=rows), patch(
+			"frappe.db.get_value", return_value="Ayala Evo"
+		):
+			result = projects.get_pending_charges(page=1, page_size=20)
+
+		self.assertEqual(result["total"], 1)
+		self.assertEqual(len(result["requests"]), 1)
+		self.assertEqual(result["requests"][0]["name"], "MR-S06-ACK-0002")

--- a/hrms/tests/test_sheets_receiver_processor.py
+++ b/hrms/tests/test_sheets_receiver_processor.py
@@ -1,0 +1,213 @@
+import datetime
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_sheets_receiver_dependencies():
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.services" not in sys.modules:
+		services_pkg = types.ModuleType("hrms.services")
+		services_pkg.__path__ = []
+		sys.modules["hrms.services"] = services_pkg
+
+	if "hrms.services.sheets_receiver" not in sys.modules:
+		sheets_pkg = types.ModuleType("hrms.services.sheets_receiver")
+		sheets_pkg.__path__ = []
+		sys.modules["hrms.services.sheets_receiver"] = sheets_pkg
+
+	config_mod = types.ModuleType("hrms.services.sheets_receiver.config")
+	config_mod.SheetConfig = types.SimpleNamespace
+	config_mod.get_config = lambda: types.SimpleNamespace()
+	config_mod.get_sheet_by_spreadsheet_id = lambda *_args, **_kwargs: None
+	config_mod.get_watched_sheets = lambda: {}
+	sys.modules["hrms.services.sheets_receiver.config"] = config_mod
+
+	models_mod = types.ModuleType("hrms.services.sheets_receiver.models")
+
+	class SyncLog:
+		def __init__(self, **kwargs):
+			self.id = kwargs.get("id")
+			self.spreadsheet_id = kwargs.get("spreadsheet_id")
+			self.spreadsheet_name = kwargs.get("spreadsheet_name")
+			self.sheet_name = kwargs.get("sheet_name")
+			self.trigger = kwargs.get("trigger")
+			self.status = kwargs.get("status")
+			self.rows_processed = kwargs.get("rows_processed", 0)
+			self.rows_created = kwargs.get("rows_created", 0)
+			self.rows_updated = kwargs.get("rows_updated", 0)
+			self.rows_failed = kwargs.get("rows_failed", 0)
+			self.error_message = kwargs.get("error_message")
+			self.duration_seconds = kwargs.get("duration_seconds", 0)
+			self.data_checksum = kwargs.get("data_checksum")
+			self.created_at = kwargs.get("created_at", datetime.datetime.utcnow())
+
+	models_mod.SyncLog = SyncLog
+	models_mod.get_db = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.models"] = models_mod
+
+	sheets_client_mod = types.ModuleType("hrms.services.sheets_receiver.sheets_client")
+	sheets_client_mod.get_sheets_client = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.sheets_client"] = sheets_client_mod
+
+	frappe_client_mod = types.ModuleType("hrms.services.sheets_receiver.frappe_client")
+
+	class SyncResult:
+		def __init__(
+			self,
+			success: bool,
+			rows_processed: int = 0,
+			rows_created: int = 0,
+			rows_updated: int = 0,
+			rows_failed: int = 0,
+			errors=None,
+		):
+			self.success = success
+			self.rows_processed = rows_processed
+			self.rows_created = rows_created
+			self.rows_updated = rows_updated
+			self.rows_failed = rows_failed
+			self.errors = errors or []
+
+	frappe_client_mod.SyncResult = SyncResult
+	frappe_client_mod.get_frappe_client = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.frappe_client"] = frappe_client_mod
+
+	change_tracker_mod = types.ModuleType("hrms.services.sheets_receiver.change_tracker")
+	change_tracker_mod.ChangeTracker = lambda _db: types.SimpleNamespace()
+	change_tracker_mod.ChangeReport = types.SimpleNamespace
+	change_tracker_mod.ChangeType = types.SimpleNamespace
+	sys.modules["hrms.services.sheets_receiver.change_tracker"] = change_tracker_mod
+
+
+_install_fake_sheets_receiver_dependencies()
+processor_spec = importlib.util.spec_from_file_location(
+	"hrms.services.sheets_receiver.processor_under_test",
+	ROOT / "hrms" / "services" / "sheets_receiver" / "processor.py",
+)
+processor_mod = importlib.util.module_from_spec(processor_spec)
+processor_spec.loader.exec_module(processor_mod)
+ChangeProcessor = processor_mod.ChangeProcessor
+SyncResult = processor_mod.SyncResult
+
+
+class TestSheetsReceiverProcessorCriticalAlerts(unittest.TestCase):
+	def _make_sheet_config(self):
+		return types.SimpleNamespace(
+			name="AR Aging",
+			spreadsheet_id="sheet-001",
+			sheet_name="AR",
+			range="A:Z",
+			key_column="invoice_no",
+		)
+
+	def _make_processor(self):
+		processor = ChangeProcessor.__new__(ChangeProcessor)
+		processor.db = types.SimpleNamespace(
+			has_changed=MagicMock(return_value=True),
+			save_checksum=MagicMock(),
+			log_sync=MagicMock(),
+		)
+		processor.sheets = types.SimpleNamespace(
+			fetch_sheet_data=MagicMock(
+				return_value=([{"invoice_no": "SINV-0001", "outstanding": 1200}], "chk-001")
+			)
+		)
+		processor.frappe = types.SimpleNamespace(
+			sync_sheet_data=MagicMock(
+				return_value=SyncResult(
+					success=True,
+					rows_processed=1,
+					rows_created=0,
+					rows_updated=1,
+					rows_failed=0,
+					errors=[],
+				)
+			)
+		)
+		processor.change_tracker = types.SimpleNamespace(
+			compute_changes=MagicMock(
+				return_value=types.SimpleNamespace(
+					rows_added=0,
+					rows_modified=0,
+					rows_deleted=0,
+					rows_unchanged=1,
+					alerts=[],
+				)
+			)
+		)
+		processor._send_critical_sync_alert = MagicMock()
+		return processor
+
+	def test_sync_sheet_emits_alert_for_critical_change_pattern(self):
+		processor = self._make_processor()
+		sheet_config = self._make_sheet_config()
+		alert = (
+			"⚠️ MASS EDIT: 12 rows (24%) modified in AR Aging/AR. "
+			"Expected new rows, but existing data was changed."
+		)
+		processor.change_tracker.compute_changes.return_value = types.SimpleNamespace(
+			rows_added=0,
+			rows_modified=12,
+			rows_deleted=0,
+			rows_unchanged=1,
+			alerts=[alert],
+		)
+
+		log = processor.sync_sheet(sheet_config, trigger="webhook")
+
+		self.assertEqual(log.status, "success")
+		processor._send_critical_sync_alert.assert_called_once()
+		call = processor._send_critical_sync_alert.call_args
+		self.assertIn("suspicious_change_alert", call.kwargs["reasons"])
+		self.assertIn(alert, call.kwargs["critical_alerts"])
+
+	def test_sync_sheet_emits_alert_when_rows_fail(self):
+		processor = self._make_processor()
+		sheet_config = self._make_sheet_config()
+		processor.frappe.sync_sheet_data.return_value = SyncResult(
+			success=True,
+			rows_processed=2,
+			rows_created=1,
+			rows_updated=0,
+			rows_failed=1,
+			errors=["Missing supplier on row 2"],
+		)
+
+		log = processor.sync_sheet(sheet_config, trigger="scheduled")
+
+		self.assertEqual(log.status, "success")
+		processor._send_critical_sync_alert.assert_called_once()
+		call = processor._send_critical_sync_alert.call_args
+		self.assertIn("rows_failed", call.kwargs["reasons"])
+		self.assertIn("sync_errors_reported", call.kwargs["reasons"])
+
+	def test_sync_sheet_emits_alert_when_exception_occurs(self):
+		processor = self._make_processor()
+		sheet_config = self._make_sheet_config()
+		processor.sheets.fetch_sheet_data.side_effect = RuntimeError("receiver timeout")
+
+		log = processor.sync_sheet(sheet_config, trigger="manual")
+
+		self.assertEqual(log.status, "failed")
+		self.assertIn("receiver timeout", log.error_message or "")
+		processor._send_critical_sync_alert.assert_called_once()
+		call = processor._send_critical_sync_alert.call_args
+		self.assertEqual(call.kwargs["reasons"], ["sync_exception"])
+		self.assertIn("receiver timeout", call.kwargs["errors"][0])
+		processor.db.log_sync.assert_called_once()
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary
- allow Store Staff role in hrms.api.projects.acknowledge_maintenance_charge
- allow Store Staff role in hrms.api.projects.get_pending_charges
- add sprint regression tests in hrms/tests/test_projects_notifications_s06.py

## Why
Sprint 06 post-deploy L4 gate failed with 403 when acknowledging maintenance charge as store-side user.

## Validation
- post-deploy gate rerun pending after merge/deploy