### PR TITLE
fix(s19): handle missing cutoff field in BEI Settings

### DIFF
--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -648,11 +648,21 @@ def _get_order_cutoff():
 	Returns (cutoff_hour, cutoff_time) where cutoff_hour is the integer hour
 	(default 12) and cutoff_time is the display string (e.g. "11:59").
 	"""
+	cutoff_hour = 12
 	try:
-		raw = frappe.db.get_single_value("BEI Settings", "order_cutoff_hour")
-		cutoff_hour = int(raw) if raw else 12
+		meta = frappe.get_meta("BEI Settings")
+		cutoff_field = None
+		for candidate in ("order_cutoff_hour", "ordering_cutoff_hour"):
+			if meta.has_field(candidate):
+				cutoff_field = candidate
+				break
+		if cutoff_field:
+			raw = frappe.db.get_single_value("BEI Settings", cutoff_field)
+			cutoff_hour = int(raw) if raw else 12
 	except Exception:
+		# Missing/legacy settings fields should not block order submission.
 		cutoff_hour = 12
+	cutoff_hour = max(1, min(cutoff_hour, 23))
 	cutoff_time = f"{cutoff_hour - 1:02d}:59"
 	return cutoff_hour, cutoff_time
 

--- a/hrms/tests/test_s19_edit_governance.py
+++ b/hrms/tests/test_s19_edit_governance.py
@@ -11,6 +11,9 @@ def _install_common_stubs():
 	class _DB:
 		@staticmethod
 		def exists(*args, **kwargs):
+			if args and args[0] == "Item":
+				item_code = args[1] if len(args) > 1 else ""
+				return bool(item_code)
 			return False
 
 		@staticmethod
@@ -45,6 +48,7 @@ def _install_common_stubs():
 	frappe.log_error = lambda *args, **kwargs: None
 	frappe.get_roles = lambda *args, **kwargs: []
 	frappe.get_all = lambda *args, **kwargs: []
+	frappe.get_meta = lambda _doctype: types.SimpleNamespace(has_field=lambda _field: False)
 	frappe.parse_json = lambda payload: payload
 
 	def _whitelist(fn=None, **kwargs):
@@ -156,3 +160,12 @@ def test_sanitize_submitted_items_drops_zero_qty_and_missing_item_code():
 	dropped_reasons = {row["reason"] for row in dropped}
 	assert "non_positive_qty" in dropped_reasons
 	assert "missing_item_code" in dropped_reasons
+
+
+def test_get_order_cutoff_defaults_when_settings_field_missing():
+	store_mod = _load_store_module()
+
+	cutoff_hour, cutoff_time = store_mod._get_order_cutoff()
+
+	assert cutoff_hour == 12
+	assert cutoff_time == "11:59"


### PR DESCRIPTION
## Summary
- make store ordering cutoff lookup resilient when BEI Settings.order_cutoff_hour is missing
- fallback to default 11:59 cutoff (hour=12) without raising validation errors
- add regression test for missing settings field behavior

## Why
Emergency order submit on my.bebang.ph was failing with:
Field order_cutoff_hour does not exist on BEI Settings

This hotfix ensures submit/validation continues safely with defaults on legacy settings schemas.

## Validation
- pre-commit run --files hrms/api/store.py hrms/tests/test_s19_edit_governance.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_s19_recommendation_engine.py hrms/tests/test_s19_edit_governance.py hrms/tests/test_s19_baseline_zero_approval.py hrms/tests/test_s19_review_queue_metrics.py hrms/tests/test_s19_adaptive_tuning.py hrms/tests/test_s19_signal_modifiers.py -q --import-mode=importlib
