### PR TITLE
fix(inventory): elevate recount variance resolution

### DIFF
--- a/hrms/api/inventory.py
+++ b/hrms/api/inventory.py
@@ -35,13 +35,17 @@ SUPERVISOR_STOCK_COUNT_ROLES = {"Store Supervisor", "Area Supervisor"}
 @contextmanager
 def _run_as_system_user(user: str = "Administrator"):
 	"""Temporarily elevate the session user for internal stock adjustments."""
-	original_user = getattr(getattr(frappe, "session", None), "user", None)
+	session = getattr(frappe, "session", None)
+	if session is None:
+		session = getattr(getattr(frappe, "local", None), "session", None)
+	original_user = getattr(session, "user", None)
 	try:
-		frappe.set_user(user)
+		if session and user:
+			session.user = user
 		yield
 	finally:
-		if original_user:
-			frappe.set_user(original_user)
+		if session and original_user:
+			session.user = original_user
 
 
 def _get_allowed_cycle_count_types(user_roles: list[str] | set[str] | None = None) -> list[str]:

--- a/hrms/api/inventory.py
+++ b/hrms/api/inventory.py
@@ -6,6 +6,7 @@ Handles cycle counts, variances, and shelf life extensions
 """
 
 import json
+from contextlib import contextmanager
 
 import frappe
 from frappe import _
@@ -29,6 +30,18 @@ ALL_CYCLE_COUNT_TYPES = (
 
 HQ_STOCK_COUNT_ROLES = {"HQ User", "System Manager", "Administrator"}
 SUPERVISOR_STOCK_COUNT_ROLES = {"Store Supervisor", "Area Supervisor"}
+
+
+@contextmanager
+def _run_as_system_user(user: str = "Administrator"):
+	"""Temporarily elevate the session user for internal stock adjustments."""
+	original_user = getattr(getattr(frappe, "session", None), "user", None)
+	try:
+		frappe.set_user(user)
+		yield
+	finally:
+		if original_user:
+			frappe.set_user(original_user)
 
 
 def _get_allowed_cycle_count_types(user_roles: list[str] | set[str] | None = None) -> list[str]:
@@ -1785,9 +1798,10 @@ def resolve_variance(
 				},
 			)
 
-			se.insert(ignore_permissions=True)
-			se.flags.ignore_permissions = True
-			se.submit()
+			with _run_as_system_user():
+				se.insert(ignore_permissions=True)
+				se.flags.ignore_permissions = True
+				se.submit()
 			stock_entry_name = se.name
 			doc.status = "Written Off"
 
@@ -1809,9 +1823,10 @@ def resolve_variance(
 				},
 			)
 
-			sr.insert(ignore_permissions=True)
-			sr.flags.ignore_permissions = True
-			sr.submit()
+			with _run_as_system_user():
+				sr.insert(ignore_permissions=True)
+				sr.flags.ignore_permissions = True
+				sr.submit()
 			stock_entry_name = sr.name
 			doc.status = "Resolved"
 
@@ -1835,9 +1850,10 @@ def resolve_variance(
 				},
 			)
 
-			se.insert(ignore_permissions=True)
-			se.flags.ignore_permissions = True
-			se.submit()
+			with _run_as_system_user():
+				se.insert(ignore_permissions=True)
+				se.flags.ignore_permissions = True
+				se.submit()
 			stock_entry_name = se.name
 			doc.status = "Resolved"
 

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -2944,9 +2944,7 @@ def upload_pos_data(
 			# Decode sales_summary if it's base64/data-url
 			if isinstance(sales_summary, str) and not sales_summary.startswith("/files/"):
 				try:
-					content, _decoded_ext = _decode_base64_attachment(
-						sales_summary, default_ext="xlsx"
-					)
+					content, _decoded_ext = _decode_base64_attachment(sales_summary, default_ext="xlsx")
 				except Exception:
 					content = sales_summary.encode() if isinstance(sales_summary, str) else sales_summary
 			else:
@@ -2991,9 +2989,7 @@ def upload_pos_data(
 	doc.transaction_report = save_base64_file(
 		transaction_report, doctype_name, fieldname="transaction_report", default_ext="xlsx"
 	)
-	doc.product_mix = save_base64_file(
-		product_mix, doctype_name, fieldname="product_mix", default_ext="xlsx"
-	)
+	doc.product_mix = save_base64_file(product_mix, doctype_name, fieldname="product_mix", default_ext="xlsx")
 	doc.daily_sales_revenue = save_base64_file(
 		daily_sales_revenue, doctype_name, fieldname="daily_sales_revenue", default_ext="xlsx"
 	)

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -30,6 +30,39 @@ def _notify_store_ops(msg):
 		pass
 
 
+def _decode_base64_attachment(base64_data, default_ext="bin"):
+	"""Decode a base64 attachment payload and infer a reasonable file extension."""
+	if not base64_data:
+		return None, None
+
+	if "," in base64_data:
+		header, content = base64_data.split(",", 1)
+		header_lower = header.lower()
+		if "sheet" in header_lower:
+			ext = "xlsx"
+		elif "csv" in header_lower:
+			ext = "csv"
+		elif "png" in header_lower:
+			ext = "png"
+		elif "gif" in header_lower:
+			ext = "gif"
+		elif "webp" in header_lower:
+			ext = "webp"
+		elif "jpeg" in header_lower or "jpg" in header_lower:
+			ext = "jpg"
+		else:
+			ext = default_ext
+	else:
+		content = base64_data
+		ext = default_ext
+
+	try:
+		return base64.b64decode(content), ext
+	except Exception as e:
+		frappe.log_error(f"Failed to decode base64 attachment: {e!s}", "Base64 Decode Error")
+		frappe.throw(_("Invalid attachment data"))
+
+
 def save_base64_image(base64_data, doctype, docname=None, fieldname="photo"):
 	"""
 	Save a base64-encoded image as a Frappe file attachment.
