### PR TITLE
fix: restore self-service employee lookup for linked test accounts

### DIFF
--- a/hrms/api/hr_reports.py
+++ b/hrms/api/hr_reports.py
@@ -568,7 +568,14 @@ def get_overtime_report(
 
 
 def get_employee_permission_query_conditions(user: str) -> str:
-	return "(`tabEmployee`.name NOT LIKE 'TEST-%')"
+	base_condition = "(`tabEmployee`.name NOT LIKE 'TEST-%')"
+	if not user or user == "Guest":
+		return base_condition
+
+	# Keep demo employees hidden from general list views, but allow a user to
+	# resolve their own linked test employee record for self-service flows.
+	escaped_user = frappe.db.escape(user)
+	return f"({base_condition} OR `tabEmployee`.user_id = {escaped_user})"
 
 
 @frappe.whitelist()

--- a/hrms/api/hr_reports.py
+++ b/hrms/api/hr_reports.py
@@ -4,12 +4,12 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, date_diff, flt, getdate, today
 
+from hrms.api import leave_dashboard as leave_dashboard_api
 from hrms.utils.api_helpers import (
 	_check_hr_permission,
 	_paginate,
 	_validate_date_range,
 )
-from hrms.api import leave_dashboard as leave_dashboard_api
 
 
 @frappe.whitelist()
@@ -621,6 +621,7 @@ def get_training_completion_by_store(training_event_type: str | None = None) -> 
 		)
 
 	return {"success": True, "data": data}
+
 
 @frappe.whitelist()
 def get_dashboard_data(

--- a/hrms/tests/test_employee_permission_query_conditions.py
+++ b/hrms/tests/test_employee_permission_query_conditions.py
@@ -28,8 +28,9 @@ def _load_hr_reports_module():
 			return "'" + str(value).replace("\\", "\\\\").replace("'", "\\'") + "'"
 
 	frappe.whitelist = whitelist
-	frappe.db = _DB()
 	frappe._ = lambda text: text
+	frappe.local = types.SimpleNamespace(db=_DB())
+	frappe.__dict__["db"] = frappe.local.db
 
 	utils.add_days = lambda value, _days: value
 	utils.date_diff = lambda *_args, **_kwargs: 0

--- a/hrms/tests/test_employee_permission_query_conditions.py
+++ b/hrms/tests/test_employee_permission_query_conditions.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _load_hr_reports_module():
+	frappe = types.ModuleType("frappe")
+	utils = types.ModuleType("frappe.utils")
+	rate_limiter = types.ModuleType("frappe.rate_limiter")
+	leave_dashboard = types.ModuleType("hrms.api.leave_dashboard")
+
+	def whitelist(*_args, **_kwargs):
+		def decorator(fn):
+			return fn
+
+		return decorator
+
+	class _DB:
+		@staticmethod
+		def escape(value):
+			return "'" + str(value).replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+	frappe.whitelist = whitelist
+	frappe.db = _DB()
+	frappe._ = lambda text: text
+
+	utils.add_days = lambda value, _days: value
+	utils.date_diff = lambda *_args, **_kwargs: 0
+	utils.flt = float
+	utils.getdate = lambda value=None: value
+	utils.today = lambda: "2026-03-07"
+
+	rate_limiter.rate_limit = lambda *args, **kwargs: (lambda fn: fn)
+
+	leave_dashboard.get_dashboard_data = lambda **kwargs: kwargs
+	leave_dashboard.get_leave_overview = lambda **kwargs: kwargs
+	leave_dashboard.get_all_leaves = lambda **kwargs: kwargs
+	leave_dashboard.check_leave_conflicts = lambda **kwargs: kwargs
+	leave_dashboard.bulk_action = lambda **kwargs: kwargs
+
+	sys.modules["frappe"] = frappe
+	sys.modules["frappe.utils"] = utils
+	sys.modules["frappe.rate_limiter"] = rate_limiter
+	sys.modules["hrms.api.leave_dashboard"] = leave_dashboard
+
+	spec = importlib.util.spec_from_file_location(
+		"hr_reports_under_test",
+		ROOT / "hrms" / "api" / "hr_reports.py",
+	)
+	module = importlib.util.module_from_spec(spec)
+	assert spec and spec.loader
+	spec.loader.exec_module(module)
+	return module
+
+
+def test_employee_permission_query_keeps_general_test_employees_hidden():
+	hr_reports = _load_hr_reports_module()
+
+	assert (
+		hr_reports.get_employee_permission_query_conditions("Guest")
+		== "(`tabEmployee`.name NOT LIKE 'TEST-%')"
+	)
+
+
+def test_employee_permission_query_allows_current_user_to_resolve_own_test_employee():
+	hr_reports = _load_hr_reports_module()
+
+	query = hr_reports.get_employee_permission_query_conditions("test.area@bebang.ph")
+
+	assert "(`tabEmployee`.name NOT LIKE 'TEST-%')" in query
+	assert "`tabEmployee`.user_id = 'test.area@bebang.ph'" in query


### PR DESCRIPTION
## Summary
- allow Employee permission queries to return the current user's linked TEST-* employee row
- keep unrelated TEST-* employees hidden from general list views
- add a regression test for the permission query contract

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_employee_permission_query_conditions.py
- python -m compileall hrms/api/hr_reports.py hrms/tests/test_employee_permission_query_conditions.py

## Why
`test.area@bebang.ph` already has a linked Employee record (`TEST-AREA-001`), but portal self-service routes resolve the current employee through list queries filtered by `user_id`. The global Employee permission hook currently strips all `TEST-*` rows from those queries, which leaves `/api/employee/me` and related routes with no employee match even though the document exists.