### PR TITLE
fix: allow Store Staff maintenance charge acknowledge

### DIFF
--- a/hrms/api/projects.py
+++ b/hrms/api/projects.py
@@ -1170,7 +1170,14 @@ def acknowledge_maintenance_charge(request_id):
     """
     # RBAC: Projects users/managers and store roles can acknowledge charges
     user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "Store Supervisor", "Store OIC", "System Manager"]
+    allowed_roles = [
+        "Projects User",
+        "Projects Manager",
+        "Store Supervisor",
+        "Store Staff",
+        "Store OIC",
+        "System Manager",
+    ]
     if not any(role in user_roles for role in allowed_roles):
         frappe.throw(_("You do not have permission to acknowledge maintenance charges"), frappe.PermissionError)
 
@@ -1231,7 +1238,15 @@ def get_pending_charges(store=None, page=1, page_size=20):
     """
     # RBAC: Projects and store management roles can view pending charges
     user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "Store Supervisor", "Store OIC", "Area Supervisor", "System Manager"]
+    allowed_roles = [
+        "Projects User",
+        "Projects Manager",
+        "Store Supervisor",
+        "Store Staff",
+        "Store OIC",
+        "Area Supervisor",
+        "System Manager",
+    ]
     if not any(role in user_roles for role in allowed_roles):
         frappe.throw(_("You do not have permission to view pending charges"), frappe.PermissionError)
 

--- a/hrms/tests/test_projects_notifications_s06.py
+++ b/hrms/tests/test_projects_notifications_s06.py
@@ -45,6 +45,20 @@ class _ChargeDoc:
 			"status": self.status,
 		}
 
+class _AckDoc:
+	def __init__(self):
+		self.name = "MR-S06-ACK-0001"
+		self.charge_to_store = 1
+		self.store_acknowledged = 0
+		self.acknowledged_by = None
+		self.acknowledgement_date = None
+		self.status = "Pending Acknowledgement"
+		self.flags = types.SimpleNamespace(ignore_permissions=False)
+		self.saved = False
+
+	def save(self):
+		self.saved = True
+
 
 class TestProjectsNotificationsS06(unittest.TestCase):
 	def test_new_request_notification_dispatches_event(self):
@@ -90,3 +104,55 @@ class TestProjectsNotificationsS06(unittest.TestCase):
 		self.assertEqual(doc.status, "Pending Acknowledgement")
 		self.assertEqual(doc.charge_amount, 1250)
 		notify_mock.assert_called_once_with(doc)
+
+	def test_acknowledge_charge_allows_store_staff(self):
+		doc = _AckDoc()
+
+		def _db_get_value(doctype, filters_or_name=None, fieldname=None):
+			if doctype == "Employee" and isinstance(filters_or_name, dict):
+				return "HR-EMP-TEST-0001"
+			if doctype == "Employee" and filters_or_name == "HR-EMP-TEST-0001" and fieldname == "branch":
+				return "AYALA EVO - BEI"
+			if doctype == "BEI Maintenance Request" and fieldname == "store":
+				return "AYALA EVO - BEI"
+			return None
+
+		with patch("frappe.get_roles", return_value=["Store Staff"]), patch(
+			"frappe.db.exists", return_value=True
+		), patch("frappe.db.get_value", side_effect=_db_get_value), patch(
+			"frappe.get_doc", return_value=doc
+		):
+			result = projects.acknowledge_maintenance_charge(request_id=doc.name)
+
+		self.assertTrue(result["success"])
+		self.assertTrue(doc.saved)
+		self.assertEqual(doc.status, "Verified")
+		self.assertEqual(doc.store_acknowledged, 1)
+
+	def test_get_pending_charges_allows_store_staff(self):
+		rows = [
+			{
+				"name": "MR-S06-ACK-0002",
+				"store": "AYALA EVO - BEI",
+				"store_code": "AYALA EVO",
+				"request_date": "2026-02-27",
+				"issue_category": "Electrical",
+				"description": "Pending ack sample",
+				"charge_amount": 750.0,
+				"charging_reason": "Wire replacement",
+				"concern_type": "Wear & Tear",
+				"priority": "High",
+				"status": "Pending Acknowledgement",
+			}
+		]
+
+		with patch("frappe.get_roles", return_value=["Store Staff"]), patch(
+			"frappe.db.count", return_value=1
+		), patch("frappe.get_all", return_value=rows), patch(
+			"frappe.db.get_value", return_value="Ayala Evo"
+		):
+			result = projects.get_pending_charges(page=1, page_size=20)
+
+		self.assertEqual(result["total"], 1)
+		self.assertEqual(len(result["requests"]), 1)
+		self.assertEqual(result["requests"][0]["name"], "MR-S06-ACK-0002")


### PR DESCRIPTION
Hotfix for Sprint 06 post-deploy L4 failure (403 on acknowledge_maintenance_charge for store-side user).\n\nChanges:\n- add Store Staff in acknowledge_maintenance_charge RBAC\n- add Store Staff in get_pending_charges RBAC\n- add regression tests in hrms/tests/test_projects_notifications_s06.py