### PR TITLE
fix: stabilize live AP and procurement sheet sync

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -7,6 +7,7 @@ and sync it to ERPNext DocTypes.
 
 import hashlib
 import json
+from types import SimpleNamespace
 from typing import Any
 
 import frappe
@@ -1043,9 +1044,16 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 		savepoint: str | None = None
 		try:
 			supplier_input = _first_non_empty(row, "supplier", "supplier_name")
-			invoice_no = _first_non_empty(row, "invoice_no", "reference", "bill_no")
-			amount = flt(_first_non_empty(row, "amount", "balance", "outstanding") or 0)
-			company = _normalize_company(_first_non_empty(row, "company"))
+			invoice_no = _first_non_empty(row, "invoice_no", "invoice_no.", "reference", "bill_no")
+			if not supplier_input or not invoice_no:
+				results["rows_failed"] += 1
+				results["errors"].append("Missing supplier or invoice_no in AP opening row")
+				continue
+
+			amount = _safe_float(
+				_first_non_empty(row, "outstanding_balance", "balance", "outstanding", "amount")
+			)
+			company = _normalize_company(_first_non_empty(row, "company", "billed_to"))
 			dedupe_key = f"{company}|{supplier_input}|{invoice_no}"
 			if supplier_input and invoice_no and dedupe_key in seen_supplier_invoice_keys:
 				results["rows_updated"] += 1
@@ -1053,19 +1061,18 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 			if supplier_input and invoice_no:
 				seen_supplier_invoice_keys.add(dedupe_key)
 
+			if amount <= 0:
+				results["rows_updated"] += 1
+				continue
+
 			savepoint = _make_savepoint("sync_ap", f"{sheet_name}|{checksum}|{dedupe_key}")
 			frappe.db.savepoint(savepoint)
 
 			posting_date = (
-				_safe_date(_first_non_empty(row, "posting_date", "invoice_date", "date")) or nowdate()
+				_safe_date(_first_non_empty(row, "posting_date", "invoice_date", "date", "date_entry"))
+				or nowdate()
 			)
 			due_date = _safe_date(_first_non_empty(row, "due_date")) or posting_date
-
-			if not supplier_input or not invoice_no:
-				results["rows_failed"] += 1
-				results["errors"].append("Missing supplier or invoice_no in AP opening row")
-				_release_savepoint(savepoint)
-				continue
 
 			supplier = _ensure_supplier(str(supplier_input))
 			existing = frappe.db.get_value(
@@ -1200,6 +1207,38 @@ def _normalize_sheet_text(value: Any) -> str | None:
 	if not text or text.lower() in _PROCUREMENT_NULL_TOKENS:
 		return None
 	return text
+
+
+def _truncate_text(value: Any, max_length: int = 140) -> str | None:
+	text = _normalize_sheet_text(value)
+	if text is None or len(text) <= max_length:
+		return text
+	if max_length <= 3:
+		return text[:max_length]
+	return f"{text[: max_length - 3].rstrip()}..."
+
+
+def _normalize_file_url(value: Any) -> str | None:
+	text = _normalize_sheet_text(value)
+	if text is None:
+		return None
+
+	normalized = text.replace("\\", "/").strip()
+	if normalized.startswith(("/files/", "/private/files/")) or "://" in normalized:
+		return normalized
+
+	filename = normalized.rsplit("/", 1)[-1].strip()
+	if not filename:
+		return None
+	return f"/files/{filename}"
+
+
+def _ensure_doc_flags(doc: Any) -> Any:
+	flags = getattr(doc, "flags", None)
+	if flags is None:
+		flags = SimpleNamespace()
+		doc.flags = flags
+	return flags
 
 
 def _safe_float(value: Any) -> float:
@@ -1483,7 +1522,7 @@ def sync_procurement_requisitions(
 				"description": description,
 				"qty": qty,
 				"uom": _normalize_sheet_text(_first_non_empty(item_row, "unit_of_issue", "uom")) or "Pcs",
-				"po_reference": _normalize_sheet_text(_first_non_empty(item_row, "po_reference")),
+				"po_reference": _truncate_text(_first_non_empty(item_row, "po_reference")),
 				"added_by": _normalize_sheet_text(_first_non_empty(item_row, "added_by")),
 			}
 		)
