### PR TITLE
fix: disable duplicate supplier SOA watch

### DIFF
--- a/hrms/services/sheets_receiver/config.py
+++ b/hrms/services/sheets_receiver/config.py
@@ -163,7 +163,7 @@ WATCHED_SHEETS: dict[str, SheetConfig] = {
 		doctype="Supplier",
 		key_column="invoice_no.",
 		sync_mode="upsert",
-		enabled=True,
+		enabled=False,
 	),
 	"procurement_suppliers": SheetConfig(
 		name="Procurement Suppliers",

--- a/hrms/tests/test_sheets_receiver_config.py
+++ b/hrms/tests/test_sheets_receiver_config.py
@@ -29,6 +29,8 @@ class TestSheetsReceiverConfig(unittest.TestCase):
 		self.assertEqual(supplier_soa_config.range, "A2:Z")
 		self.assertEqual(ap_config.key_column, "invoice_no.")
 		self.assertEqual(supplier_soa_config.key_column, "invoice_no.")
+		self.assertTrue(ap_config.enabled)
+		self.assertFalse(supplier_soa_config.enabled)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep Supplier SOA as a callable alias but disable it from automated watching
- avoid duplicate snapshot writes for the same SUPPLIERS SOA tab during receiver startup and scheduled syncs

## Verification
- python -m py_compile hrms/services/sheets_receiver/config.py hrms/tests/test_sheets_receiver_config.py
- python hrms/tests/test_sheets_receiver_config.py
- pre-commit run --files hrms/services/sheets_receiver/config.py hrms/tests/test_sheets_receiver_config.py