### PR TITLE
fix: stabilize monthly billing trigger savepoint handling

### DIFF
--- a/hrms/api/billing.py
+++ b/hrms/api/billing.py
@@ -287,7 +287,7 @@ def generate_monthly_billing(billing_period=None, store=None):
 
     for store_rec in stores:
         sp_name = "billing_" + re.sub(r'[^a-zA-Z0-9_]', '_', store_rec.store)
-        sp = frappe.db.savepoint(sp_name)
+        frappe.db.savepoint(sp_name)
         try:
             # Duplicate check
             existing = frappe.db.exists("BEI Billing Schedule", {
@@ -298,7 +298,7 @@ def generate_monthly_billing(billing_period=None, store=None):
             })
             if existing:
                 skipped += 1
-                frappe.db.release_savepoint(sp)
+                frappe.db.release_savepoint(sp_name)
                 continue
 
             # Aggregate sales from Store Closing Reports
@@ -326,7 +326,7 @@ def generate_monthly_billing(billing_period=None, store=None):
 
             if not sales_data.gross_sales and not sales_data.net_sales:
                 skipped += 1
-                frappe.db.release_savepoint(sp)
+                frappe.db.release_savepoint(sp_name)
                 continue
 
             billing = frappe.get_doc({
@@ -384,10 +384,10 @@ def generate_monthly_billing(billing_period=None, store=None):
                     )
 
             generated += 1
-            frappe.db.release_savepoint(sp)
+            frappe.db.release_savepoint(sp_name)
 
         except Exception as e:
-            frappe.db.rollback(save_point=sp)
+            frappe.db.rollback(save_point=sp_name)
             errors.append({"store": store_rec.store, "error": str(e)})
 
     return {

--- a/hrms/tests/test_or_followup_monthly_billing_s08.py
+++ b/hrms/tests/test_or_followup_monthly_billing_s08.py
@@ -4,6 +4,7 @@ import sys
 import types
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -209,6 +210,29 @@ class TestOrFollowupMonthlyBillingSprint08(unittest.TestCase):
         self.assertTrue(result["notification_sent"])
         self.assertEqual(result["notification_channels"], ["google_chat"])
         self.assertEqual(result["follow_up_count"], 1)
+
+    def test_generate_monthly_billing_uses_named_savepoint_for_release(self):
+        billing.frappe.has_permission = lambda *args, **kwargs: True
+        billing.frappe.get_all = MagicMock(
+            return_value=[SimpleNamespace(store="TEST STORE", store_type="Full Franchise")]
+        )
+
+        savepoint = MagicMock(return_value=None)
+        release_savepoint = MagicMock()
+        rollback = MagicMock()
+
+        billing.frappe.db.savepoint = savepoint
+        billing.frappe.db.release_savepoint = release_savepoint
+        billing.frappe.db.rollback = rollback
+        billing.frappe.db.exists = MagicMock(return_value="BILL-EXISTING")
+
+        result = billing.generate_monthly_billing("2099-01")
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["skipped"], 1)
+        savepoint.assert_called_once_with("billing_TEST_STORE")
+        release_savepoint.assert_called_once_with("billing_TEST_STORE")
+        rollback.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use deterministic sp_name for savepoint release/rollback in generate_monthly_billing
- avoid SAVEPOINT None does not exist errors during service trigger
- add regression test to ensure named savepoint is used

## Validation
- python hrms/tests/test_or_followup_monthly_billing_s08.py
- python hrms/tests/test_billing_doc_events_s08.py
- python hrms/tests/test_pcf_hooks_s08.py
