### PR TITLE
fix(store-ordering): enforce 2-step outside-cutoff approvals

### DIFF
--- a/hrms/api/ordering.py
+++ b/hrms/api/ordering.py
@@ -218,53 +218,78 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 	Returns:
 	    dict: {"orders": [...], "total": int}
 	"""
-	# Queue review is an approval workflow and must allow Area Supervisors.
-	_check_ordering_permission(ORDERING_APPROVAL_ROLES, "view order review queue")
+	_check_ordering_permission(ORDERING_WAREHOUSE_ROLES, "view order review queue")
 
 	filter_date = date or today()
+	current_user = frappe.session.user
+	current_roles = set(frappe.get_roles(current_user))
 
-	params = {"date": filter_date}
+	conditions = ["so.order_date = %(date)s", "so.docstatus < 2"]
+	params = {"date": filter_date, "current_user": current_user}
 
 	if status:
+		conditions.append("so.status = %(status)s")
 		params["status"] = status
 
-	query = """
-        SELECT
-            so.name,
-            so.store,
-            so.order_date,
-            so.delivery_date,
-            so.cargo_category,
-            so.status,
-            so.is_bulk_order,
-            so.is_emergency,
-            so.submitted_by,
-            COUNT(soi.name) as items_count,
-            SUM(soi.amount) as total_amount,
-            SUM(
-                CASE
-                    WHEN COALESCE(soi.is_edited, 0) = 1 OR COALESCE(soi.deviation_pct, 0) != 0
-                    THEN 1
-                    ELSE 0
-                END
-            ) as deviation_count
-        FROM `tabBEI Store Order` so
-        LEFT JOIN `tabBEI Store Order Item` soi ON soi.parent = so.name
-        WHERE so.order_date = %(date)s
-          AND so.docstatus < 2
-    """
+	admin_viewer_roles = {"System Manager", "Administrator", "HR Manager", "Warehouse Manager"}
+	is_admin_viewer = bool(current_roles.intersection(admin_viewer_roles))
+	if not is_admin_viewer:
+		conditions.append(
+			"(so.status != 'Pending Approval' OR pending_queue.assigned_approver = %(current_user)s)"
+		)
 
-	if status:
-		query += " AND so.status = %(status)s"
+	where_clause = " AND ".join(conditions)
 
-	query += """
-        GROUP BY so.name
-        ORDER BY
-            CASE so.status WHEN 'Pending Approval' THEN 0 ELSE 1 END,
-            so.store ASC
-    """
-
-	orders = frappe.db.sql(query, params, as_dict=True)
+	orders = frappe.db.sql(
+		f"""
+		SELECT
+			so.name,
+			so.store,
+			so.order_date,
+			so.delivery_date,
+			so.cargo_category,
+			so.status,
+			so.is_bulk_order,
+			so.is_emergency,
+			so.submitted_by,
+			pending_queue.queue_name AS approval_queue_name,
+			pending_queue.assigned_approver AS current_approver,
+			pending_queue.pending_since AS pending_since,
+			CASE
+				WHEN so.is_emergency = 1
+					AND pending_queue.assigned_approver IS NOT NULL
+					AND pending_queue.assigned_approver != COALESCE(wh.custom_area_supervisor, wh_parent.custom_area_supervisor)
+					THEN 'Regional Manager Review'
+				ELSE 'Area Supervisor Review'
+			END AS approval_stage,
+			COUNT(soi.name) as items_count,
+			SUM(soi.amount) as total_amount,
+			SUM(CASE WHEN COALESCE(soi.is_edited, 0) = 1 OR COALESCE(soi.deviation_pct, 0) != 0 THEN 1 ELSE 0 END) as deviation_count
+		FROM `tabBEI Store Order` so
+		LEFT JOIN (
+			SELECT
+				q.reference_name,
+				SUBSTRING_INDEX(GROUP_CONCAT(q.name ORDER BY q.creation ASC), ',', 1) AS queue_name,
+				SUBSTRING_INDEX(GROUP_CONCAT(q.assigned_approver ORDER BY q.creation ASC), ',', 1) AS assigned_approver,
+				MIN(q.submitted_at) AS pending_since
+			FROM `tabBEI Approval Queue` q
+			WHERE q.reference_doctype = 'BEI Store Order'
+			  AND q.status = 'Pending'
+			GROUP BY q.reference_name
+		) pending_queue ON pending_queue.reference_name = so.name
+		LEFT JOIN `tabWarehouse` wh ON wh.name = so.store
+		LEFT JOIN `tabWarehouse` wh_parent ON wh_parent.name = wh.parent_warehouse
+		LEFT JOIN `tabBEI Store Order Item` soi ON soi.parent = so.name
+		WHERE {where_clause}
+		GROUP BY so.name
+		ORDER BY
+			CASE so.status WHEN 'Pending Approval' THEN 0 ELSE 1 END,
+			COALESCE(pending_queue.pending_since, so.creation) ASC,
+			so.store ASC
+		""",
+		params,
+		as_dict=True,
+	)
 
 	return {
 		"orders": orders,
@@ -309,6 +334,43 @@ def reject_order(order_name: str, reason: str) -> dict[str, str]:
 
 	order.status = "Cancelled"
 	order.save(ignore_permissions=True)
+
+	pending_queue_rows = frappe.get_all(
+		"BEI Approval Queue",
+		filters={
+			"reference_doctype": "BEI Store Order",
+			"reference_name": order_name,
+			"status": "Pending",
+		},
+		fields=["name", "assigned_approver"],
+	)
+	for row in pending_queue_rows:
+		queue_doc = frappe.get_doc("BEI Approval Queue", row.name)
+		queue_doc.status = "Rejected"
+		queue_doc.approved_by = frappe.session.user
+		queue_doc.approved_at = now_datetime()
+		queue_doc.rejection_reason = reason
+		queue_doc.save(ignore_permissions=True)
+
+	try:
+		todo_rows = frappe.get_all(
+			"ToDo",
+			filters={
+				"reference_type": "BEI Store Order",
+				"reference_name": order_name,
+				"status": "Open",
+			},
+			fields=["name"],
+		)
+		for row in todo_rows:
+			todo_doc = frappe.get_doc("ToDo", row.name)
+			todo_doc.status = "Closed"
+			todo_doc.save(ignore_permissions=True)
+	except Exception:
+		frappe.log_error(
+			f"Failed to close ToDo assignments for cancelled order {order_name}",
+			"Store Ordering Reject ToDo Close Error",
+		)
 
 	# Add comment with rejection reason
 	frappe.get_doc(

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -13,7 +13,7 @@ import re
 
 import frappe
 from frappe import _
-from frappe.utils import add_days, cint, flt, getdate, now_datetime, nowdate
+from frappe.utils import add_days, cint, flt, get_datetime, getdate, now_datetime, nowdate
 
 from hrms.utils.bei_config import get_company
 from hrms.utils.scm_roles import SCM_APPROVAL_ROLES, check_scm_permission
@@ -101,12 +101,14 @@ STORE_OPS_ALLOWED_ROLES = [
 	"Store OIC",
 	"Store Supervisor",
 	"Area Supervisor",
+	"Regional Manager",
 	"System Manager",
 	"Administrator",
 ]
 AREA_SUPERVISOR_ROLE = "Area Supervisor"
 REGIONAL_MANAGER_ROLE = "Regional Manager"
 REGIONAL_MANAGER_FALLBACK_EMAIL = "edlice@bebang.ph"
+SYSTEM_APPROVER_ROLES = {"System Manager", "Administrator"}
 
 
 def validate_store_ops_role():
@@ -340,6 +342,257 @@ def _resolve_review_approver_for_store(warehouse):
 		return regional_manager, "regional_manager_fallback"
 
 	return None, "unmapped"
+
+
+def _is_system_approver(user_id):
+	try:
+		roles = set(frappe.get_roles(user_id))
+	except Exception:
+		roles = set()
+	return bool(roles.intersection(SYSTEM_APPROVER_ROLES))
+
+
+def _is_regional_manager_user(user_id):
+	user = str(user_id or "").strip()
+	if not user:
+		return False
+	try:
+		roles = set(frappe.get_roles(user))
+	except Exception:
+		roles = set()
+	return bool(roles.intersection({REGIONAL_MANAGER_ROLE, "System Manager", "HR Manager"}))
+
+
+def _create_order_notification_log(order_name, for_user, subject):
+	if not for_user:
+		return
+	try:
+		frappe.get_doc(
+			{
+				"doctype": "Notification Log",
+				"for_user": for_user,
+				"type": "Alert",
+				"document_type": "BEI Store Order",
+				"document_name": order_name,
+				"subject": subject or f"Store order {order_name} requires approval.",
+				"email_content": subject or f"Store order {order_name} requires approval.",
+			}
+		).insert(ignore_permissions=True)
+	except Exception:
+		pass
+
+
+def _assign_order_for_approval(order_name, assigned_to, description):
+	if not assigned_to:
+		return False
+	try:
+		from frappe.desk.form.assign_to import add as add_assignment
+
+		add_assignment(
+			{
+				"assign_to": [assigned_to],
+				"doctype": "BEI Store Order",
+				"name": order_name,
+				"description": description,
+				"notify": 1,
+				"assigned_by": frappe.session.user,
+				"priority": "High",
+			}
+		)
+		_create_order_notification_log(
+			order_name=order_name,
+			for_user=assigned_to,
+			subject=description,
+		)
+		return True
+	except Exception:
+		try:
+			todo = frappe.get_doc(
+				{
+					"doctype": "ToDo",
+					"allocated_to": assigned_to,
+					"reference_type": "BEI Store Order",
+					"reference_name": order_name,
+					"description": description,
+					"priority": "High",
+					"status": "Open",
+				}
+			)
+			todo.insert(ignore_permissions=True)
+			_create_order_notification_log(
+				order_name=order_name,
+				for_user=assigned_to,
+				subject=description,
+			)
+			return True
+		except Exception:
+			frappe.log_error(
+				f"Failed to assign BEI Store Order {order_name} to {assigned_to}",
+				"Store Order Assignment Error",
+			)
+			return False
+
+
+def _close_order_assignments(order_name, allocated_to=None):
+	try:
+		filters = {
+			"reference_type": "BEI Store Order",
+			"reference_name": order_name,
+			"status": "Open",
+		}
+		if allocated_to:
+			filters["allocated_to"] = allocated_to
+		for row in frappe.get_all("ToDo", filters=filters, fields=["name"]):
+			todo = frappe.get_doc("ToDo", row.name)
+			todo.status = "Closed"
+			todo.save(ignore_permissions=True)
+	except Exception:
+		frappe.log_error(
+			f"Failed to close ToDo assignments for BEI Store Order {order_name}",
+			"Store Order Assignment Close Error",
+		)
+
+
+def _append_order_comment(order_name, content):
+	try:
+		frappe.get_doc(
+			{
+				"doctype": "Comment",
+				"comment_type": "Info",
+				"reference_doctype": "BEI Store Order",
+				"reference_name": order_name,
+				"content": content,
+			}
+		).insert(ignore_permissions=True)
+	except Exception:
+		frappe.log_error(
+			f"Failed to add comment on BEI Store Order {order_name}: {content}",
+			"Store Order Comment Error",
+		)
+
+
+def _create_approval_queue_entry(order, approver, priority="Normal"):
+	if not approver:
+		return None
+	queue_entry = frappe.new_doc("BEI Approval Queue")
+	queue_entry.reference_doctype = "BEI Store Order"
+	queue_entry.reference_name = order.name
+	queue_entry.assigned_approver = approver
+	queue_entry.status = "Pending"
+	queue_entry.priority = priority
+	queue_entry.store = order.store
+	queue_entry.submitted_by = order.submitted_by or frappe.session.user
+	queue_entry.submitted_at = frappe.utils.now()
+	queue_entry.insert(ignore_permissions=True)
+	return queue_entry
+
+
+def _get_pending_approval_entries(order_name):
+	return frappe.get_all(
+		"BEI Approval Queue",
+		filters={
+			"reference_doctype": "BEI Store Order",
+			"reference_name": order_name,
+			"status": "Pending",
+		},
+		fields=["name", "assigned_approver", "priority", "submitted_at", "creation"],
+		order_by="creation asc",
+	)
+
+
+def _has_approved_stage_entry(order_name, approver):
+	if not approver:
+		return False
+	return bool(
+		frappe.db.exists(
+			"BEI Approval Queue",
+			{
+				"reference_doctype": "BEI Store Order",
+				"reference_name": order_name,
+				"assigned_approver": approver,
+				"status": "Approved",
+			},
+		)
+	)
+
+
+def _get_regional_manager_for_store(warehouse, area_supervisor=None):
+	field_candidates = [
+		"custom_regional_manager",
+		"custom_regional_supervisor",
+		"custom_regional_approver",
+	]
+
+	warehouse_chain = [warehouse]
+	parent = frappe.db.get_value("Warehouse", warehouse, "parent_warehouse")
+	if parent:
+		warehouse_chain.append(parent)
+
+	for wh in warehouse_chain:
+		for fieldname in field_candidates:
+			candidate = frappe.db.get_value("Warehouse", wh, fieldname)
+			if candidate and _is_enabled_user(candidate) and _is_regional_manager_user(candidate):
+				return candidate, f"warehouse.{fieldname}"
+
+	if area_supervisor:
+		area_employee = frappe.db.get_value(
+			"Employee",
+			{"user_id": area_supervisor, "status": "Active"},
+			["name", "reports_to"],
+			as_dict=True,
+		)
+		reports_to = area_employee.get("reports_to") if area_employee else None
+		if reports_to:
+			manager_user = frappe.db.get_value("Employee", reports_to, "user_id")
+			if manager_user and _is_enabled_user(manager_user) and _is_regional_manager_user(manager_user):
+				return manager_user, "employee.reports_to"
+
+	regional_manager = _get_regional_manager_fallback_user()
+	if regional_manager:
+		return regional_manager, "regional_manager_fallback"
+
+	return None, "unmapped"
+
+
+def _resolve_order_approval_routing(warehouse, is_emergency, submitted_after_cutoff):
+	area_approver = _get_area_supervisor_for_store(warehouse)
+	regional_approver, regional_source = _get_regional_manager_for_store(
+		warehouse, area_supervisor=area_approver
+	)
+
+	requires_regional_after_area = bool(
+		cint(is_emergency)
+		and submitted_after_cutoff
+		and area_approver
+		and regional_approver
+		and regional_approver != area_approver
+	)
+
+	if area_approver:
+		return {
+			"first_approver": area_approver,
+			"first_source": "area_supervisor",
+			"requires_regional_after_area": requires_regional_after_area,
+			"regional_approver": regional_approver,
+			"regional_source": regional_source,
+		}
+
+	if regional_approver:
+		return {
+			"first_approver": regional_approver,
+			"first_source": "regional_manager_fallback",
+			"requires_regional_after_area": False,
+			"regional_approver": regional_approver,
+			"regional_source": regional_source,
+		}
+
+	return {
+		"first_approver": None,
+		"first_source": "unmapped",
+		"requires_regional_after_area": False,
+		"regional_approver": None,
+		"regional_source": "unmapped",
+	}
 
 
 def _infer_area_supervisor_for_store(warehouse, role_cache=None):
@@ -857,9 +1110,14 @@ def get_user_store():
 				warehouse_name = frappe.db.get_value("Warehouse", warehouse, "warehouse_name") or warehouse
 				stores = [{"name": warehouse, "warehouse_name": warehouse_name}]
 
-	# System Manager / HR User fallback - return all stores
-	if not stores and ("System Manager" in user_roles or "HR User" in user_roles):
-		role = "HR User"
+	# System / HR / Regional fallback - return all stores
+	if not stores and (
+		"System Manager" in user_roles
+		or "HR User" in user_roles
+		or "HR Manager" in user_roles
+		or "Regional Manager" in user_roles
+	):
+		role = "Regional Manager" if "Regional Manager" in user_roles else "HR User"
 		stores = frappe.get_all(
 			"Warehouse",
 			filters={"is_group": 0, "disabled": 0},
@@ -1120,6 +1378,8 @@ def submit_order(
 		frappe.throw(_("Cargo category is required (FC, DRY, or FM)"))
 
 	is_emergency_flag = frappe.utils.cint(is_emergency)
+	cutoff_hour, cutoff_time = _get_order_cutoff()
+	submitted_after_cutoff = now_datetime().hour >= cutoff_hour
 
 	# Validate ordering schedule cutoff
 	_validate_order_cutoff(store, is_emergency=is_emergency_flag)
@@ -1224,12 +1484,24 @@ def submit_order(
 			edited_lines_count += 1
 		order.append("items", normalized)
 
-	requires_manual_approval = bool(is_bulk_order or edited_lines_count > 0)
-	approver = None
-	approver_source = "not_required"
-	if requires_manual_approval:
-		approver, approver_source = _resolve_review_approver_for_store(warehouse)
-	if requires_manual_approval and not approver:
+	routing = _resolve_order_approval_routing(
+		warehouse=warehouse,
+		is_emergency=is_emergency_flag,
+		submitted_after_cutoff=submitted_after_cutoff,
+	)
+	first_approver = routing["first_approver"]
+	first_source = routing["first_source"]
+	requires_regional_after_area = bool(routing["requires_regional_after_area"])
+	regional_approver = routing["regional_approver"]
+	regional_source = routing["regional_source"]
+
+	requires_manual_approval = bool(
+		is_bulk_order
+		or edited_lines_count > 0
+		or requires_regional_after_area
+		or (is_emergency_flag and submitted_after_cutoff)
+	)
+	if requires_manual_approval and not first_approver:
 		frappe.throw(
 			_(
 				"Order requires Area Supervisor approval but no valid Area Supervisor mapping was found for {0}, "
@@ -1244,44 +1516,73 @@ def submit_order(
 		f"New store order {order.name} from {warehouse} -- {len(items)} items. Review: my.bebang.ph/dashboard/store-ops/order-approvals"
 	)
 
-	# Route to area supervisor approval queue (non-fatal if it fails)
 	warning = None
-	queue_status = "skipped_auto_approved"
-	if order.status == "Pending Approval":
+	queue_status = "not_required"
+	queue_name = None
+	if order.status == "Pending Approval" and requires_manual_approval:
 		queue_status = "pending"
 		try:
-			if approver:
-				queue_entry = frappe.new_doc("BEI Approval Queue")
-				queue_entry.reference_doctype = "BEI Store Order"
-				queue_entry.reference_name = order.name
-				queue_entry.assigned_approver = approver
-				queue_entry.status = "Pending"
-				queue_entry.store = warehouse
-				queue_entry.submitted_by = frappe.session.user
-				queue_entry.submitted_at = frappe.utils.now()
-				queue_entry.insert(ignore_permissions=True)
+			if first_approver:
+				queue_priority = "Urgent" if is_emergency_flag and submitted_after_cutoff else "Normal"
+				queue_entry = _create_approval_queue_entry(
+					order=order,
+					approver=first_approver,
+					priority=queue_priority,
+				)
+				queue_name = queue_entry.name if queue_entry else None
+				_assign_order_for_approval(
+					order_name=order.name,
+					assigned_to=first_approver,
+					description=(
+						f"Store order {order.name} requires your approval."
+						if not requires_regional_after_area
+						else f"Store order {order.name} requires your Stage 1 approval before regional sign-off."
+					),
+				)
 				queue_status = "created"
 			else:
 				queue_status = "unmapped"
-				warning = "Order created but no Area Supervisor mapping was found for this store."
+				warning = "Order created but no approver mapping was found for this store."
 		except Exception:
 			frappe.log_error(
 				f"Failed to create approval queue for order {order.name}", "Approval Queue Error"
 			)
-			warning = (
-				"Order created but approval routing failed. Please notify your Area Supervisor manually."
-			)
+			warning = "Order created but approval routing failed. Please notify your approver manually."
 			queue_status = "failed"
+
+	if requires_regional_after_area and regional_approver:
+		_append_order_comment(
+			order.name,
+			_(
+				"Emergency order submitted after cutoff {0}. Approval chain: Area Supervisor -> Regional Manager ({1})."
+			).format(cutoff_time, regional_approver),
+		)
+	elif first_source == "regional_manager_fallback" and first_approver:
+		_append_order_comment(
+			order.name,
+			_("Area Supervisor mapping missing; routed directly to Regional Manager ({0}).").format(
+				first_approver
+			),
+		)
 
 	result = {
 		"success": True,
 		"name": order.name,
 		"status": order.status,
-		"requires_area_supervisor_review": 1 if edited_lines_count > 0 else 0,
+		"requires_area_supervisor_review": bool(
+			requires_manual_approval and first_source == "area_supervisor"
+		),
+		"requires_regional_manager_review": bool(requires_regional_after_area),
 		"edited_lines_count": edited_lines_count,
 		"message": f"Order {order.name} submitted successfully",
 		"approval_queue_status": queue_status,
-		"approval_approver_source": approver_source,
+		"approval_queue_name": queue_name,
+		"approval_approver_source": first_source if requires_manual_approval else "not_required",
+		"approval_assigned_approver": first_approver if requires_manual_approval else None,
+		"regional_approver": regional_approver,
+		"regional_approver_source": regional_source,
+		"submitted_after_cutoff": bool(submitted_after_cutoff),
+		"is_emergency": bool(is_emergency_flag),
 		"cargo_category": normalized_cargo_category,
 		"dropped_invalid_lines": len(dropped_items),
 	}
@@ -1317,55 +1618,184 @@ def get_order_history(store: str | None = None, limit: int | str = 20) -> dict:
 @frappe.whitelist()
 def approve_order(order_name: str, approved_quantities: list | str | None = None) -> dict:
 	"""
