### PR TITLE
fix: restore HR job offers API

### DIFF
--- a/hrms/api/hr_onboarding.py
+++ b/hrms/api/hr_onboarding.py
@@ -52,8 +52,9 @@ def get_job_offers(
         SELECT COUNT(*)
         FROM `tabJob Offer` jo
         LEFT JOIN `tabJob Applicant` ja ON ja.name = jo.job_applicant
+        LEFT JOIN `tabJob Opening` jop ON jop.name = ja.job_title
         WHERE (%(status)s IS NULL OR jo.status = %(status)s)
-          AND (%(department)s IS NULL OR ja.department = %(department)s)
+          AND (%(department)s IS NULL OR jop.department = %(department)s)
         """,
 		values,
 	)[0][0]
@@ -68,11 +69,12 @@ def get_job_offers(
             jo.offer_date,
             jo.status,
             jo.job_applicant,
-            COALESCE(ja.department, '') AS department
+            COALESCE(jop.department, '') AS department
         FROM `tabJob Offer` jo
         LEFT JOIN `tabJob Applicant` ja ON ja.name = jo.job_applicant
+        LEFT JOIN `tabJob Opening` jop ON jop.name = ja.job_title
         WHERE (%(status)s IS NULL OR jo.status = %(status)s)
-          AND (%(department)s IS NULL OR ja.department = %(department)s)
+          AND (%(department)s IS NULL OR jop.department = %(department)s)
         ORDER BY jo.creation DESC
         LIMIT %(start)s, %(page_size)s
         """,

--- a/hrms/tests/test_hr_onboarding_bridge.py
+++ b/hrms/tests/test_hr_onboarding_bridge.py
@@ -138,6 +138,14 @@ class TestHrOnboardingBridge(unittest.TestCase):
 		self.assertEqual(result["page"], 1)
 		self.assertEqual(result["page_size"], 20)
 		self.assertEqual(len(result["data"]), 2)
+		total_query = hr_onboarding.frappe.db.sql.call_args_list[0].args[0]
+		rows_query = hr_onboarding.frappe.db.sql.call_args_list[1].args[0]
+		self.assertIn("`tabJob Opening`", total_query)
+		self.assertIn("jop.department", total_query)
+		self.assertNotIn("ja.department", total_query)
+		self.assertIn("`tabJob Opening`", rows_query)
+		self.assertIn("COALESCE(jop.department, '') AS department", rows_query)
+		self.assertNotIn("ja.department", rows_query)
 
 	def test_update_job_offer_status_updates_offer_and_applicant(self):
 		offer = _Offer(status="Pending")


### PR DESCRIPTION
## Summary
- derive job offer department from Job Opening instead of a non-existent Job Applicant column
- keep the hr_onboarding bridge test aligned with the real schema path

## Verification
- python hrms/tests/test_hr_onboarding_bridge.py
- python -m compileall hrms/api/hr_onboarding.py
