### PR TITLE
Sprint 10: Inventory/Warehouse contract consistency (HRMS)

### DIFF
--- a/hrms/api/billing.py
+++ b/hrms/api/billing.py
@@ -717,6 +717,8 @@ def get_3pl_rates(partner=None, cargo_type=None):
         SELECT
             name, rate_name, threepl_partner, cargo_type, zone,
             rate_per_trip, overtime_rate, surcharge_rate,
+            COALESCE(ewt_atc, 'WC110') AS ewt_atc,
+            COALESCE(ewt_rate, 1.0) AS ewt_rate,
             effective_from, effective_to, notes
         FROM `tabBEI 3PL Rate`
         WHERE {where_clause}
@@ -725,6 +727,12 @@ def get_3pl_rates(partner=None, cargo_type=None):
         params,
         as_dict=True
     )
+
+    # Contract hardening for portal billing pages:
+    # always include EWT fields even if legacy rows/migrations omit them.
+    for rate in rates:
+        rate["ewt_atc"] = rate.get("ewt_atc") or "WC110"
+        rate["ewt_rate"] = flt(rate.get("ewt_rate") or 1.0)
 
     return {"rates": rates, "count": len(rates)}
 

--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -1273,6 +1273,7 @@ def create_trip_from_route(
 
 		# Validate all selected stores exist in route's zone pool
 		zone_stores = {s.store for s in route.stops}
+		route_stop_map = {s.store: s for s in route.stops}
 		for sel in selected_stops:
 			if sel.get("store") not in zone_stores:
 				frappe.throw(_(f"Store {sel.get('store')} is not in zone {route.route_name}"))
@@ -1303,9 +1304,14 @@ def create_trip_from_route(
 		for sel in selected_stops:
 			store = sel.get("store")
 			order = order_map.get(store)
+			route_stop = route_stop_map.get(store)
+			estimated_minutes = getattr(route_stop, "estimated_minutes", 20) if route_stop else 20
+			selected_stop_order = cint(sel.get("stop_order")) or (len(stops) + 1)
 			stops.append(
 				{
 					"store": store,
+					"stop_order": selected_stop_order,
+					"estimated_minutes": estimated_minutes,
 					"items_count": item_counts.get(order, 0) if order else 0,
 					"store_order": order or "",
 				}

--- a/hrms/api/inventory.py
+++ b/hrms/api/inventory.py
@@ -629,10 +629,20 @@ def submit_return_request(store, items, photo=None):
     doc.insert()
     doc.submit()
 
+    total_qty = sum(flt(i.get("quantity") or i.get("qty") or 0) for i in items)
+    items_count = len(items)
+
     return {
         "success": True,
         "name": doc.name,
-        "message": _("Return request submitted successfully")
+        "message": _("Return request submitted successfully"),
+        "data": {
+            "name": doc.name,
+            "items_count": items_count,
+            "total_qty": total_qty,
+            "movement_type": "Material Issue",
+            "source_warehouse": warehouse,
+        },
     }
 
 

--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -13,6 +13,7 @@ from hrms.utils.scm_roles import check_scm_permission, SCM_APPROVAL_ROLES
 
 import frappe
 from frappe import _
+from frappe.utils import flt
 import json
 
 
@@ -466,7 +467,17 @@ def create_stock_transfer(source_warehouse, target_warehouse, items, mr_name=Non
     se.remarks = remarks or f"Transfer to {target_warehouse}"
 
     # Add items
+    normalized_items = []
     for item_data in items:
+        qty_value = item_data.get("qty", item_data.get("quantity"))
+        if qty_value is None:
+            frappe.throw(
+                _("Missing quantity for item {0}").format(item_data.get("item_code", "unknown"))
+            )
+        item_data["qty"] = flt(qty_value)
+        normalized_items.append(item_data)
+
+    for item_data in normalized_items:
         # Get item details
         item = frappe.get_doc("Item", item_data["item_code"])
 
@@ -516,7 +527,10 @@ def create_stock_transfer(source_warehouse, target_warehouse, items, mr_name=Non
         "data": {
             "name": se.name,
             "total_qty": sum(i.qty for i in se.items),
-            "items_count": len(se.items)
+            "items_count": len(se.items),
+            "movement_type": "Material Transfer",
+            "source_warehouse": source_warehouse,
+            "target_warehouse": target_warehouse,
         },
         "message": f"Stock Transfer {se.name} created successfully"
     }

--- a/hrms/tests/test_billing_doc_events_s08.py
+++ b/hrms/tests/test_billing_doc_events_s08.py
@@ -12,11 +12,14 @@ if str(ROOT) not in sys.path:
 
 
 def _install_fake_frappe():
-    if "frappe" in sys.modules:
-        return
-
-    frappe = types.ModuleType("frappe")
-    utils = types.ModuleType("frappe.utils")
+    frappe = sys.modules.get("frappe")
+    if frappe is None:
+        frappe = types.ModuleType("frappe")
+        sys.modules["frappe"] = frappe
+    utils = sys.modules.get("frappe.utils")
+    if utils is None:
+        utils = types.ModuleType("frappe.utils")
+        sys.modules["frappe.utils"] = utils
 
     class ValidationError(Exception):
         pass
@@ -68,8 +71,7 @@ def _install_fake_frappe():
     utils.get_last_day = lambda value: datetime.date.fromisoformat(str(value)[:10]).replace(day=28)
     utils.getdate = _getdate
 
-    sys.modules["frappe"] = frappe
-    sys.modules["frappe.utils"] = utils
+    frappe.utils = utils
 
 
 def _install_stub_dependencies():

--- a/hrms/tests/test_returns_consistency_s10.py
+++ b/hrms/tests/test_returns_consistency_s10.py
@@ -85,6 +85,69 @@ def _install_fake_modules():
 		sys.modules["frappe"] = frappe
 		sys.modules["frappe.utils"] = utils
 
+	frappe = sys.modules["frappe"]
+	utils = sys.modules.get("frappe.utils")
+	if utils is None:
+		utils = types.ModuleType("frappe.utils")
+		sys.modules["frappe.utils"] = utils
+	frappe.utils = utils
+
+	if not hasattr(frappe, "whitelist"):
+		def whitelist(*args, **kwargs):
+			def decorator(fn):
+				return fn
+			return decorator
+		frappe.whitelist = whitelist
+	if not hasattr(frappe, "_"):
+		frappe._ = lambda text: text
+	if not hasattr(frappe, "throw"):
+		def _throw(message, exc=None, title=None):
+			if isinstance(exc, type) and issubclass(exc, Exception):
+				raise exc(message)
+			raise Exception(message)
+		frappe.throw = _throw
+	if not hasattr(frappe, "PermissionError"):
+		frappe.PermissionError = type("PermissionError", (Exception,), {})
+	if not hasattr(frappe, "DoesNotExistError"):
+		frappe.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
+	if not hasattr(frappe, "parse_json"):
+		frappe.parse_json = json.loads
+	if not hasattr(frappe, "session"):
+		frappe.session = types.SimpleNamespace(user="test.supervisor@bebang.ph")
+	if not hasattr(frappe, "get_roles"):
+		frappe.get_roles = lambda user=None: ["Store Supervisor"]
+	if not hasattr(frappe, "db"):
+		frappe.db = types.SimpleNamespace(
+			exists=lambda doctype, value: bool(value),
+			get_value=lambda doctype, filters, fieldname=None, order_by=None: None,
+			sql=lambda *args, **kwargs: [],
+			get_all=lambda *args, **kwargs: [],
+			set_value=lambda *args, **kwargs: None,
+		)
+	if not hasattr(frappe, "new_doc"):
+		frappe.new_doc = lambda doctype: _FakeStockEntry()
+	if not hasattr(frappe, "get_doc"):
+		frappe.get_doc = lambda doctype, name=None: None
+	if not hasattr(frappe, "get_all"):
+		frappe.get_all = lambda *args, **kwargs: []
+	if not hasattr(frappe, "log_error"):
+		frappe.log_error = lambda *args, **kwargs: None
+	if not hasattr(frappe, "get_traceback"):
+		frappe.get_traceback = lambda: "traceback"
+
+	if not hasattr(utils, "today"):
+		utils.today = lambda: "2026-02-28"
+	if not hasattr(utils, "nowtime"):
+		utils.nowtime = lambda: "10:00:00"
+	if not hasattr(utils, "nowdate"):
+		utils.nowdate = lambda: "2026-02-28"
+	if not hasattr(utils, "now_datetime"):
+		utils.now_datetime = lambda: "2026-02-28 10:00:00"
+	if not hasattr(utils, "flt"):
+		utils.flt = lambda value, precision=None: float(value or 0)
+	if not hasattr(utils, "add_days"):
+		utils.add_days = lambda date, days: date
+
 	if "hrms" not in sys.modules:
 		hrms_pkg = types.ModuleType("hrms")
 		hrms_pkg.__path__ = []
@@ -107,14 +170,20 @@ def _install_fake_modules():
 
 	if "hrms.utils.scm_roles" not in sys.modules:
 		scm_roles_mod = types.ModuleType("hrms.utils.scm_roles")
-		scm_roles_mod.SCM_APPROVAL_ROLES = ["System Manager"]
-		scm_roles_mod.SCM_INVENTORY_ROLES = ["System Manager"]
-		scm_roles_mod.SCM_COMPLIANCE_ROLES = ["System Manager"]
-		scm_roles_mod.SCM_STOCK_UPDATE_ROLES = ["System Manager"]
-		scm_roles_mod.SCM_STORE_ROLES = ["Store Supervisor"]
-		scm_roles_mod.SCM_DISPATCH_ROLES = ["System Manager"]
-		scm_roles_mod.check_scm_permission = lambda roles, action: None
 		sys.modules["hrms.utils.scm_roles"] = scm_roles_mod
+
+	scm_roles_mod = sys.modules["hrms.utils.scm_roles"]
+	scm_roles_mod.SCM_APPROVAL_ROLES = getattr(scm_roles_mod, "SCM_APPROVAL_ROLES", ["System Manager"])
+	scm_roles_mod.SCM_INVENTORY_ROLES = getattr(scm_roles_mod, "SCM_INVENTORY_ROLES", ["System Manager"])
+	scm_roles_mod.SCM_COMPLIANCE_ROLES = getattr(scm_roles_mod, "SCM_COMPLIANCE_ROLES", ["System Manager"])
+	scm_roles_mod.SCM_STOCK_UPDATE_ROLES = getattr(scm_roles_mod, "SCM_STOCK_UPDATE_ROLES", ["System Manager"])
+	scm_roles_mod.SCM_STORE_ROLES = getattr(scm_roles_mod, "SCM_STORE_ROLES", ["Store Supervisor"])
+	scm_roles_mod.SCM_DISPATCH_ROLES = getattr(scm_roles_mod, "SCM_DISPATCH_ROLES", ["System Manager"])
+	scm_roles_mod.check_scm_permission = getattr(
+		scm_roles_mod,
+		"check_scm_permission",
+		lambda roles, action: None,
+	)
 
 
 _install_fake_modules()

--- a/hrms/tests/test_returns_consistency_s10.py
+++ b/hrms/tests/test_returns_consistency_s10.py
@@ -1,0 +1,225 @@
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+class _FakeStockEntry:
+	def __init__(self):
+		self.name = "STE-RET-0001"
+		self.items = []
+		self.stock_entry_type = None
+		self.company = None
+		self.custom_return_request = None
+		self.custom_return_from_store = None
+		self.custom_return_photo = None
+		self.set_posting_time = None
+		self.posting_date = None
+		self.posting_time = None
+		self.remarks = None
+		self.from_warehouse = None
+		self.to_warehouse = None
+
+	def append(self, table, row):
+		self.items.append(types.SimpleNamespace(**row))
+
+	def insert(self, **kwargs):
+		return self
+
+	def submit(self):
+		return self
+
+
+def _install_fake_modules():
+	if "frappe" not in sys.modules:
+		frappe = types.ModuleType("frappe")
+		utils = types.ModuleType("frappe.utils")
+
+		def whitelist(*args, **kwargs):
+			def decorator(fn):
+				return fn
+
+			return decorator
+
+		def _throw(message, exc=None, title=None):
+			if isinstance(exc, type) and issubclass(exc, Exception):
+				raise exc(message)
+			raise Exception(message)
+
+		frappe.whitelist = whitelist
+		frappe._ = lambda text: text
+		frappe.throw = _throw
+		frappe.PermissionError = type("PermissionError", (Exception,), {})
+		frappe.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
+		frappe.log_error = lambda *args, **kwargs: None
+		frappe.get_traceback = lambda: "traceback"
+		frappe.parse_json = json.loads
+		frappe.session = types.SimpleNamespace(user="test.supervisor@bebang.ph")
+		frappe.get_roles = lambda user=None: ["Store Supervisor"]
+
+		frappe.db = types.SimpleNamespace(
+			exists=lambda doctype, value: bool(value),
+			get_value=lambda doctype, filters, fieldname=None, order_by=None: None,
+			sql=lambda *args, **kwargs: [],
+			get_all=lambda *args, **kwargs: [],
+			set_value=lambda *args, **kwargs: None,
+		)
+		frappe.new_doc = lambda doctype: _FakeStockEntry()
+		frappe.get_doc = lambda doctype, name=None: None
+		frappe.get_all = lambda *args, **kwargs: []
+		frappe.utils = utils
+
+		utils.today = lambda: "2026-02-28"
+		utils.nowtime = lambda: "10:00:00"
+		utils.nowdate = lambda: "2026-02-28"
+		utils.now_datetime = lambda: "2026-02-28 10:00:00"
+		utils.flt = lambda value, precision=None: float(value or 0)
+		utils.add_days = lambda date, days: date
+
+		sys.modules["frappe"] = frappe
+		sys.modules["frappe.utils"] = utils
+
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.utils" not in sys.modules:
+		hrms_utils_pkg = types.ModuleType("hrms.utils")
+		hrms_utils_pkg.__path__ = []
+		sys.modules["hrms.utils"] = hrms_utils_pkg
+
+	if "hrms.api" not in sys.modules:
+		hrms_api_pkg = types.ModuleType("hrms.api")
+		hrms_api_pkg.__path__ = []
+		sys.modules["hrms.api"] = hrms_api_pkg
+
+	if "hrms.utils.bei_config" not in sys.modules:
+		bei_config_mod = types.ModuleType("hrms.utils.bei_config")
+		bei_config_mod.get_company = lambda: "Bebang Enterprise Inc."
+		sys.modules["hrms.utils.bei_config"] = bei_config_mod
+
+	if "hrms.utils.scm_roles" not in sys.modules:
+		scm_roles_mod = types.ModuleType("hrms.utils.scm_roles")
+		scm_roles_mod.SCM_APPROVAL_ROLES = ["System Manager"]
+		scm_roles_mod.SCM_INVENTORY_ROLES = ["System Manager"]
+		scm_roles_mod.SCM_COMPLIANCE_ROLES = ["System Manager"]
+		scm_roles_mod.SCM_STOCK_UPDATE_ROLES = ["System Manager"]
+		scm_roles_mod.SCM_STORE_ROLES = ["Store Supervisor"]
+		scm_roles_mod.SCM_DISPATCH_ROLES = ["System Manager"]
+		scm_roles_mod.check_scm_permission = lambda roles, action: None
+		sys.modules["hrms.utils.scm_roles"] = scm_roles_mod
+
+
+_install_fake_modules()
+
+inventory_spec = importlib.util.spec_from_file_location(
+	"inventory_under_test",
+	ROOT / "hrms" / "api" / "inventory.py",
+)
+inventory = importlib.util.module_from_spec(inventory_spec)
+inventory_spec.loader.exec_module(inventory)
+
+warehouse_spec = importlib.util.spec_from_file_location(
+	"warehouse_under_test",
+	ROOT / "hrms" / "api" / "warehouse.py",
+)
+warehouse = importlib.util.module_from_spec(warehouse_spec)
+warehouse_spec.loader.exec_module(warehouse)
+
+
+class _FakeMR:
+	def __init__(self):
+		self.status = "Ordered"
+		self.items = [
+			types.SimpleNamespace(item_code="ITM-001", name="MRI-001"),
+			types.SimpleNamespace(item_code="ITM-002", name="MRI-002"),
+		]
+
+
+class _FakeItem:
+	def __init__(self, item_code):
+		self.name = item_code
+		self.item_name = f"Item {item_code}"
+		self.description = f"Desc {item_code}"
+		self.stock_uom = "Nos"
+		self.has_batch_no = False
+
+
+class TestReturnsConsistencyS10(unittest.TestCase):
+	def setUp(self):
+		self.docs_created = []
+
+		def _new_doc(doctype):
+			doc = _FakeStockEntry()
+			doc.name = "STE-0001"
+			self.docs_created.append(doc)
+			return doc
+
+		inventory.frappe.new_doc = _new_doc
+		warehouse.frappe.new_doc = _new_doc
+
+	def test_submit_return_request_includes_consistent_transfer_contract_data(self):
+		inventory.frappe.db.exists = lambda doctype, value: bool(value)
+		inventory.frappe.db.get_value = (
+			lambda doctype, filters, fieldname=None, order_by=None: f"Item {filters}" if doctype == "Item" else None
+		)
+
+		result = inventory.submit_return_request(
+			store="STORE-A",
+			items=[
+				{"item_code": "ITM-001", "quantity": 2, "reason": "expired"},
+				{"item_code": "ITM-002", "qty": 3, "reason": "damaged"},
+			],
+			photo=None,
+		)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(result["name"], "STE-0001")
+		self.assertEqual(result["data"]["name"], "STE-0001")
+		self.assertEqual(result["data"]["items_count"], 2)
+		self.assertEqual(result["data"]["total_qty"], 5.0)
+		self.assertEqual(result["data"]["movement_type"], "Material Issue")
+		self.assertEqual(result["data"]["source_warehouse"], "STORE-A")
+
+	def test_create_stock_transfer_accepts_quantity_alias_and_returns_consistent_data(self):
+		warehouse.frappe.db.exists = lambda doctype, value: True
+		warehouse.frappe.db.get_value = lambda doctype, filters, fieldname=None, order_by=None: None
+
+		def _get_doc(doctype, name=None):
+			if doctype == "Material Request":
+				return _FakeMR()
+			if doctype == "Item":
+				return _FakeItem(name)
+			return None
+
+		warehouse.frappe.get_doc = _get_doc
+
+		result = warehouse.create_stock_transfer(
+			source_warehouse="COM - BEI",
+			target_warehouse="STORE-A - BEI",
+			items=[
+				{"item_code": "ITM-001", "quantity": 4},
+				{"item_code": "ITM-002", "qty": 1},
+			],
+			mr_name="MR-0001",
+			remarks="S10 contract test",
+		)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(result["data"]["name"], "STE-0001")
+		self.assertEqual(result["data"]["items_count"], 2)
+		self.assertEqual(result["data"]["total_qty"], 5.0)
+		self.assertEqual(result["data"]["movement_type"], "Material Transfer")
+		self.assertEqual(result["data"]["source_warehouse"], "COM - BEI")
+		self.assertEqual(result["data"]["target_warehouse"], "STORE-A - BEI")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/hrms/tests/test_trip_driver_estimated_minutes_s10.py
+++ b/hrms/tests/test_trip_driver_estimated_minutes_s10.py
@@ -1,0 +1,222 @@
+import datetime
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_frappe_and_dependencies():
+	if "frappe" not in sys.modules:
+		frappe = types.ModuleType("frappe")
+		utils = types.ModuleType("frappe.utils")
+
+		def whitelist(*args, **kwargs):
+			def decorator(fn):
+				return fn
+
+			return decorator
+
+		def _throw(message, exc=None):
+			if isinstance(exc, type) and issubclass(exc, Exception):
+				raise exc(message)
+			raise Exception(message)
+
+		def _to_dt(value):
+			if isinstance(value, datetime.datetime):
+				return value
+			return datetime.datetime.fromisoformat(str(value).replace(" ", "T"))
+
+		def add_to_date(value, minutes=0):
+			return _to_dt(value) + datetime.timedelta(minutes=minutes)
+
+		def format_time(value):
+			return _to_dt(value).strftime("%H:%M")
+
+		frappe.whitelist = whitelist
+		frappe._ = lambda text: text
+		frappe.throw = _throw
+		frappe.PermissionError = type("PermissionError", (Exception,), {})
+		frappe.log_error = lambda *args, **kwargs: None
+		frappe.enqueue = lambda *args, **kwargs: None
+		frappe.parse_json = json.loads
+		frappe.__dict__["session"] = types.SimpleNamespace(user="Administrator")
+		frappe.__dict__["db"] = types.SimpleNamespace(
+			get_value=lambda *args, **kwargs: None,
+			get_all=lambda *args, **kwargs: [],
+			sql=lambda *args, **kwargs: [],
+		)
+		frappe.get_doc = lambda *args, **kwargs: None
+		frappe.get_all = lambda *args, **kwargs: []
+		frappe.new_doc = lambda *args, **kwargs: None
+
+		utils.nowdate = lambda: "2026-02-28"
+		utils.now_datetime = lambda: datetime.datetime(2026, 2, 28, 10, 0, 0)
+		utils.flt = lambda value, precision=None: float(value or 0)
+		utils.cint = lambda value: int(float(value or 0))
+		utils.add_to_date = add_to_date
+		utils.format_time = format_time
+		utils.get_datetime = _to_dt
+
+		sys.modules["frappe"] = frappe
+		sys.modules["frappe.utils"] = utils
+
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.utils" not in sys.modules:
+		hrms_utils_pkg = types.ModuleType("hrms.utils")
+		hrms_utils_pkg.__path__ = []
+		sys.modules["hrms.utils"] = hrms_utils_pkg
+
+	if "hrms.api" not in sys.modules:
+		hrms_api_pkg = types.ModuleType("hrms.api")
+		hrms_api_pkg.__path__ = []
+		sys.modules["hrms.api"] = hrms_api_pkg
+
+	if "hrms.utils.delivery_billing_policy" not in sys.modules:
+		policy_mod = types.ModuleType("hrms.utils.delivery_billing_policy")
+		policy_mod.DeliveryBillingPolicyError = type("DeliveryBillingPolicyError", (Exception,), {})
+		policy_mod.should_auto_create_billing_on_delivery = lambda setting: True
+		policy_mod.get_pre_delivery_exception_trace = lambda *args, **kwargs: {}
+		sys.modules["hrms.utils.delivery_billing_policy"] = policy_mod
+
+	if "hrms.utils.scm_roles" not in sys.modules:
+		scm_roles_mod = types.ModuleType("hrms.utils.scm_roles")
+		scm_roles_mod.SCM_ADMIN_ROLES = ["System Manager"]
+		scm_roles_mod.SCM_DISPATCH_ROLES = ["System Manager"]
+		scm_roles_mod.SCM_STORE_ROLES = ["Store User"]
+		scm_roles_mod.check_scm_permission = lambda roles, action: None
+		sys.modules["hrms.utils.scm_roles"] = scm_roles_mod
+
+
+_install_fake_frappe_and_dependencies()
+dispatch_spec = importlib.util.spec_from_file_location(
+	"dispatch_under_test",
+	ROOT / "hrms" / "api" / "dispatch.py",
+)
+dispatch = importlib.util.module_from_spec(dispatch_spec)
+dispatch_spec.loader.exec_module(dispatch)
+
+
+class _Stop:
+	def __init__(self, stop_order, estimated_minutes, status="Pending"):
+		self.stop_order = stop_order
+		self.estimated_minutes = estimated_minutes
+		self.status = status
+
+
+class _TripEta:
+	def __init__(self):
+		self.departure_time = "2026-02-28 08:00:00"
+		self.stops = [
+			_Stop(stop_order=1, estimated_minutes=15, status="Delivered"),
+			_Stop(stop_order=2, estimated_minutes=35, status="Pending"),
+			_Stop(stop_order=3, estimated_minutes=20, status="Pending"),
+		]
+
+
+class _TripDoc:
+	def __init__(self, stops):
+		self.name = "TRIP-S10-0001"
+		self.driver = None
+		self.vehicle = None
+		self.vehicle_plate = None
+		self.cargo_type = None
+		self.stops = [types.SimpleNamespace(store_order="", idx=i + 1) for i, _ in enumerate(stops)]
+
+	def insert(self):
+		return None
+
+
+class _Route:
+	def __init__(self):
+		self.route_name = "S10 Route"
+		self.default_vehicle = "TRK-001"
+		self.default_driver = "EMP-DRIVER-DEFAULT"
+		self.cargo_type = "Mixed"
+		self.active = 1
+		self.stops = [
+			types.SimpleNamespace(store="STORE-A - BEI", stop_order=1, estimated_minutes=11),
+			types.SimpleNamespace(store="STORE-B - BEI", stop_order=2, estimated_minutes=29),
+		]
+
+
+class TestTripDriverEstimatedMinutesS10(unittest.TestCase):
+	def test_calculate_eta_uses_per_stop_estimated_minutes(self):
+		trip = _TripEta()
+		result = dispatch._calculate_eta(trip, my_stop_order=3)
+		# Last delivered is stop 1, remaining path is stop 2 + stop 3 (35 + 20)
+		self.assertEqual(result["eta_minutes"], 55)
+		self.assertEqual(result["eta_window"]["min"], "08:55")
+		self.assertEqual(result["eta_window"]["max"], "09:25")
+
+	def test_create_trip_from_route_preserves_selected_stop_order_and_estimated_minutes(self):
+		route = _Route()
+		captured = {}
+
+		def _get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Distribution Trip":
+				return None
+			if doctype == "BEI Vehicle":
+				return "ABC-1234"
+			return None
+
+		def _get_all(doctype, filters=None, fields=None):
+			if doctype == "BEI Store Order":
+				return [types.SimpleNamespace(name="SO-001", store="STORE-B - BEI")]
+			return []
+
+		def _sql(*args, **kwargs):
+			return [types.SimpleNamespace(parent="SO-001", cnt=5)]
+
+		def _build_trip_doc(trip_date, route_name, stops):
+			captured["stops"] = stops
+			captured["trip_date"] = trip_date
+			captured["route_name"] = route_name
+			return _TripDoc(stops)
+
+		dispatch.frappe.get_doc = MagicMock(return_value=route)
+		dispatch.frappe.db.get_value = MagicMock(side_effect=_get_value)
+		dispatch.frappe.db.get_all = MagicMock(side_effect=_get_all)
+		dispatch.frappe.db.sql = MagicMock(side_effect=_sql)
+
+		selected_stops = json.dumps(
+			[
+				{"store": "STORE-B - BEI", "stop_order": 1},
+				{"store": "STORE-A - BEI", "stop_order": 2},
+			]
+		)
+
+		with patch.object(dispatch, "_build_trip_doc", side_effect=_build_trip_doc), patch.object(
+			dispatch, "_set_store_orders_in_transit", return_value=None
+		):
+			result = dispatch.create_trip_from_route(
+				route_name="ROUTE-S10",
+				trip_date="2026-02-28",
+				vehicle="TRK-001",
+				driver="EMP-DRIVER-001",
+				selected_stops=selected_stops,
+			)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(captured["trip_date"], "2026-02-28")
+		self.assertEqual(captured["route_name"], "S10 Route")
+		self.assertEqual(captured["stops"][0]["store"], "STORE-B - BEI")
+		self.assertEqual(captured["stops"][0]["stop_order"], 1)
+		self.assertEqual(captured["stops"][0]["estimated_minutes"], 29)
+		self.assertEqual(captured["stops"][1]["store"], "STORE-A - BEI")
+		self.assertEqual(captured["stops"][1]["stop_order"], 2)
+		self.assertEqual(captured["stops"][1]["estimated_minutes"], 11)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/hrms/tests/test_warehouse_billing_contract_s10.py
+++ b/hrms/tests/test_warehouse_billing_contract_s10.py
@@ -46,6 +46,53 @@ def _install_fake_modules():
 		sys.modules["frappe"] = frappe
 		sys.modules["frappe.utils"] = utils
 
+	frappe = sys.modules["frappe"]
+	utils = sys.modules.get("frappe.utils")
+	if utils is None:
+		utils = types.ModuleType("frappe.utils")
+		sys.modules["frappe.utils"] = utils
+	frappe.utils = utils
+
+	if not hasattr(frappe, "whitelist"):
+		def whitelist(*args, **kwargs):
+			def decorator(fn):
+				return fn
+			return decorator
+		frappe.whitelist = whitelist
+	if not hasattr(frappe, "_"):
+		frappe._ = lambda text: text
+	if not hasattr(frappe, "throw"):
+		frappe.throw = lambda message, *args, **kwargs: (_ for _ in ()).throw(Exception(message))
+	if not hasattr(frappe, "log_error"):
+		frappe.log_error = lambda *args, **kwargs: None
+	if not hasattr(frappe, "PermissionError"):
+		frappe.PermissionError = type("PermissionError", (Exception,), {})
+	if not hasattr(frappe, "ValidationError"):
+		frappe.ValidationError = type("ValidationError", (Exception,), {})
+	if not hasattr(frappe, "DoesNotExistError"):
+		frappe.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
+	if not hasattr(frappe, "session"):
+		frappe.session = types.SimpleNamespace(user="finance@bebang.ph")
+	if not hasattr(frappe, "db"):
+		frappe.db = types.SimpleNamespace(sql=lambda *args, **kwargs: [])
+
+	if not hasattr(utils, "flt"):
+		utils.flt = lambda value, precision=None: float(value or 0)
+	if not hasattr(utils, "now_datetime"):
+		utils.now_datetime = lambda: "2026-02-28 10:00:00"
+	if not hasattr(utils, "get_first_day"):
+		utils.get_first_day = lambda value: value
+	if not hasattr(utils, "get_last_day"):
+		utils.get_last_day = lambda value: value
+	if not hasattr(utils, "nowdate"):
+		utils.nowdate = lambda: "2026-02-28"
+	if not hasattr(utils, "getdate"):
+		def _getdate(value):
+			if isinstance(value, (datetime.date, datetime.datetime)):
+				return value
+			return datetime.datetime.fromisoformat(str(value))
+		utils.getdate = _getdate
+
 	if "hrms" not in sys.modules:
 		hrms_pkg = types.ModuleType("hrms")
 		hrms_pkg.__path__ = []
@@ -68,10 +115,24 @@ def _install_fake_modules():
 
 	if "hrms.utils.scm_roles" not in sys.modules:
 		scm_roles_mod = types.ModuleType("hrms.utils.scm_roles")
-		scm_roles_mod.RATE_MANAGEMENT_ROLES = ["System Manager"]
-		scm_roles_mod.SCM_BILLING_ROLES = ["System Manager"]
-		scm_roles_mod.check_scm_permission = lambda roles, action: None
 		sys.modules["hrms.utils.scm_roles"] = scm_roles_mod
+
+	scm_roles_mod = sys.modules["hrms.utils.scm_roles"]
+	scm_roles_mod.RATE_MANAGEMENT_ROLES = getattr(
+		scm_roles_mod,
+		"RATE_MANAGEMENT_ROLES",
+		["System Manager"],
+	)
+	scm_roles_mod.SCM_BILLING_ROLES = getattr(
+		scm_roles_mod,
+		"SCM_BILLING_ROLES",
+		["System Manager"],
+	)
+	scm_roles_mod.check_scm_permission = getattr(
+		scm_roles_mod,
+		"check_scm_permission",
+		lambda roles, action: None,
+	)
 
 
 _install_fake_modules()

--- a/hrms/tests/test_warehouse_billing_contract_s10.py
+++ b/hrms/tests/test_warehouse_billing_contract_s10.py
@@ -1,0 +1,132 @@
+import datetime
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_modules():
+	if "frappe" not in sys.modules:
+		frappe = types.ModuleType("frappe")
+		utils = types.ModuleType("frappe.utils")
+
+		def whitelist(*args, **kwargs):
+			def decorator(fn):
+				return fn
+
+			return decorator
+
+		frappe.whitelist = whitelist
+		frappe._ = lambda text: text
+		frappe.throw = lambda message, *args, **kwargs: (_ for _ in ()).throw(Exception(message))
+		frappe.log_error = lambda *args, **kwargs: None
+		frappe.PermissionError = type("PermissionError", (Exception,), {})
+		frappe.ValidationError = type("ValidationError", (Exception,), {})
+		frappe.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
+		frappe.session = types.SimpleNamespace(user="finance@bebang.ph")
+		frappe.db = types.SimpleNamespace(sql=lambda *args, **kwargs: [])
+
+		utils.flt = lambda value, precision=None: float(value or 0)
+		utils.now_datetime = lambda: "2026-02-28 10:00:00"
+		utils.get_first_day = lambda value: value
+		utils.get_last_day = lambda value: value
+		utils.nowdate = lambda: "2026-02-28"
+		def _getdate(value):
+			if isinstance(value, (datetime.date, datetime.datetime)):
+				return value
+			return datetime.datetime.fromisoformat(str(value))
+
+		utils.getdate = _getdate
+
+		sys.modules["frappe"] = frappe
+		sys.modules["frappe.utils"] = utils
+
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.utils" not in sys.modules:
+		hrms_utils_pkg = types.ModuleType("hrms.utils")
+		hrms_utils_pkg.__path__ = []
+		sys.modules["hrms.utils"] = hrms_utils_pkg
+
+	if "hrms.api" not in sys.modules:
+		hrms_api_pkg = types.ModuleType("hrms.api")
+		hrms_api_pkg.__path__ = []
+		sys.modules["hrms.api"] = hrms_api_pkg
+
+	if "hrms.utils.bei_config" not in sys.modules:
+		bei_config_mod = types.ModuleType("hrms.utils.bei_config")
+		bei_config_mod.get_company = lambda: "Bebang Enterprise Inc."
+		sys.modules["hrms.utils.bei_config"] = bei_config_mod
+
+	if "hrms.utils.scm_roles" not in sys.modules:
+		scm_roles_mod = types.ModuleType("hrms.utils.scm_roles")
+		scm_roles_mod.RATE_MANAGEMENT_ROLES = ["System Manager"]
+		scm_roles_mod.SCM_BILLING_ROLES = ["System Manager"]
+		scm_roles_mod.check_scm_permission = lambda roles, action: None
+		sys.modules["hrms.utils.scm_roles"] = scm_roles_mod
+
+
+_install_fake_modules()
+
+billing_spec = importlib.util.spec_from_file_location(
+	"billing_under_test",
+	ROOT / "hrms" / "api" / "billing.py",
+)
+billing = importlib.util.module_from_spec(billing_spec)
+billing_spec.loader.exec_module(billing)
+
+
+class TestWarehouseBillingContractS10(unittest.TestCase):
+	def test_get_3pl_rates_applies_ewt_defaults_when_missing(self):
+		billing.frappe.db.sql = lambda *args, **kwargs: [
+			{
+				"name": "RATE-001",
+				"rate_name": "3MD Frozen",
+				"threepl_partner": "3MD",
+				"cargo_type": "FC",
+				"zone": "NORTH",
+				"rate_per_trip": 1000,
+				"overtime_rate": 100,
+				"surcharge_rate": 50,
+			}
+		]
+
+		result = billing.get_3pl_rates(partner="3MD")
+
+		self.assertEqual(result["count"], 1)
+		self.assertEqual(result["rates"][0]["ewt_atc"], "WC110")
+		self.assertEqual(result["rates"][0]["ewt_rate"], 1.0)
+
+	def test_get_3pl_rates_preserves_existing_ewt_fields(self):
+		billing.frappe.db.sql = lambda *args, **kwargs: [
+			{
+				"name": "RATE-002",
+				"rate_name": "RCS Mixed",
+				"threepl_partner": "RCS",
+				"cargo_type": "Mixed",
+				"zone": "SOUTH",
+				"rate_per_trip": 1200,
+				"overtime_rate": 120,
+				"surcharge_rate": 60,
+				"ewt_atc": "WC158",
+				"ewt_rate": 2.0,
+			}
+		]
+
+		result = billing.get_3pl_rates(partner="RCS")
+
+		self.assertEqual(result["count"], 1)
+		self.assertEqual(result["rates"][0]["ewt_atc"], "WC158")
+		self.assertEqual(result["rates"][0]["ewt_rate"], 2.0)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Scope\n- Preserve trip selected-stop estimated-minutes contract\n- Normalize returns/material transfer API response contracts\n- Harden 3PL billing rate contract with EWT fields\n- Add Sprint 10 backend contract tests and resilient shared-stub coverage\n\n## Validation\n- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_trip_driver_estimated_minutes_s10.py hrms/tests/test_returns_consistency_s10.py hrms/tests/test_warehouse_billing_contract_s10.py hrms/tests/test_dispatch_pre_delivery.py hrms/tests/test_delivery_billing_policy.py hrms/tests/test_billing_doc_events_s08.py -q\n\nResult: 18 passed.