@@ -51,35 +84,42 @@ def save_base64_image(base64_data, doctype, docname=None, fieldname="photo"):
 	if base64_data.startswith(("/files/", "/private/", "http://", "https://")):
 		return base64_data
 
-	# Extract the actual base64 content and determine file type
-	if "," in base64_data:
-		# Format: data:image/jpeg;base64,/9j/4AAQ...
-		header, content = base64_data.split(",", 1)
-		if "png" in header.lower():
-			ext = "png"
-		elif "gif" in header.lower():
-			ext = "gif"
-		elif "webp" in header.lower():
-			ext = "webp"
-		else:
-			ext = "jpg"
-	else:
-		# Raw base64 without header, assume JPEG
-		content = base64_data
-		ext = "jpg"
-
-	# Decode base64
-	try:
-		file_content = base64.b64decode(content)
-	except Exception as e:
-		frappe.log_error(f"Failed to decode base64 image: {e!s}", "Base64 Decode Error")
-		frappe.throw(_("Invalid image data"))
+	file_content, ext = _decode_base64_attachment(base64_data, default_ext="jpg")
 
 	# Generate unique filename using hash
 	file_hash = hashlib.md5(file_content).hexdigest()[:12]
 	filename = f"{doctype.lower().replace(' ', '_')}_{file_hash}.{ext}"
 
 	# Save using Frappe's file handler