@@ -1756,7 +1795,8 @@ def sync_procurement_goods_receipts(
 			doc.delivery_note_no = _normalize_sheet_text(_first_non_empty(row, "invoice_no")) or gr_no
 			doc.warehouse = _resolve_warehouse(_first_non_empty(row, "issue_to"))
 			if _doctype_has_field("BEI Goods Receipt", "supplier_invoice_photo"):
-				doc.supplier_invoice_photo = _normalize_sheet_text(_first_non_empty(row, "invoice"))
+				doc.supplier_invoice_photo = _normalize_file_url(_first_non_empty(row, "invoice"))
+			_ensure_doc_flags(doc).ignore_mandatory = True
 			doc.inspection_required = 0
 			doc.status = _build_gr_status(row)
 			_replace_child_rows(doc, "items", items)

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -89,6 +89,7 @@ class _FakeDoc:
 		self.name = None
 		self.items = []
 		self.remarks = ""
+		self.flags = types.SimpleNamespace()
 		self._on_insert = on_insert
 		self.insert_calls = 0
 		self.save_calls = 0
@@ -163,6 +164,7 @@ class TestErpSync(unittest.TestCase):
 		erp_sync.frappe.db.savepoint = MagicMock(return_value=None)
 		erp_sync.frappe.db.release_savepoint = MagicMock()
 		erp_sync.frappe.db.rollback = MagicMock()
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda *_: True))
 
 	def test_sync_ar_aging_writes_sales_invoice_fields(self):
 		erp_sync.frappe.db.exists = MagicMock(return_value="SINV-0001")
@@ -495,6 +497,69 @@ class TestErpSync(unittest.TestCase):
 		)
 		self.assertEqual(result, expected)
 
+	def test_sync_ap_opening_supports_supplier_soa_headers_and_skips_zero_balance_rows(self):
+		created_docs = []
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "Purchase Invoice" and isinstance(filters, dict):
+				return None
+			return None
+
+		def new_doc(doctype):
+			if doctype != "Purchase Invoice":
+				return _FakeDoc(doctype)
+
+			def on_insert(doc):
+				doc.name = f"PI-{len(created_docs) + 1:04d}"
+				created_docs.append(doc)
+
+			return _FakeDoc(doctype, on_insert=on_insert)
+
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.db.set_value = MagicMock()
+		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
+		erp_sync.frappe.log_error = MagicMock()
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		rows = [
+			{
+				"supplier_name": "1 TO 1 MARKETING INC.",
+				"invoice_no.": "INV-ZERO",
+				"amount": 1200,
+				"outstanding_balance": 0,
+				"invoice_date": "2026-01-05",
+				"due_date": "2026-01-20",
+				"billed_to": "BEBANG SHAW INC",
+			},
+			{
+				"supplier_name": "1 TO 1 MARKETING INC.",
+				"invoice_no.": "INV-OPEN",
+				"amount": 1200,
+				"outstanding_balance": 40,
+				"invoice_date": "2026-01-05",
+				"due_date": "2026-01-20",
+				"billed_to": "BEBANG SHAW INC",
+			},
+		]
+
+		with (
+			patch.object(erp_sync, "_ensure_ap_opening_item", return_value="ERP-SYNC-AP-OPENING"),
+			patch.object(erp_sync, "_normalize_company", return_value="BEI"),
+			patch.object(erp_sync, "_ensure_supplier", return_value="SUP-0001"),
+			patch.object(erp_sync, "_default_expense_account", return_value="Expense - BEI"),
+			patch.object(erp_sync, "_default_payable_account", return_value="Payable - BEI"),
+			patch.object(erp_sync, "_default_cost_center", return_value="Main - BEI"),
+			patch.object(erp_sync, "_doctype_has_field", return_value=True),
+		):
+			result = erp_sync.sync_ap_opening("Supplier SOA", rows, "chk-ap-soa-1")
+
+		self.assertEqual(result["rows_created"], 1)
+		self.assertEqual(result["rows_updated"], 1)
+		self.assertEqual(result["rows_failed"], 0)
+		self.assertEqual(len(created_docs), 1)
+		self.assertEqual(created_docs[0].bill_no, "INV-OPEN")
+		self.assertEqual(created_docs[0].items[0]["rate"], 40)
+
 	def test_sync_procurement_suppliers_creates_then_updates_by_supplier_code(self):
 		registry = {}
 		counters = {}
