### PR TITLE
fix: allow store staff to complete receiving

### DIFF
--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -2092,7 +2092,7 @@ def complete_receiving(
 			has_issues = True
 
 	receiving.status = "With Issues" if has_issues else "Completed"
-	receiving.insert()
+	receiving.insert(ignore_permissions=True)
 
 	return {"success": True, "receiving": receiving.name, "message": f"Receiving {receiving.name} completed"}
 


### PR DESCRIPTION
## Summary
- allow `complete_receiving` to insert `BEI Store Receiving` with `ignore_permissions=True`
- unblock live store-staff receiving completion from my.bebang.ph

## Verification
- `python -m py_compile hrms/api/store.py`
- reran portal FQI lane and confirmed both failures are the same live backend 403 permission error this change addresses