### PR TITLE
fix: harden HR onboarding creation for legacy offer data

### DIFF
--- a/hrms/api/hr_onboarding.py
+++ b/hrms/api/hr_onboarding.py
@@ -27,6 +27,31 @@ def _as_int(value: Any, default: int) -> int:
 	return parsed if parsed > 0 else default
 
 
+def _optional_link_value(doctype: str, value: str | None) -> str | None:
+	if not value:
+		return None
+	return value if frappe.db.exists(doctype, value) else None
+
+
+def _resolve_job_applicant(value: str | None, applicant_name: str | None = None) -> str:
+	if not value:
+		frappe.throw(_("Job Applicant is required."))
+
+	if frappe.db.exists("Job Applicant", value):
+		return value
+
+	resolved = frappe.db.get_value("Job Applicant", {"email_id": value}, "name")
+	if resolved:
+		return resolved
+
+	if applicant_name:
+		resolved = frappe.db.get_value("Job Applicant", {"applicant_name": applicant_name}, "name")
+		if resolved:
+			return resolved
+
+	frappe.throw(_("Could not resolve Job Applicant for job offer {0}.").format(value))
+
+
 @frappe.whitelist()
 def get_job_offers(
 	status: str | None = None,
@@ -131,14 +156,17 @@ def create_onboarding_from_offer(job_offer: str) -> dict[str, Any]:
 	if existing:
 		return {"success": True, "onboarding_name": existing, "already_exists": True}
 
+	job_applicant = _resolve_job_applicant(offer.job_applicant, offer.applicant_name)
+	designation = _optional_link_value("Designation", offer.designation)
+
 	onboarding = frappe.get_doc(
 		{
 			"doctype": "Employee Onboarding",
-			"job_applicant": offer.job_applicant,
+			"job_applicant": job_applicant,
 			"job_offer": offer.name,
 			"employee_name": offer.applicant_name,
 			"company": offer.company,
-			"designation": offer.designation,
+			"designation": designation,
 			"date_of_joining": nowdate(),
 			"boarding_begins_on": nowdate(),
 			"boarding_status": "Pending",

--- a/hrms/tests/test_hr_onboarding_bridge.py
+++ b/hrms/tests/test_hr_onboarding_bridge.py
@@ -185,11 +185,9 @@ class TestHrOnboardingBridge(unittest.TestCase):
 
 		hr_onboarding.frappe.get_doc = MagicMock(side_effect=_get_doc)
 		hr_onboarding.frappe.db.exists = MagicMock(
-			side_effect=lambda doctype, filters=None, *args, **kwargs: (
-				None
-				if doctype == "Employee Onboarding"
-				else doctype in {"Job Applicant", "Designation"}
-			)
+			side_effect=lambda doctype, filters=None, *args, **kwargs: None
+			if doctype == "Employee Onboarding"
+			else doctype in {"Job Applicant", "Designation"}
 		)
 
 		result = hr_onboarding.create_onboarding_from_offer("OFF-0001")

--- a/hrms/tests/test_hr_onboarding_bridge.py
+++ b/hrms/tests/test_hr_onboarding_bridge.py
@@ -173,22 +173,71 @@ class TestHrOnboardingBridge(unittest.TestCase):
 	def test_create_onboarding_from_offer_creates_new_doc(self):
 		offer = _Offer(status="Accepted")
 		draft = _OnboardingDraft()
+		captured_payload = {}
 
 		def _get_doc(arg1, arg2=None):
 			if arg1 == "Job Offer":
 				return offer
 			if isinstance(arg1, dict):
+				captured_payload.update(arg1)
 				return draft
 			raise AssertionError("unexpected get_doc call")
 
 		hr_onboarding.frappe.get_doc = MagicMock(side_effect=_get_doc)
-		hr_onboarding.frappe.db.exists = MagicMock(return_value=None)
+		hr_onboarding.frappe.db.exists = MagicMock(
+			side_effect=lambda doctype, filters=None, *args, **kwargs: (
+				None
+				if doctype == "Employee Onboarding"
+				else doctype in {"Job Applicant", "Designation"}
+			)
+		)
 
 		result = hr_onboarding.create_onboarding_from_offer("OFF-0001")
 
 		self.assertTrue(draft.inserted)
 		self.assertFalse(result["already_exists"])
 		self.assertEqual(result["onboarding_name"], "ONB-0001")
+		self.assertEqual(captured_payload["job_applicant"], "APP-001")
+		self.assertEqual(captured_payload["designation"], "Store OIC")
+
+	def test_create_onboarding_from_offer_resolves_email_job_applicant_and_skips_invalid_designation(self):
+		offer = _Offer(status="Accepted", job_applicant="juan@example.com")
+		offer.designation = "Crew"
+		draft = _OnboardingDraft()
+		captured_payload = {}
+
+		def _get_doc(arg1, arg2=None):
+			if arg1 == "Job Offer":
+				return offer
+			if isinstance(arg1, dict):
+				captured_payload.update(arg1)
+				return draft
+			raise AssertionError("unexpected get_doc call")
+
+		def _exists(doctype, filters=None, *args, **kwargs):
+			if doctype == "Employee Onboarding":
+				return None
+			if doctype == "Designation":
+				return False
+			if doctype == "Job Applicant":
+				return False
+			return None
+
+		def _get_value(doctype, filters=None, fieldname=None, *args, **kwargs):
+			if doctype == "Job Applicant" and filters == {"email_id": "juan@example.com"}:
+				return "HR-APP-2026-00001"
+			return None
+
+		hr_onboarding.frappe.get_doc = MagicMock(side_effect=_get_doc)
+		hr_onboarding.frappe.db.exists = MagicMock(side_effect=_exists)
+		hr_onboarding.frappe.db.get_value = MagicMock(side_effect=_get_value)
+
+		result = hr_onboarding.create_onboarding_from_offer("OFF-0001")
+
+		self.assertTrue(draft.inserted)
+		self.assertFalse(result["already_exists"])
+		self.assertEqual(captured_payload["job_applicant"], "HR-APP-2026-00001")
+		self.assertIsNone(captured_payload["designation"])
 
 	def test_get_onboarding_checklist_computes_progress(self):
 		onboarding = types.SimpleNamespace(


### PR DESCRIPTION
## Summary
- resolve email-based job applicant references before creating onboarding records
- skip invalid designation links so legacy offer rows do not block onboarding creation
- extend hr_onboarding bridge tests for the legacy data path

## Verification
- python hrms/tests/test_hr_onboarding_bridge.py
- python -m compileall hrms/api/hr_onboarding.py
