### PR TITLE
fix(s19): tolerate Item schema without cargo_category

### DIFF
--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -800,10 +800,17 @@ def submit_order(
 	item_codes = [row.get("item_code") for row in items if row.get("item_code")]
 	item_meta = {}
 	if item_codes:
+		item_fields = ["name", "item_group", "item_name"]
+		try:
+			if frappe.get_meta("Item").has_field("cargo_category"):
+				item_fields.append("cargo_category")
+		except Exception:
+			pass
+
 		for row in frappe.get_all(
 			"Item",
 			filters={"name": ["in", item_codes]},
-			fields=["name", "item_group", "item_name", "cargo_category"],
+			fields=item_fields,
 			limit_page_length=max(200, len(item_codes)),
 		):
 			item_meta[row.name] = row


### PR DESCRIPTION
## Summary
- make `hrms.api.store.submit_order` dynamically include `Item.cargo_category` only when that field exists
- prevent emergency submission crashes on environments where Item has no `cargo_category` column

## Why
Live emergency submit still failed after PR #123 with:
`pymysql.err.OperationalError: (1054, "Unknown column 'cargo_category' in 'SELECT'")`

This hotfix keeps the metadata lookup schema-safe while preserving lane/category validation.

## Validation
- `pre-commit run --files hrms/api/store.py hrms/tests/test_s19_edit_governance.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_s19_recommendation_engine.py hrms/tests/test_s19_edit_governance.py hrms/tests/test_s19_baseline_zero_approval.py hrms/tests/test_s19_review_queue_metrics.py hrms/tests/test_s19_adaptive_tuning.py hrms/tests/test_s19_signal_modifiers.py -q --import-mode=importlib`
