### PR TITLE
fix(transfer): enforce HR-only org-change fields end-to-end

### DIFF
--- a/hrms/api/transfer_requests.py
+++ b/hrms/api/transfer_requests.py
@@ -25,7 +25,6 @@ from hrms.utils.adms_validation import (
 from hrms.utils.device_mapping import DEVICE_TO_STORE
 from hrms.utils.roving_employees import is_roving
 
-
 DOCTYPE_TRANSFER_REQUEST = "BEI Transfer Request"
 DOCTYPE_TRANSFER_DEVICE_COMMAND = "BEI Transfer Device Command"
 BEI_COMPANY_NAME = "Bebang Enterprise Inc."
@@ -112,13 +111,14 @@ def _coerce_positive_int(value: Any, *, field_label: str) -> int | None:
 
 
 def _enforce_org_change_field_guard(*, to_department: str | None, to_designation: str | None):
+	if not to_department and not to_designation:
+		return
 	if _can_manage_org_changes():
 		return
-	if to_department or to_designation:
-		frappe.throw(
-			_("Only HR users can set Department or Designation in transfer requests"),
-			frappe.PermissionError,
-		)
+	frappe.throw(
+		_("Only HR users can set Department or Designation in transfer requests"),
+		frappe.PermissionError,
+	)
 
 
 def _compute_reliever_window(effective_date: Any, reliever_days: int | None) -> tuple[Any | None, Any | None]:
@@ -168,7 +168,7 @@ def _build_branch_reports_to_defaults(options: list[dict[str, str]]) -> dict[str
 		if not bucket["store_oic"] and ("OIC" in designation or "STORE SUPERVISOR" in designation):
 			bucket["store_oic"] = candidate
 
-	for branch_name, leadership in by_branch.items():
+	for leadership in by_branch.values():
 		default_candidate = leadership.get("area_manager") or leadership.get("store_oic")
 		if default_candidate:
 			leadership["default_reports_to"] = default_candidate.get("employee")
@@ -209,8 +209,16 @@ def _notify_transfer_event(doc, event_title: str, details: str | None = None):
 		from hrms.api.google_chat import send_message_to_space
 		from hrms.utils.bei_config import SPACE_ADMIN_IT, SPACE_NOTIFICATIONS, get_chat_space
 
-		technical_stages = {STAGE_PENDING_IT, STAGE_READY_SYNC, STAGE_SYNC_IN_PROGRESS, STAGE_SYNC_FAILED, STAGE_SYNCED}
-		target_space = get_chat_space(SPACE_ADMIN_IT if doc.current_stage in technical_stages else SPACE_NOTIFICATIONS)
+		technical_stages = {
+			STAGE_PENDING_IT,
+			STAGE_READY_SYNC,
+			STAGE_SYNC_IN_PROGRESS,
+			STAGE_SYNC_FAILED,
+			STAGE_SYNCED,
+		}
+		target_space = get_chat_space(
+			SPACE_ADMIN_IT if doc.current_stage in technical_stages else SPACE_NOTIFICATIONS
+		)
 		message_lines = [
 			f"*{event_title}*",
 			f"Request: {doc.name}",
@@ -457,7 +465,9 @@ def _get_branch_index() -> dict[str, str]:
 	return index
 
 
-def _resolve_branch_from_store_warehouse(store_warehouse: str | None, branch_index: dict[str, str] | None = None) -> str | None:
+def _resolve_branch_from_store_warehouse(
+	store_warehouse: str | None, branch_index: dict[str, str] | None = None
+) -> str | None:
 	if not store_warehouse:
 		return None
 
@@ -478,7 +488,9 @@ def _resolve_branch_from_store_warehouse(store_warehouse: str | None, branch_ind
 	return None
 
 
-def _validate_store_warehouse_for_transfer(store_warehouse: str | None, expected_branch: str | None = None) -> dict[str, Any]:
+def _validate_store_warehouse_for_transfer(
+	store_warehouse: str | None, expected_branch: str | None = None
+) -> dict[str, Any]:
 	warehouse_name = (store_warehouse or "").strip()
 	if not warehouse_name:
 		frappe.throw(_("Missing Warehouse Mapping for target store"))
@@ -518,9 +530,9 @@ def _validate_store_warehouse_for_transfer(store_warehouse: str | None, expected
 		branch_key = _normalize_store_key(branch_name)
 		if expected_key and branch_key and expected_key != branch_key:
 			frappe.throw(
-				_(
-					"Target branch {0} does not match warehouse {1} (derived branch: {2})"
-				).format(expected_branch, warehouse_name, branch_name)
+				_("Target branch {0} does not match warehouse {1} (derived branch: {2})").format(
+					expected_branch, warehouse_name, branch_name
+				)
 			)
 
 	return {
@@ -531,7 +543,9 @@ def _validate_store_warehouse_for_transfer(store_warehouse: str | None, expected
 	}
 
 
-def _list_transfer_store_warehouse_options(search_text: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+def _list_transfer_store_warehouse_options(
+	search_text: str | None = None, limit: int = 100
+) -> list[dict[str, Any]]:
 	branch_index = _get_branch_index()
 	search_lower = (search_text or "").strip().lower()
 	limit = max(1, min(500, cint(limit) or 100))
@@ -564,14 +578,18 @@ def _list_transfer_store_warehouse_options(search_text: str | None = None, limit
 		warehouse_label = (row.get("warehouse_name") or warehouse_name).strip()
 		if not warehouse_name:
 			continue
-		if _contains_blocked_warehouse_term(warehouse_name) or _contains_blocked_warehouse_term(warehouse_label):
+		if _contains_blocked_warehouse_term(warehouse_name) or _contains_blocked_warehouse_term(
+			warehouse_label
+		):
 			continue
 
 		branch_name = (row.get("branch") or "").strip()
 		if branch_name and not frappe.db.exists("Branch", branch_name):
 			branch_name = ""
 		if not branch_name:
-			branch_name = _resolve_branch_from_store_warehouse(warehouse_name, branch_index=branch_index) or ""
+			branch_name = (
+				_resolve_branch_from_store_warehouse(warehouse_name, branch_index=branch_index) or ""
+			)
 		if not branch_name:
 			continue
 
@@ -613,10 +631,9 @@ def _list_transfer_store_warehouse_options(search_text: str | None = None, limit
 
 def _get_employee_bio_id(employee_id: str) -> str:
 	employee = frappe.get_doc("Employee", employee_id)
-	bio_id = (
-		(getattr(employee, "attendance_device_id", None) or "").strip()
-		or (getattr(employee, "new_attendance_device_id", None) or "").strip()
-	)
+	bio_id = (getattr(employee, "attendance_device_id", None) or "").strip() or (
+		getattr(employee, "new_attendance_device_id", None) or ""
+	).strip()
 	if not bio_id:
 		frappe.throw(_("Employee {0} has no biometric ID assigned").format(employee_id))
 	return bio_id
@@ -644,7 +661,9 @@ def _compute_transfer_device_plan(doc, bio_id: str) -> dict[str, Any]:
 	target_devices = [sn for sn, store_name in device_pairs if _normalize_store_key(store_name) == store_key]
 	if not target_devices:
 		frappe.throw(
-			_("No biometric devices mapped for target store warehouse {0}").format(doc.store_warehouse or doc.to_branch)
+			_("No biometric devices mapped for target store warehouse {0}").format(
+				doc.store_warehouse or doc.to_branch
+			)
 		)
 
 	if is_reliever:
@@ -683,9 +702,8 @@ def _get_adms_config() -> dict[str, Any]:
 		or "http://localhost:8080"
 	)
 	token = (
-		(frappe.conf.get("adms_admin_token") if getattr(frappe, "conf", None) else None)
-		or os.environ.get("ADMS_ADMIN_TOKEN")
-	)
+		frappe.conf.get("adms_admin_token") if getattr(frappe, "conf", None) else None
+	) or os.environ.get("ADMS_ADMIN_TOKEN")
 	timeout_seconds = cint(
 		(frappe.conf.get("adms_request_timeout_seconds") if getattr(frappe, "conf", None) else None)
 		or os.environ.get("ADMS_REQUEST_TIMEOUT_SECONDS")
@@ -926,7 +944,9 @@ def _refresh_transfer_stage_from_commands(doc):
 			doc,
 			_("Transfer sync stage updated: {0} -> {1}").format(stage_before, doc.current_stage),
 		)
-		_notify_transfer_event(doc, "Transfer Sync Stage Updated", details=f"{stage_before} -> {doc.current_stage}")
+		_notify_transfer_event(
+			doc, "Transfer Sync Stage Updated", details=f"{stage_before} -> {doc.current_stage}"
+		)
 		return True
 	return reliever_cleanup_changed
 
@@ -961,7 +981,12 @@ def _sync_command_statuses_from_adms(doc, config: dict[str, Any]) -> dict[str, A
 			remote = remote_by_id.get(cint(cmd_doc.adms_command_id))
 			if remote:
 				remote_status = (remote.get("status") or "").upper()
-				if remote_status in {ADMS_STATUS_PENDING, ADMS_STATUS_SENT, ADMS_STATUS_ACKED, ADMS_STATUS_FAILED}:
+				if remote_status in {
+					ADMS_STATUS_PENDING,
+					ADMS_STATUS_SENT,
+					ADMS_STATUS_ACKED,
+					ADMS_STATUS_FAILED,
+				}:
 					cmd_doc.status = remote_status
 				cmd_doc.last_error = remote.get("last_error")
 				cmd_doc.sent_at = _coerce_datetime(remote.get("sent_at")) or cmd_doc.sent_at
@@ -981,7 +1006,9 @@ def _sync_command_statuses_from_adms(doc, config: dict[str, Any]) -> dict[str, A
 	return {"updated": updated, "errors": errors}
 
 
-def _dispatch_transfer_sync(doc, *, force_retry_failed: bool = False, remarks: str | None = None) -> dict[str, Any]:
+def _dispatch_transfer_sync(
+	doc, *, force_retry_failed: bool = False, remarks: str | None = None
+) -> dict[str, Any]:
 	_require_store_warehouse_mapping(doc)
 	_enforce_effective_date_dispatch_guard(doc)
 
@@ -1007,7 +1034,9 @@ def _dispatch_transfer_sync(doc, *, force_retry_failed: bool = False, remarks: s
 	)
 	if not preflight.get("can_proceed"):
 		frappe.throw(
-			_("ADMS preflight failed: {0}").format(preflight.get("error_message") or "Unknown validation error")
+			_("ADMS preflight failed: {0}").format(
+				preflight.get("error_message") or "Unknown validation error"
+			)
 		)
 
 	dispatch_plan = []
@@ -1099,9 +1128,9 @@ def _dispatch_transfer_sync(doc, *, force_retry_failed: bool = False, remarks: s
 	doc.sync_batch_id = f"tr-sync-{now_datetime().strftime('%Y%m%d%H%M%S')}"
 	doc.save(ignore_permissions=True)
 
-	log_text = _(
-		"Transfer sync dispatch executed. queued={0}, failed={1}, skipped={2}, active={3}"
-	).format(queued, failed, skipped, already_active)
+	log_text = _("Transfer sync dispatch executed. queued={0}, failed={1}, skipped={2}, active={3}").format(
+		queued, failed, skipped, already_active
+	)
 	if remarks:
 		log_text += _(". Notes: {0}").format(remarks)
 	_append_timeline_comment(doc, log_text)
@@ -1151,16 +1180,12 @@ def audit_transfer_store_mappings(pilot_warehouses=None):
 			for part in re.split(r"[\n,]+", pilot_warehouses):
 				if part and part.strip():
 					targets.append(part.strip())
-		elif isinstance(pilot_warehouses, (list, tuple)):
+		elif isinstance(pilot_warehouses, list | tuple):
 			targets = [str(v).strip() for v in pilot_warehouses if str(v).strip()]
 
 	if not targets:
 		targets = sorted(
-			{
-				store_name
-				for store_name in DEVICE_TO_STORE.values()
-				if store_name and str(store_name).strip()
-			}
+			{store_name for store_name in DEVICE_TO_STORE.values() if store_name and str(store_name).strip()}
 		)
 
 	rows = []
@@ -1170,9 +1195,7 @@ def audit_transfer_store_mappings(pilot_warehouses=None):
 		store_key = _normalize_store_key(target)
 		warehouse_exists = bool(frappe.db.exists("Warehouse", target))
 		devices = [
-			sn
-			for sn, store_name in DEVICE_TO_STORE.items()
-			if _normalize_store_key(store_name) == store_key
+			sn for sn, store_name in DEVICE_TO_STORE.items() if _normalize_store_key(store_name) == store_key
 		]
 		has_devices = len(devices) > 0
 
@@ -1200,6 +1223,7 @@ def audit_transfer_store_mappings(pilot_warehouses=None):
 		"missing_device_mapping": sorted(set(missing_device_mapping)),
 		"rows": rows,
 	}
+
 
 @frappe.whitelist()
 @rate_limit(limit=20, seconds=60)
@@ -1305,7 +1329,9 @@ def _pending_stages_for_user() -> list[str]:
 
 
 @frappe.whitelist()
-def list_transfer_requests(current_stage=None, employee=None, my_requests=0, pending_for_me=0, page=1, page_size=20):
+def list_transfer_requests(
+	current_stage=None, employee=None, my_requests=0, pending_for_me=0, page=1, page_size=20
+):
 	_require_any_role(
 		REQUESTER_ROLES.union(AREA_APPROVER_ROLES).union(HR_APPROVER_ROLES).union(IT_APPROVER_ROLES),
 		"You do not have permission to view transfer requests",
@@ -1499,7 +1525,9 @@ def cancel_transfer_request(transfer_request_name, reason=None):
 		doc,
 		_("Cancelled request from stage {0}. Reason: {1}").format(stage_before, reason or "-"),
 	)
-	_notify_transfer_event(doc, "Transfer Request Cancelled", details=f"{stage_before}. Reason: {reason or '-'}")
+	_notify_transfer_event(
+		doc, "Transfer Request Cancelled", details=f"{stage_before}. Reason: {reason or '-'}"
+	)
 
 	return {"success": True, "name": doc.name, "current_stage": doc.current_stage}
 
@@ -1555,7 +1583,12 @@ def reconcile_transfer_sync_status(transfer_request_name=None, limit=100):
 	else:
 		targets = frappe.get_all(
 			DOCTYPE_TRANSFER_REQUEST,
-			filters={"current_stage": ["in", [STAGE_READY_SYNC, STAGE_SYNC_IN_PROGRESS, STAGE_SYNC_FAILED, STAGE_SYNCED]]},
+			filters={
+				"current_stage": [
+					"in",
+					[STAGE_READY_SYNC, STAGE_SYNC_IN_PROGRESS, STAGE_SYNC_FAILED, STAGE_SYNCED],
+				]
+			},
 			fields=["name"],
 			limit=min(max(cint(limit) or 100, 1), 500),
 			order_by="modified asc",
@@ -1593,10 +1626,21 @@ def get_transfer_sync_dashboard(status=None, page=1, page_size=50):
 	page_size = min(200, max(1, cint(page_size) or 50))
 
 	stage_counts = {}
-	for stage in [STAGE_PENDING_IT, STAGE_READY_SYNC, STAGE_SYNC_IN_PROGRESS, STAGE_SYNCED, STAGE_SYNC_FAILED]:
+	for stage in [
+		STAGE_PENDING_IT,
+		STAGE_READY_SYNC,
+		STAGE_SYNC_IN_PROGRESS,
+		STAGE_SYNCED,
+		STAGE_SYNC_FAILED,
+	]:
 		stage_counts[stage] = frappe.db.count(DOCTYPE_TRANSFER_REQUEST, filters={"current_stage": stage})
 
-	transfer_filters = {"current_stage": ["in", [STAGE_PENDING_IT, STAGE_READY_SYNC, STAGE_SYNC_IN_PROGRESS, STAGE_SYNCED, STAGE_SYNC_FAILED]]}
+	transfer_filters = {
+		"current_stage": [
+			"in",
+			[STAGE_PENDING_IT, STAGE_READY_SYNC, STAGE_SYNC_IN_PROGRESS, STAGE_SYNCED, STAGE_SYNC_FAILED],
+		]
+	}
 	if status:
 		transfer_filters["current_stage"] = status
 

--- a/hrms/api/transfer_requests.py
+++ b/hrms/api/transfer_requests.py
@@ -1170,7 +1170,9 @@ def get_transfer_sync_config_status():
 
 
 @frappe.whitelist()
-def audit_transfer_store_mappings(pilot_warehouses=None):
+def audit_transfer_store_mappings(
+	pilot_warehouses: str | list[str] | tuple[str, ...] | None = None,
+) -> dict[str, Any]:
 	"""AUDIT-2 utility: verify warehouse/device mapping coverage for pilot stores."""
 	_require_any_role(READ_ALL_ROLES, "You do not have permission to audit transfer mappings")
 
@@ -1330,8 +1332,13 @@ def _pending_stages_for_user() -> list[str]:
 
 @frappe.whitelist()
 def list_transfer_requests(
-	current_stage=None, employee=None, my_requests=0, pending_for_me=0, page=1, page_size=20
-):
+	current_stage: str | None = None,
+	employee: str | None = None,
+	my_requests: int = 0,
+	pending_for_me: int = 0,
+	page: int = 1,
+	page_size: int = 20,
+) -> dict[str, Any]:
 	_require_any_role(
 		REQUESTER_ROLES.union(AREA_APPROVER_ROLES).union(HR_APPROVER_ROLES).union(IT_APPROVER_ROLES),
 		"You do not have permission to view transfer requests",
@@ -1504,7 +1511,10 @@ def reject_transfer_stage(transfer_request_name, reason):
 
 @frappe.whitelist()
 @rate_limit(limit=20, seconds=60)
-def cancel_transfer_request(transfer_request_name, reason=None):
+def cancel_transfer_request(
+	transfer_request_name: str,
+	reason: str | None = None,
+) -> dict[str, Any]:
 	if not frappe.db.exists(DOCTYPE_TRANSFER_REQUEST, transfer_request_name):
 		frappe.throw(_("Transfer request not found"), frappe.DoesNotExistError)
 
@@ -1568,7 +1578,10 @@ def retry_transfer_sync(transfer_request_name, remarks=None):
 
 
 @frappe.whitelist()
-def reconcile_transfer_sync_status(transfer_request_name=None, limit=100):
+def reconcile_transfer_sync_status(
+	transfer_request_name: str | None = None,
+	limit: int = 100,
+) -> dict[str, Any]:
 	"""Poll ADMS command rows and reconcile transfer sync stages."""
 	if frappe.session.user != "Administrator":
 		_require_any_role(IT_APPROVER_ROLES, "You do not have permission to reconcile transfer sync status")
@@ -1619,7 +1632,11 @@ def reconcile_transfer_sync_status(transfer_request_name=None, limit=100):
 
 
 @frappe.whitelist()
-def get_transfer_sync_dashboard(status=None, page=1, page_size=50):
+def get_transfer_sync_dashboard(
+	status: str | None = None,
+	page: int = 1,
+	page_size: int = 50,
+) -> dict[str, Any]:
 	_require_any_role(READ_ALL_ROLES, "You do not have permission to view transfer sync dashboard")
 
 	page = max(1, cint(page) or 1)

--- a/hrms/api/transfer_requests.py
+++ b/hrms/api/transfer_requests.py
@@ -292,6 +292,9 @@ def _sync_designation_roles(employee_id: str, designation_hint: str | None = Non
 
 def _serialize_request(doc, include_comments: bool = False):
 	payload = doc.as_dict()
+	if not _can_manage_org_changes():
+		payload["to_department"] = None
+		payload["to_designation"] = None
 
 	if include_comments:
 		payload["timeline"] = frappe.get_all(

--- a/hrms/hr/doctype/bei_transfer_request/bei_transfer_request.py
+++ b/hrms/hr/doctype/bei_transfer_request/bei_transfer_request.py
@@ -5,6 +5,8 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import add_to_date, cint, getdate, now_datetime
 
+HR_ORG_CHANGE_ROLES = {"HR User", "HR Manager", "System Manager"}
+
 
 class BEITransferRequest(Document):
 	def before_insert(self):
@@ -19,7 +21,41 @@ class BEITransferRequest(Document):
 
 	def validate(self):
 		self._sync_employee_snapshot()
+		self._enforce_org_change_permissions()
 		self._validate_reliever_window()
+
+	def _can_manage_org_changes(self) -> bool:
+		return bool(set(frappe.get_roles(frappe.session.user)).intersection(HR_ORG_CHANGE_ROLES))
+
+	@staticmethod
+	def _normalize_optional(value):
+		text = (value or "").strip()
+		return text or None
+
+	def _enforce_org_change_permissions(self):
+		if self._can_manage_org_changes():
+			return
+
+		current_department = self._normalize_optional(self.to_department)
+		current_designation = self._normalize_optional(self.to_designation)
+		if self.is_new():
+			if current_department or current_designation:
+				frappe.throw(
+					"Only HR users can set Department or Designation in transfer requests",
+					frappe.PermissionError,
+				)
+			return
+
+		previous = self.get_doc_before_save()
+		if not previous:
+			return
+		previous_department = self._normalize_optional(previous.to_department)
+		previous_designation = self._normalize_optional(previous.to_designation)
+		if current_department != previous_department or current_designation != previous_designation:
+			frappe.throw(
+				"Only HR users can set or change Department or Designation in transfer requests",
+				frappe.PermissionError,
+			)
 
 	def _sync_employee_snapshot(self):
 		if not self.employee or not frappe.db.exists("Employee", self.employee):

--- a/hrms/hr/doctype/bei_transfer_request/bei_transfer_request.py
+++ b/hrms/hr/doctype/bei_transfer_request/bei_transfer_request.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_to_date, cint, getdate, now_datetime
 
@@ -41,7 +42,7 @@ class BEITransferRequest(Document):
 		if self.is_new():
 			if current_department or current_designation:
 				frappe.throw(
-					"Only HR users can set Department or Designation in transfer requests",
+					_("Only HR users can set Department or Designation in transfer requests"),
 					frappe.PermissionError,
 				)
 			return
@@ -53,7 +54,7 @@ class BEITransferRequest(Document):
 		previous_designation = self._normalize_optional(previous.to_designation)
 		if current_department != previous_department or current_designation != previous_designation:
 			frappe.throw(
-				"Only HR users can set or change Department or Designation in transfer requests",
+				_("Only HR users can set or change Department or Designation in transfer requests"),
 				frappe.PermissionError,
 			)
 
@@ -84,7 +85,7 @@ class BEITransferRequest(Document):
 
 		reliever_days = cint(self.reliever_days)
 		if reliever_days <= 0:
-			frappe.throw("Reliever days is required when reliever mode is enabled")
+			frappe.throw(_("Reliever days is required when reliever mode is enabled"))
 
 		start_date = getdate(self.effective_date)
 		self.reliever_start_date = start_date

--- a/hrms/hr/doctype/bei_transfer_request/bei_transfer_request.py
+++ b/hrms/hr/doctype/bei_transfer_request/bei_transfer_request.py
@@ -91,4 +91,3 @@ class BEITransferRequest(Document):
 		self.reliever_end_date = getdate(add_to_date(start_date, days=reliever_days))
 		if not self.reliever_cleanup_status:
 			self.reliever_cleanup_status = "Pending"
-

--- a/hrms/tests/test_bei_transfer_request_permissions.py
+++ b/hrms/tests/test_bei_transfer_request_permissions.py
@@ -1,0 +1,62 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import frappe
+
+from hrms.hr.doctype.bei_transfer_request.bei_transfer_request import BEITransferRequest
+
+
+def _make_doc(*, is_new, to_department=None, to_designation=None, previous=None):
+	doc = BEITransferRequest.__new__(BEITransferRequest)
+	doc.to_department = to_department
+	doc.to_designation = to_designation
+	doc.is_new = lambda: is_new
+	doc.get_doc_before_save = lambda: previous
+	return doc
+
+
+class TestBEITransferRequestPermissions(unittest.TestCase):
+	def test_non_hr_cannot_set_department_or_designation_on_new_doc(self):
+		doc = _make_doc(is_new=True, to_department="Operations - BEI")
+
+		with patch("frappe.get_roles", return_value=["Store Supervisor"]):
+			with self.assertRaises(frappe.PermissionError):
+				doc._enforce_org_change_permissions()
+
+	def test_non_hr_cannot_change_existing_department_or_designation(self):
+		previous = SimpleNamespace(to_department="Operations - BEI", to_designation=None)
+		doc = _make_doc(
+			is_new=False,
+			to_department="Finance - BEI",
+			to_designation=None,
+			previous=previous,
+		)
+
+		with patch("frappe.get_roles", return_value=["Area Supervisor"]):
+			with self.assertRaises(frappe.PermissionError):
+				doc._enforce_org_change_permissions()
+
+	def test_non_hr_can_save_when_org_change_fields_are_unchanged(self):
+		previous = SimpleNamespace(to_department="Operations - BEI", to_designation=None)
+		doc = _make_doc(
+			is_new=False,
+			to_department="Operations - BEI",
+			to_designation=None,
+			previous=previous,
+		)
+
+		with patch("frappe.get_roles", return_value=["Store Supervisor"]):
+			doc._enforce_org_change_permissions()
+
+	def test_hr_can_set_or_change_org_change_fields(self):
+		previous = SimpleNamespace(to_department=None, to_designation=None)
+		doc = _make_doc(
+			is_new=False,
+			to_department="Finance - BEI",
+			to_designation="Store Supervisor",
+			previous=previous,
+		)
+
+		with patch("frappe.get_roles", return_value=["HR User"]):
+			doc._enforce_org_change_permissions()

--- a/hrms/tests/test_transfer_requests.py
+++ b/hrms/tests/test_transfer_requests.py
@@ -1,8 +1,9 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, getdate, now_datetime, nowdate
-from unittest.mock import patch
-from types import SimpleNamespace
 
 from hrms.api import transfer_requests
 
@@ -25,7 +26,9 @@ class TestTransferRequests(FrappeTestCase):
 		doc = frappe._dict({"store_warehouse": "UNKNOWN-WH"})
 		original_exists = frappe.db.exists
 		try:
-			frappe.db.exists = lambda doctype, name: False if doctype == "Warehouse" else original_exists(doctype, name)
+			frappe.db.exists = (
+				lambda doctype, name: False if doctype == "Warehouse" else original_exists(doctype, name)
+			)
 			with self.assertRaises(frappe.ValidationError):
 				transfer_requests._require_store_warehouse_mapping(doc)
 		finally:
@@ -53,7 +56,9 @@ class TestTransferRequests(FrappeTestCase):
 
 		try:
 			transfer_requests._has_any_role = lambda roles, user=None: True
-			frappe.db.exists = lambda doctype, name: True if doctype == "User" else original_exists(doctype, name)
+			frappe.db.exists = (
+				lambda doctype, name: True if doctype == "User" else original_exists(doctype, name)
+			)
 			frappe.get_roles = lambda user=None: ["HR Manager"]
 
 			transfer_requests._enforce_effective_date_dispatch_guard(
@@ -125,9 +130,11 @@ class TestTransferRequests(FrappeTestCase):
 			warehouse_name = "AYALA EVO"
 			branch = "AYALA EVO"
 
-		with patch("frappe.db.exists", side_effect=lambda doctype, name: True), patch(
-			"frappe.get_doc", return_value=_FakeWarehouse()
-		), patch("hrms.api.transfer_requests._get_branch_index", return_value={"AYALAEVO": "AYALA EVO"}):
+		with (
+			patch("frappe.db.exists", side_effect=lambda doctype, name: True),
+			patch("frappe.get_doc", return_value=_FakeWarehouse()),
+			patch("hrms.api.transfer_requests._get_branch_index", return_value={"AYALAEVO": "AYALA EVO"}),
+		):
 			with self.assertRaises(frappe.ValidationError):
 				transfer_requests._validate_store_warehouse_for_transfer("AYALA EVO - BEI")
 
@@ -274,20 +281,23 @@ class TestTransferRequests(FrappeTestCase):
 
 	def test_build_branch_reports_to_defaults_prefers_area_manager(self):
 		options = [{"branch": "AYALA EVO"}]
-		with patch("frappe.get_all", return_value=[
-			{
-				"name": "EMP-AREA-001",
-				"employee_name": "Area Leader",
-				"designation": "Area Supervisor",
-				"branch": "AYALA EVO",
-			},
-			{
-				"name": "EMP-OIC-001",
-				"employee_name": "Store OIC",
-				"designation": "Store OIC",
-				"branch": "AYALA EVO",
-			},
-		]):
+		with patch(
+			"frappe.get_all",
+			return_value=[
+				{
+					"name": "EMP-AREA-001",
+					"employee_name": "Area Leader",
+					"designation": "Area Supervisor",
+					"branch": "AYALA EVO",
+				},
+				{
+					"name": "EMP-OIC-001",
+					"employee_name": "Store OIC",
+					"designation": "Store OIC",
+					"branch": "AYALA EVO",
+				},
+			],
+		):
 			defaults = transfer_requests._build_branch_reports_to_defaults(options)
 		self.assertEqual(defaults["AYALA EVO"]["default_reports_to"], "EMP-AREA-001")
 
@@ -302,21 +312,24 @@ class TestTransferRequests(FrappeTestCase):
 				"branch": "AYALA EVO",
 			}
 		]
-		with patch("frappe.get_meta") as mock_meta, patch("frappe.get_all", return_value=warehouse_rows), patch(
-			"frappe.db.exists", return_value=True
-		), patch(
-			"hrms.api.transfer_requests._build_branch_reports_to_defaults",
-			return_value={
-				"AYALA EVO": {
-					"area_manager": {
-						"employee": "EMP-AREA-001",
-						"employee_name": "Area Leader",
-						"designation": "Area Supervisor",
-					},
-					"store_oic": None,
-					"default_reports_to": "EMP-AREA-001",
-				}
-			},
+		with (
+			patch("frappe.get_meta") as mock_meta,
+			patch("frappe.get_all", return_value=warehouse_rows),
+			patch("frappe.db.exists", return_value=True),
+			patch(
+				"hrms.api.transfer_requests._build_branch_reports_to_defaults",
+				return_value={
+					"AYALA EVO": {
+						"area_manager": {
+							"employee": "EMP-AREA-001",
+							"employee_name": "Area Leader",
+							"designation": "Area Supervisor",
+						},
+						"store_oic": None,
+						"default_reports_to": "EMP-AREA-001",
+					}
+				},
+			),
 		):
 			mock_meta.return_value = SimpleNamespace(has_field=lambda field: True)
 			options = transfer_requests._list_transfer_store_warehouse_options(limit=10)
@@ -334,13 +347,19 @@ class TestTransferRequests(FrappeTestCase):
 			}
 		)
 
-		with patch.object(frappe, "session", SimpleNamespace(user="test.supervisor@bebang.ph")), patch(
-			"hrms.api.transfer_requests._require_any_role"
-		), patch("frappe.db.exists", return_value=True), patch(
-			"frappe.get_doc", return_value=employee_doc
-		), patch(
-			"hrms.api.transfer_requests._validate_store_warehouse_for_transfer",
-			return_value={"warehouse": "BRITTANY OFFICE - BEI", "branch": "BRITTANY OFFICE", "company": "Bebang Enterprise Inc."},
+		with (
+			patch.object(frappe, "session", SimpleNamespace(user="test.supervisor@bebang.ph")),
+			patch("hrms.api.transfer_requests._require_any_role"),
+			patch("frappe.db.exists", return_value=True),
+			patch("frappe.get_doc", return_value=employee_doc),
+			patch(
+				"hrms.api.transfer_requests._validate_store_warehouse_for_transfer",
+				return_value={
+					"warehouse": "BRITTANY OFFICE - BEI",
+					"branch": "BRITTANY OFFICE",
+					"company": "Bebang Enterprise Inc.",
+				},
+			),
 		):
 			with self.assertRaises(frappe.ValidationError):
 				transfer_requests.create_transfer_request(
@@ -360,8 +379,9 @@ class TestTransferRequests(FrappeTestCase):
 					"to_designation": "Store Supervisor",
 				}
 
-		with patch("hrms.api.transfer_requests._can_manage_org_changes", return_value=False), patch(
-			"frappe.db.exists", return_value=False
+		with (
+			patch("hrms.api.transfer_requests._can_manage_org_changes", return_value=False),
+			patch("frappe.db.exists", return_value=False),
 		):
 			payload = transfer_requests._serialize_request(_Doc())
 
@@ -377,8 +397,9 @@ class TestTransferRequests(FrappeTestCase):
 					"to_designation": "Store Supervisor",
 				}
 
-		with patch("hrms.api.transfer_requests._can_manage_org_changes", return_value=True), patch(
-			"frappe.db.exists", return_value=False
+		with (
+			patch("hrms.api.transfer_requests._can_manage_org_changes", return_value=True),
+			patch("frappe.db.exists", return_value=False),
 		):
 			payload = transfer_requests._serialize_request(_Doc())
 

--- a/hrms/tests/test_transfer_requests.py
+++ b/hrms/tests/test_transfer_requests.py
@@ -350,3 +350,37 @@ class TestTransferRequests(FrappeTestCase):
 					store_warehouse="BRITTANY OFFICE - BEI",
 					is_reliever=1,
 				)
+
+	def test_serialize_request_redacts_org_change_targets_for_non_hr_viewers(self):
+		class _Doc:
+			def as_dict(self):
+				return {
+					"name": "BEI-TRF-0001",
+					"to_department": "Operations - BEI",
+					"to_designation": "Store Supervisor",
+				}
+
+		with patch("hrms.api.transfer_requests._can_manage_org_changes", return_value=False), patch(
+			"frappe.db.exists", return_value=False
+		):
+			payload = transfer_requests._serialize_request(_Doc())
+
+		self.assertIsNone(payload["to_department"])
+		self.assertIsNone(payload["to_designation"])
+
+	def test_serialize_request_keeps_org_change_targets_for_hr_viewers(self):
+		class _Doc:
+			def as_dict(self):
+				return {
+					"name": "BEI-TRF-0002",
+					"to_department": "Operations - BEI",
+					"to_designation": "Store Supervisor",
+				}
+
+		with patch("hrms.api.transfer_requests._can_manage_org_changes", return_value=True), patch(
+			"frappe.db.exists", return_value=False
+		):
+			payload = transfer_requests._serialize_request(_Doc())
+
+		self.assertEqual(payload["to_department"], "Operations - BEI")
+		self.assertEqual(payload["to_designation"], "Store Supervisor")


### PR DESCRIPTION
## Scope\n- hard-block non-HR edits to 	o_department / 	o_designation at BEI Transfer Request DocType validation\n- redact HR-only org-change target fields from transfer payloads for non-HR viewers\n- add regression tests for both guard layers\n\n## Why\nSupervisors/area/IT should not be able to set/change or view HR-only org-change targets from transfer request paths.\n\n## Validation\n- python -m py_compile on updated transfer API, doctype, and tests\n- unit tests added (requires Frappe runtime in CI)