-	Approve a store order. Optionally adjust quantities.
-	Only Area Supervisors can approve orders.
-
-	approved_quantities: {item_code: qty_approved}
+	Approve a store order with staged routing support.
+	- Regular/manual orders: single-step approval
+	- Emergency orders submitted after cutoff: Area Supervisor -> Regional Manager
 	"""
-	# Verify user has an approver role
-	user_roles = frappe.get_roles(frappe.session.user)
-	if (
-		AREA_SUPERVISOR_ROLE not in user_roles
-		and REGIONAL_MANAGER_ROLE not in user_roles
-		and "System Manager" not in user_roles
-		and frappe.session.user != REGIONAL_MANAGER_FALLBACK_EMAIL
-	):
-		frappe.throw(_("Only Area Supervisors or Regional Managers can approve store orders"))
-
+	user = frappe.session.user
 	order = frappe.get_doc("BEI Store Order", order_name)
 
 	if order.status != "Pending Approval":
 		frappe.throw(_("Order is not pending approval"))
 
-	if approved_quantities:
-		if isinstance(approved_quantities, str):
-			approved_quantities = json.loads(approved_quantities)
-		for item in order.items:
-			if item.item_code in approved_quantities:
-				item.qty_approved = approved_quantities[item.item_code]
-			else:
-				item.qty_approved = item.qty_requested
+	pending_entries = _get_pending_approval_entries(order_name)
+	active_entry = pending_entries[0] if pending_entries else None
+	assigned_approver = active_entry.get("assigned_approver") if active_entry else None
+
+	is_system_user = _is_system_approver(user)
+	if assigned_approver:
+		if assigned_approver != user and not is_system_user:
+			frappe.throw(
+				_("Order {0} is currently assigned to {1}.").format(order_name, assigned_approver),
+				frappe.PermissionError,
+			)
 	else:
-		for item in order.items:
+		user_roles = set(frappe.get_roles(user))
+		allowed_roles = {AREA_SUPERVISOR_ROLE, REGIONAL_MANAGER_ROLE}.union(SYSTEM_APPROVER_ROLES)
+		if not user_roles.intersection(allowed_roles):
+			frappe.throw(
+				_("Only assigned approvers, Area Supervisors, Regional Managers, or System Managers can approve."),
+				frappe.PermissionError,
+			)
+
+	approved_qty_map = {}
+	if approved_quantities:
+		parsed = approved_quantities
+		if isinstance(parsed, str):
+			parsed = json.loads(parsed)
+		if isinstance(parsed, list):
+			for row in parsed:
+				item_code = (row or {}).get("item_code")
+				if not item_code:
+					continue
+				approved_qty_map[item_code] = flt((row or {}).get("qty_approved", 0))
+		elif isinstance(parsed, dict):
+			for item_code, qty in parsed.items():
+				approved_qty_map[item_code] = flt(qty)
+
+	for item in order.items:
+		if item.item_code in approved_qty_map:
+			item.qty_approved = approved_qty_map[item.item_code]
+		elif not flt(getattr(item, "qty_approved", 0)):
 			item.qty_approved = item.qty_requested
 
+	area_approver = _get_area_supervisor_for_store(order.store)
+	regional_approver, _regional_source = _get_regional_manager_for_store(
+		order.store, area_supervisor=area_approver
+	)
+	cutoff_hour, _cutoff_time = _get_order_cutoff()
+	order_created_dt = get_datetime(order.creation) if getattr(order, "creation", None) else now_datetime()
+	submitted_after_cutoff = order_created_dt.hour >= cutoff_hour
+	requires_dual_stage = bool(
+		cint(order.is_emergency)
+		and submitted_after_cutoff
+		and area_approver
+		and regional_approver
+		and regional_approver != area_approver
+	)
+
+	current_stage = "single_step"
+	if assigned_approver and assigned_approver == area_approver:
+		current_stage = "area_supervisor"
+	elif assigned_approver and assigned_approver == regional_approver:
+		current_stage = "regional_manager"
+	elif requires_dual_stage:
+		if user == area_approver:
+			current_stage = "area_supervisor"
+		elif user == regional_approver:
+			current_stage = "regional_manager"
+
+	if requires_dual_stage and current_stage == "regional_manager":
+		if not _has_approved_stage_entry(order_name, area_approver):
+			frappe.throw(
+				_("Area Supervisor approval is required before Regional Manager final approval."),
+				frappe.PermissionError,
+			)
+
+	if requires_dual_stage and current_stage == "single_step" and not is_system_user:
+		frappe.throw(
+			_("Dual-stage approval is configured, but current approval stage could not be resolved."),
+			frappe.PermissionError,
+		)
+
+	if active_entry:
+		queue_doc = frappe.get_doc("BEI Approval Queue", active_entry["name"])
+		queue_doc.status = "Approved"
+		queue_doc.approved_by = user
+		queue_doc.approved_at = now_datetime()
+		queue_doc.save(ignore_permissions=True)
+		_close_order_assignments(order_name, allocated_to=assigned_approver)
+
+	is_area_stage_approval = current_stage == "area_supervisor"
+	should_forward_to_regional = bool(
+		requires_dual_stage
+		and is_area_stage_approval
+		and regional_approver
+		and regional_approver != user
+	)
+
+	if should_forward_to_regional:
+		order.status = "Pending Approval"
+		order.save(ignore_permissions=True)
+
+		queue_entry = None
+		try:
+			queue_entry = _create_approval_queue_entry(
+				order=order,
+				approver=regional_approver,
+				priority="Urgent",
+			)
+		except Exception:
+			frappe.log_error(
+				f"Failed to create regional approval queue for order {order_name}",
+				"Store Order Regional Queue Error",
+			)
+		if queue_entry:
+			_assign_order_for_approval(
+				order_name=order_name,
+				assigned_to=regional_approver,
+				description=(
+					f"Store order {order_name} completed Area Supervisor approval. "
+					"Regional Manager final approval required."
+				),
+			)
+			_append_order_comment(
+				order_name,
+				_(
+					"Area Supervisor approval completed by {0}. Routed to Regional Manager ({1}) for final sign-off."
+				).format(user, regional_approver),
+			)
+
+		_notify_store_ops(
+			f"Store order {order_name} approved by Area Supervisor {user} and routed to Regional Manager {regional_approver}."
+		)
+		return {
+			"success": True,
+			"status": order.status,
+			"stage": "area_supervisor",
+			"message": f"Area Supervisor approval captured. Routed to Regional Manager ({regional_approver}).",
+			"requires_regional_manager_review": True,
+			"approval_approver_source": "regional_manager",
+			"approval_assigned_approver": regional_approver,
+			"approval_queue_status": "created" if queue_entry else "failed",
+			"material_request": None,
+			"dr_number": "",
+		}
+
 	order.status = "Approved"
-	order.approved_by = frappe.session.user
+	order.approved_by = user
 	order.approved_at = now_datetime()
 	order.save(ignore_permissions=True)
+	_close_order_assignments(order_name)
 
 	_notify_store_ops(
-		f"Store order {order_name} approved by {frappe.session.user}. Check my.bebang.ph/dashboard/store-ops/order-approvals for details."
+		f"Store order {order_name} approved by {user}. Check my.bebang.ph/dashboard/store-ops/order-approvals for details."
 	)
 
 	# Create Material Request so commissary can pick it up, linking back to this store order
 	mr_name = _create_mr_for_store_order(order)
+	final_stage = "regional_manager" if requires_dual_stage else current_stage
 
 	return {
 		"success": True,
 		"message": f"Order {order_name} approved",
+		"status": order.status,
+		"stage": final_stage,
+		"approval_queue_status": "completed",
+		"requires_regional_manager_review": False,
+		"approval_approver_source": final_stage,
 		"material_request": mr_name,
-		"dr_number": mr_name,
+		"dr_number": mr_name or "",
 	}
 
 

--- a/hrms/tests/test_store_order_approval_flow.py
+++ b/hrms/tests/test_store_order_approval_flow.py
@@ -1,0 +1,181 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from hrms.api import store
+
+
+class _FakeOrder:
+    def __init__(
+        self,
+        name="BEI-ORD-TEST-0001",
+        status="Pending Approval",
+        is_emergency=1,
+        store_name="TEST-STORE - BEI",
+        creation="2026-03-03 12:30:00",
+    ):
+        self.name = name
+        self.status = status
+        self.is_emergency = is_emergency
+        self.store = store_name
+        self.creation = creation
+        self.approved_by = None
+        self.approved_at = None
+        self.items = [
+            SimpleNamespace(item_code="ITEM-001", qty_requested=3, qty_approved=0),
+            SimpleNamespace(item_code="ITEM-002", qty_requested=5, qty_approved=0),
+        ]
+        self._save_count = 0
+
+    def save(self, ignore_permissions=True):
+        self._save_count += 1
+
+
+class _FakeQueueDoc:
+    def __init__(self, name):
+        self.name = name
+        self.status = "Pending"
+        self.approved_by = None
+        self.approved_at = None
+        self._save_count = 0
+
+    def save(self, ignore_permissions=True):
+        self._save_count += 1
+
+
+class TestStoreOrderApprovalFlow(FrappeTestCase):
+    def test_resolve_routing_requires_regional_after_area_when_emergency_after_cutoff(self):
+        with patch("hrms.api.store._get_area_supervisor_for_store", return_value="test.area@bebang.ph"), patch(
+            "hrms.api.store._get_regional_manager_for_store",
+            return_value=("test.regional@bebang.ph", "unit-test"),
+        ):
+            routing = store._resolve_order_approval_routing(
+                warehouse="TEST-STORE - BEI",
+                is_emergency=1,
+                submitted_after_cutoff=True,
+            )
+
+        self.assertEqual(routing["first_source"], "area_supervisor")
+        self.assertEqual(routing["first_approver"], "test.area@bebang.ph")
+        self.assertTrue(routing["requires_regional_after_area"])
+        self.assertEqual(routing["regional_approver"], "test.regional@bebang.ph")
+
+    def test_resolve_routing_falls_back_to_regional_when_area_unmapped(self):
+        with patch("hrms.api.store._get_area_supervisor_for_store", return_value=None), patch(
+            "hrms.api.store._get_regional_manager_for_store",
+            return_value=("edlice@bebang.ph", "default_regional_manager"),
+        ):
+            routing = store._resolve_order_approval_routing(
+                warehouse="TEST-STORE - BEI",
+                is_emergency=1,
+                submitted_after_cutoff=True,
+            )
+
+        self.assertEqual(routing["first_source"], "regional_manager_fallback")
+        self.assertEqual(routing["first_approver"], "edlice@bebang.ph")
+        self.assertFalse(routing["requires_regional_after_area"])
+
+    def test_approve_order_area_stage_forwards_to_regional(self):
+        fake_order = _FakeOrder()
+        fake_queue_doc = _FakeQueueDoc("BEI-APQ-AREA-0001")
+        frappe.session.user = "test.area@bebang.ph"
+
+        def fake_get_doc(doctype, name):
+            if doctype == "BEI Store Order":
+                return fake_order
+            if doctype == "BEI Approval Queue":
+                return fake_queue_doc
+            raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
+
+        with patch("frappe.get_doc", side_effect=fake_get_doc), patch(
+            "hrms.api.store._get_pending_approval_entries",
+            return_value=[
+                {
+                    "name": "BEI-APQ-AREA-0001",
+                    "assigned_approver": "test.area@bebang.ph",
+                }
+            ],
+        ), patch("hrms.api.store._is_system_approver", return_value=False), patch(
+            "hrms.api.store._get_area_supervisor_for_store",
+            return_value="test.area@bebang.ph",
+        ), patch(
+            "hrms.api.store._get_regional_manager_for_store",
+            return_value=("test.hr@bebang.ph", "employee.reports_to"),
+        ), patch(
+            "hrms.api.store._create_approval_queue_entry",
+            return_value=SimpleNamespace(name="BEI-APQ-REG-0001"),
+        ) as create_queue, patch("hrms.api.store._assign_order_for_approval"), patch(
+            "hrms.api.store._append_order_comment"
+        ), patch(
+            "hrms.api.store._notify_store_ops"
+        ), patch(
+            "hrms.api.store._close_order_assignments"
+        ), patch(
+            "hrms.api.store._create_mr_for_store_order"
+        ) as create_mr:
+            result = store.approve_order(
+                order_name=fake_order.name,
+                approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["stage"], "area_supervisor")
+        self.assertTrue(result["requires_regional_manager_review"])
+        self.assertEqual(fake_order.status, "Pending Approval")
+        self.assertEqual(fake_queue_doc.status, "Approved")
+        self.assertEqual(fake_queue_doc.approved_by, "test.area@bebang.ph")
+        self.assertEqual(create_queue.call_count, 1)
+        self.assertFalse(create_mr.called)
+
+    def test_approve_order_regional_stage_finalizes(self):
+        fake_order = _FakeOrder()
+        fake_queue_doc = _FakeQueueDoc("BEI-APQ-REG-0001")
+        frappe.session.user = "test.hr@bebang.ph"
+
+        def fake_get_doc(doctype, name):
+            if doctype == "BEI Store Order":
+                return fake_order
+            if doctype == "BEI Approval Queue":
+                return fake_queue_doc
+            raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
+
+        with patch("frappe.get_doc", side_effect=fake_get_doc), patch(
+            "hrms.api.store._get_pending_approval_entries",
+            return_value=[
+                {
+                    "name": "BEI-APQ-REG-0001",
+                    "assigned_approver": "test.hr@bebang.ph",
+                }
+            ],
+        ), patch("hrms.api.store._is_system_approver", return_value=False), patch(
+            "hrms.api.store._get_area_supervisor_for_store",
+            return_value="test.area@bebang.ph",
+        ), patch(
+            "hrms.api.store._get_regional_manager_for_store",
+            return_value=("test.hr@bebang.ph", "employee.reports_to"),
+        ), patch(
+            "hrms.api.store._notify_store_ops"
+        ), patch(
+            "hrms.api.store._close_order_assignments"
+        ), patch(
+            "hrms.api.store._create_mr_for_store_order",
+            return_value="MAT-REQ-0001",
+        ) as create_mr, patch(
+            "hrms.api.store._create_approval_queue_entry"
+        ) as create_queue:
+            result = store.approve_order(
+                order_name=fake_order.name,
+                approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 3}],
+            )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["stage"], "regional_manager")
+        self.assertEqual(result["status"], "Approved")
+        self.assertEqual(result["material_request"], "MAT-REQ-0001")
+        self.assertEqual(fake_order.status, "Approved")
+        self.assertEqual(fake_order.approved_by, "test.hr@bebang.ph")
+        self.assertEqual(fake_queue_doc.status, "Approved")
+        self.assertEqual(create_mr.call_count, 1)
+        self.assertFalse(create_queue.called)

--- a/hrms/utils/scm_roles.py
+++ b/hrms/utils/scm_roles.py
@@ -26,8 +26,20 @@ SCM_PICKING_ROLES = {"Warehouse Manager", "Warehouse Staff", "Logistics Coordina
 
 # Ordering (ordering.py)
 ORDERING_STORE_ROLES = {"Store Staff", "Store Supervisor", "Store OIC", "System Manager"}
-ORDERING_WAREHOUSE_ROLES = {"HR Manager", "Warehouse Manager", "System Manager"}
-ORDERING_APPROVAL_ROLES = {"Area Supervisor", "HR Manager", "Warehouse Manager", "System Manager"}
+ORDERING_WAREHOUSE_ROLES = {
+    "Area Supervisor",
+    "Regional Manager",
+    "HR Manager",
+    "Warehouse Manager",
+    "System Manager",
+}
+ORDERING_APPROVAL_ROLES = {
+    "Area Supervisor",
+    "Regional Manager",
+    "HR Manager",
+    "Warehouse Manager",
+    "System Manager",
+}
 
 # Billing (billing.py)
 RATE_MANAGEMENT_ROLES = {"Accounts Manager", "Supply Chain Manager", "System Manager"}


### PR DESCRIPTION
## Summary\n- enforce dual-stage approval (Area Supervisor -> Regional Manager) for outside-cutoff emergency orders\n- fallback to Regional Manager when Area Supervisor mapping is unavailable\n- add assignment + Notification Log generation for approval routing\n- expose current approver/stage in review queue and close queue/todos on reject\n- add regression tests for stage routing and final approval\n\n## Requirement Covered\nOutside-cutoff orders now require Area Supervisor and Regional Manager approvals; unmapped area routes to Regional Manager fallback (edlice@bebang.ph).