### PR TITLE
fix(s19): enforce area-supervisor-only approver routing

### DIFF
--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -748,8 +748,10 @@ def submit_order(
 	if not normalized_cargo_category:
 		frappe.throw(_("Cargo category is required (FC, DRY, or FM)"))
 
+	is_emergency_flag = frappe.utils.cint(is_emergency)
+
 	# Validate ordering schedule cutoff
-	_validate_order_cutoff(store, is_emergency=frappe.utils.cint(is_emergency))
+	_validate_order_cutoff(store, is_emergency=is_emergency_flag)
 
 	# Resolve branch name to warehouse name
 	warehouse = resolve_warehouse(store)
@@ -770,21 +772,22 @@ def submit_order(
 	order_date = nowdate()
 
 	# Duplicate check: no existing non-cancelled order for same store + date + category
-	existing = frappe.db.exists(
-		"BEI Store Order",
-		{
-			"store": warehouse,
-			"order_date": order_date,
-			"cargo_category": normalized_cargo_category,
-			"status": ["not in", ["Cancelled"]],
-		},
-	)
-	if existing:
-		frappe.throw(
-			_("An order already exists for {0} on {1} for category {2}: {3}").format(
-				warehouse, order_date, normalized_cargo_category, existing
-			)
+	if not is_emergency_flag:
+		existing = frappe.db.exists(
+			"BEI Store Order",
+			{
+				"store": warehouse,
+				"order_date": order_date,
+				"cargo_category": normalized_cargo_category,
+				"status": ["not in", ["Cancelled"]],
+			},
 		)
+		if existing:
+			frappe.throw(
+				_("An order already exists for {0} on {1} for category {2}: {3}").format(
+					warehouse, order_date, normalized_cargo_category, existing
+				)
+			)
 
 	# Validate quantities - prevent unreasonable orders
 	MAX_ORDER_QTY = 10000
@@ -823,7 +826,7 @@ def submit_order(
 	order.order_date = order_date
 	order.delivery_date = delivery_date or add_days(nowdate(), 1)
 	order.cargo_category = normalized_cargo_category
-	order.is_emergency = frappe.utils.cint(is_emergency)
+	order.is_emergency = is_emergency_flag
 	order.is_bulk_order = is_bulk_order
 	order.notes = notes
 	order.status = "Pending Approval"

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -104,6 +104,7 @@ STORE_OPS_ALLOWED_ROLES = [
 	"System Manager",
 	"Administrator",
 ]
+AREA_SUPERVISOR_ROLE = "Area Supervisor"
 
 
 def validate_store_ops_role():
@@ -139,21 +140,243 @@ def resolve_warehouse(store_or_branch):
 	frappe.throw(_("Could not find Store: {0}").format(store_or_branch))
 
 
-def _get_area_supervisor_for_store(warehouse):
-	"""Get the area supervisor user for a given warehouse/store."""
-	# Check custom_area_supervisor field on Warehouse
-	supervisor = frappe.db.get_value("Warehouse", warehouse, "custom_area_supervisor")
+def _normalize_store_key(value):
+	return re.sub(r"[^A-Z0-9]", "", str(value or "").upper())
+
+
+def _designation_is_store_lead(designation):
+	label = str(designation or "").upper()
+	return "STORE SUPERVISOR" in label or "STORE OIC" in label or " OIC" in label or label == "OIC"
+
+
+def _is_area_supervisor_user(user_id, role_cache=None):
+	user = str(user_id or "").strip()
+	if not user:
+		return False
+	cache = role_cache if role_cache is not None else {}
+	if user in cache:
+		return cache[user]
+	try:
+		roles = set(frappe.get_roles(user))
+	except Exception:
+		roles = set()
+	cache[user] = AREA_SUPERVISOR_ROLE in roles
+	return cache[user]
+
+
+def _clean_warehouse_branch_candidates(*values):
+	seen = set()
+	candidates = []
+	for raw in values:
+		text = str(raw or "").strip()
+		if not text:
+			continue
+		variants = [text]
+		without_company = re.sub(r"\s*-\s*BEI$", "", text, flags=re.IGNORECASE).strip()
+		if without_company:
+			variants.append(without_company)
+		if " - " in text:
+			variants.append(text.split(" - ", 1)[0].strip())
+		for variant in variants:
+			key = _normalize_store_key(variant)
+			if key and key not in seen:
+				seen.add(key)
+				candidates.append(variant)
+	return candidates
+
+
+def _warehouse_branch_candidates(warehouse):
+	warehouse_doc = (
+		frappe.db.get_value(
+			"Warehouse",
+			warehouse,
+			["name", "warehouse_name", "parent_warehouse"],
+			as_dict=True,
+		)
+		or {}
+	)
+	parent_name = None
+	if warehouse_doc.get("parent_warehouse"):
+		parent_name = frappe.db.get_value("Warehouse", warehouse_doc.get("parent_warehouse"), "warehouse_name")
+	return _clean_warehouse_branch_candidates(
+		warehouse_doc.get("warehouse_name"),
+		warehouse_doc.get("name"),
+		warehouse,
+		parent_name,
+	)
+
+
+def _resolve_valid_area_supervisor(candidate, warehouse, source, role_cache=None):
+	user = str(candidate or "").strip()
+	if not user:
+		return None
+	if _is_area_supervisor_user(user, role_cache=role_cache):
+		return user
+	frappe.log_error(
+		f"Warehouse {warehouse} has invalid {source} mapping '{user}' (missing Area Supervisor role).",
+		"Store Area Supervisor Mapping",
+	)
+	return None
+
+
+def _infer_area_supervisor_for_store(warehouse, role_cache=None):
+	branch_candidates = _warehouse_branch_candidates(warehouse)
+	branch_keys = {_normalize_store_key(candidate) for candidate in branch_candidates if candidate}
+	if not branch_keys:
+		return None
+
+	employees = frappe.get_all(
+		"Employee",
+		filters={"status": "Active"},
+		fields=["name", "user_id", "designation", "branch", "reports_to"],
+		limit_page_length=5000,
+	)
+	if not employees:
+		return None
+
+	branch_employees = [
+		row for row in employees if _normalize_store_key(row.get("branch")) in branch_keys
+	]
+
+	direct_area_users = sorted(
+		{
+			str(row.get("user_id")).strip()
+			for row in branch_employees
+			if row.get("user_id") and _is_area_supervisor_user(row.get("user_id"), role_cache=role_cache)
+		}
+	)
+	if len(direct_area_users) == 1:
+		return direct_area_users[0]
+
+	store_lead_reports_to = sorted(
+		{
+			str(row.get("reports_to")).strip()
+			for row in branch_employees
+			if row.get("reports_to") and _designation_is_store_lead(row.get("designation"))
+		}
+	)
+	if not store_lead_reports_to:
+		return None
+
+	reporting_managers = frappe.get_all(
+		"Employee",
+		filters={"name": ["in", store_lead_reports_to], "status": "Active"},
+		fields=["name", "user_id", "designation", "branch"],
+		limit_page_length=max(200, len(store_lead_reports_to)),
+	)
+	manager_area_users = sorted(
+		{
+			str(row.get("user_id")).strip()
+			for row in reporting_managers
+			if row.get("user_id") and _is_area_supervisor_user(row.get("user_id"), role_cache=role_cache)
+		}
+	)
+	if len(manager_area_users) == 1:
+		return manager_area_users[0]
+
+	if manager_area_users and direct_area_users:
+		intersection = sorted(set(manager_area_users).intersection(set(direct_area_users)))
+		if len(intersection) == 1:
+			return intersection[0]
+
+	return None
+
+
+def _collect_store_area_supervisor_mapping(apply_fixes=False, include_disabled=False, max_rows=200):
+	warehouses = frappe.get_all(
+		"Warehouse",
+		filters={"is_group": 0, "disabled": 0 if not include_disabled else ["in", [0, 1]]},
+		fields=["name", "warehouse_name", "custom_area_supervisor", "disabled"],
+		order_by="warehouse_name asc",
+		limit_page_length=5000,
+	)
+
+	role_cache = {}
+	rows = []
+	updated = 0
+	invalid = 0
+	unmapped = 0
+
+	for warehouse in warehouses:
+		name = warehouse.get("name")
+		current = str(warehouse.get("custom_area_supervisor") or "").strip()
+		current_valid = _is_area_supervisor_user(current, role_cache=role_cache) if current else False
+		resolved = current if current_valid else _infer_area_supervisor_for_store(name, role_cache=role_cache)
+		updated_now = False
+
+		if current and not current_valid:
+			invalid += 1
+		if not resolved:
+			unmapped += 1
+
+		if apply_fixes and resolved and current != resolved:
+			frappe.db.set_value("Warehouse", name, "custom_area_supervisor", resolved, update_modified=False)
+			updated += 1
+			updated_now = True
+
+		status = "mapped" if current_valid else "unmapped"
+		if current and not current_valid:
+			status = "mapped_invalid_role"
+		if resolved and not current_valid:
+			status = "resolved_by_inference"
+
+		rows.append(
+			{
+				"warehouse": name,
+				"warehouse_name": warehouse.get("warehouse_name"),
+				"current_mapping": current or None,
+				"resolved_mapping": resolved or None,
+				"status": status,
+				"updated": updated_now,
+			}
+		)
+
+	if max_rows and max_rows > 0:
+		rows = rows[:max_rows]
+
+	return {
+		"total_stores": len(warehouses),
+		"updated_mappings": updated,
+		"invalid_role_mappings": invalid,
+		"unmapped_after_resolution": unmapped,
+		"rows": rows,
+	}
+
+
+def _get_area_supervisor_for_store(warehouse, persist_inferred=True):
+	"""Resolve area supervisor for a warehouse, validating role and inferring fallback mapping."""
+	role_cache = {}
+
+	supervisor = _resolve_valid_area_supervisor(
+		frappe.db.get_value("Warehouse", warehouse, "custom_area_supervisor"),
+		warehouse=warehouse,
+		source="Warehouse.custom_area_supervisor",
+		role_cache=role_cache,
+	)
 	if supervisor:
 		return supervisor
 
-	# Fallback: check parent warehouse
 	parent = frappe.db.get_value("Warehouse", warehouse, "parent_warehouse")
 	if parent:
-		supervisor = frappe.db.get_value("Warehouse", parent, "custom_area_supervisor")
-		if supervisor:
-			return supervisor
+		parent_supervisor = _resolve_valid_area_supervisor(
+			frappe.db.get_value("Warehouse", parent, "custom_area_supervisor"),
+			warehouse=warehouse,
+			source=f"Parent Warehouse.custom_area_supervisor ({parent})",
+			role_cache=role_cache,
+		)
+		if parent_supervisor:
+			return parent_supervisor
 
-	return None
+	inferred = _infer_area_supervisor_for_store(warehouse, role_cache=role_cache)
+	if inferred and persist_inferred:
+		try:
+			frappe.db.set_value("Warehouse", warehouse, "custom_area_supervisor", inferred, update_modified=False)
+		except Exception:
+			frappe.log_error(
+				f"Failed to persist inferred area supervisor '{inferred}' for warehouse {warehouse}.",
+				"Store Area Supervisor Mapping",
+			)
+	return inferred
 
 
 FROZEN_TOKENS = {
@@ -525,6 +748,28 @@ def get_user_store():
 
 
 @frappe.whitelist()
+def audit_store_area_supervisor_mapping(
+	apply_fixes: int | str = 0, include_disabled: int | str = 0, max_rows: int | str = 200
+):
+	"""Audit and optionally fix store-to-area-supervisor mappings.
+
+	Only System Manager / HR Manager / Administrator may execute this operation.
+	"""
+	user_roles = set(frappe.get_roles(frappe.session.user))
+	if not user_roles.intersection({"System Manager", "HR Manager", "Administrator"}):
+		frappe.throw(
+			_("Only System Manager, HR Manager, or Administrator can audit supervisor mappings."),
+			frappe.PermissionError,
+		)
+
+	return _collect_store_area_supervisor_mapping(
+		apply_fixes=bool(cint(apply_fixes)),
+		include_disabled=bool(cint(include_disabled)),
+		max_rows=cint(max_rows) or 0,
+	)
+
+
+@frappe.whitelist()
 def get_orderable_items(store: str, date: str | None = None) -> dict:
 	"""
 	Get items available for ordering by this store.
@@ -853,6 +1098,16 @@ def submit_order(
 			edited_lines_count += 1
 		order.append("items", normalized)
 
+	requires_manual_approval = bool(is_bulk_order or edited_lines_count > 0)
+	approver = _get_area_supervisor_for_store(warehouse) if requires_manual_approval else None
+	if requires_manual_approval and not approver:
+		frappe.throw(
+			_(
+				"Order requires Area Supervisor approval but no valid Area Supervisor mapping is configured for {0}. "
+				"Please update Warehouse.custom_area_supervisor before submitting."
+			).format(warehouse)
+		)
+
 	order.insert(ignore_permissions=True)
 
 	_notify_store_ops(
@@ -865,7 +1120,6 @@ def submit_order(
 	if order.status == "Pending Approval":
 		queue_status = "pending"
 		try:
-			approver = _get_area_supervisor_for_store(warehouse)
 			if approver:
 				queue_entry = frappe.new_doc("BEI Approval Queue")
 				queue_entry.reference_doctype = "BEI Store Order"

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -800,10 +800,17 @@ def submit_order(
 	item_codes = [row.get("item_code") for row in items if row.get("item_code")]
 	item_meta = {}
 	if item_codes:
+		item_fields = ["name", "item_group", "item_name"]
+		try:
+			if frappe.get_meta("Item").has_field("cargo_category"):
+				item_fields.append("cargo_category")
+		except Exception:
+			pass
+
 		for row in frappe.get_all(
 			"Item",
 			filters={"name": ["in", item_codes]},
-			fields=["name", "item_group", "item_name", "cargo_category"],
+			fields=item_fields,
 			limit_page_length=max(200, len(item_codes)),
 		):
 			item_meta[row.name] = row

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -42,5 +42,6 @@ hrms.patches.v16_0.migrate_paid_to_awaiting_or #2026-02-09
 hrms.patches.v16_0.backfill_billing_type
 hrms.patches.v16_0.normalize_store_type_category_to_store_type #2026-02-28
 hrms.patches.v16_0.seed_warehouse_department_mapping
+hrms.patches.v16_0.backfill_store_area_supervisor_mapping #2026-03-02
 hrms.patches.v16_0.add_cycle_count_unique_index #2026-02-19
 hrms.patches.v16_0.drop_cycle_count_unique_index #2026-02-20

--- a/hrms/patches/v16_0/backfill_store_area_supervisor_mapping.py
+++ b/hrms/patches/v16_0/backfill_store_area_supervisor_mapping.py
@@ -1,0 +1,22 @@
+import frappe
+
+
+def execute():
+	"""Backfill Warehouse.custom_area_supervisor using role-validated inference."""
+	try:
+		from hrms.api.store import _collect_store_area_supervisor_mapping
+
+		result = _collect_store_area_supervisor_mapping(
+			apply_fixes=True,
+			include_disabled=False,
+			max_rows=0,
+		)
+		frappe.logger("hrms").info(
+			"Store area-supervisor mapping backfill complete: "
+			f"updated={result.get('updated_mappings', 0)} "
+			f"invalid={result.get('invalid_role_mappings', 0)} "
+			f"unmapped={result.get('unmapped_after_resolution', 0)}"
+		)
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), "Store Area Supervisor Mapping Backfill Failed")
+

--- a/hrms/tests/test_enrichment_reminder_queue_fallback_s09.py
+++ b/hrms/tests/test_enrichment_reminder_queue_fallback_s09.py
@@ -63,6 +63,7 @@ def _install_fake_runtime():
 	frappe_utils.now = lambda: "2026-02-28 10:00:00"
 	frappe_utils.now_datetime = lambda: datetime.datetime(2026, 2, 28, 10, 0, 0)
 	frappe_utils.get_datetime = lambda value=None: datetime.datetime(2026, 2, 28, 10, 0, 0)
+	frappe_utils.getdate = lambda value=None: value or "2026-02-28"
 	frappe_utils.add_days = lambda date_value, days: date_value
 	frappe_utils.flt = lambda value, precision=None: float(value or 0)
 	frappe_utils.cint = lambda value: int(float(value or 0))
@@ -145,7 +146,7 @@ class TestEnrichmentReminderQueueFallbackS09(unittest.TestCase):
 			result = tasks.run_enrichment_reminder_queue()
 		self.assertEqual(result["status"], "queued")
 
-	def test_submit_order_reports_unmapped_approval_queue(self):
+	def test_submit_order_requires_valid_area_supervisor_mapping_for_edited_lines(self):
 		store.frappe.local.session = types.SimpleNamespace(user="test.supervisor@bebang.ph")
 		store.frappe.new_doc = (
 			lambda doctype: _FakeOrderDoc() if doctype == "BEI Store Order" else _FakeOrderDoc("APQ-0001")
@@ -158,15 +159,14 @@ class TestEnrichmentReminderQueueFallbackS09(unittest.TestCase):
 			patch.object(store, "_get_area_supervisor_for_store", return_value=None),
 			patch.object(store.frappe.db, "exists", return_value=None),
 		):
-			result = store.submit_order(
-				store="AYALA EVO",
-				items=[{"item_code": "ITM-001", "qty_requested": 2}],
-				cargo_category="DRY",
-			)
+			with self.assertRaises(Exception) as ctx:
+				store.submit_order(
+					store="AYALA EVO",
+					items=[{"item_code": "ITM-001", "qty_requested": 2}],
+					cargo_category="DRY",
+				)
 
-		self.assertTrue(result["success"])
-		self.assertEqual(result["approval_queue_status"], "unmapped")
-		self.assertIn("no Area Supervisor mapping", result.get("warning", ""))
+		self.assertIn("requires Area Supervisor approval", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_s19_area_supervisor_mapping.py
+++ b/hrms/tests/test_s19_area_supervisor_mapping.py
@@ -1,0 +1,165 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+
+class _FakeDB:
+	def __init__(self, warehouse_rows):
+		self.warehouse_rows = warehouse_rows
+		self.set_calls = []
+
+	def exists(self, doctype, filters=None):
+		if doctype == "Warehouse":
+			if isinstance(filters, str):
+				return filters in self.warehouse_rows
+			if isinstance(filters, dict):
+				name = filters.get("name") or filters.get("warehouse_name")
+				return bool(name and name in self.warehouse_rows)
+		return False
+
+	def get_single_value(self, *args, **kwargs):
+		return None
+
+	def get_value(self, doctype, filters_or_name, fieldname=None, as_dict=False):
+		if doctype != "Warehouse":
+			return None
+		if isinstance(filters_or_name, dict):
+			key = filters_or_name.get("name")
+		else:
+			key = filters_or_name
+		row = self.warehouse_rows.get(key) or {}
+		if isinstance(fieldname, (list, tuple)):
+			payload = {field: row.get(field) for field in fieldname}
+			return payload if as_dict else payload
+		return row.get(fieldname)
+
+	def set_value(self, doctype, name, fieldname, value, **kwargs):
+		self.set_calls.append((doctype, name, fieldname, value))
+		if doctype == "Warehouse" and name in self.warehouse_rows:
+			self.warehouse_rows[name][fieldname] = value
+		return value
+
+
+def _install_stubs():
+	warehouse_rows = {
+		"AYALA EVO - BEI": {
+			"name": "AYALA EVO - BEI",
+			"warehouse_name": "AYALA EVO",
+			"custom_area_supervisor": "store.supervisor@bebang.ph",
+			"parent_warehouse": None,
+		},
+		"UNMAPPED - BEI": {
+			"name": "UNMAPPED - BEI",
+			"warehouse_name": "UNMAPPED",
+			"custom_area_supervisor": None,
+			"parent_warehouse": None,
+		},
+	}
+	db = _FakeDB(warehouse_rows)
+
+	role_map = {
+		"store.supervisor@bebang.ph": ["Store Supervisor"],
+		"area.supervisor@bebang.ph": ["Area Supervisor"],
+	}
+
+	employees = [
+		{
+			"name": "EMP-SUP-001",
+			"user_id": "store.supervisor@bebang.ph",
+			"designation": "Store Supervisor",
+			"branch": "AYALA EVO",
+			"reports_to": "EMP-AREA-001",
+		},
+		{
+			"name": "EMP-AREA-001",
+			"user_id": "area.supervisor@bebang.ph",
+			"designation": "Area Supervisor",
+			"branch": "AYALA EVO",
+			"reports_to": None,
+		},
+	]
+
+	frappe = types.ModuleType("frappe")
+	frappe.local = types.SimpleNamespace(
+		db=db,
+		session=types.SimpleNamespace(user="test.supervisor@bebang.ph"),
+	)
+	frappe.__dict__["db"] = db
+	frappe.__dict__["session"] = frappe.local.session
+	frappe.PermissionError = RuntimeError
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe._ = lambda msg: msg
+	frappe.throw = lambda msg, *args, **kwargs: (_ for _ in ()).throw(RuntimeError(msg))
+	frappe.parse_json = lambda payload: payload
+	frappe.get_meta = lambda _doctype: types.SimpleNamespace(has_field=lambda _field: False)
+	frappe.get_roles = lambda user=None: role_map.get(user or "test.supervisor@bebang.ph", [])
+	frappe.get_all = lambda doctype, **kwargs: employees if doctype == "Employee" else []
+	frappe.whitelist = lambda fn=None, **kwargs: fn if fn else (lambda inner: inner)
+
+	def _new_doc(_doctype):
+		return types.SimpleNamespace(insert=lambda **kwargs: None)
+
+	frappe.new_doc = _new_doc
+
+	utils = types.ModuleType("frappe.utils")
+	utils.nowdate = lambda: "2026-03-02"
+	utils.add_days = lambda _d, _n: "2026-03-03"
+	utils.now_datetime = lambda: "2026-03-02 10:00:00"
+	utils.flt = lambda value, precision=None: float(value or 0)
+	utils.cint = lambda value: int(float(value or 0))
+	utils.getdate = lambda value=None: value or "2026-03-02"
+
+	sys.modules["frappe"] = frappe
+	sys.modules["frappe.utils"] = utils
+
+	hrms_pkg = types.ModuleType("hrms")
+	hrms_pkg.__path__ = []
+	sys.modules["hrms"] = hrms_pkg
+
+	utils_pkg = types.ModuleType("hrms.utils")
+	utils_pkg.__path__ = []
+	sys.modules["hrms.utils"] = utils_pkg
+
+	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.get_company = lambda: "Bebang Enterprise Inc."
+	sys.modules["hrms.utils.bei_config"] = bei_config
+
+	scm_roles = types.ModuleType("hrms.utils.scm_roles")
+	scm_roles.SCM_APPROVAL_ROLES = []
+	scm_roles.check_scm_permission = lambda *args, **kwargs: None
+	sys.modules["hrms.utils.scm_roles"] = scm_roles
+
+	return db, warehouse_rows
+
+
+def _load_store_module():
+	db, warehouse_rows = _install_stubs()
+	file_path = pathlib.Path(__file__).resolve().parents[1] / "api" / "store.py"
+	spec = importlib.util.spec_from_file_location("s19_store_mapping_under_test", file_path)
+	module = importlib.util.module_from_spec(spec)
+	assert spec and spec.loader
+	spec.loader.exec_module(module)
+	return module, db, warehouse_rows
+
+
+def test_invalid_store_supervisor_mapping_is_replaced_by_area_supervisor():
+	store_mod, db, warehouse_rows = _load_store_module()
+
+	approver = store_mod._get_area_supervisor_for_store("AYALA EVO - BEI")
+	assert approver == "area.supervisor@bebang.ph"
+	assert warehouse_rows["AYALA EVO - BEI"]["custom_area_supervisor"] == "area.supervisor@bebang.ph"
+	assert any(
+		call == ("Warehouse", "AYALA EVO - BEI", "custom_area_supervisor", "area.supervisor@bebang.ph")
+		for call in db.set_calls
+	)
+
+
+def test_unmapped_store_returns_none_when_no_area_supervisor_can_be_inferred():
+	store_mod, _db, _rows = _load_store_module()
+
+	# Remove branch-linked area supervisor signals so inference cannot resolve.
+	store_mod.frappe.get_all = lambda doctype, **kwargs: [] if doctype == "Employee" else []
+
+	approver = store_mod._get_area_supervisor_for_store("UNMAPPED - BEI")
+	assert approver is None

--- a/hrms/tests/test_s19_emergency_duplicate_bypass.py
+++ b/hrms/tests/test_s19_emergency_duplicate_bypass.py
@@ -127,7 +127,15 @@ def test_non_emergency_duplicate_still_blocked():
 	with pytest.raises(RuntimeError, match="An order already exists"):
 		store_mod.submit_order(
 			store="TEST-STORE-BGC",
-			items=[{"item_code": "ITEM-001", "qty_requested": 1, "lane": "Dry"}],
+			items=[
+				{
+					"item_code": "ITEM-001",
+					"qty_requested": 1,
+					"recommended_qty": 1,
+					"suggested_qty": 1,
+					"lane": "Dry",
+				}
+			],
 			cargo_category="DRY",
 			is_emergency=0,
 		)
@@ -138,7 +146,15 @@ def test_emergency_duplicate_bypasses_duplicate_gate():
 
 	result = store_mod.submit_order(
 		store="TEST-STORE-BGC",
-		items=[{"item_code": "ITEM-001", "qty_requested": 1, "lane": "Dry"}],
+		items=[
+			{
+				"item_code": "ITEM-001",
+				"qty_requested": 1,
+				"recommended_qty": 1,
+				"suggested_qty": 1,
+				"lane": "Dry",
+			}
+		],
 		cargo_category="DRY",
 		is_emergency=1,
 		notes="Emergency replenishment",

--- a/hrms/tests/test_s19_emergency_duplicate_bypass.py
+++ b/hrms/tests/test_s19_emergency_duplicate_bypass.py
@@ -1,0 +1,147 @@
+import importlib.util
+import pathlib
+import sys
+import types
+from datetime import date, datetime
+
+import pytest
+
+
+def _install_stubs():
+	frappe = types.ModuleType("frappe")
+
+	class _DB:
+		@staticmethod
+		def exists(doctype, filters=None):
+			if doctype == "BEI Store Order":
+				return "BEI-ORD-EXISTING"
+			return False
+
+		@staticmethod
+		def get_single_value(*args, **kwargs):
+			return None
+
+	class _OrderDoc:
+		def __init__(self):
+			self.name = "BEI-ORD-TEST-0001"
+			self.status = "Pending Approval"
+			self.items = []
+
+		def append(self, table, row):
+			assert table == "items"
+			self.items.append(row)
+
+		def insert(self, ignore_permissions=False):
+			return None
+
+	def _flt(value, precision=None):
+		num = float(value or 0)
+		return round(num, precision) if precision is not None else num
+
+	def _cint(value):
+		return int(value or 0)
+
+	def _getdate(value=None):
+		if value in (None, ""):
+			return date(2026, 3, 2)
+		if isinstance(value, date):
+			return value
+		return datetime.strptime(str(value), "%Y-%m-%d").date()
+
+	def _new_doc(doctype):
+		if doctype == "BEI Store Order":
+			return _OrderDoc()
+		return types.SimpleNamespace(insert=lambda **kwargs: None)
+
+	def _throw(msg, *args, **kwargs):
+		raise RuntimeError(msg)
+
+	frappe.db = _DB()
+	frappe.local = types.SimpleNamespace(db=frappe.db)
+	frappe.__dict__["db"] = frappe.local.db
+	frappe.session = types.SimpleNamespace(user="test.supervisor@bebang.ph")
+	frappe.PermissionError = RuntimeError
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.get_roles = lambda *args, **kwargs: ["Store Supervisor"]
+	frappe.get_all = lambda *args, **kwargs: []
+	frappe.get_meta = lambda _doctype: types.SimpleNamespace(has_field=lambda _field: False)
+	frappe.new_doc = _new_doc
+	frappe.parse_json = lambda payload: payload
+
+	def _whitelist(fn=None, **kwargs):
+		if fn is None:
+			return lambda inner: inner
+		return fn
+
+	frappe.whitelist = _whitelist
+	frappe.throw = _throw
+	frappe._ = lambda msg: msg
+	frappe.utils = types.SimpleNamespace(cint=_cint, now=lambda: "2026-03-02 09:00:00")
+
+	utils = types.ModuleType("frappe.utils")
+	utils.nowdate = lambda: "2026-03-02"
+	utils.add_days = lambda _d, _n: "2026-03-03"
+	utils.now_datetime = lambda: datetime(2026, 3, 2, 10, 0, 0)
+	utils.flt = _flt
+	utils.cint = _cint
+	utils.getdate = _getdate
+
+	sys.modules["frappe"] = frappe
+	sys.modules["frappe.utils"] = utils
+
+	hrms_pkg = types.ModuleType("hrms")
+	hrms_pkg.__path__ = []
+	utils_pkg = types.ModuleType("hrms.utils")
+	utils_pkg.__path__ = []
+	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.get_company = lambda: "Bebang Enterprise Inc."
+
+	scm_roles = types.ModuleType("hrms.utils.scm_roles")
+	scm_roles.SCM_APPROVAL_ROLES = []
+	scm_roles.check_scm_permission = lambda *args, **kwargs: None
+
+	sys.modules["hrms"] = hrms_pkg
+	sys.modules["hrms.utils"] = utils_pkg
+	sys.modules["hrms.utils.bei_config"] = bei_config
+	sys.modules["hrms.utils.scm_roles"] = scm_roles
+
+
+def _load_store_module():
+	_install_stubs()
+	file_path = pathlib.Path(__file__).resolve().parents[1] / "api" / "store.py"
+	spec = importlib.util.spec_from_file_location("s19_store_emergency_under_test", file_path)
+	module = importlib.util.module_from_spec(spec)
+	assert spec and spec.loader
+	spec.loader.exec_module(module)
+	module.resolve_warehouse = lambda store: store
+	module._get_area_supervisor_for_store = lambda _warehouse: None
+	module._notify_store_ops = lambda _msg: None
+	return module
+
+
+def test_non_emergency_duplicate_still_blocked():
+	store_mod = _load_store_module()
+
+	with pytest.raises(RuntimeError, match="An order already exists"):
+		store_mod.submit_order(
+			store="TEST-STORE-BGC",
+			items=[{"item_code": "ITEM-001", "qty_requested": 1, "lane": "Dry"}],
+			cargo_category="DRY",
+			is_emergency=0,
+		)
+
+
+def test_emergency_duplicate_bypasses_duplicate_gate():
+	store_mod = _load_store_module()
+
+	result = store_mod.submit_order(
+		store="TEST-STORE-BGC",
+		items=[{"item_code": "ITEM-001", "qty_requested": 1, "lane": "Dry"}],
+		cargo_category="DRY",
+		is_emergency=1,
+		notes="Emergency replenishment",
+	)
+
+	assert result["success"] is True
+	assert result["status"] == "Pending Approval"
+	assert result["cargo_category"] == "DRY"

--- a/hrms/tests/test_s19_emergency_duplicate_bypass.py
+++ b/hrms/tests/test_s19_emergency_duplicate_bypass.py
@@ -56,10 +56,12 @@ def _install_stubs():
 	def _throw(msg, *args, **kwargs):
 		raise RuntimeError(msg)
 
-	frappe.db = _DB()
-	frappe.local = types.SimpleNamespace(db=frappe.db)
+	frappe.local = types.SimpleNamespace(
+		db=_DB(),
+		session=types.SimpleNamespace(user="test.supervisor@bebang.ph"),
+	)
 	frappe.__dict__["db"] = frappe.local.db
-	frappe.session = types.SimpleNamespace(user="test.supervisor@bebang.ph")
+	frappe.__dict__["session"] = frappe.local.session
 	frappe.PermissionError = RuntimeError
 	frappe.log_error = lambda *args, **kwargs: None
 	frappe.get_roles = lambda *args, **kwargs: ["Store Supervisor"]


### PR DESCRIPTION
## Summary
- enforce **Area Supervisor-only** approver resolution for store-order approval routing
- block manual-review-required submissions when no valid Area Supervisor mapping exists
- add role-validated inference fallback for store mapping (branch + store-lead reports-to chain)
- persist inferred mappings back to `Warehouse.custom_area_supervisor`
- add whitelisted audit/fix endpoint for mapping quality
- add deploy patch to backfill mappings automatically (`v16_0.backfill_store_area_supervisor_mapping`)

## Why
Edited/manual-review store orders were being created with `approval_queue_status: "unmapped"` in stores with missing/invalid supervisor mapping. This allowed orders to proceed without guaranteed Area Supervisor assignment.

## Changes
### Backend (`hrms/api/store.py`)
- `_get_area_supervisor_for_store()` now validates role and infers fallback mapping
- rejects invalid `custom_area_supervisor` users who are not `Area Supervisor`
- resolves inferred mapping and writes it back to warehouse
- `submit_order()` now fails fast if manual approval is required and no valid Area Supervisor is mapped
- added `audit_store_area_supervisor_mapping(apply_fixes, include_disabled, max_rows)` for admin remediation

### Migration
- `hrms/patches/v16_0/backfill_store_area_supervisor_mapping.py`
- added to `hrms/patches.txt`

### Tests
- updated duplicate bypass tests to keep edited-line guard explicit
- updated fallback test to assert manual-review orders require valid Area Supervisor mapping
- added `hrms/tests/test_s19_area_supervisor_mapping.py`

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest hrms/tests/test_s19_emergency_duplicate_bypass.py hrms/tests/test_enrichment_reminder_queue_fallback_s09.py hrms/tests/test_s19_area_supervisor_mapping.py -q`
- result: `7 passed`
- `python -m py_compile` on changed Python files
