### PR TITLE
fix: harden receiver AP sync and build context

### DIFF
--- a/hrms/services/sheets_receiver/.dockerignore
+++ b/hrms/services/sheets_receiver/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+deploy/credentials/
+deploy/data/
+deploy/logs/

--- a/hrms/services/sheets_receiver/config.py
+++ b/hrms/services/sheets_receiver/config.py
@@ -82,6 +82,9 @@ class ServiceConfig:
 	sync_retry_attempts: int = 3
 	sync_retry_delay_seconds: int = 5
 	batch_size: int = 100  # Rows per API call
+	frappe_request_timeout_seconds: int = field(
+		default_factory=lambda: int(os.environ.get("FRAPPE_REQUEST_TIMEOUT_SECONDS", "180"))
+	)
 
 	# Logging
 	log_level: str = field(default_factory=lambda: os.environ.get("LOG_LEVEL", "INFO"))
@@ -142,11 +145,11 @@ WATCHED_SHEETS: dict[str, SheetConfig] = {
 		name="AP Opening Balance",
 		spreadsheet_id="1ZHe2VoAFa94ET4I68C1jWM7nMzTdTCvttwZbICaLtB4",
 		sheet_name="SUPPLIERS SOA",
-		range="A:Z",
+		range="A2:Z",
 		owner_email="alyssa@bebang.ph",
 		sync_endpoint="/api/method/hrms.api.erp_sync.sync_ap_opening",
 		doctype="Purchase Invoice",
-		key_column="invoice_no",
+		key_column="invoice_no.",
 		sync_mode="upsert",
 		enabled=True,
 	),
@@ -154,11 +157,11 @@ WATCHED_SHEETS: dict[str, SheetConfig] = {
 		name="Supplier SOA",
 		spreadsheet_id="1ZHe2VoAFa94ET4I68C1jWM7nMzTdTCvttwZbICaLtB4",
 		sheet_name="SUPPLIERS SOA",
-		range="A:Z",
+		range="A2:Z",
 		owner_email="alyssa@bebang.ph",
 		sync_endpoint="/api/method/hrms.api.erp_sync.sync_supplier_soa",
 		doctype="Supplier",
-		key_column="supplier_name",
+		key_column="invoice_no.",
 		sync_mode="upsert",
 		enabled=True,
 	),

--- a/hrms/services/sheets_receiver/frappe_client.py
+++ b/hrms/services/sheets_receiver/frappe_client.py
@@ -42,6 +42,7 @@ class FrappeClient:
 		self.base_url = config.frappe_url.rstrip("/")
 		self.api_key = config.frappe_api_key
 		self.api_secret = config.frappe_api_secret
+		self.request_timeout = config.frappe_request_timeout_seconds
 
 		# Set up session with retry logic
 		self.session = requests.Session()
@@ -68,7 +69,13 @@ class FrappeClient:
 		url = f"{self.base_url}{endpoint}"
 
 		try:
-			response = self.session.request(method=method, url=url, json=data, params=params, timeout=30)
+			response = self.session.request(
+				method=method,
+				url=url,
+				json=data,
+				params=params,
+				timeout=self.request_timeout,
+			)
 			response.raise_for_status()
 			return response.json()
 

--- a/hrms/tests/test_sheets_receiver_config.py
+++ b/hrms/tests/test_sheets_receiver_config.py
@@ -25,6 +25,10 @@ class TestSheetsReceiverConfig(unittest.TestCase):
 		self.assertIsNotNone(supplier_soa_config)
 		self.assertEqual(ap_config.sheet_name, "SUPPLIERS SOA")
 		self.assertEqual(ap_config.sheet_name, supplier_soa_config.sheet_name)
+		self.assertEqual(ap_config.range, "A2:Z")
+		self.assertEqual(supplier_soa_config.range, "A2:Z")
+		self.assertEqual(ap_config.key_column, "invoice_no.")
+		self.assertEqual(supplier_soa_config.key_column, "invoice_no.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- start Supplier SOA sync from row 2 so the real header row is used
- use invoice_no. as the AP/SOA change-tracking key to match the live sheet payload
- make receiver Frappe request timeout configurable and default it higher for large procurement syncs
- add a receiver .dockerignore so deploy credentials/data do not poison Docker build context

## Verification
- python -m py_compile hrms/services/sheets_receiver/config.py hrms/services/sheets_receiver/frappe_client.py hrms/tests/test_sheets_receiver_config.py hrms/tests/test_sheets_receiver_processor.py hrms/tests/test_sheets_receiver_notifications.py
- python hrms/tests/test_sheets_receiver_config.py
- python hrms/tests/test_sheets_receiver_processor.py
- python hrms/tests/test_sheets_receiver_notifications.py
- pre-commit run --files hrms/services/sheets_receiver/config.py hrms/services/sheets_receiver/frappe_client.py hrms/tests/test_sheets_receiver_config.py hrms/services/sheets_receiver/.dockerignore