### PR TITLE
feat: sync procurement workbook through sheets receiver

### DIFF
--- a/.github/helper/documentation.py
+++ b/.github/helper/documentation.py
@@ -1,7 +1,8 @@
 import os
 import sys
-import requests
 from urllib.parse import urlparse
+
+import requests
 
 
 def uri_validator(x):
@@ -9,14 +10,16 @@ def uri_validator(x):
 	return all([result.scheme, result.netloc, result.path])
 
 
-def docs_link_exists(body):
+def docs_link_exists(body, repository):
+	allowed_repos = {"frappe/hrms", repository.lower()}
 	for line in body.splitlines():
 		for word in line.split():
 			if word.startswith("http") and uri_validator(word):
 				parsed_url = urlparse(word)
 				if parsed_url.netloc == "github.com":
 					parts = parsed_url.path.split("/")
-					if len(parts) == 5 and parts[1] == "frappe" and parts[2] == "hrms":
+					repo_path = "/".join(parts[1:3]).lower()
+					if len(parts) == 5 and repo_path in allowed_repos:
 						return True
 				elif parsed_url.netloc == "docs.frappe.io":
 					return True
@@ -34,12 +37,12 @@ if __name__ == "__main__":
 		body = (payload.get("body") or "").lower()
 
 		if title.startswith("feat") and head_sha and "no-docs" not in body and "backport" not in body:
-			if docs_link_exists(body):
-				print("Documentation Link Found. You're Awesome! 🎉")
+			if docs_link_exists(body, repository):
+				print("Documentation Link Found.")
 
 			else:
-				print("Documentation Link Not Found! ⚠️")
+				print("Documentation Link Not Found.")
 				sys.exit(1)
 
 		else:
-			print("Skipping documentation checks... 🏃")
+			print("Skipping documentation checks...")

--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -165,7 +165,23 @@ def _resolve_warehouse(raw_value: str | None) -> str | None:
 		if frappe.db.exists("Warehouse", candidate):
 			return candidate
 
+	warehouse_name_match = frappe.db.get_value("Warehouse", {"warehouse_name": value}, "name")
+	if warehouse_name_match:
+		return warehouse_name_match
+
 	return None
+
+
+def _coerce_metadata_dict(value: Any) -> dict[str, Any]:
+	if isinstance(value, dict):
+		return dict(value)
+	if isinstance(value, str) and value.strip():
+		try:
+			parsed = json.loads(value)
+		except Exception:
+			return {}
+		return parsed if isinstance(parsed, dict) else {}
+	return {}
 
 
 def _resolve_root_type(account_type: str | None, gl_code: str | None, row: dict[str, Any]) -> str:
@@ -582,6 +598,153 @@ def sync_inventory(sheet_name: str, data: list[dict], checksum: str, **kwargs) -
 					continue
 			results["errors"].append(f"{warehouse}: {exc!s}")
 			results["rows_failed"] += len(items)
+
+	return results
+
+
+@frappe.whitelist()
+def sync_store_demand_snapshot(sheet_name: str, data: list[dict], checksum: str, **kwargs) -> dict:
+	"""
+	Sync store-item demand snapshots into BEI Inventory Risk Snapshot.
+
+	Rows are upserted by (snapshot_date, warehouse, item_code). Additional
+	demand metadata is stored as JSON in source_reference.
+	"""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	results = _init_results(len(rows))
+
+	latest_rows: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+	for row in rows:
+		try:
+			item_code = str(_first_non_empty(row, "item_code", "sku") or "").strip()
+			warehouse = _resolve_warehouse(_first_non_empty(row, "warehouse", "store", "location"))
+			snapshot_date = _safe_date(_first_non_empty(row, "snapshot_date", "as_of_date", "date")) or nowdate()
+
+			if not item_code:
+				results["rows_failed"] += 1
+				results["errors"].append("Missing item_code in demand snapshot row")
+				continue
+
+			if not frappe.db.exists("Item", item_code):
+				results["rows_failed"] += 1
+				results["errors"].append(f"Item not found: {item_code}")
+				continue
+
+			if not warehouse:
+				results["rows_failed"] += 1
+				results["errors"].append(f"Warehouse not found for item {item_code}")
+				continue
+
+			row_key = (snapshot_date, warehouse, item_code)
+			latest_rows[row_key] = {
+				"snapshot_date": snapshot_date,
+				"warehouse": warehouse,
+				"item_code": item_code,
+				"available_qty": flt(_first_non_empty(row, "available_qty", "available_stock") or 0),
+				"avg_daily_demand": flt(
+					_first_non_empty(row, "avg_daily_demand", "daily_demand", "bom_consumption") or 0
+				),
+				"inbound_qty": flt(_first_non_empty(row, "inbound_qty") or 0),
+				"pending_po_count": cint(_first_non_empty(row, "pending_po_count") or 0),
+				"delayed_po_count": cint(_first_non_empty(row, "delayed_po_count") or 0),
+				"in_transit_qty": flt(_first_non_empty(row, "in_transit_qty") or 0),
+				"next_eta": _first_non_empty(row, "next_eta"),
+				"days_to_stockout": flt(_first_non_empty(row, "days_to_stockout") or 0),
+				"projected_stockout_at": _first_non_empty(row, "projected_stockout_at"),
+				"supplier_on_time_rate": flt(_first_non_empty(row, "supplier_on_time_rate") or 0),
+				"risk_score": flt(_first_non_empty(row, "risk_score") or 0),
+				"risk_level": _first_non_empty(row, "risk_level"),
+				"value_at_risk": flt(_first_non_empty(row, "value_at_risk") or 0),
+				"margin_at_risk": flt(_first_non_empty(row, "margin_at_risk") or 0),
+				"source_reference": _coerce_metadata_dict(_first_non_empty(row, "source_reference")),
+				"projected_sales": flt(_first_non_empty(row, "projected_sales") or 0),
+				"bom_consumption": flt(_first_non_empty(row, "bom_consumption") or 0),
+				"coverage_window_days": flt(_first_non_empty(row, "coverage_window_days") or 0),
+				"lookback_days": cint(_first_non_empty(row, "lookback_days") or 0),
+				"signal_source": _first_non_empty(row, "signal_source") or "sales_demand_snapshot",
+				"channel_mix": _first_non_empty(row, "channel_mix"),
+			}
+		except Exception as e:
+			results["errors"].append(str(e))
+			results["rows_failed"] += 1
+
+	for snapshot_key, snapshot in latest_rows.items():
+		snapshot_date, warehouse, item_code = snapshot_key
+		sync_ref = _sync_ref("DSNAP", sheet_name, checksum, f"{snapshot_date}|{warehouse}|{item_code}")
+		savepoint = _make_savepoint("sync_dsnap", f"{sheet_name}|{checksum}|{warehouse}|{item_code}")
+		frappe.db.savepoint(savepoint)
+		try:
+			source_reference = dict(snapshot["source_reference"])
+			source_reference.update(
+				{
+					"sync_ref": sync_ref,
+					"source_sheet": sheet_name,
+					"checksum": checksum,
+					"signal_source": snapshot["signal_source"],
+					"lookback_days": snapshot["lookback_days"],
+					"projected_sales": snapshot["projected_sales"],
+					"bom_consumption": snapshot["bom_consumption"],
+					"coverage_window_days": snapshot["coverage_window_days"],
+				}
+			)
+			if snapshot["channel_mix"] not in (None, ""):
+				source_reference["channel_mix"] = snapshot["channel_mix"]
+			source_reference_json = json.dumps(source_reference, sort_keys=True)
+
+			values = {
+				"snapshot_date": snapshot_date,
+				"warehouse": warehouse,
+				"item_code": item_code,
+				"available_qty": snapshot["available_qty"],
+				"avg_daily_demand": snapshot["avg_daily_demand"],
+				"inbound_qty": snapshot["inbound_qty"],
+				"pending_po_count": snapshot["pending_po_count"],
+				"delayed_po_count": snapshot["delayed_po_count"],
+				"in_transit_qty": snapshot["in_transit_qty"],
+				"next_eta": snapshot["next_eta"],
+				"days_to_stockout": snapshot["days_to_stockout"],
+				"projected_stockout_at": snapshot["projected_stockout_at"],
+				"supplier_on_time_rate": snapshot["supplier_on_time_rate"],
+				"risk_score": snapshot["risk_score"],
+				"risk_level": snapshot["risk_level"],
+				"value_at_risk": snapshot["value_at_risk"],
+				"margin_at_risk": snapshot["margin_at_risk"],
+				"source_reference": source_reference_json,
+			}
+			values = {
+				fieldname: value
+				for fieldname, value in values.items()
+				if fieldname in {"snapshot_date", "warehouse", "item_code"} or _doctype_has_field("BEI Inventory Risk Snapshot", fieldname)
+			}
+
+			existing = frappe.db.get_value(
+				"BEI Inventory Risk Snapshot",
+				{
+					"snapshot_date": snapshot_date,
+					"warehouse": warehouse,
+					"item_code": item_code,
+				},
+				"name",
+			)
+
+			if existing:
+				frappe.db.set_value("BEI Inventory Risk Snapshot", existing, values, update_modified=False)
+				results["rows_updated"] += 1
+				_release_savepoint(savepoint)
+				continue
+
+			doc = frappe.new_doc("BEI Inventory Risk Snapshot")
+			for fieldname, value in values.items():
+				setattr(doc, fieldname, value)
+			doc.insert(ignore_permissions=True)
+			results["rows_created"] += 1
+			_release_savepoint(savepoint)
+		except Exception as exc:
+			frappe.db.rollback(save_point=savepoint)
+			results["errors"].append(f"{warehouse}/{item_code}: {exc!s}")
+			results["rows_failed"] += 1
 
 	return results
 
