### PR TITLE
fix: populate required standard buying bridge fields

### DIFF
--- a/hrms/hr/doctype/bei_goods_receipt/bei_goods_receipt.py
+++ b/hrms/hr/doctype/bei_goods_receipt/bei_goods_receipt.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt, now_datetime
 from hrms.utils.bei_config import get_company
+from hrms.utils.standard_buying_bridge import apply_standard_buying_context
 
 
 class BEIGoodsReceipt(Document):
@@ -271,6 +272,7 @@ class BEIGoodsReceipt(Document):
             "bei_goods_receipt": self.name,  # Reference back to BEI GR
             "items": pr_items
         })
+        apply_standard_buying_context(pr, store_label=self.warehouse or bei_po.ship_to)
 
         # Add rejected warehouse if there are rejections
         if self.total_rejected_qty > 0:

--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt, now_datetime, getdate, add_days
 from hrms.utils.bei_config import get_company
+from hrms.utils.standard_buying_bridge import apply_standard_buying_context
 
 
 class BEIInvoice(Document):
@@ -324,6 +325,10 @@ class BEIInvoice(Document):
             "payment_terms_template": self.payment_terms,
             "items": pi_items
         })
+        apply_standard_buying_context(
+            pi,
+            store_label=bei_gr.warehouse or bei_po.ship_to,
+        )
 
         # Add withholding tax (EWT) if applicable
         if flt(self.withholding_tax, 2) > 0:

--- a/hrms/hr/doctype/bei_purchase_order/bei_purchase_order.py
+++ b/hrms/hr/doctype/bei_purchase_order/bei_purchase_order.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import now_datetime, flt
 from hrms.utils.bei_config import get_company
+from hrms.utils.standard_buying_bridge import apply_standard_buying_context
 
 
 # Approval threshold - PO above this needs both Mae AND Butch
@@ -352,6 +353,7 @@ class BEIPurchaseOrder(Document):
             "bei_purchase_order": self.name,  # Reference back to BEI PO
             "items": po_items
         })
+        apply_standard_buying_context(po, store_label=self.ship_to)
 
         # Apply discount if any
         if flt(self.discount_amount, 2) > 0:

--- a/hrms/utils/standard_buying_bridge.py
+++ b/hrms/utils/standard_buying_bridge.py
@@ -1,0 +1,23 @@
+import frappe
+
+from hrms.utils.bei_config import get_company
+
+
+def doctype_has_field(doctype: str, fieldname: str) -> bool:
+    """Return True when a DocType currently exposes *fieldname*."""
+    try:
+        return bool(frappe.get_meta(doctype).has_field(fieldname))
+    except Exception:
+        return False
+
+
+def apply_standard_buying_context(doc, *, store_label: str | None = None, legal_entity: str | None = None) -> None:
+    """Populate BEI-required bridge fields only when they exist on the target DocType."""
+    resolved_store_label = (store_label or "").strip() or "Stores - BEI"
+    resolved_legal_entity = legal_entity or get_company()
+
+    if doctype_has_field(doc.doctype, "bei_legal_entity"):
+        doc.set("bei_legal_entity", resolved_legal_entity)
+
+    if doctype_has_field(doc.doctype, "bei_store_label"):
+        doc.set("bei_store_label", resolved_store_label)


### PR DESCRIPTION
Live procurement cutover verification failed because standard Purchase Order, Purchase Receipt, and Purchase Invoice now require bei_legal_entity and bei_store_label. This patch conditionally populates those fields when the target DocType exposes them.