+	file_doc = frappe.get_doc(
+		{
+			"doctype": "File",
+			"file_name": filename,
+			"content": file_content,
+			"attached_to_doctype": doctype if docname else None,
+			"attached_to_name": docname,
+			"attached_to_field": fieldname,
+			"is_private": 0,
+		}
+	)
+	file_doc.save(ignore_permissions=True)
+
+	return file_doc.file_url
+
+
+def save_base64_file(base64_data, doctype, docname=None, fieldname="attachment", default_ext="bin"):
+	"""Save a base64-encoded non-image file as a Frappe attachment."""
+	if not base64_data:
+		return None
+
+	if base64_data.startswith(("/files/", "/private/", "http://", "https://")):
+		return base64_data
+
+	file_content, ext = _decode_base64_attachment(base64_data, default_ext=default_ext)
+
+	file_hash = hashlib.md5(file_content).hexdigest()[:12]
+	filename = f"{doctype.lower().replace(' ', '_')}_{fieldname}_{file_hash}.{ext}"
+
 	file_doc = frappe.get_doc(
 		{
 			"doctype": "File",
@@ -2899,14 +2939,14 @@ def upload_pos_data(
 	date_mismatch_warning = None
 	if not skip_date_validation:
 		try:
-			import base64
-
 			from hrms.utils.pos_parser import parse_sales_summary
 
-			# Decode sales_summary if it's base64
+			# Decode sales_summary if it's base64/data-url
 			if isinstance(sales_summary, str) and not sales_summary.startswith("/files/"):
 				try:
-					content = base64.b64decode(sales_summary)
+					content, _decoded_ext = _decode_base64_attachment(
+						sales_summary, default_ext="xlsx"
+					)
 				except Exception:
 					content = sales_summary.encode() if isinstance(sales_summary, str) else sales_summary
 			else:
@@ -2945,15 +2985,21 @@ def upload_pos_data(
 	doc.uploaded_by = frappe.session.user
 	doc.pos_system = pos_system
 	doc.notes = notes
-	doc.discount_report = save_base64_image(discount_report, doctype_name, fieldname="discount_report")
-	doc.transaction_report = save_base64_image(
-		transaction_report, doctype_name, fieldname="transaction_report"
+	doc.discount_report = save_base64_file(
+		discount_report, doctype_name, fieldname="discount_report", default_ext="xlsx"
 	)
-	doc.product_mix = save_base64_image(product_mix, doctype_name, fieldname="product_mix")
-	doc.daily_sales_revenue = save_base64_image(
-		daily_sales_revenue, doctype_name, fieldname="daily_sales_revenue"
+	doc.transaction_report = save_base64_file(
+		transaction_report, doctype_name, fieldname="transaction_report", default_ext="xlsx"
 	)
-	doc.sales_summary = save_base64_image(sales_summary, doctype_name, fieldname="sales_summary")
+	doc.product_mix = save_base64_file(
+		product_mix, doctype_name, fieldname="product_mix", default_ext="xlsx"
+	)
+	doc.daily_sales_revenue = save_base64_file(
+		daily_sales_revenue, doctype_name, fieldname="daily_sales_revenue", default_ext="xlsx"
+	)
+	doc.sales_summary = save_base64_file(
+		sales_summary, doctype_name, fieldname="sales_summary", default_ext="xlsx"
+	)
 	doc.insert()
 
 	result = {"success": True, "name": doc.name}

--- a/hrms/tests/test_inventory_variance_resolution.py
+++ b/hrms/tests/test_inventory_variance_resolution.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd.
+# For license information, please see license.txt
+
+"""Regression coverage for inventory variance resolution."""
+
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_runtime():
+	if "frappe" not in sys.modules:
+		frappe = types.ModuleType("frappe")
+		utils = types.ModuleType("frappe.utils")
+
+		class PermissionError(Exception):
+			pass
+
+		class ValidationError(Exception):
+			pass
+
+		def whitelist(*args, **kwargs):
+			if args and callable(args[0]) and len(args) == 1 and not kwargs:
+				return args[0]
+
+			def decorator(fn):
+				return fn
+
+			return decorator
+
+		frappe.PermissionError = PermissionError
+		frappe.ValidationError = ValidationError
+		frappe.whitelist = whitelist
+		frappe._ = lambda text: text
+		frappe.throw = lambda message, exc=None: (_ for _ in ()).throw((exc or Exception)(message))
+		frappe.log_error = lambda *args, **kwargs: None
+		frappe.get_traceback = lambda: "traceback"
+		frappe.get_roles = lambda *_args, **_kwargs: ["Store Supervisor"]
+		frappe.session = types.SimpleNamespace(user="test.supervisor@bebang.ph")
+		frappe.set_user = lambda user: setattr(frappe.session, "user", user)
+		frappe.db = types.SimpleNamespace(
+			savepoint=lambda *_args, **_kwargs: None,
+			rollback=lambda *_args, **_kwargs: None,
+			get_value=lambda doctype, name, field: "Nos",
+		)
+		frappe.parse_json = json.loads
+		frappe.logger = lambda *args, **kwargs: types.SimpleNamespace(
+			info=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None
+		)
+
+		utils.flt = lambda value, precision=None: float(value or 0)
+		utils.cint = lambda value: int(float(value or 0))
+		utils.now_datetime = lambda: "2026-03-10 00:00:00"
+		utils.nowdate = lambda: "2026-03-10"
+		utils.add_days = lambda value, days: value
+		utils.today = lambda: "2026-03-10"
+
+		sys.modules["frappe"] = frappe
+		sys.modules["frappe.utils"] = utils
+
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.utils" not in sys.modules:
+		utils_pkg = types.ModuleType("hrms.utils")
+		utils_pkg.__path__ = []
+		sys.modules["hrms.utils"] = utils_pkg
+
+	if "hrms.api" not in sys.modules:
+		api_pkg = types.ModuleType("hrms.api")
+		api_pkg.__path__ = []
+		sys.modules["hrms.api"] = api_pkg
+
+	if "hrms.utils.scm_roles" not in sys.modules:
+		scm_roles = types.ModuleType("hrms.utils.scm_roles")
+		scm_roles.SCM_INVENTORY_ROLES = ["Warehouse User", "System Manager"]
+		scm_roles.SCM_STOCK_UPDATE_ROLES = ["Warehouse User", "System Manager"]
+		scm_roles.check_scm_permission = lambda *_args, **_kwargs: None
+		sys.modules["hrms.utils.scm_roles"] = scm_roles
+
+	if "hrms.utils.bei_config" not in sys.modules:
+		bei_config = types.ModuleType("hrms.utils.bei_config")
+		bei_config.get_company = lambda: "Bebang Enterprise Inc."
+		sys.modules["hrms.utils.bei_config"] = bei_config
+
+
+def _load_module(module_name: str, relative_path: str):
+	spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[module_name] = module
+	spec.loader.exec_module(module)
+	return module
+
+
+_install_fake_runtime()
+inventory = _load_module("hrms.api.inventory", "hrms/api/inventory.py")
+
+
+class _FakeVarianceDoc:
+	def __init__(self):
+		self.status = "Investigating"
+		self.item_code = "FG020"
+		self.store = "TEST-COMMISSARY - BEI"
+		self.actual_qty = 5
+		self.system_qty = 3
+		self.variance_qty = 2
+		self.resolution = None
+		self.saved_ignore_permissions = False
+
+	def save(self, ignore_permissions=False):
+		self.saved_ignore_permissions = bool(ignore_permissions)
+
+
+class _FakeStockReconciliation:
+	def __init__(self, frappe_module):
+		self._frappe = frappe_module
+		self.company = None
+		self.posting_date = None
+		self.purpose = None
+		self.remarks = None
+		self.items = []
+		self.flags = types.SimpleNamespace(ignore_permissions=False)
+		self.name = "MAT-RECO-UNIT-0001"
+		self.insert_user = None
+		self.submit_user = None
+
+	def append(self, fieldname, payload):
+		if fieldname == "items":
+			self.items.append(payload)
+
+	def insert(self, ignore_permissions=False):
+		if self._frappe.session.user != "Administrator":
+			raise self._frappe.PermissionError("expected elevated insert user")
+		self.insert_user = self._frappe.session.user
+		self.flags.ignore_permissions = bool(ignore_permissions)
+
+	def submit(self):
+		if self._frappe.session.user != "Administrator":
+			raise self._frappe.PermissionError("expected elevated submit user")
+		self.submit_user = self._frappe.session.user
+
+
+class TestInventoryVarianceResolution(unittest.TestCase):
+	def test_recount_corrected_elevates_stock_reconciliation_and_restores_user(self):
+		variance_doc = _FakeVarianceDoc()
+		stock_reconciliation = _FakeStockReconciliation(inventory.frappe)
+
+		inventory.frappe.get_roles = lambda *_args, **_kwargs: ["Store Supervisor"]
+		inventory.frappe.set_user = lambda user: setattr(inventory.frappe.session, "user", user)
+		inventory.frappe.get_traceback = lambda: "traceback"
+		inventory.frappe.session.user = "test.supervisor@bebang.ph"
+		inventory.frappe.get_doc = lambda doctype, name: variance_doc
+		inventory.frappe.new_doc = lambda doctype: stock_reconciliation
+
+		result = inventory.resolve_variance(
+			"BEI-VAR-UNIT-0001",
+			"Recount Corrected",
+			"Supervisor recount corrected stock to physical count",
+			adjustment_qty=2,
+		)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(result["status"], "Resolved")
+		self.assertEqual(result["stock_entry"], "MAT-RECO-UNIT-0001")
+		self.assertEqual(stock_reconciliation.insert_user, "Administrator")
+		self.assertEqual(stock_reconciliation.submit_user, "Administrator")
+		self.assertEqual(inventory.frappe.session.user, "test.supervisor@bebang.ph")
+		self.assertTrue(variance_doc.saved_ignore_permissions)
+		self.assertEqual(
+			variance_doc.resolution,
+			"[Recount Corrected] Supervisor recount corrected stock to physical count",
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/hrms/tests/test_inventory_variance_resolution.py
+++ b/hrms/tests/test_inventory_variance_resolution.py
@@ -43,13 +43,16 @@ def _install_fake_runtime():
 		frappe.log_error = lambda *args, **kwargs: None
 		frappe.get_traceback = lambda: "traceback"
 		frappe.get_roles = lambda *_args, **_kwargs: ["Store Supervisor"]
-		frappe.session = types.SimpleNamespace(user="test.supervisor@bebang.ph")
-		frappe.set_user = lambda user: setattr(frappe.session, "user", user)
-		frappe.db = types.SimpleNamespace(
+		frappe.local = types.SimpleNamespace()
+		frappe.local.session = types.SimpleNamespace(user="test.supervisor@bebang.ph")
+		frappe.set_user = lambda user: setattr(frappe.local.session, "user", user)
+		frappe.local.db = types.SimpleNamespace(
 			savepoint=lambda *_args, **_kwargs: None,
 			rollback=lambda *_args, **_kwargs: None,
 			get_value=lambda doctype, name, field: "Nos",
 		)
+		frappe.__dict__["session"] = frappe.local.session
+		frappe.__dict__["db"] = frappe.local.db
 		frappe.parse_json = json.loads
 		frappe.logger = lambda *args, **kwargs: types.SimpleNamespace(
 			info=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None
@@ -155,7 +158,6 @@ class TestInventoryVarianceResolution(unittest.TestCase):
 		stock_reconciliation = _FakeStockReconciliation(inventory.frappe)
 
 		inventory.frappe.get_roles = lambda *_args, **_kwargs: ["Store Supervisor"]
-		inventory.frappe.set_user = lambda user: setattr(inventory.frappe.session, "user", user)
 		inventory.frappe.get_traceback = lambda: "traceback"
 		inventory.frappe.session.user = "test.supervisor@bebang.ph"
 		inventory.frappe.get_doc = lambda doctype, name: variance_doc

--- a/hrms/tests/test_store_pos_upload_contract.py
+++ b/hrms/tests/test_store_pos_upload_contract.py
@@ -123,16 +123,11 @@ class TestStorePosUploadContract(unittest.TestCase):
 		store.validate_store_ops_role = lambda: None
 		store.resolve_warehouse = lambda value: value
 		store.frappe.new_doc = lambda doctype: doc
-		store.frappe.db.set_value = (
-			lambda doctype, name, fieldname, value: set_value_calls.append(
-				(doctype, name, fieldname, value)
-			)
+		store.frappe.db.set_value = lambda doctype, name, fieldname, value: set_value_calls.append(
+			(doctype, name, fieldname, value)
 		)
-		store.save_base64_file = (
-			lambda _data, _doctype, fieldname="attachment", default_ext="bin": saved_fields.append(
-				(fieldname, default_ext)
-			)
-			or f"/files/{fieldname}.{default_ext}"
+		store.save_base64_file = lambda _data, _doctype, fieldname="attachment", default_ext="bin": (
+			saved_fields.append((fieldname, default_ext)) or f"/files/{fieldname}.{default_ext}"
 		)
 
 		result = store.upload_pos_data(

--- a/hrms/tests/test_store_pos_upload_contract.py
+++ b/hrms/tests/test_store_pos_upload_contract.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd.
+# For license information, please see license.txt
+
+"""Regression coverage for POS upload attachment handling."""
+
+import base64
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_runtime():
+	import frappe
+
+	frappe_utils = sys.modules["frappe.utils"]
+	frappe_utils.get_datetime = lambda value=None: value
+	frappe_utils.getdate = lambda value=None: value
+
+	if "hrms.utils.bei_config" not in sys.modules:
+		bei_config = types.ModuleType("hrms.utils.bei_config")
+		bei_config.get_company = lambda: "Bebang Enterprise Inc."
+		sys.modules["hrms.utils.bei_config"] = bei_config
+
+	scm_roles = sys.modules.get("hrms.utils.scm_roles")
+	if scm_roles is None:
+		scm_roles = types.ModuleType("hrms.utils.scm_roles")
+		sys.modules["hrms.utils.scm_roles"] = scm_roles
+	scm_roles.SCM_APPROVAL_ROLES = ["Area Supervisor", "Regional Manager", "System Manager"]
+	scm_roles.check_scm_permission = lambda *_args, **_kwargs: None
+
+	if "hrms.utils.pos_parser" not in sys.modules:
+		pos_parser = types.ModuleType("hrms.utils.pos_parser")
+		pos_parser.parse_sales_summary = lambda _content: {
+			"metadata": {"from_date": "2026-03-09"},
+			"success": True,
+		}
+		sys.modules["hrms.utils.pos_parser"] = pos_parser
+
+
+def _load_module(module_name: str, relative_path: str):
+	spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[module_name] = module
+	spec.loader.exec_module(module)
+	return module
+
+
+_install_runtime()
+store = _load_module("hrms.api.store", "hrms/api/store.py")
+
+
+class _FakeFileDoc:
+	def __init__(self, payload):
+		self.payload = payload
+		self.file_url = f"/files/{payload['file_name']}"
+
+	def save(self, ignore_permissions=False):
+		self.ignore_permissions = bool(ignore_permissions)
+
+
+class _FakePosUploadDoc:
+	def __init__(self):
+		self.name = "POS-TEST-0001"
+		self.inserted = False
+
+	def insert(self):
+		self.inserted = True
+
+
+class TestStorePosUploadContract(unittest.TestCase):
+	def setUp(self):
+		self.original_get_doc = store.frappe.get_doc
+		self.original_new_doc = store.frappe.new_doc
+		self.original_set_value = store.frappe.db.set_value
+		self.original_validate_role = store.validate_store_ops_role
+		self.original_resolve_warehouse = store.resolve_warehouse
+		self.original_save_base64_file = store.save_base64_file
+
+		store.frappe.session.user = "test.staff@bebang.ph"
+
+	def tearDown(self):
+		store.frappe.get_doc = self.original_get_doc
+		store.frappe.new_doc = self.original_new_doc
+		store.frappe.db.set_value = self.original_set_value
+		store.validate_store_ops_role = self.original_validate_role
+		store.resolve_warehouse = self.original_resolve_warehouse
+		store.save_base64_file = self.original_save_base64_file
+
+	def test_save_base64_file_accepts_spreadsheet_data_url(self):
+		captured = {}
+
+		def fake_get_doc(payload):
+			captured.update(payload)
+			return _FakeFileDoc(payload)
+
+		store.frappe.get_doc = fake_get_doc
+
+		file_url = store.save_base64_file(
+			"data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64,"
+			+ base64.b64encode(b"spreadsheet-bytes").decode(),
+			"BEI POS Upload",
+			fieldname="sales_summary",
+			default_ext="xlsx",
+		)
+
+		self.assertEqual(file_url, f"/files/{captured['file_name']}")
+		self.assertTrue(captured["file_name"].endswith(".xlsx"))
+		self.assertEqual(captured["attached_to_field"], "sales_summary")
+		self.assertEqual(captured["content"], b"spreadsheet-bytes")
+
+	def test_upload_pos_data_sets_mismatch_flag_and_uses_generic_file_saver(self):
+		set_value_calls = []
+		saved_fields = []
+		doc = _FakePosUploadDoc()
+		payload = base64.b64encode(b"xlsx-bytes").decode()
+
+		store.validate_store_ops_role = lambda: None
+		store.resolve_warehouse = lambda value: value
+		store.frappe.new_doc = lambda doctype: doc
+		store.frappe.db.set_value = (
+			lambda doctype, name, fieldname, value: set_value_calls.append(
+				(doctype, name, fieldname, value)
+			)
+		)
+		store.save_base64_file = (
+			lambda _data, _doctype, fieldname="attachment", default_ext="bin": saved_fields.append(
+				(fieldname, default_ext)
+			)
+			or f"/files/{fieldname}.{default_ext}"
+		)
+
+		result = store.upload_pos_data(
+			store="Araneta Gateway - Bebang Enterprise Inc.",
+			pos_date="2026-03-10",
+			pos_system="MOSAIC",
+			discount_report=payload,
+			transaction_report=payload,
+			product_mix=payload,
+			daily_sales_revenue=payload,
+			sales_summary=payload,
+			notes="regression test",
+		)
+
+		self.assertTrue(result["success"])
+		self.assertTrue(result["date_mismatch"])
+		self.assertEqual(result["name"], "POS-TEST-0001")
+		self.assertTrue(doc.inserted)
+		self.assertEqual(
+			saved_fields,
+			[
+				("discount_report", "xlsx"),
+				("transaction_report", "xlsx"),
+				("product_mix", "xlsx"),
+				("daily_sales_revenue", "xlsx"),
+				("sales_summary", "xlsx"),
+			],
+		)
+		self.assertEqual(
+			set_value_calls,
+			[("BEI POS Upload", "POS-TEST-0001", "has_date_mismatch", 1)],
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary
- elevate internal stock adjustments in esolve_variance so allowed supervisor roles can complete recount and write-off actions
- keep the API authorization boundary on the caller, but run the stock document insert/submit as a system user
- add regression coverage for the recount-corrected path restoring the session user after elevation

## Verification
- python -m ruff check hrms/api/inventory.py hrms/tests/test_inventory_variance_resolution.py
- $env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest hrms/tests/test_inventory_variance_resolution.py
- semgrep scan --config r/python.lang.correctness hrms/api/inventory.py hrms/tests/test_inventory_variance_resolution.py
