### PR TITLE
fix: normalize receiving warehouse input

### DIFF
--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -2061,8 +2061,10 @@ def complete_receiving(
 	if isinstance(items, str):
 		items = json.loads(items)
 
+	warehouse = resolve_warehouse(store)
+
 	receiving = frappe.new_doc("BEI Store Receiving")
-	receiving.store = store
+	receiving.store = warehouse
 	receiving.trip = trip
 	receiving.receiving_date = now_datetime()
 	receiving.receiver_1 = frappe.session.user


### PR DESCRIPTION
## Summary
- normalize `complete_receiving` store input through `resolve_warehouse`
- align receiving completion with the rest of `hrms.api.store` endpoints that accept short store/branch names from the portal
- unblock live receiving creation after the permission fix exposed the warehouse-link mismatch

## Verification
- `python -m py_compile hrms/api/store.py`
- reran portal FQI lane after the permission deploy and confirmed the remaining failure is `LinkValidationError: Could not find Store: Araneta Gateway`