### PR TITLE
feat(frontend-procurement): add reports/settings pages for sidebar links

### DIFF
--- a/frontend-procurement/app/dashboard/procurement/reports/page.tsx
+++ b/frontend-procurement/app/dashboard/procurement/reports/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { BarChart3, ArrowRight } from 'lucide-react';
+
+const REPORT_LINKS = [
+  { title: 'Purchase Orders', href: '/dashboard/procurement/purchase-orders' },
+  { title: 'Goods Receipts', href: '/dashboard/procurement/goods-receipts' },
+  { title: 'Invoices', href: '/dashboard/procurement/invoices' },
+  { title: 'Payments', href: '/dashboard/procurement/payments' },
+];
+
+export default function ProcurementReportsPage() {
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center gap-3">
+        <BarChart3 className="h-6 w-6" />
+        <h1 className="text-2xl font-semibold">Procurement Reports</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Report Entry Points</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-3 sm:grid-cols-2">
+          {REPORT_LINKS.map((item) => (
+            <Button key={item.href} asChild variant="outline" className="justify-between">
+              <Link href={item.href}>
+                {item.title}
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </Button>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/frontend-procurement/app/dashboard/procurement/settings/page.tsx
+++ b/frontend-procurement/app/dashboard/procurement/settings/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Settings } from 'lucide-react';
+
+export default function ProcurementSettingsPage() {
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center gap-3">
+        <Settings className="h-6 w-6" />
+        <h1 className="text-2xl font-semibold">Procurement Settings</h1>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Configuration</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Procurement configuration is enabled. Additional setting controls can be added in this page.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add procurement Reports landing page
- add procurement Settings page
- closes missing sidebar link targets in frontend-procurement

## Scope
- frontend-procurement/app/dashboard/procurement/reports/page.tsx
- frontend-procurement/app/dashboard/procurement/settings/page.tsx