@@ -1004,6 +1167,621 @@ def sync_supplier_soa(sheet_name: str, data: list[dict], checksum: str, **kwargs
 	Source config still points to this method name.
 	"""
 	return sync_ap_opening(sheet_name=sheet_name, data=data, checksum=checksum, **kwargs)
+
+
+_PROCUREMENT_APPROVED_VALUES = {"approved", "approve", "ok", "yes"}
+_PROCUREMENT_REJECTED_VALUES = {"rejected", "reject", "disapproved", "declined", "no", "cancelled", "canceled"}
+_PROCUREMENT_NULL_TOKENS = {"na", "n/a", "none", "null", "nan"}
+
+
+def _normalize_sheet_text(value: Any) -> str | None:
+	if value is None:
+		return None
+	if isinstance(value, str):
+		text = value.strip()
+		if not text:
+			return None
+		if text.lower() in _PROCUREMENT_NULL_TOKENS:
+			return None
+		return text
+
+	text = str(value).strip()
+	if not text or text.lower() in _PROCUREMENT_NULL_TOKENS:
+		return None
+	return text
+
+
+def _safe_float(value: Any) -> float:
+	text = _normalize_sheet_text(value)
+	if text is None:
+		return 0.0
+	try:
+		return flt(str(text).replace(",", ""))
+	except Exception:
+		return 0.0
+
+
+def _sheet_flag(value: Any) -> int:
+	text = (_normalize_sheet_text(value) or "").lower()
+	return 1 if text in {"1", "true", "yes", "y"} else 0
+
+
+def _normalize_approval_state(value: Any) -> str:
+	text = (_normalize_sheet_text(value) or "").lower()
+	if text in _PROCUREMENT_APPROVED_VALUES:
+		return "Approved"
+	if text in _PROCUREMENT_REJECTED_VALUES:
+		return "Rejected"
+	return "Pending"
+
+
+def _parse_related_data(value: Any) -> dict[str, list[dict[str, Any]]]:
+	if isinstance(value, str):
+		try:
+			value = json.loads(value)
+		except Exception:
+			return {}
+
+	if not isinstance(value, dict):
+		return {}
+
+	parsed: dict[str, list[dict[str, Any]]] = {}
+	for key, rows in value.items():
+		parsed[key] = _parse_rows(rows)
+	return parsed
+
+
+def _resolve_user_identity(name_or_email: Any = None, email: Any = None) -> str:
+	email_value = _normalize_sheet_text(email)
+	if email_value and frappe.db.exists("User", email_value):
+		return email_value
+
+	name_value = _normalize_sheet_text(name_or_email)
+	if name_value:
+		if frappe.db.exists("User", name_value):
+			return name_value
+		existing = frappe.db.get_value("User", {"full_name": name_value}, "name")
+		if existing:
+			return existing
+
+	return "Administrator"
+
+
+def _resolve_payment_terms_template(value: Any) -> str | None:
+	text = _normalize_sheet_text(value)
+	if not text:
+		return None
+	if frappe.db.exists("Payment Terms Template", text):
+		return text
+	return frappe.db.get_value("Payment Terms Template", {"template_name": text}, "name")
+
+
+def _find_doc_by_business_key(doctype: str, fieldname: str, value: Any) -> str | None:
+	text = _normalize_sheet_text(value)
+	if not text:
+		return None
+	if frappe.db.exists(doctype, text):
+		return text
+	return frappe.db.get_value(doctype, {fieldname: text}, "name")
+
+
+def _replace_child_rows(doc: Any, table_field: str, rows: list[dict[str, Any]]) -> None:
+	if hasattr(doc, "set"):
+		doc.set(table_field, [])
+	else:
+		setattr(doc, table_field, [])
+	for row in rows:
+		doc.append(table_field, row)
+
+
+def _persist_doc(doc: Any, existing_name: str | None, business_field: str | None = None, business_value: Any = None) -> str:
+	if existing_name:
+		doc.save(ignore_permissions=True)
+		return "updated"
+
+	doc.insert(ignore_permissions=True)
+	if business_field and business_value and getattr(doc, business_field, None) != business_value:
+		if hasattr(doc, "db_set"):
+			doc.db_set(business_field, business_value, update_modified=False)
+		else:
+			frappe.db.set_value(doc.doctype, doc.name, business_field, business_value, update_modified=False)
+		setattr(doc, business_field, business_value)
+	return "created"
+
+
+def _resolve_procurement_supplier(supplier_code: Any, supplier_name: Any) -> str:
+	code = _normalize_sheet_text(supplier_code)
+	name = _normalize_sheet_text(supplier_name)
+
+	if code and frappe.db.exists("BEI Supplier", code):
+		return code
+
+	if name:
+		existing = frappe.db.get_value("BEI Supplier", {"supplier_name": name}, "name")
+		if existing:
+			return existing
+
+	if not code:
+		frappe.throw(_("Supplier code is required to create missing BEI Supplier records"))
+
+	doc = frappe.get_doc(
+		{
+			"doctype": "BEI Supplier",
+			"supplier_code": code,
+			"supplier_name": name or code,
+			"status": "Pending Verification",
+		}
+	)
+	doc.insert(ignore_permissions=True)
+	return doc.name
+
+
+def _resolve_item_code(item_code: Any, item_name: Any = None) -> str | None:
+	code = _normalize_sheet_text(item_code)
+	if not code:
+		return None
+	if frappe.db.exists("Item", code):
+		return code
+	name = _normalize_sheet_text(item_name)
+	if name:
+		matched = frappe.db.get_value("Item", {"item_name": name}, "name")
+		if matched:
+			return matched
+	return code
+
+
+def _resolve_uom(value: Any) -> str | None:
+	text = _normalize_sheet_text(value)
+	if not text:
+		return None
+	if frappe.db.exists("UOM", text):
+		return text
+	return None
+
+
+def _build_pr_status(row: dict[str, Any], items: list[dict[str, Any]]) -> str:
+	if any(_normalize_sheet_text(item.get("po_reference")) for item in items):
+		return "Converted to PO"
+	approval_state = _normalize_approval_state(_first_non_empty(row, "approval"))
+	if approval_state == "Approved":
+		return "Approved"
+	if approval_state == "Rejected":
+		return "Rejected"
+	if _normalize_sheet_text(_first_non_empty(row, "send_for_approval_timestamp")):
+		return "Pending Approval"
+	return "Draft"
+
+
+def _build_po_status(row: dict[str, Any], requires_dual_approval: bool) -> str:
+	mae_state = _normalize_approval_state(_first_non_empty(row, "approval"))
+	butch_state = _normalize_approval_state(_first_non_empty(row, "2nd_approval"))
+	if mae_state == "Rejected" or butch_state == "Rejected":
+		return "Cancelled"
+	if _normalize_sheet_text(_first_non_empty(row, "send_po_to_supplier_timestamp")):
+		return "Sent to Supplier"
+	if mae_state == "Approved":
+		if requires_dual_approval and butch_state != "Approved":
+			return "Pending Butch Approval"
+		return "Approved"
+	if _normalize_sheet_text(_first_non_empty(row, "send_for_approval_timestamp", "reviewer_timestamp")):
+		return "Pending Mae Approval"
+	return "Draft"
+
+
+def _build_gr_status(row: dict[str, Any]) -> str:
+	if _normalize_sheet_text(_first_non_empty(row, "approved_by", "approval_timestamp", "invoice")):
+		return "Accepted"
+	return "Draft"
+
+
+@frappe.whitelist()
+def sync_procurement_suppliers(sheet_name: str, data: list[dict], checksum: str, **kwargs) -> dict:
+	"""Sync AppSheet supplier master rows into BEI Supplier."""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	results = _init_results(len(rows))
+	seen_supplier_codes: set[str] = set()
+
+	for row in rows:
+		supplier_code = _normalize_sheet_text(_first_non_empty(row, "supplier_code"))
+		supplier_name = _normalize_sheet_text(_first_non_empty(row, "supplier_name"))
+		if not supplier_code and not supplier_name:
+			continue
+
+		dedupe_key = supplier_code or supplier_name or "unknown"
+		if dedupe_key in seen_supplier_codes:
+			results["rows_updated"] += 1
+			continue
+		seen_supplier_codes.add(dedupe_key)
+
+		savepoint = _make_savepoint("sync_proc_supplier", f"{sheet_name}|{checksum}|{dedupe_key}")
+		frappe.db.savepoint(savepoint)
+		try:
+			if not supplier_code:
+				raise ValueError(f"Missing supplier_code for supplier '{supplier_name or 'unknown'}'")
+
+			existing_name = _find_doc_by_business_key("BEI Supplier", "supplier_code", supplier_code)
+			if not existing_name and supplier_name:
+				existing_name = frappe.db.get_value("BEI Supplier", {"supplier_name": supplier_name}, "name")
+
+			doc = (
+				frappe.get_doc("BEI Supplier", existing_name)
+				if existing_name
+				else frappe.get_doc({"doctype": "BEI Supplier"})
+			)
+			doc.supplier_code = supplier_code
+			doc.supplier_name = supplier_name or supplier_code
+			doc.contact_number = _normalize_sheet_text(_first_non_empty(row, "contact_no", "contact_number"))
+			doc.contact_person = _normalize_sheet_text(_first_non_empty(row, "contact_person"))
+			doc.email = _normalize_sheet_text(_first_non_empty(row, "email_id", "email"))
+			doc.address = _normalize_sheet_text(_first_non_empty(row, "address"))
+			doc.bank_name = _normalize_sheet_text(_first_non_empty(row, "bank_name"))
+			doc.bank_account_name = _normalize_sheet_text(_first_non_empty(row, "bank_account_name"))
+			doc.bank_account_number = _normalize_sheet_text(
+				_first_non_empty(row, "bank_account_no", "bank_account_number")
+			)
+			if not existing_name and not _normalize_sheet_text(getattr(doc, "status", None)):
+				doc.status = "Pending Verification"
+
+			action = _persist_doc(doc, existing_name, business_field="supplier_code", business_value=supplier_code)
+			results[f"rows_{action}"] += 1
+			_release_savepoint(savepoint)
+		except Exception as exc:
+			frappe.db.rollback(save_point=savepoint)
+			results["rows_failed"] += 1
+			results["errors"].append(f"{dedupe_key}: {exc!s}")
+
+	return results
+
+
+@frappe.whitelist()
+def sync_procurement_requisitions(
+	sheet_name: str,
+	data: list[dict],
+	checksum: str,
+	related_data: Any = None,
+	**kwargs,
+) -> dict:
+	"""Sync AppSheet PR headers with PR item rows into BEI Purchase Requisition."""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	related = _parse_related_data(related_data)
+	results = _init_results(len(rows))
+	seen_pr_numbers: set[str] = set()
+
+	items_by_pr: dict[str, list[dict[str, Any]]] = {}
+	for item_row in related.get("procurement_pr_items", []):
+		pr_no = _normalize_sheet_text(_first_non_empty(item_row, "pr_no"))
+		item_code = _normalize_sheet_text(_first_non_empty(item_row, "item_code"))
+		description = _normalize_sheet_text(_first_non_empty(item_row, "description"))
+		qty = _safe_float(_first_non_empty(item_row, "total_order", "qty"))
+		if not pr_no or not item_code or qty <= 0:
+			continue
+
+		items_by_pr.setdefault(pr_no, []).append(
+			{
+				"item_code": item_code,
+				"item_name": _normalize_sheet_text(_first_non_empty(item_row, "item_name")) or description or item_code,
+				"description": description,
+				"qty": qty,
+				"uom": _normalize_sheet_text(_first_non_empty(item_row, "unit_of_issue", "uom")) or "Pcs",
+				"po_reference": _normalize_sheet_text(_first_non_empty(item_row, "po_reference")),
+				"added_by": _normalize_sheet_text(_first_non_empty(item_row, "added_by")),
+			}
+		)
+
+	for row in rows:
+		pr_no = _normalize_sheet_text(_first_non_empty(row, "pr_no"))
+		if not pr_no:
+			continue
+		if pr_no in seen_pr_numbers:
+			results["rows_updated"] += 1
+			continue
+		seen_pr_numbers.add(pr_no)
+
+		savepoint = _make_savepoint("sync_proc_pr", f"{sheet_name}|{checksum}|{pr_no}")
+		frappe.db.savepoint(savepoint)
+		try:
+			items = items_by_pr.get(pr_no, [])
+			if not items:
+				raise ValueError("No PR items found for requisition")
+
+			existing_name = _find_doc_by_business_key("BEI Purchase Requisition", "pr_no", pr_no)
+			doc = (
+				frappe.get_doc("BEI Purchase Requisition", existing_name)
+				if existing_name
+				else frappe.get_doc({"doctype": "BEI Purchase Requisition"})
+			)
+
+			doc.request_date = _safe_date(_first_non_empty(row, "timestamp")) or nowdate()
+			doc.requested_by = _resolve_user_identity(
+				_first_non_empty(row, "requested_by"),
+				_first_non_empty(row, "requested_by_email"),
+			)
+			doc.delivery_to = _resolve_warehouse(_first_non_empty(row, "delivery_to"))
+			doc.date_required = _safe_date(_first_non_empty(row, "date_required")) or doc.request_date
+			doc.purpose = _normalize_sheet_text(_first_non_empty(row, "purpose")) or "Legacy AppSheet import"
+			doc.recurring = _sheet_flag(_first_non_empty(row, "recurring"))
+			doc.status = _build_pr_status(row, items)
+			doc.approved_by = (
+				_resolve_user_identity(_first_non_empty(row, "approved_by"), _first_non_empty(row, "approved_by_email"))
+				if doc.status in {"Approved", "Rejected", "Converted to PO"}
+				else None
+			)
+			doc.approval_date = _safe_date(_first_non_empty(row, "approval_timestamp"))
+			doc.rejection_reason = (
+				_normalize_sheet_text(_first_non_empty(row, "comment"))
+				if doc.status == "Rejected"
+				else None
+			)
+			_replace_child_rows(doc, "items", items)
+
+			action = _persist_doc(doc, existing_name, business_field="pr_no", business_value=pr_no)
+			results[f"rows_{action}"] += 1
+			_release_savepoint(savepoint)
+		except Exception as exc:
+			frappe.db.rollback(save_point=savepoint)
+			results["rows_failed"] += 1
+			results["errors"].append(f"{pr_no}: {exc!s}")
+
+	return results
+
+
+@frappe.whitelist()
+def sync_procurement_purchase_orders(
+	sheet_name: str,
+	data: list[dict],
+	checksum: str,
+	related_data: Any = None,
+	**kwargs,
+) -> dict:
+	"""Sync AppSheet PO headers with child items into BEI Purchase Order."""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	related = _parse_related_data(related_data)
+	results = _init_results(len(rows))
+	seen_po_numbers: set[str] = set()
+
+	items_by_po: dict[str, list[dict[str, Any]]] = {}
+	for item_row in related.get("procurement_po_items", []):
+		po_no = _normalize_sheet_text(_first_non_empty(item_row, "po_no"))
+		item_code = _normalize_sheet_text(_first_non_empty(item_row, "item_code"))
+		qty = _safe_float(_first_non_empty(item_row, "qty"))
+		unit_cost = _safe_float(_first_non_empty(item_row, "unit_cost"))
+		if not po_no or not item_code or qty <= 0:
+			continue
+
+		vat_per_unit = _safe_float(_first_non_empty(item_row, "vat"))
+		vat_rate = round((vat_per_unit / unit_cost) * 100, 4) if unit_cost > 0 and vat_per_unit > 0 else 12.0
+		items_by_po.setdefault(po_no, []).append(
+			{
+				"item_code": item_code,
+				"item_name": _normalize_sheet_text(_first_non_empty(item_row, "item_name")) or item_code,
+				"description": _normalize_sheet_text(_first_non_empty(item_row, "item_name")) or item_code,
+				"packaging_size": _normalize_sheet_text(_first_non_empty(item_row, "packaging_size")),
+				"qty": qty,
+				"uom": _normalize_sheet_text(_first_non_empty(item_row, "uom")) or "Pcs",
+				"unit_cost": unit_cost,
+				"vat_rate": vat_rate,
+				"delivery_schedule": _safe_date(_first_non_empty(item_row, "delivery_schedule")),
+				"price_variance_override": "Legacy AppSheet sync baseline import",
+			}
+		)
+
+	for row in rows:
+		po_no = _normalize_sheet_text(_first_non_empty(row, "po_no"))
+		if not po_no:
+			continue
+		if po_no in seen_po_numbers:
+			results["rows_updated"] += 1
+			continue
+		seen_po_numbers.add(po_no)
+
+		savepoint = _make_savepoint("sync_proc_po", f"{sheet_name}|{checksum}|{po_no}")
+		frappe.db.savepoint(savepoint)
+		try:
+			items = items_by_po.get(po_no, [])
+			if not items:
+				raise ValueError("No PO items found for purchase order")
+
+			existing_name = _find_doc_by_business_key("BEI Purchase Order", "po_no", po_no)
+			doc = (
+				frappe.get_doc("BEI Purchase Order", existing_name)
+				if existing_name
+				else frappe.get_doc({"doctype": "BEI Purchase Order"})
+			)
+
+			doc.po_date = _safe_date(_first_non_empty(row, "po_date", "timestamp")) or nowdate()
+			doc.pr_reference = _find_doc_by_business_key(
+				"BEI Purchase Requisition", "pr_no", _first_non_empty(row, "pr_no")
+			)
+			doc.supplier = _resolve_procurement_supplier(
+				_first_non_empty(row, "supplier_code"),
+				_first_non_empty(row, "supplier_name"),
+			)
+			doc.delivery_date = _safe_date(_first_non_empty(row, "delivery_date")) or doc.po_date
+			doc.ship_to = _resolve_warehouse(_first_non_empty(row, "ship_to"))
+			doc.payment_terms = _resolve_payment_terms_template(_first_non_empty(row, "terms_of_payment"))
+			doc.discount_amount = _safe_float(_first_non_empty(row, "total_discount"))
+			doc.delivery_fee = _safe_float(_first_non_empty(row, "delivery_fee"))
+			doc.mae_approval = _normalize_approval_state(_first_non_empty(row, "approval"))
+			doc.mae_comment = _normalize_sheet_text(_first_non_empty(row, "comment", "reviewer_comment"))
+			doc.mae_approval_date = _safe_date(_first_non_empty(row, "approval_timestamp"))
+			doc.butch_approval = _normalize_approval_state(_first_non_empty(row, "2nd_approval"))
+			doc.butch_comment = _normalize_sheet_text(_first_non_empty(row, "2nd_comment"))
+			doc.butch_approval_date = _safe_date(_first_non_empty(row, "2nd_approval_timestamp"))
+			doc.sent_to_supplier_date = _safe_date(_first_non_empty(row, "send_po_to_supplier_timestamp"))
+			doc.sent_by = (
+				_resolve_user_identity(_first_non_empty(row, "sent_by"))
+				if _normalize_sheet_text(_first_non_empty(row, "sent_by"))
+				else None
+			)
+			_replace_child_rows(doc, "items", items)
+			estimated_grand_total = sum(
+				_safe_float(item.get("qty"))
+				* _safe_float(item.get("unit_cost"))
+				* (1 + (_safe_float(item.get("vat_rate")) / 100))
+				for item in items
+			)
+			estimated_grand_total = (
+				estimated_grand_total
+				- _safe_float(_first_non_empty(row, "total_discount"))
+				+ _safe_float(_first_non_empty(row, "delivery_fee"))
+			)
+			doc.status = _build_po_status(row, requires_dual_approval=estimated_grand_total > 500000)
+
+			action = _persist_doc(doc, existing_name, business_field="po_no", business_value=po_no)
+			results[f"rows_{action}"] += 1
+			_release_savepoint(savepoint)
+		except Exception as exc:
+			frappe.db.rollback(save_point=savepoint)
+			results["rows_failed"] += 1
+			results["errors"].append(f"{po_no}: {exc!s}")
+
+	return results
+
+
+@frappe.whitelist()
+def sync_procurement_goods_receipts(
+	sheet_name: str,
+	data: list[dict],
+	checksum: str,
+	related_data: Any = None,
+	**kwargs,
+) -> dict:
+	"""Sync AppSheet GR headers and items into BEI Goods Receipt, then reconcile PO receipts."""
+	_assert_sync_authorized()
+	rows = _parse_rows(data)
+	related = _parse_related_data(related_data)
+	results = _init_results(len(rows))
+	seen_gr_numbers: set[str] = set()
+	po_doc_cache: dict[str, Any] = {}
+	po_name_cache: dict[str, str] = {}
+	received_qty_by_po: dict[str, dict[str, float]] = {}
+
+	def get_po_doc(po_no: str) -> Any:
+		if po_no in po_doc_cache:
+			return po_doc_cache[po_no]
+
+		po_name = _find_doc_by_business_key("BEI Purchase Order", "po_no", po_no)
+		if not po_name:
+			raise ValueError(f"Linked purchase order not found: {po_no}")
+
+		po_name_cache[po_no] = po_name
+		po_doc_cache[po_no] = frappe.get_doc("BEI Purchase Order", po_name)
+		return po_doc_cache[po_no]
+
+	items_by_gr: dict[str, list[dict[str, Any]]] = {}
+	for item_row in related.get("procurement_gr_items", []):
+		gr_no = _normalize_sheet_text(_first_non_empty(item_row, "gr_no"))
+		po_no = _normalize_sheet_text(_first_non_empty(item_row, "po_no"))
+		item_code = _normalize_sheet_text(_first_non_empty(item_row, "item_code"))
+		received_qty = _safe_float(_first_non_empty(item_row, "issued_qty", "received_qty"))
+		if not gr_no or not po_no or not item_code or received_qty <= 0:
+			continue
+
+		po_doc = get_po_doc(po_no)
+		po_item_lookup = {po_item.item_code: po_item for po_item in getattr(po_doc, "items", [])}
+		po_item = po_item_lookup.get(item_code)
+		resolved_item_code = _resolve_item_code(item_code, _first_non_empty(item_row, "item_name"))
+		items_by_gr.setdefault(gr_no, []).append(
+			{
+				"item_code": resolved_item_code,
+				"item_name": _normalize_sheet_text(_first_non_empty(item_row, "item_name")) or item_code,
+				"description": _normalize_sheet_text(_first_non_empty(item_row, "item_name")) or item_code,
+				"ordered_qty": flt(getattr(po_item, "qty", received_qty), 2) if po_item else received_qty,
+				"received_qty": received_qty,
+				"uom": _resolve_uom(_first_non_empty(item_row, "uom")),
+				"rejected_qty": 0,
+				"unit_cost": flt(getattr(po_item, "unit_cost", 0), 2) if po_item else 0,
+			}
+		)
+		received_qty_by_po.setdefault(po_no, {})
+		received_qty_by_po[po_no][item_code] = received_qty_by_po[po_no].get(item_code, 0) + received_qty
+
+	for row in rows:
+		gr_no = _normalize_sheet_text(_first_non_empty(row, "gr_no"))
+		po_no = _normalize_sheet_text(_first_non_empty(row, "po_no"))
+		if not gr_no:
+			continue
+		if gr_no in seen_gr_numbers:
+			results["rows_updated"] += 1
+			continue
+		seen_gr_numbers.add(gr_no)
+
+		savepoint = _make_savepoint("sync_proc_gr", f"{sheet_name}|{checksum}|{gr_no}")
+		frappe.db.savepoint(savepoint)
+		try:
+			if not po_no:
+				raise ValueError("Missing linked purchase order reference")
+
+			po_doc = get_po_doc(po_no)
+			items = items_by_gr.get(gr_no, [])
+			if not items:
+				raise ValueError("No GR items found for goods receipt")
+
+			existing_name = _find_doc_by_business_key("BEI Goods Receipt", "gr_no", gr_no)
+			doc = (
+				frappe.get_doc("BEI Goods Receipt", existing_name)
+				if existing_name
+				else frappe.get_doc({"doctype": "BEI Goods Receipt"})
+			)
+
+			doc.purchase_order = po_doc.name
+			doc.receipt_date = _safe_date(_first_non_empty(row, "date", "timestamp")) or nowdate()
+			doc.delivery_date = _safe_date(_first_non_empty(row, "date")) or doc.receipt_date
+			doc.delivery_note_no = _normalize_sheet_text(_first_non_empty(row, "invoice_no")) or gr_no
+			doc.warehouse = _resolve_warehouse(_first_non_empty(row, "issue_to"))
+			doc.supplier_invoice_photo = _normalize_sheet_text(_first_non_empty(row, "invoice"))
+			doc.inspection_required = 0
+			doc.status = _build_gr_status(row)
+			_replace_child_rows(doc, "items", items)
+
+			action = _persist_doc(doc, existing_name, business_field="gr_no", business_value=gr_no)
+			results[f"rows_{action}"] += 1
+			_release_savepoint(savepoint)
+		except Exception as exc:
+			frappe.db.rollback(save_point=savepoint)
+			results["rows_failed"] += 1
+			results["errors"].append(f"{gr_no}: {exc!s}")
+
+	for po_no, item_totals in received_qty_by_po.items():
+		savepoint = _make_savepoint("sync_proc_gr_po", f"{sheet_name}|{checksum}|{po_no}")
+		frappe.db.savepoint(savepoint)
+		try:
+			po_doc = get_po_doc(po_no)
+			changed = False
+			for po_item in getattr(po_doc, "items", []):
+				new_qty = flt(item_totals.get(po_item.item_code, 0), 2)
+				if flt(getattr(po_item, "received_qty", 0), 2) != new_qty:
+					po_item.received_qty = new_qty
+					if getattr(po_item, "name", None):
+						frappe.db.set_value("BEI PO Item", po_item.name, "received_qty", new_qty, update_modified=False)
+					changed = True
+
+			fully_received = bool(getattr(po_doc, "items", [])) and all(
+				flt(getattr(item, "received_qty", 0), 2) >= flt(getattr(item, "qty", 0), 2)
+				for item in po_doc.items
+			)
+			partially_received = any(flt(getattr(item, "received_qty", 0), 2) > 0 for item in getattr(po_doc, "items", []))
+			new_status = po_doc.status
+			if fully_received:
+				new_status = "Fully Received"
+			elif partially_received:
+				new_status = "Partially Received"
+
+			if new_status != po_doc.status:
+				po_doc.status = new_status
+				changed = True
+
+			if changed:
+				po_doc.save(ignore_permissions=True)
+			_release_savepoint(savepoint)
+		except Exception as exc:
+			frappe.db.rollback(save_point=savepoint)
+			results["errors"].append(f"{po_no}: failed to reconcile PO received qty - {exc!s}")
+
+	return results
 
 
 # nosemgrep: frappe-semgrep-rules.rules.security.guest-whitelisted-method

--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -620,7 +620,9 @@ def sync_store_demand_snapshot(sheet_name: str, data: list[dict], checksum: str,
 		try:
 			item_code = str(_first_non_empty(row, "item_code", "sku") or "").strip()
 			warehouse = _resolve_warehouse(_first_non_empty(row, "warehouse", "store", "location"))
-			snapshot_date = _safe_date(_first_non_empty(row, "snapshot_date", "as_of_date", "date")) or nowdate()
+			snapshot_date = (
+				_safe_date(_first_non_empty(row, "snapshot_date", "as_of_date", "date")) or nowdate()
+			)
 
 			if not item_code:
 				results["rows_failed"] += 1
@@ -716,7 +718,8 @@ def sync_store_demand_snapshot(sheet_name: str, data: list[dict], checksum: str,
 			values = {
 				fieldname: value
 				for fieldname, value in values.items()
-				if fieldname in {"snapshot_date", "warehouse", "item_code"} or _doctype_has_field("BEI Inventory Risk Snapshot", fieldname)
+				if fieldname in {"snapshot_date", "warehouse", "item_code"}
+				or _doctype_has_field("BEI Inventory Risk Snapshot", fieldname)
 			}
 
 			existing = frappe.db.get_value(
@@ -1170,7 +1173,15 @@ def sync_supplier_soa(sheet_name: str, data: list[dict], checksum: str, **kwargs
 
 
 _PROCUREMENT_APPROVED_VALUES = {"approved", "approve", "ok", "yes"}
-_PROCUREMENT_REJECTED_VALUES = {"rejected", "reject", "disapproved", "declined", "no", "cancelled", "canceled"}
+_PROCUREMENT_REJECTED_VALUES = {
+	"rejected",
+	"reject",
+	"disapproved",
+	"declined",
+	"no",
+	"cancelled",
+	"canceled",
+}
 _PROCUREMENT_NULL_TOKENS = {"na", "n/a", "none", "null", "nan"}
 
 
@@ -1274,7 +1285,9 @@ def _replace_child_rows(doc: Any, table_field: str, rows: list[dict[str, Any]]) 
 		doc.append(table_field, row)
 
 
-def _persist_doc(doc: Any, existing_name: str | None, business_field: str | None = None, business_value: Any = None) -> str:
+def _persist_doc(
+	doc: Any, existing_name: str | None, business_field: str | None = None, business_value: Any = None
+) -> str:
 	if existing_name:
 		doc.save(ignore_permissions=True)
 		return "updated"
@@ -1423,7 +1436,9 @@ def sync_procurement_suppliers(sheet_name: str, data: list[dict], checksum: str,
 			if not existing_name and not _normalize_sheet_text(getattr(doc, "status", None)):
 				doc.status = "Pending Verification"
 
-			action = _persist_doc(doc, existing_name, business_field="supplier_code", business_value=supplier_code)
+			action = _persist_doc(
+				doc, existing_name, business_field="supplier_code", business_value=supplier_code
+			)
 			results[f"rows_{action}"] += 1
 			_release_savepoint(savepoint)
 		except Exception as exc:
@@ -1461,7 +1476,9 @@ def sync_procurement_requisitions(
 		items_by_pr.setdefault(pr_no, []).append(
 			{
 				"item_code": item_code,
-				"item_name": _normalize_sheet_text(_first_non_empty(item_row, "item_name")) or description or item_code,
+				"item_name": _normalize_sheet_text(_first_non_empty(item_row, "item_name"))
+				or description
+				or item_code,
 				"description": description,
 				"qty": qty,
 				"uom": _normalize_sheet_text(_first_non_empty(item_row, "unit_of_issue", "uom")) or "Pcs",
@@ -1504,15 +1521,15 @@ def sync_procurement_requisitions(
 			doc.recurring = _sheet_flag(_first_non_empty(row, "recurring"))
 			doc.status = _build_pr_status(row, items)
 			doc.approved_by = (
-				_resolve_user_identity(_first_non_empty(row, "approved_by"), _first_non_empty(row, "approved_by_email"))
+				_resolve_user_identity(
+					_first_non_empty(row, "approved_by"), _first_non_empty(row, "approved_by_email")
+				)
 				if doc.status in {"Approved", "Rejected", "Converted to PO"}
 				else None
 			)
 			doc.approval_date = _safe_date(_first_non_empty(row, "approval_timestamp"))
 			doc.rejection_reason = (
-				_normalize_sheet_text(_first_non_empty(row, "comment"))
-				if doc.status == "Rejected"
-				else None
+				_normalize_sheet_text(_first_non_empty(row, "comment")) if doc.status == "Rejected" else None
 			)
 			_replace_child_rows(doc, "items", items)
 
@@ -1756,14 +1773,18 @@ def sync_procurement_goods_receipts(
 				if flt(getattr(po_item, "received_qty", 0), 2) != new_qty:
 					po_item.received_qty = new_qty
 					if getattr(po_item, "name", None):
-						frappe.db.set_value("BEI PO Item", po_item.name, "received_qty", new_qty, update_modified=False)
+						frappe.db.set_value(
+							"BEI PO Item", po_item.name, "received_qty", new_qty, update_modified=False
+						)
 					changed = True
 
 			fully_received = bool(getattr(po_doc, "items", [])) and all(
 				flt(getattr(item, "received_qty", 0), 2) >= flt(getattr(item, "qty", 0), 2)
 				for item in po_doc.items
 			)
-			partially_received = any(flt(getattr(item, "received_qty", 0), 2) > 0 for item in getattr(po_doc, "items", []))
+			partially_received = any(
+				flt(getattr(item, "received_qty", 0), 2) > 0 for item in getattr(po_doc, "items", [])
+			)
 			new_status = po_doc.status
 			if fully_received:
 				new_status = "Fully Received"

--- a/hrms/services/sheets_receiver/config.py
+++ b/hrms/services/sheets_receiver/config.py
@@ -4,312 +4,289 @@ Configuration for Sheets Receiver Service.
 Defines which sheets/folders to watch, sync mappings, and service settings.
 """
 
-import os
 import json
+import os
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
 from pathlib import Path
 
 
 @dataclass
 class FolderConfig:
-    """Configuration for a watched folder."""
-    name: str
-    folder_id: str
-    parent_folder_id: Optional[str] = None  # For subfolders
-    store_code: Optional[str] = None        # Normalized store identifier
-    owner_email: str = "ops@bebang.ph"
-    enabled: bool = True
-    file_patterns: List[str] = field(default_factory=lambda: ['*.xlsx', '*.pdf'])
-    processor: str = "pos"  # Processor type: pos, invoice, etc.
+	"""Configuration for a watched folder."""
+
+	name: str
+	folder_id: str
+	parent_folder_id: str | None = None  # For subfolders
+	store_code: str | None = None  # Normalized store identifier
+	owner_email: str = "ops@bebang.ph"
+	enabled: bool = True
+	file_patterns: list[str] = field(default_factory=lambda: ["*.xlsx", "*.pdf"])
+	processor: str = "pos"  # Processor type: pos, invoice, etc.
 
 
 @dataclass
 class SheetConfig:
-    """Configuration for a single watched sheet."""
-    name: str
-    spreadsheet_id: str
-    sheet_name: str  # Tab name within spreadsheet
-    range: str  # A1 notation range to sync
-    owner_email: str
-    sync_endpoint: str  # Frappe API endpoint to call
-    doctype: Optional[str] = None  # Target ERPNext DocType
-    key_column: str = "name"  # Column to use as unique key
-    enabled: bool = True
-    sync_mode: str = "upsert"  # upsert, replace, append
-    related_sheet_keys: List[str] = field(default_factory=list)
+	"""Configuration for a single watched sheet."""
+
+	name: str
+	spreadsheet_id: str
+	sheet_name: str  # Tab name within spreadsheet
+	range: str  # A1 notation range to sync
+	owner_email: str
+	sync_endpoint: str  # Frappe API endpoint to call
+	doctype: str | None = None  # Target ERPNext DocType
+	key_column: str = "name"  # Column to use as unique key
+	enabled: bool = True
+	sync_mode: str = "upsert"  # upsert, replace, append
+	related_sheet_keys: list[str] = field(default_factory=list)
 
 
 @dataclass
 class ServiceConfig:
-    """Main service configuration."""
+	"""Main service configuration."""
 
-    # Google API
-    service_account_file: str = field(
-        default_factory=lambda: os.environ.get(
-            'GOOGLE_SERVICE_ACCOUNT_FILE',
-            '/app/credentials/task-manager-service.json'
-        )
-    )
-    impersonate_user: str = field(
-        default_factory=lambda: os.environ.get('IMPERSONATE_USER', 'sam@bebang.ph')
-    )
+	# Google API
+	service_account_file: str = field(
+		default_factory=lambda: os.environ.get(
+			"GOOGLE_SERVICE_ACCOUNT_FILE", "/app/credentials/task-manager-service.json"
+		)
+	)
+	impersonate_user: str = field(default_factory=lambda: os.environ.get("IMPERSONATE_USER", "sam@bebang.ph"))
 
-    # Frappe API
-    frappe_url: str = field(
-        default_factory=lambda: os.environ.get('FRAPPE_URL', 'https://hq.bebang.ph')
-    )
-    frappe_api_key: str = field(
-        default_factory=lambda: os.environ.get('FRAPPE_API_KEY', '')
-    )
-    frappe_api_secret: str = field(
-        default_factory=lambda: os.environ.get('FRAPPE_API_SECRET', '')
-    )
+	# Frappe API
+	frappe_url: str = field(default_factory=lambda: os.environ.get("FRAPPE_URL", "https://hq.bebang.ph"))
+	frappe_api_key: str = field(default_factory=lambda: os.environ.get("FRAPPE_API_KEY", ""))
+	frappe_api_secret: str = field(default_factory=lambda: os.environ.get("FRAPPE_API_SECRET", ""))
 
-    # Webhook server
-    webhook_host: str = field(
-        default_factory=lambda: os.environ.get('SHEETS_RECEIVER_HOST', '0.0.0.0')
-    )
-    webhook_port: int = field(
-        default_factory=lambda: int(os.environ.get('SHEETS_RECEIVER_PORT', '8765'))
-    )
-    webhook_path: str = "/webhook/sheets"
+	# Webhook server
+	webhook_host: str = field(default_factory=lambda: os.environ.get("SHEETS_RECEIVER_HOST", "0.0.0.0"))
+	webhook_port: int = field(default_factory=lambda: int(os.environ.get("SHEETS_RECEIVER_PORT", "8765")))
+	webhook_path: str = "/webhook/sheets"
 
-    # Public URL for Google to send webhooks to
-    # Uses nginx proxy directly - NOT routed through Frappe
-    public_webhook_url: str = field(
-        default_factory=lambda: os.environ.get(
-            'PUBLIC_WEBHOOK_URL',
-            'https://hq.bebang.ph/sheets-webhook'
-        )
-    )
+	# Public URL for Google to send webhooks to
+	# Uses nginx proxy directly - NOT routed through Frappe
+	public_webhook_url: str = field(
+		default_factory=lambda: os.environ.get("PUBLIC_WEBHOOK_URL", "https://hq.bebang.ph/sheets-webhook")
+	)
 
-    # Database
-    db_path: str = field(
-        default_factory=lambda: os.environ.get(
-            'SHEETS_RECEIVER_DB',
-            '/app/data/sheets_receiver.db'
-        )
-    )
+	# Database
+	db_path: str = field(
+		default_factory=lambda: os.environ.get("SHEETS_RECEIVER_DB", "/app/data/sheets_receiver.db")
+	)
 
-    # Watch settings
-    watch_expiry_hours: int = 24  # Google limit
-    watch_renewal_buffer_hours: int = 1  # Renew this many hours before expiry
+	# Watch settings
+	watch_expiry_hours: int = 24  # Google limit
+	watch_renewal_buffer_hours: int = 1  # Renew this many hours before expiry
 
-    # Sync settings
-    sync_retry_attempts: int = 3
-    sync_retry_delay_seconds: int = 5
-    batch_size: int = 100  # Rows per API call
+	# Sync settings
+	sync_retry_attempts: int = 3
+	sync_retry_delay_seconds: int = 5
+	batch_size: int = 100  # Rows per API call
 
-    # Logging
-    log_level: str = field(
-        default_factory=lambda: os.environ.get('LOG_LEVEL', 'INFO')
-    )
-    log_file: str = field(
-        default_factory=lambda: os.environ.get(
-            'SHEETS_RECEIVER_LOG',
-            '/app/logs/sheets_receiver.log'
-        )
-    )
+	# Logging
+	log_level: str = field(default_factory=lambda: os.environ.get("LOG_LEVEL", "INFO"))
+	log_file: str = field(
+		default_factory=lambda: os.environ.get("SHEETS_RECEIVER_LOG", "/app/logs/sheets_receiver.log")
+	)
 
 
 # Sheets to watch and sync
-PROCUREMENT_COMPLIANCE_SPREADSHEET_ID = '1QWdoZlT7XWLppfVKpJ2VRXhbMkYtE5TbUwg4lMbO03Q'
+PROCUREMENT_COMPLIANCE_SPREADSHEET_ID = "1QWdoZlT7XWLppfVKpJ2VRXhbMkYtE5TbUwg4lMbO03Q"
 
-WATCHED_SHEETS: Dict[str, SheetConfig] = {
-    'ar_aging': SheetConfig(
-        name='AR Aging',
-        spreadsheet_id='1puwkr5hzrki9srxq10_jOeb5mfngkbo-VVpydmAf2kQ',
-        sheet_name='AR',  # Actual tab name
-        range='A:Z',
-        owner_email='alyssa@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_ar_aging',
-        doctype='Sales Invoice',
-        key_column='invoice_no',
-        sync_mode='upsert'
-    ),
-    'inventory': SheetConfig(
-        name='Inventory',
-        spreadsheet_id='1Eh_BhDK_LgdOzJ002F7XUYLBsd4EM8ec7sPz43mudGc',
-        sheet_name='SUMMARY 2026',  # Case-sensitive tab name
-        range='A:Z',
-        owner_email='ian@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_inventory',
-        doctype='Stock Reconciliation',
-        key_column='item_code',
-        sync_mode='replace'
-    ),
-    'coa': SheetConfig(
-        name='Chart of Accounts',
-        spreadsheet_id='1EXCd4Ah2n6Q42vQvTG3dYLFzPsPFhdbzmHp_2wBpN7g',
-        sheet_name='01 - Chart of Accounts (217)',  # Actual tab name
-        range='A:I',
-        owner_email='sam@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_coa',
-        doctype='Account',
-        key_column='gl_code',
-        sync_mode='upsert'
-    ),
-    'bank_directory': SheetConfig(
-        name='Bank Directory',
-        spreadsheet_id='1rkQDLREjTG8eyqB7wO5rRsnkjvaasOgmnPcKnqjXNnY',
-        sheet_name='02 - Bank Directory (53)',  # Actual tab name
-        range='A:G',
-        owner_email='sam@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_bank_accounts',
-        doctype='Bank Account',
-        key_column='account_number',
-        sync_mode='upsert'
-    ),
-    'ap_opening_balance': SheetConfig(
-        name='AP Opening Balance',
-        spreadsheet_id='1ZHe2VoAFa94ET4I68C1jWM7nMzTdTCvttwZbICaLtB4',
-        sheet_name='05 - AP Opening Balance (PHP 24.4M)',
-        range='A:Z',
-        owner_email='alyssa@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_ap_opening',
-        doctype='Purchase Invoice',
-        key_column='invoice_no',
-        sync_mode='upsert',
-        enabled=True
-    ),
-    'supplier_soa': SheetConfig(
-        name='Supplier SOA',
-        spreadsheet_id='1ZHe2VoAFa94ET4I68C1jWM7nMzTdTCvttwZbICaLtB4',
-        sheet_name='SUPPLIERS SOA',
-        range='A:Z',
-        owner_email='alyssa@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_supplier_soa',
-        doctype='Supplier',
-        key_column='supplier_name',
-        sync_mode='upsert',
-        enabled=True
-    ),
-    'procurement_suppliers': SheetConfig(
-        name='Procurement Suppliers',
-        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
-        sheet_name='Suppliers',
-        range='A:Z',
-        owner_email='aldrin@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_suppliers',
-        doctype='BEI Supplier',
-        key_column='supplier_code',
-        sync_mode='upsert',
-        enabled=True
-    ),
-    'procurement_pr_items': SheetConfig(
-        name='Procurement PR Items',
-        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
-        sheet_name='PR Items',
-        range='A:Z',
-        owner_email='aldrin@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_requisitions',
-        doctype='BEI PR Item',
-        key_column='unique_id',
-        sync_mode='upsert',
-        enabled=False
-    ),
-    'procurement_requisitions': SheetConfig(
-        name='Procurement Requisitions',
-        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
-        sheet_name='Purchase Requisitions',
-        range='A:Z',
-        owner_email='aldrin@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_requisitions',
-        doctype='BEI Purchase Requisition',
-        key_column='pr_no',
-        sync_mode='upsert',
-        enabled=True,
-        related_sheet_keys=['procurement_pr_items']
-    ),
-    'procurement_po_items': SheetConfig(
-        name='Procurement PO Items',
-        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
-        sheet_name='PO Items',
-        range='A:Z',
-        owner_email='aldrin@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_purchase_orders',
-        doctype='BEI PO Item',
-        key_column='uniqueid',
-        sync_mode='upsert',
-        enabled=False
-    ),
-    'procurement_purchase_orders': SheetConfig(
-        name='Procurement Purchase Orders',
-        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
-        sheet_name='Purchase Order',
-        range='A:Z',
-        owner_email='aldrin@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_purchase_orders',
-        doctype='BEI Purchase Order',
-        key_column='po_no',
-        sync_mode='upsert',
-        enabled=True,
-        related_sheet_keys=['procurement_po_items']
-    ),
-    'procurement_gr_items': SheetConfig(
-        name='Procurement GR Items',
-        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
-        sheet_name='GR Items',
-        range='A:Z',
-        owner_email='aldrin@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_goods_receipts',
-        doctype='BEI GR Item',
-        key_column='unique_id',
-        sync_mode='upsert',
-        enabled=False
-    ),
-    'procurement_goods_receipts': SheetConfig(
-        name='Procurement Goods Receipts',
-        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
-        sheet_name='Goods Receipts',
-        range='A:Z',
-        owner_email='aldrin@bebang.ph',
-        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_goods_receipts',
-        doctype='BEI Goods Receipt',
-        key_column='gr_no',
-        sync_mode='upsert',
-        enabled=True,
-        related_sheet_keys=['procurement_gr_items']
-    ),
+WATCHED_SHEETS: dict[str, SheetConfig] = {
+	"ar_aging": SheetConfig(
+		name="AR Aging",
+		spreadsheet_id="1puwkr5hzrki9srxq10_jOeb5mfngkbo-VVpydmAf2kQ",
+		sheet_name="AR",  # Actual tab name
+		range="A:Z",
+		owner_email="alyssa@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_ar_aging",
+		doctype="Sales Invoice",
+		key_column="invoice_no",
+		sync_mode="upsert",
+	),
+	"inventory": SheetConfig(
+		name="Inventory",
+		spreadsheet_id="1Eh_BhDK_LgdOzJ002F7XUYLBsd4EM8ec7sPz43mudGc",
+		sheet_name="SUMMARY 2026",  # Case-sensitive tab name
+		range="A:Z",
+		owner_email="ian@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_inventory",
+		doctype="Stock Reconciliation",
+		key_column="item_code",
+		sync_mode="replace",
+	),
+	"coa": SheetConfig(
+		name="Chart of Accounts",
+		spreadsheet_id="1EXCd4Ah2n6Q42vQvTG3dYLFzPsPFhdbzmHp_2wBpN7g",
+		sheet_name="01 - Chart of Accounts (217)",  # Actual tab name
+		range="A:I",
+		owner_email="sam@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_coa",
+		doctype="Account",
+		key_column="gl_code",
+		sync_mode="upsert",
+	),
+	"bank_directory": SheetConfig(
+		name="Bank Directory",
+		spreadsheet_id="1rkQDLREjTG8eyqB7wO5rRsnkjvaasOgmnPcKnqjXNnY",
+		sheet_name="02 - Bank Directory (53)",  # Actual tab name
+		range="A:G",
+		owner_email="sam@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_bank_accounts",
+		doctype="Bank Account",
+		key_column="account_number",
+		sync_mode="upsert",
+	),
+	"ap_opening_balance": SheetConfig(
+		name="AP Opening Balance",
+		spreadsheet_id="1ZHe2VoAFa94ET4I68C1jWM7nMzTdTCvttwZbICaLtB4",
+		sheet_name="05 - AP Opening Balance (PHP 24.4M)",
+		range="A:Z",
+		owner_email="alyssa@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_ap_opening",
+		doctype="Purchase Invoice",
+		key_column="invoice_no",
+		sync_mode="upsert",
+		enabled=True,
+	),
+	"supplier_soa": SheetConfig(
+		name="Supplier SOA",
+		spreadsheet_id="1ZHe2VoAFa94ET4I68C1jWM7nMzTdTCvttwZbICaLtB4",
+		sheet_name="SUPPLIERS SOA",
+		range="A:Z",
+		owner_email="alyssa@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_supplier_soa",
+		doctype="Supplier",
+		key_column="supplier_name",
+		sync_mode="upsert",
+		enabled=True,
+	),
+	"procurement_suppliers": SheetConfig(
+		name="Procurement Suppliers",
+		spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+		sheet_name="Suppliers",
+		range="A:Z",
+		owner_email="aldrin@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_procurement_suppliers",
+		doctype="BEI Supplier",
+		key_column="supplier_code",
+		sync_mode="upsert",
+		enabled=True,
+	),
+	"procurement_pr_items": SheetConfig(
+		name="Procurement PR Items",
+		spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+		sheet_name="PR Items",
+		range="A:Z",
+		owner_email="aldrin@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_procurement_requisitions",
+		doctype="BEI PR Item",
+		key_column="unique_id",
+		sync_mode="upsert",
+		enabled=False,
+	),
+	"procurement_requisitions": SheetConfig(
+		name="Procurement Requisitions",
+		spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+		sheet_name="Purchase Requisitions",
+		range="A:Z",
+		owner_email="aldrin@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_procurement_requisitions",
+		doctype="BEI Purchase Requisition",
+		key_column="pr_no",
+		sync_mode="upsert",
+		enabled=True,
+		related_sheet_keys=["procurement_pr_items"],
+	),
+	"procurement_po_items": SheetConfig(
+		name="Procurement PO Items",
+		spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+		sheet_name="PO Items",
+		range="A:Z",
+		owner_email="aldrin@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_procurement_purchase_orders",
+		doctype="BEI PO Item",
+		key_column="uniqueid",
+		sync_mode="upsert",
+		enabled=False,
+	),
+	"procurement_purchase_orders": SheetConfig(
+		name="Procurement Purchase Orders",
+		spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+		sheet_name="Purchase Order",
+		range="A:Z",
+		owner_email="aldrin@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_procurement_purchase_orders",
+		doctype="BEI Purchase Order",
+		key_column="po_no",
+		sync_mode="upsert",
+		enabled=True,
+		related_sheet_keys=["procurement_po_items"],
+	),
+	"procurement_gr_items": SheetConfig(
+		name="Procurement GR Items",
+		spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+		sheet_name="GR Items",
+		range="A:Z",
+		owner_email="aldrin@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_procurement_goods_receipts",
+		doctype="BEI GR Item",
+		key_column="unique_id",
+		sync_mode="upsert",
+		enabled=False,
+	),
+	"procurement_goods_receipts": SheetConfig(
+		name="Procurement Goods Receipts",
+		spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+		sheet_name="Goods Receipts",
+		range="A:Z",
+		owner_email="aldrin@bebang.ph",
+		sync_endpoint="/api/method/hrms.api.erp_sync.sync_procurement_goods_receipts",
+		doctype="BEI Goods Receipt",
+		key_column="gr_no",
+		sync_mode="upsert",
+		enabled=True,
+		related_sheet_keys=["procurement_gr_items"],
+	),
 }
 
 
 def get_config() -> ServiceConfig:
-    """Get service configuration."""
-    return ServiceConfig()
+	"""Get service configuration."""
+	return ServiceConfig()
 
 
-def get_all_sheet_configs() -> Dict[str, SheetConfig]:
-    """Get all configured sheets, including helper tabs used for bundle sync."""
-    return dict(WATCHED_SHEETS)
+def get_all_sheet_configs() -> dict[str, SheetConfig]:
+	"""Get all configured sheets, including helper tabs used for bundle sync."""
+	return dict(WATCHED_SHEETS)
 
 
-def get_watched_sheets() -> Dict[str, SheetConfig]:
-    """Get all enabled watched sheets."""
-    return {k: v for k, v in WATCHED_SHEETS.items() if v.enabled}
+def get_watched_sheets() -> dict[str, SheetConfig]:
+	"""Get all enabled watched sheets."""
+	return {k: v for k, v in WATCHED_SHEETS.items() if v.enabled}
 
 
-def get_sheet_config(sheet_key: str) -> Optional[SheetConfig]:
-    """Get a sheet config by key."""
-    return WATCHED_SHEETS.get(sheet_key)
+def get_sheet_config(sheet_key: str) -> SheetConfig | None:
+	"""Get a sheet config by key."""
+	return WATCHED_SHEETS.get(sheet_key)
 
 
-def get_sheets_by_spreadsheet_id(spreadsheet_id: str) -> Dict[str, SheetConfig]:
-    """Get all enabled watched sheets for a spreadsheet/workbook."""
-    return {
-        key: sheet
-        for key, sheet in WATCHED_SHEETS.items()
-        if sheet.enabled and sheet.spreadsheet_id == spreadsheet_id
-    }
+def get_sheets_by_spreadsheet_id(spreadsheet_id: str) -> dict[str, SheetConfig]:
+	"""Get all enabled watched sheets for a spreadsheet/workbook."""
+	return {
+		key: sheet
+		for key, sheet in WATCHED_SHEETS.items()
+		if sheet.enabled and sheet.spreadsheet_id == spreadsheet_id
+	}
 
 
-def get_sheet_by_spreadsheet_id(spreadsheet_id: str) -> Optional[SheetConfig]:
-    """Look up sheet config by Google spreadsheet ID."""
-    matching = get_sheets_by_spreadsheet_id(spreadsheet_id)
-    for sheet in matching.values():
-        return sheet
-    return None
+def get_sheet_by_spreadsheet_id(spreadsheet_id: str) -> SheetConfig | None:
+	"""Look up sheet config by Google spreadsheet ID."""
+	matching = get_sheets_by_spreadsheet_id(spreadsheet_id)
+	for sheet in matching.values():
+		return sheet
+	return None
 
 
 # ============================================================================
@@ -321,83 +298,86 @@ POS_ROOT_FOLDER_ID = "1z5_26svRHFmrCujWEY4oQH8eEg6d5YqT"
 POS_ROOT_FOLDER_NAME = "Operations - ERPNEXT Project"
 
 # Store folders - loaded from JSON or discovered via Drive API
-_store_folders_cache: Optional[Dict[str, FolderConfig]] = None
+_store_folders_cache: dict[str, FolderConfig] | None = None
 
 
 def _normalize_store_code(folder_name: str) -> str:
-    """
-    Convert folder name to normalized store code.
+	"""
+	Convert folder name to normalized store code.
 
-    Examples:
-        'SM Megamall' -> 'sm_megamall'
-        'Ayala Market! Market!' -> 'ayala_market_market'
-        'D'VERDE' -> 'd_verde'
-    """
-    import re
-    # Remove special characters, replace spaces/punctuation with underscore
-    code = re.sub(r"[^a-zA-Z0-9\s]", "", folder_name)
-    code = re.sub(r"\s+", "_", code.strip())
-    return code.lower()
+	Examples:
+	    'SM Megamall' -> 'sm_megamall'
+	    'Ayala Market! Market!' -> 'ayala_market_market'
+	    'D'VERDE' -> 'd_verde'
+	"""
+	import re
 
-
-def load_store_folders() -> Dict[str, FolderConfig]:
-    """
-    Load store folder configurations.
-
-    First tries to load from cached JSON file, falls back to empty dict
-    (folders will be discovered via Drive API on service startup).
-    """
-    global _store_folders_cache
-
-    if _store_folders_cache is not None:
-        return _store_folders_cache
-
-    config = get_config()
-    json_path = Path(config.db_path).parent / "store_folders.json"
-
-    # Also check local development path
-    if not json_path.exists():
-        json_path = Path(__file__).parent.parent.parent.parent / "data" / "POS_Extraction" / "store_folders.json"
-
-    if json_path.exists():
-        try:
-            with open(json_path) as f:
-                data = json.load(f)
-
-            _store_folders_cache = {}
-            for store in data.get("stores", []):
-                # Skip non-store folders
-                if store["name"].startswith("01. Sample") or "Finance Validation" in store["name"]:
-                    continue
-
-                store_code = _normalize_store_code(store["name"])
-                _store_folders_cache[store_code] = FolderConfig(
-                    name=store["name"],
-                    folder_id=store["folder_id"],
-                    parent_folder_id=POS_ROOT_FOLDER_ID,
-                    store_code=store_code,
-                    owner_email="ops@bebang.ph",
-                    enabled=True,
-                    processor="pos"
-                )
-
-            return _store_folders_cache
-        except Exception as e:
-            print(f"Warning: Failed to load store folders from {json_path}: {e}")
-
-    _store_folders_cache = {}
-    return _store_folders_cache
+	# Remove special characters, replace spaces/punctuation with underscore
+	code = re.sub(r"[^a-zA-Z0-9\s]", "", folder_name)
+	code = re.sub(r"\s+", "_", code.strip())
+	return code.lower()
 
 
-def get_watched_folders() -> Dict[str, FolderConfig]:
-    """Get all enabled watched folders."""
-    folders = load_store_folders()
-    return {k: v for k, v in folders.items() if v.enabled}
+def load_store_folders() -> dict[str, FolderConfig]:
+	"""
+	Load store folder configurations.
+
+	First tries to load from cached JSON file, falls back to empty dict
+	(folders will be discovered via Drive API on service startup).
+	"""
+	global _store_folders_cache
+
+	if _store_folders_cache is not None:
+		return _store_folders_cache
+
+	config = get_config()
+	json_path = Path(config.db_path).parent / "store_folders.json"
+
+	# Also check local development path
+	if not json_path.exists():
+		json_path = (
+			Path(__file__).parent.parent.parent.parent / "data" / "POS_Extraction" / "store_folders.json"
+		)
+
+	if json_path.exists():
+		try:
+			with open(json_path) as f:
+				data = json.load(f)
+
+			_store_folders_cache = {}
+			for store in data.get("stores", []):
+				# Skip non-store folders
+				if store["name"].startswith("01. Sample") or "Finance Validation" in store["name"]:
+					continue
+
+				store_code = _normalize_store_code(store["name"])
+				_store_folders_cache[store_code] = FolderConfig(
+					name=store["name"],
+					folder_id=store["folder_id"],
+					parent_folder_id=POS_ROOT_FOLDER_ID,
+					store_code=store_code,
+					owner_email="ops@bebang.ph",
+					enabled=True,
+					processor="pos",
+				)
+
+			return _store_folders_cache
+		except Exception as e:
+			print(f"Warning: Failed to load store folders from {json_path}: {e}")
+
+	_store_folders_cache = {}
+	return _store_folders_cache
 
 
-def get_folder_by_id(folder_id: str) -> Optional[FolderConfig]:
-    """Look up folder config by Google Drive folder ID."""
-    for folder in load_store_folders().values():
-        if folder.folder_id == folder_id:
-            return folder
-    return None
+def get_watched_folders() -> dict[str, FolderConfig]:
+	"""Get all enabled watched folders."""
+	folders = load_store_folders()
+	return {k: v for k, v in folders.items() if v.enabled}
+
+
+def get_folder_by_id(folder_id: str) -> FolderConfig | None:
+	"""Look up folder config by Google Drive folder ID."""
+	for folder in load_store_folders().values():
+		if folder.folder_id == folder_id:
+			return folder
+	return None

--- a/hrms/services/sheets_receiver/config.py
+++ b/hrms/services/sheets_receiver/config.py
@@ -37,6 +37,7 @@ class SheetConfig:
     key_column: str = "name"  # Column to use as unique key
     enabled: bool = True
     sync_mode: str = "upsert"  # upsert, replace, append
+    related_sheet_keys: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -113,6 +114,8 @@ class ServiceConfig:
 
 
 # Sheets to watch and sync
+PROCUREMENT_COMPLIANCE_SPREADSHEET_ID = '1QWdoZlT7XWLppfVKpJ2VRXhbMkYtE5TbUwg4lMbO03Q'
+
 WATCHED_SHEETS: Dict[str, SheetConfig] = {
     'ar_aging': SheetConfig(
         name='AR Aging',
@@ -182,6 +185,93 @@ WATCHED_SHEETS: Dict[str, SheetConfig] = {
         sync_mode='upsert',
         enabled=True
     ),
+    'procurement_suppliers': SheetConfig(
+        name='Procurement Suppliers',
+        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+        sheet_name='Suppliers',
+        range='A:Z',
+        owner_email='aldrin@bebang.ph',
+        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_suppliers',
+        doctype='BEI Supplier',
+        key_column='supplier_code',
+        sync_mode='upsert',
+        enabled=True
+    ),
+    'procurement_pr_items': SheetConfig(
+        name='Procurement PR Items',
+        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+        sheet_name='PR Items',
+        range='A:Z',
+        owner_email='aldrin@bebang.ph',
+        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_requisitions',
+        doctype='BEI PR Item',
+        key_column='unique_id',
+        sync_mode='upsert',
+        enabled=False
+    ),
+    'procurement_requisitions': SheetConfig(
+        name='Procurement Requisitions',
+        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+        sheet_name='Purchase Requisitions',
+        range='A:Z',
+        owner_email='aldrin@bebang.ph',
+        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_requisitions',
+        doctype='BEI Purchase Requisition',
+        key_column='pr_no',
+        sync_mode='upsert',
+        enabled=True,
+        related_sheet_keys=['procurement_pr_items']
+    ),
+    'procurement_po_items': SheetConfig(
+        name='Procurement PO Items',
+        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+        sheet_name='PO Items',
+        range='A:Z',
+        owner_email='aldrin@bebang.ph',
+        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_purchase_orders',
+        doctype='BEI PO Item',
+        key_column='uniqueid',
+        sync_mode='upsert',
+        enabled=False
+    ),
+    'procurement_purchase_orders': SheetConfig(
+        name='Procurement Purchase Orders',
+        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+        sheet_name='Purchase Order',
+        range='A:Z',
+        owner_email='aldrin@bebang.ph',
+        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_purchase_orders',
+        doctype='BEI Purchase Order',
+        key_column='po_no',
+        sync_mode='upsert',
+        enabled=True,
+        related_sheet_keys=['procurement_po_items']
+    ),
+    'procurement_gr_items': SheetConfig(
+        name='Procurement GR Items',
+        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+        sheet_name='GR Items',
+        range='A:Z',
+        owner_email='aldrin@bebang.ph',
+        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_goods_receipts',
+        doctype='BEI GR Item',
+        key_column='unique_id',
+        sync_mode='upsert',
+        enabled=False
+    ),
+    'procurement_goods_receipts': SheetConfig(
+        name='Procurement Goods Receipts',
+        spreadsheet_id=PROCUREMENT_COMPLIANCE_SPREADSHEET_ID,
+        sheet_name='Goods Receipts',
+        range='A:Z',
+        owner_email='aldrin@bebang.ph',
+        sync_endpoint='/api/method/hrms.api.erp_sync.sync_procurement_goods_receipts',
+        doctype='BEI Goods Receipt',
+        key_column='gr_no',
+        sync_mode='upsert',
+        enabled=True,
+        related_sheet_keys=['procurement_gr_items']
+    ),
 }
 
 
@@ -190,16 +280,35 @@ def get_config() -> ServiceConfig:
     return ServiceConfig()
 
 
+def get_all_sheet_configs() -> Dict[str, SheetConfig]:
+    """Get all configured sheets, including helper tabs used for bundle sync."""
+    return dict(WATCHED_SHEETS)
+
+
 def get_watched_sheets() -> Dict[str, SheetConfig]:
     """Get all enabled watched sheets."""
     return {k: v for k, v in WATCHED_SHEETS.items() if v.enabled}
 
 
+def get_sheet_config(sheet_key: str) -> Optional[SheetConfig]:
+    """Get a sheet config by key."""
+    return WATCHED_SHEETS.get(sheet_key)
+
+
+def get_sheets_by_spreadsheet_id(spreadsheet_id: str) -> Dict[str, SheetConfig]:
+    """Get all enabled watched sheets for a spreadsheet/workbook."""
+    return {
+        key: sheet
+        for key, sheet in WATCHED_SHEETS.items()
+        if sheet.enabled and sheet.spreadsheet_id == spreadsheet_id
+    }
+
+
 def get_sheet_by_spreadsheet_id(spreadsheet_id: str) -> Optional[SheetConfig]:
     """Look up sheet config by Google spreadsheet ID."""
-    for sheet in WATCHED_SHEETS.values():
-        if sheet.spreadsheet_id == spreadsheet_id:
-            return sheet
+    matching = get_sheets_by_spreadsheet_id(spreadsheet_id)
+    for sheet in matching.values():
+        return sheet
     return None
 
 

--- a/hrms/services/sheets_receiver/frappe_client.py
+++ b/hrms/services/sheets_receiver/frappe_client.py
@@ -6,241 +6,220 @@ Handles syncing data to ERPNext via REST API.
 
 import logging
 import time
-from typing import List, Dict, Any, Optional, Tuple
 from dataclasses import dataclass
+from typing import Any
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .config import get_config, SheetConfig
+from .config import SheetConfig, get_config
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class SyncResult:
-    """Result of a sync operation."""
-    success: bool
-    rows_processed: int = 0
-    rows_created: int = 0
-    rows_updated: int = 0
-    rows_failed: int = 0
-    errors: List[str] = None
+	"""Result of a sync operation."""
 
-    def __post_init__(self):
-        if self.errors is None:
-            self.errors = []
+	success: bool
+	rows_processed: int = 0
+	rows_created: int = 0
+	rows_updated: int = 0
+	rows_failed: int = 0
+	errors: list[str] | None = None
+
+	def __post_init__(self):
+		if self.errors is None:
+			self.errors = []
 
 
 class FrappeClient:
-    """Client for Frappe REST API."""
+	"""Client for Frappe REST API."""
 
-    def __init__(self):
-        config = get_config()
-        self.base_url = config.frappe_url.rstrip('/')
-        self.api_key = config.frappe_api_key
-        self.api_secret = config.frappe_api_secret
+	def __init__(self):
+		config = get_config()
+		self.base_url = config.frappe_url.rstrip("/")
+		self.api_key = config.frappe_api_key
+		self.api_secret = config.frappe_api_secret
 
-        # Set up session with retry logic
-        self.session = requests.Session()
-        retry = Retry(
-            total=config.sync_retry_attempts,
-            backoff_factor=0.5,
-            status_forcelist=[500, 502, 503, 504]
-        )
-        adapter = HTTPAdapter(max_retries=retry)
-        self.session.mount('https://', adapter)
-        self.session.mount('http://', adapter)
+		# Set up session with retry logic
+		self.session = requests.Session()
+		retry = Retry(
+			total=config.sync_retry_attempts, backoff_factor=0.5, status_forcelist=[500, 502, 503, 504]
+		)
+		adapter = HTTPAdapter(max_retries=retry)
+		self.session.mount("https://", adapter)
+		self.session.mount("http://", adapter)
 
-        # Set auth headers
-        self.session.headers.update({
-            'Authorization': f'token {self.api_key}:{self.api_secret}',
-            'Content-Type': 'application/json'
-        })
+		# Set auth headers
+		self.session.headers.update(
+			{"Authorization": f"token {self.api_key}:{self.api_secret}", "Content-Type": "application/json"}
+		)
 
-    def _request(
-        self,
-        method: str,
-        endpoint: str,
-        data: Dict = None,
-        params: Dict = None
-    ) -> Dict[str, Any]:
-        """Make authenticated request to Frappe API."""
-        url = f"{self.base_url}{endpoint}"
+	def _request(
+		self,
+		method: str,
+		endpoint: str,
+		data: dict[str, Any] | None = None,
+		params: dict[str, Any] | None = None,
+	) -> dict[str, Any]:
+		"""Make authenticated request to Frappe API."""
+		url = f"{self.base_url}{endpoint}"
 
-        try:
-            response = self.session.request(
-                method=method,
-                url=url,
-                json=data,
-                params=params,
-                timeout=30
-            )
-            response.raise_for_status()
-            return response.json()
+		try:
+			response = self.session.request(method=method, url=url, json=data, params=params, timeout=30)
+			response.raise_for_status()
+			return response.json()
 
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Frappe API error: {method} {endpoint} - {e}")
-            raise
+		except requests.exceptions.RequestException as e:
+			logger.error(f"Frappe API error: {method} {endpoint} - {e}")
+			raise
 
-    def get_doc(self, doctype: str, name: str) -> Optional[Dict]:
-        """Get a single document."""
-        try:
-            result = self._request('GET', f'/api/resource/{doctype}/{name}')
-            return result.get('data')
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 404:
-                return None
-            raise
+	def get_doc(self, doctype: str, name: str) -> dict[str, Any] | None:
+		"""Get a single document."""
+		try:
+			result = self._request("GET", f"/api/resource/{doctype}/{name}")
+			return result.get("data")
+		except requests.exceptions.HTTPError as e:
+			if e.response.status_code == 404:
+				return None
+			raise
 
-    def create_doc(self, doctype: str, data: Dict) -> Dict:
-        """Create a new document."""
-        result = self._request('POST', f'/api/resource/{doctype}', data=data)
-        return result.get('data', {})
+	def create_doc(self, doctype: str, data: dict[str, Any]) -> dict[str, Any]:
+		"""Create a new document."""
+		result = self._request("POST", f"/api/resource/{doctype}", data=data)
+		return result.get("data", {})
 
-    def update_doc(self, doctype: str, name: str, data: Dict) -> Dict:
-        """Update an existing document."""
-        result = self._request('PUT', f'/api/resource/{doctype}/{name}', data=data)
-        return result.get('data', {})
+	def update_doc(self, doctype: str, name: str, data: dict[str, Any]) -> dict[str, Any]:
+		"""Update an existing document."""
+		result = self._request("PUT", f"/api/resource/{doctype}/{name}", data=data)
+		return result.get("data", {})
 
-    def call_method(self, method: str, data: Dict = None) -> Dict:
-        """Call a whitelisted Frappe method."""
-        endpoint = f'/api/method/{method}'
-        result = self._request('POST', endpoint, data=data or {})
-        return result.get('message', result)
+	def call_method(self, method: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+		"""Call a whitelisted Frappe method."""
+		endpoint = f"/api/method/{method}"
+		result = self._request("POST", endpoint, data=data or {})
+		return result.get("message", result)
 
-    def sync_sheet_data(
-        self,
-        sheet_config: SheetConfig,
-        data: List[Dict[str, Any]],
-        checksum: str,
-        related_data: Optional[Dict[str, List[Dict[str, Any]]]] = None,
-    ) -> SyncResult:
-        """
-        Sync sheet data to Frappe using the configured endpoint.
+	def sync_sheet_data(
+		self,
+		sheet_config: SheetConfig,
+		data: list[dict[str, Any]],
+		checksum: str,
+		related_data: dict[str, list[dict[str, Any]]] | None = None,
+	) -> SyncResult:
+		"""
+		Sync sheet data to Frappe using the configured endpoint.
 
-        Args:
-            sheet_config: Configuration for this sheet
-            data: List of row dictionaries
-            checksum: Data checksum for change detection
+		Args:
+		    sheet_config: Configuration for this sheet
+		    data: List of row dictionaries
+		    checksum: Data checksum for change detection
 
-        Returns:
-            SyncResult with statistics
-        """
-        try:
-            # Call the sync endpoint with the data
-            payload = {
-                'sheet_name': sheet_config.name,
-                'sheet_tab_name': sheet_config.sheet_name,
-                'data': data,
-                'checksum': checksum,
-                'sync_mode': sheet_config.sync_mode,
-                'key_column': sheet_config.key_column,
-            }
-            if related_data:
-                payload['related_data'] = related_data
+		Returns:
+		    SyncResult with statistics
+		"""
+		try:
+			# Call the sync endpoint with the data
+			payload = {
+				"sheet_name": sheet_config.name,
+				"sheet_tab_name": sheet_config.sheet_name,
+				"data": data,
+				"checksum": checksum,
+				"sync_mode": sheet_config.sync_mode,
+				"key_column": sheet_config.key_column,
+			}
+			if related_data:
+				payload["related_data"] = related_data
 
-            result = self.call_method(
-                sheet_config.sync_endpoint.replace('/api/method/', ''),
-                data=payload
-            )
+			result = self.call_method(sheet_config.sync_endpoint.replace("/api/method/", ""), data=payload)
 
-            return SyncResult(
-                success=True,
-                rows_processed=result.get('rows_processed', len(data)),
-                rows_created=result.get('rows_created', 0),
-                rows_updated=result.get('rows_updated', 0),
-                rows_failed=result.get('rows_failed', 0),
-                errors=result.get('errors', [])
-            )
+			return SyncResult(
+				success=True,
+				rows_processed=result.get("rows_processed", len(data)),
+				rows_created=result.get("rows_created", 0),
+				rows_updated=result.get("rows_updated", 0),
+				rows_failed=result.get("rows_failed", 0),
+				errors=result.get("errors", []),
+			)
 
-        except Exception as e:
-            logger.error(f"Sync failed for {sheet_config.name}: {e}")
-            return SyncResult(
-                success=False,
-                rows_processed=len(data),
-                errors=[str(e)]
-            )
+		except Exception as e:
+			logger.error(f"Sync failed for {sheet_config.name}: {e}")
+			return SyncResult(success=False, rows_processed=len(data), errors=[str(e)])
 
-    def sync_batch(
-        self,
-        doctype: str,
-        data: List[Dict[str, Any]],
-        key_field: str,
-        batch_size: int = 100
-    ) -> SyncResult:
-        """
-        Batch upsert records to a DocType.
+	def sync_batch(
+		self, doctype: str, data: list[dict[str, Any]], key_field: str, batch_size: int = 100
+	) -> SyncResult:
+		"""
+		Batch upsert records to a DocType.
 
-        Args:
-            doctype: Target DocType
-            data: List of records
-            key_field: Field to use for matching existing records
-            batch_size: Records per batch
+		Args:
+		    doctype: Target DocType
+		    data: List of records
+		    key_field: Field to use for matching existing records
+		    batch_size: Records per batch
 
-        Returns:
-            SyncResult with statistics
-        """
-        result = SyncResult(success=True, rows_processed=len(data))
+		Returns:
+		    SyncResult with statistics
+		"""
+		result = SyncResult(success=True, rows_processed=len(data))
 
-        for i in range(0, len(data), batch_size):
-            batch = data[i:i + batch_size]
+		for i in range(0, len(data), batch_size):
+			batch = data[i : i + batch_size]
 
-            for record in batch:
-                try:
-                    key_value = record.get(key_field)
-                    if not key_value:
-                        result.errors.append(f"Missing key field {key_field}")
-                        result.rows_failed += 1
-                        continue
+			for record in batch:
+				try:
+					key_value = record.get(key_field)
+					if not key_value:
+						result.errors.append(f"Missing key field {key_field}")
+						result.rows_failed += 1
+						continue
 
-                    # Check if exists
-                    existing = self.get_doc(doctype, key_value)
+					# Check if exists
+					existing = self.get_doc(doctype, key_value)
 
-                    if existing:
-                        self.update_doc(doctype, key_value, record)
-                        result.rows_updated += 1
-                    else:
-                        self.create_doc(doctype, record)
-                        result.rows_created += 1
+					if existing:
+						self.update_doc(doctype, key_value, record)
+						result.rows_updated += 1
+					else:
+						self.create_doc(doctype, record)
+						result.rows_created += 1
 
-                except Exception as e:
-                    result.errors.append(f"{key_value}: {str(e)}")
-                    result.rows_failed += 1
+				except Exception as e:
+					result.errors.append(f"{key_value}: {e!s}")
+					result.rows_failed += 1
 
-            # Small delay between batches to avoid overwhelming the server
-            time.sleep(0.1)
+			# Small delay between batches to avoid overwhelming the server
+			time.sleep(0.1)
 
-        result.success = result.rows_failed == 0
-        return result
+		result.success = result.rows_failed == 0
+		return result
 
-    def send_notification(
-        self,
-        title: str,
-        message: str,
-        user: str = 'Administrator',
-        doctype: str = None,
-        docname: str = None
-    ):
-        """Send a Frappe notification."""
-        try:
-            self.call_method('frappe.client.send_alert', {
-                'message': message,
-                'title': title,
-                'indicator': 'blue'
-            })
-        except Exception as e:
-            logger.warning(f"Failed to send notification: {e}")
+	def send_notification(
+		self,
+		title: str,
+		message: str,
+		user: str = "Administrator",
+		doctype: str | None = None,
+		docname: str | None = None,
+	):
+		"""Send a Frappe notification."""
+		try:
+			self.call_method(
+				"frappe.client.send_alert", {"message": message, "title": title, "indicator": "blue"}
+			)
+		except Exception as e:
+			logger.warning(f"Failed to send notification: {e}")
 
 
 # Singleton instance
-_client: Optional[FrappeClient] = None
+_client: FrappeClient | None = None
 
 
 def get_frappe_client() -> FrappeClient:
-    """Get Frappe client instance."""
-    global _client
-    if _client is None:
-        _client = FrappeClient()
-    return _client
+	"""Get Frappe client instance."""
+	global _client
+	if _client is None:
+		_client = FrappeClient()
+	return _client

--- a/hrms/services/sheets_receiver/frappe_client.py
+++ b/hrms/services/sheets_receiver/frappe_client.py
@@ -114,7 +114,8 @@ class FrappeClient:
         self,
         sheet_config: SheetConfig,
         data: List[Dict[str, Any]],
-        checksum: str
+        checksum: str,
+        related_data: Optional[Dict[str, List[Dict[str, Any]]]] = None,
     ) -> SyncResult:
         """
         Sync sheet data to Frappe using the configured endpoint.
@@ -129,15 +130,20 @@ class FrappeClient:
         """
         try:
             # Call the sync endpoint with the data
+            payload = {
+                'sheet_name': sheet_config.name,
+                'sheet_tab_name': sheet_config.sheet_name,
+                'data': data,
+                'checksum': checksum,
+                'sync_mode': sheet_config.sync_mode,
+                'key_column': sheet_config.key_column,
+            }
+            if related_data:
+                payload['related_data'] = related_data
+
             result = self.call_method(
                 sheet_config.sync_endpoint.replace('/api/method/', ''),
-                data={
-                    'sheet_name': sheet_config.name,
-                    'data': data,
-                    'checksum': checksum,
-                    'sync_mode': sheet_config.sync_mode,
-                    'key_column': sheet_config.key_column
-                }
+                data=payload
             )
 
             return SyncResult(

--- a/hrms/services/sheets_receiver/processor.py
+++ b/hrms/services/sheets_receiver/processor.py
@@ -9,6 +9,8 @@ Handles:
 - Logging all operations
 """
 
+import hashlib
+import json
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -16,7 +18,13 @@ from datetime import datetime
 from typing import Any
 
 from .change_tracker import ChangeReport, ChangeTracker, ChangeType
-from .config import SheetConfig, get_config, get_sheet_by_spreadsheet_id, get_watched_sheets
+from .config import (
+	SheetConfig,
+	get_all_sheet_configs,
+	get_config,
+	get_sheets_by_spreadsheet_id,
+	get_watched_sheets,
+)
 from .frappe_client import SyncResult, get_frappe_client
 from .models import SyncLog, get_db
 from .sheets_client import get_sheets_client
@@ -106,17 +114,57 @@ class ChangeProcessor:
 
 		# Change notification - process it
 		if resource_state == "change":
-			sheet_config = get_sheet_by_spreadsheet_id(spreadsheet_id)
+			matching_sheets = get_sheets_by_spreadsheet_id(spreadsheet_id)
 
-			if not sheet_config:
+			if not matching_sheets:
 				logger.warning(f"Received change for unknown sheet: {spreadsheet_id}")
 				return None
 
-			logger.info(f"Processing change for {sheet_config.name}")
-			return self.sync_sheet(sheet_config, trigger="webhook")
+			last_log = None
+			for _sheet_key, sheet_config in matching_sheets.items():
+				logger.info(f"Processing change for {sheet_config.name}")
+				last_log = self.sync_sheet(sheet_config, trigger="webhook")
+			return last_log
 
 		logger.debug(f"Ignoring resource_state: {resource_state}")
 		return None
+
+	@staticmethod
+	def _build_bundle_checksum(primary_checksum: str, related_checksums: dict[str, str]) -> str:
+		"""Create a stable checksum for sync payloads that include related tabs."""
+		if not related_checksums:
+			return primary_checksum
+
+		payload = {
+			"primary": primary_checksum,
+			"related": related_checksums,
+		}
+		content = json.dumps(payload, sort_keys=True)
+		return hashlib.md5(content.encode()).hexdigest()
+
+	def _fetch_related_sheet_payload(
+		self, sheet_config: SheetConfig
+	) -> tuple[dict[str, list[dict[str, Any]]], dict[str, str]]:
+		"""Fetch related tabs for logical bundle syncs such as PR/PO/GR parent-child data."""
+		related_data: dict[str, list[dict[str, Any]]] = {}
+		related_checksums: dict[str, str] = {}
+		if not sheet_config.related_sheet_keys:
+			return related_data, related_checksums
+
+		all_sheet_configs = get_all_sheet_configs()
+		for related_key in sheet_config.related_sheet_keys:
+			related_config = all_sheet_configs.get(related_key)
+			if not related_config:
+				raise ValueError(f"Missing related sheet config: {related_key}")
+
+			range_name = f"{related_config.sheet_name}!{related_config.range}"
+			related_rows, related_checksum = self.sheets.fetch_sheet_data(
+				related_config.spreadsheet_id, range_name
+			)
+			related_data[related_key] = related_rows
+			related_checksums[related_key] = related_checksum
+
+		return related_data, related_checksums
 
 	def sync_sheet(self, sheet_config: SheetConfig, trigger: str = "manual", force: bool = False) -> SyncLog:
 		"""
@@ -145,7 +193,9 @@ class ChangeProcessor:
 		try:
 			# Fetch data from Google Sheets
 			range_name = f"{sheet_config.sheet_name}!{sheet_config.range}"
-			data, checksum = self.sheets.fetch_sheet_data(sheet_config.spreadsheet_id, range_name)
+			data, primary_checksum = self.sheets.fetch_sheet_data(sheet_config.spreadsheet_id, range_name)
+			related_data, related_checksums = self._fetch_related_sheet_payload(sheet_config)
+			checksum = self._build_bundle_checksum(primary_checksum, related_checksums)
 
 			log.rows_processed = len(data)
 			log.data_checksum = checksum
@@ -186,7 +236,12 @@ class ChangeProcessor:
 					critical_alerts.append(alert)
 
 			# Sync to Frappe
-			result = self.frappe.sync_sheet_data(sheet_config, data, checksum)
+			result = self.frappe.sync_sheet_data(
+				sheet_config,
+				data,
+				checksum,
+				related_data=related_data or None,
+			)
 
 			log.status = "success" if result.success else "failed"
 			log.rows_created = result.rows_created

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -525,7 +525,9 @@ class TestErpSync(unittest.TestCase):
 		updated_row = dict(row, contact_no="09170000000")
 
 		first = erp_sync.sync_procurement_suppliers("Procurement Suppliers", [row], "chk-proc-supplier-1")
-		second = erp_sync.sync_procurement_suppliers("Procurement Suppliers", [updated_row], "chk-proc-supplier-2")
+		second = erp_sync.sync_procurement_suppliers(
+			"Procurement Suppliers", [updated_row], "chk-proc-supplier-2"
+		)
 
 		self.assertEqual(first["rows_created"], 1)
 		self.assertEqual(second["rows_updated"], 1)

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -13,9 +13,6 @@ if str(ROOT) not in sys.path:
 
 
 def _install_fake_frappe():
-	if "frappe" in sys.modules:
-		return
-
 	frappe = types.ModuleType("frappe")
 	utils = types.ModuleType("frappe.utils")
 
@@ -67,7 +64,7 @@ def _install_fake_frappe():
 
 	utils.now_datetime = lambda: datetime.datetime(2026, 1, 1, 8, 0, 0)
 	utils.nowdate = lambda: "2026-01-01"
-	utils.flt = lambda value: float(value or 0)
+	utils.flt = lambda value, precision=None: round(float(value or 0), precision or 2)
 	utils.cint = lambda value: int(float(value or 0))
 	utils.getdate = (
 		lambda value=None: datetime.date.fromisoformat(str(value)) if value else datetime.date(2026, 1, 1)
@@ -94,11 +91,15 @@ class _FakeDoc:
 		self.remarks = ""
 		self._on_insert = on_insert
 		self.insert_calls = 0
+		self.save_calls = 0
 		self.submit_calls = 0
 
 	def append(self, table, row):
 		if table == "items":
 			self.items.append(row)
+
+	def set(self, fieldname, value):
+		setattr(self, fieldname, value)
 
 	def insert(self, ignore_permissions=False):
 		self.insert_calls += 1
@@ -110,6 +111,48 @@ class _FakeDoc:
 
 	def submit(self):
 		self.submit_calls += 1
+
+	def save(self, ignore_permissions=False):
+		self.save_calls += 1
+		return self
+
+	def db_set(self, fieldname, value, update_modified=False):
+		setattr(self, fieldname, value)
+
+
+def _build_fake_get_doc(registry, counters=None):
+	counters = counters or {}
+
+	def get_doc(arg1, arg2=None):
+		if isinstance(arg1, dict):
+			payload = dict(arg1)
+			doctype = payload.pop("doctype")
+			doc = _FakeDoc(doctype)
+			for key, value in payload.items():
+				setattr(doc, key, value)
+			if not hasattr(doc, "items"):
+				doc.items = []
+
+			def on_insert(inserted_doc):
+				counters[doctype] = counters.get(doctype, 0) + 1
+				if not inserted_doc.name:
+					for candidate_field in ("supplier_code", "pr_no", "po_no", "gr_no"):
+						candidate_value = getattr(inserted_doc, candidate_field, None)
+						if candidate_value:
+							inserted_doc.name = candidate_value
+							break
+				if not inserted_doc.name:
+					inserted_doc.name = f"{doctype}-{counters[doctype]:04d}"
+				registry.setdefault(doctype, {})[inserted_doc.name] = inserted_doc
+
+			doc._on_insert = on_insert
+			return doc
+
+		doctype = arg1
+		name = arg2
+		return registry[doctype][name]
+
+	return get_doc
 
 
 class TestErpSync(unittest.TestCase):
@@ -199,6 +242,96 @@ class TestErpSync(unittest.TestCase):
 		self.assertEqual(first["rows_created"], 2)
 		self.assertEqual(second["rows_updated"], 2)
 		self.assertEqual(len(created_docs), 1)
+
+	def test_sync_store_demand_snapshot_upserts_by_snapshot_date_warehouse_item(self):
+		created_snapshot_rows = {}
+		created_docs = []
+
+		def db_exists(doctype, name=None):
+			if doctype in ("Item", "Warehouse"):
+				return name or True
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Inventory Risk Snapshot" and isinstance(filters, dict):
+				key = (
+					filters.get("snapshot_date"),
+					filters.get("warehouse"),
+					filters.get("item_code"),
+				)
+				return created_snapshot_rows.get(key)
+			return None
+
+		def db_set_value(doctype, name, values, update_modified=False):
+			if doctype != "BEI Inventory Risk Snapshot":
+				return None
+			for key, row_name in list(created_snapshot_rows.items()):
+				if row_name == name:
+					created_snapshot_rows[key] = name
+					break
+			return None
+
+		def new_doc(doctype):
+			if doctype != "BEI Inventory Risk Snapshot":
+				return _FakeDoc(doctype)
+
+			def on_insert(doc):
+				doc.name = f"SNAP-{len(created_docs) + 1:04d}"
+				created_docs.append(doc)
+				key = (doc.snapshot_date, doc.warehouse, doc.item_code)
+				created_snapshot_rows[key] = doc.name
+
+			return _FakeDoc(doctype, on_insert=on_insert)
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.db.set_value = MagicMock(side_effect=db_set_value)
+		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		row = {
+			"snapshot_date": "2026-03-09",
+			"warehouse": "Store A - BEI",
+			"item_code": "RM-001",
+			"avg_daily_demand": 4.25,
+			"available_qty": 12,
+			"projected_sales": 0,
+			"bom_consumption": 4.25,
+			"lookback_days": 14,
+			"signal_source": "sales_bom_snapshot",
+		}
+
+		first = erp_sync.sync_store_demand_snapshot(
+			sheet_name="Demand Snapshot",
+			data=[row],
+			checksum="chk-demand-1",
+		)
+		second = erp_sync.sync_store_demand_snapshot(
+			sheet_name="Demand Snapshot",
+			data=[row],
+			checksum="chk-demand-1",
+		)
+
+		self.assertEqual(first["rows_created"], 1)
+		self.assertEqual(second["rows_updated"], 1)
+		self.assertEqual(len(created_docs), 1)
+		erp_sync.frappe.db.set_value.assert_called_once()
+
+	def test_resolve_warehouse_accepts_warehouse_name_lookup(self):
+		def db_exists(doctype, name=None):
+			if doctype == "Warehouse":
+				return name == "Store A - BEI"
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "Warehouse" and filters == {"warehouse_name": "Store A"}:
+				return "Store A - BEI"
+			return None
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+
+		assert erp_sync._resolve_warehouse("Store A") == "Store A - BEI"
 
 	def test_sync_coa_creates_then_updates_same_account(self):
 		created_accounts = {}
@@ -361,6 +494,296 @@ class TestErpSync(unittest.TestCase):
 			checksum="chk-supplier-1",
 		)
 		self.assertEqual(result, expected)
+
+	def test_sync_procurement_suppliers_creates_then_updates_by_supplier_code(self):
+		registry = {}
+		counters = {}
+
+		def db_exists(doctype, name=None):
+			if doctype == "BEI Supplier":
+				return name if name in registry.get("BEI Supplier", {}) else None
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Supplier" and isinstance(filters, dict):
+				supplier_name = filters.get("supplier_name")
+				for supplier in registry.get("BEI Supplier", {}).values():
+					if getattr(supplier, "supplier_name", None) == supplier_name:
+						return supplier.name
+			return None
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.get_doc = MagicMock(side_effect=_build_fake_get_doc(registry, counters))
+
+		row = {
+			"supplier_code": "GPDNC5",
+			"supplier_name": "GLOBAL PACIFIC DISTRIBUTION NETWORK CORP.",
+			"contact_no": "09615113774",
+			"email_id": "nice@globalpacific.com.ph",
+		}
+		updated_row = dict(row, contact_no="09170000000")
+
+		first = erp_sync.sync_procurement_suppliers("Procurement Suppliers", [row], "chk-proc-supplier-1")
+		second = erp_sync.sync_procurement_suppliers("Procurement Suppliers", [updated_row], "chk-proc-supplier-2")
+
+		self.assertEqual(first["rows_created"], 1)
+		self.assertEqual(second["rows_updated"], 1)
+		self.assertEqual(len(registry["BEI Supplier"]), 1)
+		self.assertEqual(registry["BEI Supplier"]["GPDNC5"].contact_number, "09170000000")
+
+	def test_sync_procurement_requisitions_upserts_parent_and_child_rows(self):
+		registry = {}
+		counters = {}
+
+		def db_exists(doctype, name=None):
+			if doctype == "BEI Purchase Requisition":
+				return name if name in registry.get("BEI Purchase Requisition", {}) else None
+			if doctype == "User":
+				return bool(name and "@" in str(name))
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Purchase Requisition" and isinstance(filters, dict):
+				pr_no = filters.get("pr_no")
+				for doc in registry.get("BEI Purchase Requisition", {}).values():
+					if getattr(doc, "pr_no", None) == pr_no:
+						return doc.name
+			return None
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.get_doc = MagicMock(side_effect=_build_fake_get_doc(registry, counters))
+
+		row = {
+			"pr_no": "PR202510",
+			"timestamp": "2025-09-24 12:38:30",
+			"delivery_to": "JENTEC WAREHOUSE",
+			"purpose": "warehouse stock replenishment",
+			"date_required": "2025-09-26",
+			"recurring": "Yes",
+			"requested_by": "Ian Dionisio",
+			"requested_by_email": "ian@bebang.ph",
+			"approval": "Approved",
+			"approved_by": "Aldrin",
+			"approved_by_email": "aldrin@bebang.ph",
+			"approval_timestamp": "2025-09-25 10:38:30",
+		}
+		related_data = {
+			"procurement_pr_items": [
+				{
+					"pr_no": "PR202510",
+					"item_code": "CM34",
+					"description": "SANDO ECO BAG LARGE",
+					"total_order": 5000,
+					"unit_of_issue": "PIECE",
+					"po_reference": "PO-20253",
+					"added_by": "Ian Dionisio",
+				}
+			]
+		}
+
+		with patch.object(erp_sync, "_resolve_warehouse", return_value="Stores - BEI"):
+			first = erp_sync.sync_procurement_requisitions(
+				"Procurement Requisitions",
+				[row],
+				"chk-proc-pr-1",
+				related_data=related_data,
+			)
+			second = erp_sync.sync_procurement_requisitions(
+				"Procurement Requisitions",
+				[row],
+				"chk-proc-pr-2",
+				related_data=related_data,
+			)
+
+		self.assertEqual(first["rows_created"], 1)
+		self.assertEqual(second["rows_updated"], 1)
+		stored = next(iter(registry["BEI Purchase Requisition"].values()))
+		self.assertEqual(stored.pr_no, "PR202510")
+		self.assertEqual(stored.status, "Converted to PO")
+		self.assertEqual(len(stored.items), 1)
+		self.assertEqual(stored.items[0]["item_code"], "CM34")
+
+	def test_sync_procurement_purchase_orders_creates_then_updates_status(self):
+		registry = {
+			"BEI Supplier": {},
+			"BEI Purchase Requisition": {},
+		}
+		counters = {}
+		supplier = _FakeDoc("BEI Supplier")
+		supplier.name = "1T1MI3"
+		supplier.supplier_name = "1 To 1 Marketing, Inc."
+		registry["BEI Supplier"][supplier.name] = supplier
+		pr_doc = _FakeDoc("BEI Purchase Requisition")
+		pr_doc.name = "BEI Purchase Requisition-0001"
+		pr_doc.pr_no = "PR202513"
+		registry["BEI Purchase Requisition"][pr_doc.name] = pr_doc
+
+		def db_exists(doctype, name=None):
+			if doctype in registry:
+				return name if name in registry.get(doctype, {}) else None
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Purchase Order" and isinstance(filters, dict):
+				po_no = filters.get("po_no")
+				for doc in registry.get("BEI Purchase Order", {}).values():
+					if getattr(doc, "po_no", None) == po_no:
+						return doc.name
+			if doctype == "BEI Purchase Requisition" and isinstance(filters, dict):
+				pr_no = filters.get("pr_no")
+				for doc in registry.get("BEI Purchase Requisition", {}).values():
+					if getattr(doc, "pr_no", None) == pr_no:
+						return doc.name
+			if doctype == "BEI Supplier" and isinstance(filters, dict):
+				supplier_name = filters.get("supplier_name")
+				for doc in registry.get("BEI Supplier", {}).values():
+					if getattr(doc, "supplier_name", None) == supplier_name:
+						return doc.name
+			return None
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.get_doc = MagicMock(side_effect=_build_fake_get_doc(registry, counters))
+
+		row = {
+			"po_no": "PO-20252",
+			"po_date": "2025-09-26",
+			"pr_no": "PR202513",
+			"supplier_code": "1T1MI3",
+			"supplier_name": "1 To 1 Marketing, Inc.",
+			"delivery_date": "2025-09-26",
+			"terms_of_payment": "30 days",
+			"approval": "Approved",
+		}
+		related_data = {
+			"procurement_po_items": [
+				{
+					"po_no": "PO-20252",
+					"item_code": "A016",
+					"item_name": "ALASKA EVAP 1L",
+					"qty": 50,
+					"uom": "BOX",
+					"unit_cost": 926.02,
+					"vat": 111.12,
+				}
+			]
+		}
+
+		with (
+			patch.object(erp_sync, "_resolve_warehouse", return_value="Stores - BEI"),
+			patch.object(erp_sync, "_resolve_payment_terms_template", return_value=None),
+		):
+			first = erp_sync.sync_procurement_purchase_orders(
+				"Procurement Purchase Orders",
+				[row],
+				"chk-proc-po-1",
+				related_data=related_data,
+			)
+			second = erp_sync.sync_procurement_purchase_orders(
+				"Procurement Purchase Orders",
+				[dict(row, send_po_to_supplier_timestamp="2025-09-26 17:50:45", sent_by="Aldrin")],
+				"chk-proc-po-2",
+				related_data=related_data,
+			)
+
+		self.assertEqual(first["rows_created"], 1)
+		self.assertEqual(second["rows_updated"], 1)
+		stored = next(iter(registry["BEI Purchase Order"].values()))
+		self.assertEqual(stored.po_no, "PO-20252")
+		self.assertEqual(stored.status, "Sent to Supplier")
+		self.assertEqual(len(stored.items), 1)
+		self.assertEqual(stored.items[0]["item_code"], "A016")
+
+	def test_sync_procurement_goods_receipts_updates_po_received_quantities(self):
+		registry = {
+			"BEI Purchase Order": {},
+			"BEI Goods Receipt": {},
+		}
+		counters = {}
+
+		po_doc = _FakeDoc("BEI Purchase Order")
+		po_doc.name = "BEI Purchase Order-0001"
+		po_doc.po_no = "PO-20253"
+		po_doc.status = "Sent to Supplier"
+		po_doc.items = [
+			types.SimpleNamespace(
+				name="POITEM-0001",
+				item_code="CM34",
+				qty=5000,
+				unit_cost=4.55,
+				received_qty=0,
+			)
+		]
+		registry["BEI Purchase Order"][po_doc.name] = po_doc
+
+		def db_exists(doctype, name=None):
+			if doctype in registry:
+				return name if name in registry.get(doctype, {}) else None
+			if doctype == "Item":
+				return name == "CM34"
+			if doctype == "UOM":
+				return bool(name)
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Purchase Order" and isinstance(filters, dict):
+				po_no = filters.get("po_no")
+				for doc in registry.get("BEI Purchase Order", {}).values():
+					if getattr(doc, "po_no", None) == po_no:
+						return doc.name
+			if doctype == "BEI Goods Receipt" and isinstance(filters, dict):
+				gr_no = filters.get("gr_no")
+				for doc in registry.get("BEI Goods Receipt", {}).values():
+					if getattr(doc, "gr_no", None) == gr_no:
+						return doc.name
+			return None
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.db.set_value = MagicMock()
+		erp_sync.frappe.get_doc = MagicMock(side_effect=_build_fake_get_doc(registry, counters))
+
+		row = {
+			"gr_no": "GR202561",
+			"po_no": "PO-20253",
+			"date": "2025-10-20",
+			"issue_to": "JENTEC",
+			"invoice_no": "122952",
+			"invoice": "Supplier Invoices/GR202561.Invoice.044645.jpg",
+			"approved_by": "Ian Dionisio",
+		}
+		related_data = {
+			"procurement_gr_items": [
+				{
+					"gr_no": "GR202561",
+					"po_no": "PO-20253",
+					"item_code": "CM34",
+					"item_name": "SANDO ECO BAG LARGE",
+					"uom": "PIECE",
+					"issued_qty": 5000,
+				}
+			]
+		}
+
+		with (
+			patch.object(erp_sync, "_resolve_warehouse", return_value="Stores - BEI"),
+			patch.object(erp_sync, "_resolve_uom", return_value="PIECE"),
+		):
+			result = erp_sync.sync_procurement_goods_receipts(
+				"Procurement Goods Receipts",
+				[row],
+				"chk-proc-gr-1",
+				related_data=related_data,
+			)
+
+		self.assertEqual(result["rows_created"], 1)
+		stored_gr = next(iter(registry["BEI Goods Receipt"].values()))
+		self.assertEqual(stored_gr.gr_no, "GR202561")
+		self.assertEqual(stored_gr.status, "Accepted")
+		self.assertEqual(po_doc.items[0].received_qty, 5000)
+		self.assertEqual(po_doc.status, "Fully Received")
 
 	def test_sync_authorization_blocks_guest(self):
 		erp_sync.frappe.session.user = "Guest"

--- a/hrms/tests/test_sheets_receiver_processor.py
+++ b/hrms/tests/test_sheets_receiver_processor.py
@@ -30,7 +30,9 @@ def _install_fake_sheets_receiver_dependencies():
 	config_mod = types.ModuleType("hrms.services.sheets_receiver.config")
 	config_mod.SheetConfig = types.SimpleNamespace
 	config_mod.get_config = lambda: types.SimpleNamespace()
+	config_mod.get_all_sheet_configs = lambda: {}
 	config_mod.get_sheet_by_spreadsheet_id = lambda *_args, **_kwargs: None
+	config_mod.get_sheets_by_spreadsheet_id = lambda *_args, **_kwargs: {}
 	config_mod.get_watched_sheets = lambda: {}
 	sys.modules["hrms.services.sheets_receiver.config"] = config_mod
 
@@ -110,6 +112,7 @@ class TestSheetsReceiverProcessorCriticalAlerts(unittest.TestCase):
 			sheet_name="AR",
 			range="A:Z",
 			key_column="invoice_no",
+			related_sheet_keys=[],
 		)
 
 	def _make_processor(self):
@@ -207,6 +210,54 @@ class TestSheetsReceiverProcessorCriticalAlerts(unittest.TestCase):
 		self.assertEqual(call.kwargs["reasons"], ["sync_exception"])
 		self.assertIn("receiver timeout", call.kwargs["errors"][0])
 		processor.db.log_sync.assert_called_once()
+
+	def test_process_webhook_syncs_all_matching_sheet_configs_for_workbook(self):
+		processor = self._make_processor()
+		sheet_a = self._make_sheet_config()
+		sheet_b = types.SimpleNamespace(**{**sheet_a.__dict__, "name": "Supplier SOA", "sheet_name": "SUPPLIERS SOA"})
+		processor.sync_sheet = MagicMock(side_effect=["log-a", "log-b"])
+
+		processor_mod.get_sheets_by_spreadsheet_id = MagicMock(
+			return_value={"ap_opening_balance": sheet_a, "supplier_soa": sheet_b}
+		)
+
+		result = processor.process_webhook("sheet-001", "change")
+
+		self.assertEqual(result, "log-b")
+		self.assertEqual(processor.sync_sheet.call_count, 2)
+
+	def test_sync_sheet_fetches_related_tabs_and_passes_bundle_payload(self):
+		processor = self._make_processor()
+		sheet_config = types.SimpleNamespace(
+			name="Procurement Requisitions",
+			spreadsheet_id="sheet-002",
+			sheet_name="Purchase Requisitions",
+			range="A:Z",
+			key_column="pr_no",
+			related_sheet_keys=["procurement_pr_items"],
+		)
+		related_config = types.SimpleNamespace(
+			name="Procurement PR Items",
+			spreadsheet_id="sheet-002",
+			sheet_name="PR Items",
+			range="A:Z",
+		)
+		processor.sheets.fetch_sheet_data = MagicMock(
+			side_effect=[
+				([{"pr_no": "PR202510"}], "chk-parent"),
+				([{"pr_no": "PR202510", "item_code": "CM34"}], "chk-child"),
+			]
+		)
+
+		processor_mod.get_all_sheet_configs = MagicMock(return_value={"procurement_pr_items": related_config})
+
+		log = processor.sync_sheet(sheet_config, trigger="manual")
+
+		self.assertEqual(log.status, "success")
+		self.assertNotEqual(log.data_checksum, "chk-parent")
+		call = processor.frappe.sync_sheet_data.call_args
+		self.assertEqual(call.args[0], sheet_config)
+		self.assertEqual(call.kwargs["related_data"], {"procurement_pr_items": [{"pr_no": "PR202510", "item_code": "CM34"}]})
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_sheets_receiver_processor.py
+++ b/hrms/tests/test_sheets_receiver_processor.py
@@ -214,7 +214,9 @@ class TestSheetsReceiverProcessorCriticalAlerts(unittest.TestCase):
 	def test_process_webhook_syncs_all_matching_sheet_configs_for_workbook(self):
 		processor = self._make_processor()
 		sheet_a = self._make_sheet_config()
-		sheet_b = types.SimpleNamespace(**{**sheet_a.__dict__, "name": "Supplier SOA", "sheet_name": "SUPPLIERS SOA"})
+		sheet_b = types.SimpleNamespace(
+			**{**sheet_a.__dict__, "name": "Supplier SOA", "sheet_name": "SUPPLIERS SOA"}
+		)
 		processor.sync_sheet = MagicMock(side_effect=["log-a", "log-b"])
 
 		processor_mod.get_sheets_by_spreadsheet_id = MagicMock(
@@ -257,7 +259,10 @@ class TestSheetsReceiverProcessorCriticalAlerts(unittest.TestCase):
 		self.assertNotEqual(log.data_checksum, "chk-parent")
 		call = processor.frappe.sync_sheet_data.call_args
 		self.assertEqual(call.args[0], sheet_config)
-		self.assertEqual(call.kwargs["related_data"], {"procurement_pr_items": [{"pr_no": "PR202510", "item_code": "CM34"}]})
+		self.assertEqual(
+			call.kwargs["related_data"],
+			{"procurement_pr_items": [{"pr_no": "PR202510", "item_code": "CM34"}]},
+		)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add procurement workbook configs to Sheets Receiver
- bundle child tabs into parent procurement sync payloads
- add Frappe procurement sync endpoints and tests
- no-docs: internal integration change, no external docs required

## Verification
- python -m py_compile hrms/services/sheets_receiver/config.py hrms/services/sheets_receiver/frappe_client.py hrms/services/sheets_receiver/processor.py hrms/api/erp_sync.py hrms/tests/test_erp_sync.py hrms/tests/test_sheets_receiver_processor.py
- python hrms/tests/test_sheets_receiver_processor.py
- python hrms/tests/test_erp_sync.py
- python hrms/tests/test_erp_sync_runtime.py