@@ -671,6 +736,71 @@ class TestErpSync(unittest.TestCase):
 		stored = next(iter(registry["BEI Purchase Requisition"].values()))
 		self.assertEqual(stored.status, "Converted to PO")
 		self.assertNotIn("po_reference", stored.items[0])
+
+	def test_sync_procurement_requisitions_truncates_long_po_reference(self):
+		registry = {}
+		counters = {}
+
+		def db_exists(doctype, name=None):
+			if doctype == "BEI Purchase Requisition":
+				return name if name in registry.get("BEI Purchase Requisition", {}) else None
+			if doctype == "User":
+				return bool(name and "@" in str(name))
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Purchase Requisition" and isinstance(filters, dict):
+				pr_no = filters.get("pr_no")
+				for doc in registry.get("BEI Purchase Requisition", {}).values():
+					if getattr(doc, "pr_no", None) == pr_no:
+						return doc.name
+			return None
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.get_doc = MagicMock(side_effect=_build_fake_get_doc(registry, counters))
+
+		long_po_reference = (
+			"DEC 16 - 3MD / 50K CUP AND LID, DEC 17 - JENTEC / 50K CUP AND LID "
+			"DEC 18 - 3MD / 50K CUP AND LID, DEC 19 - JENTEC / 50K CUP AND LID "
+			"DEC 20 - 3MD / 50K CUP AND LID DEC 22 - 3MD / 50K CUP AND LID"
+		)
+		row = {
+			"pr_no": "PR2025249_12e1548d",
+			"timestamp": "2025-12-14 07:28:55",
+			"delivery_to": "JENTEC WAREHOUSE",
+			"purpose": "Legacy import",
+			"date_required": "2025-12-16",
+			"requested_by": "Ian Dionisio",
+			"requested_by_email": "ian@bebang.ph",
+		}
+		related_data = {
+			"procurement_pr_items": [
+				{
+					"pr_no": "PR2025249_12e1548d",
+					"item_code": "PM001",
+					"description": "16OZ CUP WITH LOGO",
+					"total_order": 600000,
+					"unit_of_issue": "PIECE",
+					"po_reference": long_po_reference,
+					"added_by": "Ian Dionisio",
+				}
+			]
+		}
+
+		with patch.object(erp_sync, "_resolve_warehouse", return_value="Stores - BEI"):
+			result = erp_sync.sync_procurement_requisitions(
+				"Procurement Requisitions",
+				[row],
+				"chk-proc-pr-truncate-1",
+				related_data=related_data,
+			)
+
+		self.assertEqual(result["rows_created"], 1)
+		self.assertEqual(result["rows_failed"], 0)
+		stored = next(iter(registry["BEI Purchase Requisition"].values()))
+		self.assertLessEqual(len(stored.items[0]["po_reference"]), 140)
+		self.assertTrue(stored.items[0]["po_reference"].endswith("..."))
 
 	def test_sync_procurement_purchase_orders_creates_then_updates_status(self):
 		registry = {
@@ -851,6 +981,8 @@ class TestErpSync(unittest.TestCase):
 		self.assertEqual(stored_gr.status, "Accepted")
 		self.assertEqual(po_doc.items[0].received_qty, 5000)
 		self.assertEqual(po_doc.status, "Fully Received")
+		self.assertEqual(stored_gr.supplier_invoice_photo, "/files/GR202561.Invoice.044645.jpg")
+		self.assertTrue(stored_gr.flags.ignore_mandatory)
 
 	def test_sync_procurement_goods_receipts_skips_supplier_invoice_photo_when_field_missing(self):
 		registry = {


### PR DESCRIPTION
## Summary
- support raw Supplier SOA sheet headers and skip zero-outstanding AP rows
- truncate oversized legacy PR item PO references before writing to BEI PR Item
- normalize legacy GR invoice file paths and set sync flags for legacy mandatory handling
- add regression tests for the live AP, PR, and GR failure shapes

## Verification
- python -m py_compile hrms/api/erp_sync.py hrms/tests/test_erp_sync.py hrms/tests/test_erp_sync_runtime.py
- python hrms/tests/test_erp_sync.py
- python hrms/tests/test_erp_sync_runtime.py
- python hrms/tests/test_sheets_receiver_processor.py
- python hrms/tests/test_sheets_receiver_config.py
- python hrms/tests/test_sheets_receiver_notifications.py
- pre-commit run --files hrms/api/erp_sync.py hrms/tests/test_erp_sync.py