### PR TITLE
fix: restore store fallback for branchless staff

### DIFF
--- a/hrms/api/expense.py
+++ b/hrms/api/expense.py
@@ -9,9 +9,8 @@ import frappe
 from frappe import _
 import json
 import os
-from hrms.utils.bei_config import get_company
-from frappe.utils import today, now_datetime, flt, get_url
-from hrms.api.store import save_base64_image
+from frappe.utils import today, flt
+from hrms.api.store import resolve_employee_store_context, save_base64_image
 # Lazy imports - only when OCR/classification is needed
 # This prevents module load failures if dependencies are missing
 def _get_classifier():
@@ -86,30 +85,15 @@ def submit_expense(
     employee = frappe.db.get_value(
         "Employee",
         {"user_id": frappe.session.user},
-        ["name", "employee_name", "branch", "company"],
+        ["name", "employee_name", "branch", "reports_to", "company"],
         as_dict=True
     )
 
     if not employee:
         frappe.throw(_("Employee record not found for current user"))
 
-    # Look up warehouse for the employee's branch
-    # ERPNext warehouses are named like "Branch - Company"
-    store = None
-    if employee.branch:
-        # Try exact match first
-        store = frappe.db.exists("Warehouse", employee.branch)
-        if not store:
-            # Try with company suffix
-            company = employee.company or get_company()
-            store = frappe.db.exists("Warehouse", f"{employee.branch} - {company}")
-        if not store:
-            # Try partial match (warehouse name starts with branch)
-            store = frappe.db.get_value(
-                "Warehouse",
-                {"name": ["like", f"{employee.branch}%"]},
-                "name"
-            )
+    store_context = resolve_employee_store_context(employee)
+    store = store_context.get("warehouse")
 
     if not store:
         frappe.throw(_("Could not find warehouse for your branch. Please contact HR."))

--- a/hrms/api/pcf.py
+++ b/hrms/api/pcf.py
@@ -11,7 +11,7 @@ from frappe.utils import today, now_datetime, flt, nowdate, getdate
 from hrms.utils.bei_config import get_company
 from calendar import monthrange
 from datetime import datetime
-from hrms.api.store import save_base64_image
+from hrms.api.store import resolve_employee_store_context, save_base64_image
 
 
 # ============================================================
@@ -271,7 +271,7 @@ def get_pcf_status(store: str = None):
         employee = frappe.db.get_value(
             "Employee",
             {"user_id": frappe.session.user},
-            ["branch", "company"],
+            ["branch", "reports_to", "company"],
             as_dict=True,
         )
         if employee:
@@ -1218,23 +1218,8 @@ def _get_store_for_employee(employee):
     """
     Get the store warehouse for an employee based on their branch.
     """
-    if not employee.branch:
-        return None
-
-    # Try exact match first
-    store = frappe.db.exists("Warehouse", employee.branch)
-    if store:
-        return store
-
-    # Try with company suffix
-    company = employee.company or get_company()
-    store = frappe.db.exists("Warehouse", f"{employee.branch} - {company}")
-    if store:
-        return store
-
-    # Try partial match
-    store = frappe.db.get_value("Warehouse", {"name": ["like", f"{employee.branch}%"]}, "name")
-    return store
+    store_context = resolve_employee_store_context(employee)
+    return store_context.get("warehouse")
 
 
 def _resolve_store_name(store_or_branch: str) -> str:

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -155,6 +155,64 @@ def resolve_warehouse(store_or_branch):
 	frappe.throw(_("Could not find Store: {0}").format(store_or_branch))
 
 
+def resolve_employee_store_context(employee):
+	"""Resolve a warehouse for an employee, falling back to the reporting chain.
+
+	This keeps store-scoped workflows usable when a store employee is linked to a
+	reporting manager with a branch but the employee record itself is still missing
+	its direct branch assignment.
+	"""
+	employee_row = dict(employee or {})
+	visited = set()
+	manager_name = str(employee_row.get("reports_to") or "").strip()
+	branch = str(employee_row.get("branch") or "").strip()
+	resolved_via = "employee_branch" if branch else None
+	resolved_manager = None
+
+	while not branch and manager_name and manager_name not in visited:
+		visited.add(manager_name)
+		manager = frappe.db.get_value(
+			"Employee", manager_name, ["name", "branch", "reports_to"], as_dict=True
+		)
+		if not manager:
+			break
+		manager_branch = str(manager.get("branch") or "").strip()
+		if manager_branch:
+			branch = manager_branch
+			resolved_via = "reports_to_branch"
+			resolved_manager = manager.get("name")
+			break
+		manager_name = str(manager.get("reports_to") or "").strip()
+
+	if not branch:
+		return {
+			"branch": None,
+			"warehouse": None,
+			"warehouse_name": None,
+			"resolved_via": resolved_via or "unresolved",
+			"resolved_manager": resolved_manager,
+		}
+
+	try:
+		warehouse = resolve_warehouse(branch)
+	except Exception:
+		return {
+			"branch": branch,
+			"warehouse": None,
+			"warehouse_name": None,
+			"resolved_via": resolved_via or "employee_branch",
+			"resolved_manager": resolved_manager,
+		}
+
+	return {
+		"branch": branch,
+		"warehouse": warehouse,
+		"warehouse_name": frappe.db.get_value("Warehouse", warehouse, "warehouse_name") or warehouse,
+		"resolved_via": resolved_via or "employee_branch",
+		"resolved_manager": resolved_manager,
+	}
+
+
 def _normalize_store_key(value):
 	return re.sub(r"[^A-Z0-9]", "", str(value or "").upper())
 
@@ -1135,13 +1193,20 @@ def get_user_store():
 		# Store staff/supervisors get their branch from Employee record
 		role = "Store Supervisor" if "Store Supervisor" in user_roles else "Store Staff"
 		employee = frappe.db.get_value(
-			"Employee", {"user_id": user, "status": "Active"}, ["branch", "employee_name"], as_dict=True
+			"Employee",
+			{"user_id": user, "status": "Active"},
+			["name", "branch", "employee_name", "reports_to"],
+			as_dict=True,
 		)
-		if employee and employee.branch:
-			warehouse = resolve_warehouse(employee.branch)
-			if warehouse:
-				warehouse_name = frappe.db.get_value("Warehouse", warehouse, "warehouse_name") or warehouse
-				stores = [{"name": warehouse, "warehouse_name": warehouse_name}]
+		if employee:
+			store_context = resolve_employee_store_context(employee)
+			if store_context.get("warehouse"):
+				stores = [
+					{
+						"name": store_context["warehouse"],
+						"warehouse_name": store_context["warehouse_name"],
+					}
+				]
 
 	# System / HR / Regional fallback - return all stores
 	if not stores and (


### PR DESCRIPTION
## Summary
- restore store resolution when a store employee is missing a direct branch but reports to a manager with a branch
- reuse the same fallback in expense and PCF store lookup paths
- unblock exact crew-role expense coverage and /api/store for branchless store staff personas

## Verification
- python -m py_compile hrms/api/store.py hrms/api/expense.py hrms/api/pcf.py