### PR TITLE
fix: normalize discount benchmark snapshot payloads

### DIFF
--- a/hrms/api/discount_abuse.py
+++ b/hrms/api/discount_abuse.py
@@ -2153,6 +2153,7 @@ def _base_snapshot_row(
 		row[_category_field(category, "high_confidence_same_day_incidents")] = 0
 		row[_category_field(category, "same_day_flagged_discount_total")] = 0.0
 		row[_category_field(category, "weighted_risk_score")] = 0.0
+		row[_category_field(category, "weighted_risk_rate")] = 0.0
 	return row
 
 

--- a/hrms/tests/test_discount_abuse_api_s12.py
+++ b/hrms/tests/test_discount_abuse_api_s12.py
@@ -833,6 +833,70 @@ class TestDiscountAbuseApiS12(unittest.TestCase):
 		mock_replace_day.assert_called_once()
 		mock_replace_month.assert_called_once()
 
+	def test_build_store_day_snapshot_rows_keeps_postgrest_row_keys_consistent(self):
+		with (
+			patch.object(
+				discount_abuse,
+				"_get_store_catalog",
+				return_value={
+					1: {"store_name": "SM North EDSA", "legal_entity": "BEI", "store_type": "mall"}
+				},
+			),
+			patch.object(
+				discount_abuse,
+				"_query_store_daily_closing_rows",
+				return_value=[
+					{
+						"location_id": 1,
+						"store_name": "SM North EDSA",
+						"legal_entity": "BEI",
+						"store_type": "mall",
+						"business_date": "2026-02-13",
+						"pos_orders": 2,
+						"pos_original_gross": 1000,
+						"pos_after_discount": 900,
+						"pos_net_of_vat": 803.57,
+						"pos_discounts": 80,
+						"pos_vat": 96.43,
+						"pos_vat_exempt": 0,
+					}
+				],
+			),
+			patch.object(
+				discount_abuse,
+				"_query_all_channel_daily_rows",
+				return_value=[
+					{
+						"business_date": "2026-02-13",
+						"total_orders": 5,
+						"total_gross_sales": 1500,
+					}
+				],
+			),
+			patch.object(
+				discount_abuse,
+				"_query_paid_orders_for_range",
+				return_value=[
+					{
+						"id": 10,
+						"location_id": 1,
+						"business_date": "2026-02-13",
+						"original_gross_sales": 1000,
+						"gross_sales": 900,
+						"total_discounts": 80,
+					}
+				],
+			),
+			patch.object(discount_abuse, "_query_discount_item_rows_for_orders", return_value=[]),
+			patch.object(discount_abuse, "_query_same_day_rows_range", return_value=[]),
+			patch.object(discount_abuse, "_cluster_queue_rows", return_value=[]),
+		):
+			rows = discount_abuse._build_store_day_snapshot_rows(date(2026, 2, 13))
+
+		self.assertEqual(len(rows), 2)
+		key_sets = {tuple(sorted(row.keys())) for row in rows}
+		self.assertEqual(len(key_sets), 1)
+
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Summary
- normalize benchmark snapshot rows so all objects share identical keys before PostgREST bulk insert
- add regression coverage for store and chain snapshot row key parity
- unblock production backfill for Discount Monitoring executive analytics

## Testing
- python -m py_compile hrms/api/discount_abuse.py hrms/tests/test_discount_abuse_api_s12.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_discount_abuse_api_s12.py -q

## Docs
- no-docs