### PR TITLE
fix: tolerate duplicate AP row keys in receiver snapshots

### DIFF
--- a/hrms/services/sheets_receiver/change_tracker.py
+++ b/hrms/services/sheets_receiver/change_tracker.py
@@ -10,93 +10,95 @@ Detects and logs:
 Designed to catch when team members edit existing records instead of creating new ones.
 """
 
+import hashlib
 import json
 import logging
-import hashlib
+from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Dict, Any, Optional, Tuple
-from dataclasses import dataclass, asdict
 from enum import Enum
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
 class ChangeType(Enum):
-    ADDED = "added"
-    MODIFIED = "modified"
-    DELETED = "deleted"
-    UNCHANGED = "unchanged"
+	ADDED = "added"
+	MODIFIED = "modified"
+	DELETED = "deleted"
+	UNCHANGED = "unchanged"
 
 
 @dataclass
 class RowChange:
-    """Represents a change to a single row."""
-    change_type: ChangeType
-    row_key: str  # Unique identifier for the row
-    row_number: int  # Excel row number (for reference)
-    old_values: Optional[Dict[str, Any]] = None
-    new_values: Optional[Dict[str, Any]] = None
-    changed_fields: Optional[List[str]] = None  # Which columns changed
+	"""Represents a change to a single row."""
 
-    def to_dict(self) -> Dict:
-        return {
-            'change_type': self.change_type.value,
-            'row_key': self.row_key,
-            'row_number': self.row_number,
-            'old_values': self.old_values,
-            'new_values': self.new_values,
-            'changed_fields': self.changed_fields
-        }
+	change_type: ChangeType
+	row_key: str  # Unique identifier for the row
+	row_number: int  # Excel row number (for reference)
+	old_values: dict[str, Any] | None = None
+	new_values: dict[str, Any] | None = None
+	changed_fields: list[str] | None = None  # Which columns changed
+
+	def to_dict(self) -> dict:
+		return {
+			"change_type": self.change_type.value,
+			"row_key": self.row_key,
+			"row_number": self.row_number,
+			"old_values": self.old_values,
+			"new_values": self.new_values,
+			"changed_fields": self.changed_fields,
+		}
 
 
 @dataclass
 class ChangeReport:
-    """Summary of all changes in a sync."""
-    spreadsheet_id: str
-    spreadsheet_name: str
-    sheet_name: str
-    timestamp: datetime
-    total_rows_before: int
-    total_rows_after: int
-    rows_added: int
-    rows_modified: int
-    rows_deleted: int
-    rows_unchanged: int
-    changes: List[RowChange]
-    alerts: List[str]  # Suspicious patterns detected
+	"""Summary of all changes in a sync."""
 
-    def to_dict(self) -> Dict:
-        return {
-            'spreadsheet_id': self.spreadsheet_id,
-            'spreadsheet_name': self.spreadsheet_name,
-            'sheet_name': self.sheet_name,
-            'timestamp': self.timestamp.isoformat(),
-            'total_rows_before': self.total_rows_before,
-            'total_rows_after': self.total_rows_after,
-            'rows_added': self.rows_added,
-            'rows_modified': self.rows_modified,
-            'rows_deleted': self.rows_deleted,
-            'rows_unchanged': self.rows_unchanged,
-            'changes': [c.to_dict() for c in self.changes],
-            'alerts': self.alerts
-        }
+	spreadsheet_id: str
+	spreadsheet_name: str
+	sheet_name: str
+	timestamp: datetime
+	total_rows_before: int
+	total_rows_after: int
+	rows_added: int
+	rows_modified: int
+	rows_deleted: int
+	rows_unchanged: int
+	changes: list[RowChange]
+	alerts: list[str]  # Suspicious patterns detected
+
+	def to_dict(self) -> dict:
+		return {
+			"spreadsheet_id": self.spreadsheet_id,
+			"spreadsheet_name": self.spreadsheet_name,
+			"sheet_name": self.sheet_name,
+			"timestamp": self.timestamp.isoformat(),
+			"total_rows_before": self.total_rows_before,
+			"total_rows_after": self.total_rows_after,
+			"rows_added": self.rows_added,
+			"rows_modified": self.rows_modified,
+			"rows_deleted": self.rows_deleted,
+			"rows_unchanged": self.rows_unchanged,
+			"changes": [c.to_dict() for c in self.changes],
+			"alerts": self.alerts,
+		}
 
 
 class ChangeTracker:
-    """
-    Tracks row-level changes between sync operations.
+	"""
+	Tracks row-level changes between sync operations.
 
-    Stores previous data snapshots and computes diffs.
-    """
+	Stores previous data snapshots and computes diffs.
+	"""
 
-    def __init__(self, db):
-        self.db = db
-        self._init_tables()
+	def __init__(self, db):
+		self.db = db
+		self._init_tables()
 
-    def _init_tables(self):
-        """Create change tracking tables."""
-        with self.db._connection() as conn:
-            conn.executescript("""
+	def _init_tables(self):
+		"""Create change tracking tables."""
+		with self.db._connection() as conn:
+			conn.executescript("""
                 -- Store previous data snapshots
                 CREATE TABLE IF NOT EXISTS data_snapshots (
                     spreadsheet_id TEXT NOT NULL,
@@ -144,346 +146,377 @@ class ChangeTracker:
                 ON change_alerts(acknowledged, created_at DESC);
             """)
 
-    def compute_changes(
-        self,
-        spreadsheet_id: str,
-        spreadsheet_name: str,
-        sheet_name: str,
-        new_data: List[Dict[str, Any]],
-        key_column: str
-    ) -> ChangeReport:
-        """
-        Compare new data with stored snapshot and compute changes.
+	def compute_changes(
+		self,
+		spreadsheet_id: str,
+		spreadsheet_name: str,
+		sheet_name: str,
+		new_data: list[dict[str, Any]],
+		key_column: str,
+	) -> ChangeReport:
+		"""
+		Compare new data with stored snapshot and compute changes.
 
-        Args:
-            spreadsheet_id: Google Spreadsheet ID
-            spreadsheet_name: Human-readable name
-            sheet_name: Tab name
-            new_data: Current data from sheet
-            key_column: Column to use as unique row identifier
+		Args:
+		    spreadsheet_id: Google Spreadsheet ID
+		    spreadsheet_name: Human-readable name
+		    sheet_name: Tab name
+		    new_data: Current data from sheet
+		    key_column: Column to use as unique row identifier
 
-        Returns:
-            ChangeReport with all detected changes
-        """
-        timestamp = datetime.utcnow()
+		Returns:
+		    ChangeReport with all detected changes
+		"""
+		timestamp = datetime.utcnow()
 
-        # Get previous snapshot
-        old_data = self._get_snapshot(spreadsheet_id, sheet_name)
+		# Get previous snapshot
+		old_data = self._get_snapshot(spreadsheet_id, sheet_name)
+		new_entries = self._enumerate_rows_with_keys(new_data, key_column)
 
-        # Build lookup by key
-        old_by_key = {row.get(key_column): row for row in old_data if row.get(key_column)}
-        new_by_key = {row.get(key_column): row for row in new_data if row.get(key_column)}
+		# Build lookup by key
+		old_by_key = {row_key: row for row_key, row in old_data}
+		new_by_key = {row_key: row for _row_num, row_key, row in new_entries}
 
-        changes = []
-        alerts = []
+		changes = []
+		alerts = []
 
-        # Find added and modified rows
-        for row_num, row in enumerate(new_data, start=2):  # Start at 2 (row 1 is header)
-            key = row.get(key_column)
-            if not key:
-                continue
+		# Find added and modified rows
+		for row_num, key, row in new_entries:
+			if key not in old_by_key:
+				# New row
+				changes.append(
+					RowChange(
+						change_type=ChangeType.ADDED, row_key=str(key), row_number=row_num, new_values=row
+					)
+				)
+			else:
+				# Check if modified
+				old_row = old_by_key[key]
+				changed_fields = self._get_changed_fields(old_row, row)
 
-            if key not in old_by_key:
-                # New row
-                changes.append(RowChange(
-                    change_type=ChangeType.ADDED,
-                    row_key=str(key),
-                    row_number=row_num,
-                    new_values=row
-                ))
-            else:
-                # Check if modified
-                old_row = old_by_key[key]
-                changed_fields = self._get_changed_fields(old_row, row)
+				if changed_fields:
+					changes.append(
+						RowChange(
+							change_type=ChangeType.MODIFIED,
+							row_key=str(key),
+							row_number=row_num,
+							old_values=old_row,
+							new_values=row,
+							changed_fields=changed_fields,
+						)
+					)
 
-                if changed_fields:
-                    changes.append(RowChange(
-                        change_type=ChangeType.MODIFIED,
-                        row_key=str(key),
-                        row_number=row_num,
-                        old_values=old_row,
-                        new_values=row,
-                        changed_fields=changed_fields
-                    ))
+		# Find deleted rows
+		for key, old_row in old_by_key.items():
+			if key not in new_by_key:
+				changes.append(
+					RowChange(
+						change_type=ChangeType.DELETED,
+						row_key=str(key),
+						row_number=0,  # Unknown
+						old_values=old_row,
+					)
+				)
 
-        # Find deleted rows
-        for key, old_row in old_by_key.items():
-            if key not in new_by_key:
-                changes.append(RowChange(
-                    change_type=ChangeType.DELETED,
-                    row_key=str(key),
-                    row_number=0,  # Unknown
-                    old_values=old_row
-                ))
+		# Count by type
+		added = sum(1 for c in changes if c.change_type == ChangeType.ADDED)
+		modified = sum(1 for c in changes if c.change_type == ChangeType.MODIFIED)
+		deleted = sum(1 for c in changes if c.change_type == ChangeType.DELETED)
+		unchanged = len(new_entries) - added - modified
 
-        # Count by type
-        added = sum(1 for c in changes if c.change_type == ChangeType.ADDED)
-        modified = sum(1 for c in changes if c.change_type == ChangeType.MODIFIED)
-        deleted = sum(1 for c in changes if c.change_type == ChangeType.DELETED)
-        unchanged = len(new_data) - added - modified
+		# Detect suspicious patterns
+		alerts = self._detect_suspicious_patterns(
+			spreadsheet_name, sheet_name, added, modified, deleted, len(old_data), len(new_data), changes
+		)
 
-        # Detect suspicious patterns
-        alerts = self._detect_suspicious_patterns(
-            spreadsheet_name, sheet_name,
-            added, modified, deleted,
-            len(old_data), len(new_data),
-            changes
-        )
+		report = ChangeReport(
+			spreadsheet_id=spreadsheet_id,
+			spreadsheet_name=spreadsheet_name,
+			sheet_name=sheet_name,
+			timestamp=timestamp,
+			total_rows_before=len(old_data),
+			total_rows_after=len(new_data),
+			rows_added=added,
+			rows_modified=modified,
+			rows_deleted=deleted,
+			rows_unchanged=unchanged,
+			changes=changes,
+			alerts=alerts,
+		)
 
-        report = ChangeReport(
-            spreadsheet_id=spreadsheet_id,
-            spreadsheet_name=spreadsheet_name,
-            sheet_name=sheet_name,
-            timestamp=timestamp,
-            total_rows_before=len(old_data),
-            total_rows_after=len(new_data),
-            rows_added=added,
-            rows_modified=modified,
-            rows_deleted=deleted,
-            rows_unchanged=unchanged,
-            changes=changes,
-            alerts=alerts
-        )
+		# Log changes to database
+		self._log_changes(report)
 
-        # Log changes to database
-        self._log_changes(report)
+		# Save new snapshot
+		self._save_snapshot(spreadsheet_id, sheet_name, new_data, key_column)
 
-        # Save new snapshot
-        self._save_snapshot(spreadsheet_id, sheet_name, new_data, key_column)
+		return report
 
-        return report
+	def _get_changed_fields(self, old_row: dict[str, Any], new_row: dict[str, Any]) -> list[str]:
+		"""Find which fields changed between old and new row."""
+		changed = []
+		all_keys = set(old_row.keys()) | set(new_row.keys())
 
-    def _get_changed_fields(
-        self,
-        old_row: Dict[str, Any],
-        new_row: Dict[str, Any]
-    ) -> List[str]:
-        """Find which fields changed between old and new row."""
-        changed = []
-        all_keys = set(old_row.keys()) | set(new_row.keys())
+		for key in all_keys:
+			old_val = old_row.get(key)
+			new_val = new_row.get(key)
 
-        for key in all_keys:
-            old_val = old_row.get(key)
-            new_val = new_row.get(key)
+			# Normalize for comparison
+			if self._normalize_value(old_val) != self._normalize_value(new_val):
+				changed.append(key)
 
-            # Normalize for comparison
-            if self._normalize_value(old_val) != self._normalize_value(new_val):
-                changed.append(key)
+		return changed
 
-        return changed
+	def _normalize_value(self, val: Any) -> str:
+		"""Normalize value for comparison."""
+		if val is None:
+			return ""
+		if isinstance(val, float):
+			return f"{val:.2f}"
+		return str(val).strip()
 
-    def _normalize_value(self, val: Any) -> str:
-        """Normalize value for comparison."""
-        if val is None:
-            return ""
-        if isinstance(val, float):
-            return f"{val:.2f}"
-        return str(val).strip()
+	def _detect_suspicious_patterns(
+		self,
+		spreadsheet_name: str,
+		sheet_name: str,
+		added: int,
+		modified: int,
+		deleted: int,
+		old_count: int,
+		new_count: int,
+		changes: list[RowChange],
+	) -> list[str]:
+		"""
+		Detect patterns that might indicate data issues.
 
-    def _detect_suspicious_patterns(
-        self,
-        spreadsheet_name: str,
-        sheet_name: str,
-        added: int,
-        modified: int,
-        deleted: int,
-        old_count: int,
-        new_count: int,
-        changes: List[RowChange]
-    ) -> List[str]:
-        """
-        Detect patterns that might indicate data issues.
+		Returns list of alert messages.
+		"""
+		alerts = []
 
-        Returns list of alert messages.
-        """
-        alerts = []
+		# Alert: Many rows modified at once (possible mass edit)
+		if modified > 10 and old_count > 0:
+			pct = (modified / old_count) * 100
+			if pct > 20:
+				alerts.append(
+					f"⚠️ MASS EDIT: {modified} rows ({pct:.0f}%) modified in {spreadsheet_name}/{sheet_name}. "
+					f"Expected new rows, but existing data was changed."
+				)
 
-        # Alert: Many rows modified at once (possible mass edit)
-        if modified > 10 and old_count > 0:
-            pct = (modified / old_count) * 100
-            if pct > 20:
-                alerts.append(
-                    f"⚠️ MASS EDIT: {modified} rows ({pct:.0f}%) modified in {spreadsheet_name}/{sheet_name}. "
-                    f"Expected new rows, but existing data was changed."
-                )
+		# Alert: Rows deleted
+		if deleted > 0:
+			alerts.append(f"🗑️ DELETION: {deleted} rows removed from {spreadsheet_name}/{sheet_name}.")
 
-        # Alert: Rows deleted
-        if deleted > 0:
-            alerts.append(
-                f"🗑️ DELETION: {deleted} rows removed from {spreadsheet_name}/{sheet_name}."
-            )
+		# Alert: Key financial fields changed
+		financial_fields = [
+			"amount",
+			"balance",
+			"outstanding",
+			"total",
+			"net",
+			"gross",
+			"payment",
+			"qty",
+			"quantity",
+		]
+		financial_changes = []
+		for change in changes:
+			if change.change_type == ChangeType.MODIFIED and change.changed_fields:
+				for field in change.changed_fields:
+					if any(ff in field.lower() for ff in financial_fields):
+						financial_changes.append(change)
+						break
 
-        # Alert: Key financial fields changed
-        financial_fields = ['amount', 'balance', 'outstanding', 'total', 'net', 'gross', 'payment', 'qty', 'quantity']
-        financial_changes = []
-        for change in changes:
-            if change.change_type == ChangeType.MODIFIED and change.changed_fields:
-                for field in change.changed_fields:
-                    if any(ff in field.lower() for ff in financial_fields):
-                        financial_changes.append(change)
-                        break
+		if financial_changes:
+			alerts.append(
+				f"💰 FINANCIAL DATA MODIFIED: {len(financial_changes)} rows with amount/balance changes in {spreadsheet_name}/{sheet_name}."
+			)
 
-        if financial_changes:
-            alerts.append(
-                f"💰 FINANCIAL DATA MODIFIED: {len(financial_changes)} rows with amount/balance changes in {spreadsheet_name}/{sheet_name}."
-            )
+		# Alert: More modifications than additions
+		if modified > added and modified > 5:
+			alerts.append(
+				f"⚠️ UNUSUAL PATTERN: More modifications ({modified}) than additions ({added}) in {spreadsheet_name}/{sheet_name}. "
+				f"Team may be editing existing records instead of adding new ones."
+			)
 
-        # Alert: More modifications than additions
-        if modified > added and modified > 5:
-            alerts.append(
-                f"⚠️ UNUSUAL PATTERN: More modifications ({modified}) than additions ({added}) in {spreadsheet_name}/{sheet_name}. "
-                f"Team may be editing existing records instead of adding new ones."
-            )
+		return alerts
 
-        return alerts
+	def _build_row_key(self, raw_key: Any, row_number: int, duplicate_count: int) -> str:
+		"""Build a stable row key even when the source key is blank or duplicated."""
+		normalized = self._normalize_value(raw_key)
+		if not normalized:
+			return f"__row_{row_number}"
+		if duplicate_count > 1:
+			return f"{normalized}__row_{row_number}"
+		return normalized
 
-    def _get_snapshot(self, spreadsheet_id: str, sheet_name: str) -> List[Dict]:
-        """Get previous data snapshot."""
-        with self.db._connection() as conn:
-            rows = conn.execute("""
-                SELECT row_data FROM data_snapshots
+	def _enumerate_rows_with_keys(
+		self, data: list[dict[str, Any]], key_column: str
+	) -> list[tuple[int, str, dict[str, Any]]]:
+		"""Return rows paired with stable unique keys for change tracking."""
+		duplicate_counts: dict[str, int] = {}
+		normalized_keys: list[str] = []
+
+		for row_num, row in enumerate(data, start=2):
+			normalized_key = self._normalize_value(row.get(key_column))
+			normalized_keys.append(normalized_key)
+			duplicate_key = normalized_key or f"__row_{row_num}"
+			duplicate_counts[duplicate_key] = duplicate_counts.get(duplicate_key, 0) + 1
+
+		keyed_rows: list[tuple[int, str, dict[str, Any]]] = []
+		for index, row in enumerate(data, start=2):
+			normalized_key = normalized_keys[index - 2]
+			duplicate_key = normalized_key or f"__row_{index}"
+			row_key = self._build_row_key(row.get(key_column), index, duplicate_counts[duplicate_key])
+			keyed_rows.append((index, row_key, row))
+
+		return keyed_rows
+
+	def _get_snapshot(self, spreadsheet_id: str, sheet_name: str) -> list[tuple[str, dict[str, Any]]]:
+		"""Get previous data snapshot."""
+		with self.db._connection() as conn:
+			rows = conn.execute(
+				"""
+                SELECT row_key, row_data FROM data_snapshots
                 WHERE spreadsheet_id = ? AND sheet_name = ?
-            """, (spreadsheet_id, sheet_name)).fetchall()
+            """,
+				(spreadsheet_id, sheet_name),
+			).fetchall()
 
-            return [json.loads(row['row_data']) for row in rows]
+			return [(row["row_key"], json.loads(row["row_data"])) for row in rows]
 
-    def _save_snapshot(
-        self,
-        spreadsheet_id: str,
-        sheet_name: str,
-        data: List[Dict],
-        key_column: str
-    ):
-        """Save current data as snapshot for next comparison."""
-        timestamp = datetime.utcnow().isoformat()
+	def _save_snapshot(self, spreadsheet_id: str, sheet_name: str, data: list[dict], key_column: str):
+		"""Save current data as snapshot for next comparison."""
+		timestamp = datetime.utcnow().isoformat()
 
-        with self.db._connection() as conn:
-            # Clear old snapshot
-            conn.execute("""
+		with self.db._connection() as conn:
+			# Clear old snapshot
+			conn.execute(
+				"""
                 DELETE FROM data_snapshots
                 WHERE spreadsheet_id = ? AND sheet_name = ?
-            """, (spreadsheet_id, sheet_name))
+            """,
+				(spreadsheet_id, sheet_name),
+			)
 
-            # Save new snapshot
-            for row_num, row in enumerate(data, start=2):
-                key = row.get(key_column)
-                if not key:
-                    continue
+			# Save new snapshot
+			for row_num, key, row in self._enumerate_rows_with_keys(data, key_column):
+				row_json = json.dumps(row, default=str)
+				row_hash = hashlib.md5(row_json.encode()).hexdigest()
 
-                row_json = json.dumps(row, default=str)
-                row_hash = hashlib.md5(row_json.encode()).hexdigest()
-
-                conn.execute("""
+				conn.execute(
+					"""
                     INSERT INTO data_snapshots
                     (spreadsheet_id, sheet_name, row_key, row_number, row_data, row_hash, snapshot_time)
                     VALUES (?, ?, ?, ?, ?, ?, ?)
-                """, (spreadsheet_id, sheet_name, str(key), row_num, row_json, row_hash, timestamp))
+                """,
+					(spreadsheet_id, sheet_name, str(key), row_num, row_json, row_hash, timestamp),
+				)
 
-    def _log_changes(self, report: ChangeReport):
-        """Log all changes to database."""
-        timestamp = report.timestamp.isoformat()
+	def _log_changes(self, report: ChangeReport):
+		"""Log all changes to database."""
+		timestamp = report.timestamp.isoformat()
 
-        with self.db._connection() as conn:
-            for change in report.changes:
-                conn.execute("""
+		with self.db._connection() as conn:
+			for change in report.changes:
+				conn.execute(
+					"""
                     INSERT INTO change_logs
                     (spreadsheet_id, spreadsheet_name, sheet_name, change_type,
                      row_key, row_number, old_values, new_values, changed_fields, created_at)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """, (
-                    report.spreadsheet_id,
-                    report.spreadsheet_name,
-                    report.sheet_name,
-                    change.change_type.value,
-                    change.row_key,
-                    change.row_number,
-                    json.dumps(change.old_values, default=str) if change.old_values else None,
-                    json.dumps(change.new_values, default=str) if change.new_values else None,
-                    json.dumps(change.changed_fields) if change.changed_fields else None,
-                    timestamp
-                ))
+                """,
+					(
+						report.spreadsheet_id,
+						report.spreadsheet_name,
+						report.sheet_name,
+						change.change_type.value,
+						change.row_key,
+						change.row_number,
+						json.dumps(change.old_values, default=str) if change.old_values else None,
+						json.dumps(change.new_values, default=str) if change.new_values else None,
+						json.dumps(change.changed_fields) if change.changed_fields else None,
+						timestamp,
+					),
+				)
 
-            # Log alerts
-            for alert in report.alerts:
-                conn.execute("""
+			# Log alerts
+			for alert in report.alerts:
+				conn.execute(
+					"""
                     INSERT INTO change_alerts
                     (spreadsheet_id, spreadsheet_name, sheet_name, alert_type,
                      alert_message, created_at)
                     VALUES (?, ?, ?, ?, ?, ?)
-                """, (
-                    report.spreadsheet_id,
-                    report.spreadsheet_name,
-                    report.sheet_name,
-                    'suspicious_pattern',
-                    alert,
-                    timestamp
-                ))
+                """,
+					(
+						report.spreadsheet_id,
+						report.spreadsheet_name,
+						report.sheet_name,
+						"suspicious_pattern",
+						alert,
+						timestamp,
+					),
+				)
 
-    def get_recent_changes(
-        self,
-        spreadsheet_id: str = None,
-        limit: int = 100,
-        change_type: str = None
-    ) -> List[Dict]:
-        """Get recent change logs."""
-        with self.db._connection() as conn:
-            query = "SELECT * FROM change_logs WHERE 1=1"
-            params = []
+	def get_recent_changes(
+		self, spreadsheet_id: str | None = None, limit: int = 100, change_type: str | None = None
+	) -> list[dict]:
+		"""Get recent change logs."""
+		with self.db._connection() as conn:
+			query = "SELECT * FROM change_logs WHERE 1=1"
+			params = []
 
-            if spreadsheet_id:
-                query += " AND spreadsheet_id = ?"
-                params.append(spreadsheet_id)
+			if spreadsheet_id:
+				query += " AND spreadsheet_id = ?"
+				params.append(spreadsheet_id)
 
-            if change_type:
-                query += " AND change_type = ?"
-                params.append(change_type)
+			if change_type:
+				query += " AND change_type = ?"
+				params.append(change_type)
 
-            query += " ORDER BY created_at DESC LIMIT ?"
-            params.append(limit)
+			query += " ORDER BY created_at DESC LIMIT ?"
+			params.append(limit)
 
-            rows = conn.execute(query, params).fetchall()
+			rows = conn.execute(query, params).fetchall()
 
-            return [
-                {
-                    'id': row['id'],
-                    'spreadsheet_name': row['spreadsheet_name'],
-                    'sheet_name': row['sheet_name'],
-                    'change_type': row['change_type'],
-                    'row_key': row['row_key'],
-                    'row_number': row['row_number'],
-                    'old_values': json.loads(row['old_values']) if row['old_values'] else None,
-                    'new_values': json.loads(row['new_values']) if row['new_values'] else None,
-                    'changed_fields': json.loads(row['changed_fields']) if row['changed_fields'] else None,
-                    'created_at': row['created_at']
-                }
-                for row in rows
-            ]
+			return [
+				{
+					"id": row["id"],
+					"spreadsheet_name": row["spreadsheet_name"],
+					"sheet_name": row["sheet_name"],
+					"change_type": row["change_type"],
+					"row_key": row["row_key"],
+					"row_number": row["row_number"],
+					"old_values": json.loads(row["old_values"]) if row["old_values"] else None,
+					"new_values": json.loads(row["new_values"]) if row["new_values"] else None,
+					"changed_fields": json.loads(row["changed_fields"]) if row["changed_fields"] else None,
+					"created_at": row["created_at"],
+				}
+				for row in rows
+			]
 
-    def get_unacknowledged_alerts(self) -> List[Dict]:
-        """Get alerts that haven't been acknowledged."""
-        with self.db._connection() as conn:
-            rows = conn.execute("""
+	def get_unacknowledged_alerts(self) -> list[dict]:
+		"""Get alerts that haven't been acknowledged."""
+		with self.db._connection() as conn:
+			rows = conn.execute("""
                 SELECT * FROM change_alerts
                 WHERE acknowledged = 0
                 ORDER BY created_at DESC
             """).fetchall()
 
-            return [
-                {
-                    'id': row['id'],
-                    'spreadsheet_name': row['spreadsheet_name'],
-                    'sheet_name': row['sheet_name'],
-                    'alert_type': row['alert_type'],
-                    'alert_message': row['alert_message'],
-                    'created_at': row['created_at']
-                }
-                for row in rows
-            ]
+			return [
+				{
+					"id": row["id"],
+					"spreadsheet_name": row["spreadsheet_name"],
+					"sheet_name": row["sheet_name"],
+					"alert_type": row["alert_type"],
+					"alert_message": row["alert_message"],
+					"created_at": row["created_at"],
+				}
+				for row in rows
+			]
 
-    def acknowledge_alert(self, alert_id: int):
-        """Mark an alert as acknowledged."""
-        with self.db._connection() as conn:
-            conn.execute(
-                "UPDATE change_alerts SET acknowledged = 1 WHERE id = ?",
-                (alert_id,)
-            )
+	def acknowledge_alert(self, alert_id: int):
+		"""Mark an alert as acknowledged."""
+		with self.db._connection() as conn:
+			conn.execute("UPDATE change_alerts SET acknowledged = 1 WHERE id = ?", (alert_id,))

--- a/hrms/tests/test_sheets_receiver_change_tracker.py
+++ b/hrms/tests/test_sheets_receiver_change_tracker.py
@@ -1,0 +1,79 @@
+import importlib.util
+import sqlite3
+import sys
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+change_tracker_spec = importlib.util.spec_from_file_location(
+	"sheets_receiver_change_tracker_under_test",
+	ROOT / "hrms" / "services" / "sheets_receiver" / "change_tracker.py",
+)
+change_tracker = importlib.util.module_from_spec(change_tracker_spec)
+change_tracker_spec.loader.exec_module(change_tracker)
+ChangeTracker = change_tracker.ChangeTracker
+
+
+class _FakeDB:
+	def __init__(self):
+		self.conn = sqlite3.connect(":memory:")
+		self.conn.row_factory = sqlite3.Row
+
+	@contextmanager
+	def _connection(self):
+		try:
+			yield self.conn
+			self.conn.commit()
+		except Exception:
+			self.conn.rollback()
+			raise
+
+
+class TestSheetsReceiverChangeTracker(unittest.TestCase):
+	def test_compute_changes_handles_duplicate_and_blank_keys(self):
+		db = _FakeDB()
+		tracker = ChangeTracker(db)
+		rows = [
+			{"invoice_no.": "", "supplier_name": "ALYANA CHUA", "amount": 20300},
+			{"invoice_no.": "16538", "supplier_name": "FORWARD DYNAMIC", "amount": 10500},
+			{"invoice_no.": "16538", "supplier_name": "FORWARD DYNAMIC", "amount": 8500},
+		]
+
+		first = tracker.compute_changes(
+			spreadsheet_id="sheet-1",
+			spreadsheet_name="Supplier SOA",
+			sheet_name="SUPPLIERS SOA",
+			new_data=rows,
+			key_column="invoice_no.",
+		)
+		second = tracker.compute_changes(
+			spreadsheet_id="sheet-1",
+			spreadsheet_name="Supplier SOA",
+			sheet_name="SUPPLIERS SOA",
+			new_data=rows,
+			key_column="invoice_no.",
+		)
+
+		self.assertEqual(first.rows_added, 3)
+		self.assertEqual(second.rows_added, 0)
+		self.assertEqual(second.rows_modified, 0)
+		self.assertEqual(second.rows_unchanged, 3)
+
+		with db._connection() as conn:
+			stored_keys = [
+				row["row_key"]
+				for row in conn.execute(
+					"SELECT row_key FROM data_snapshots WHERE spreadsheet_id = ? AND sheet_name = ? ORDER BY row_number",
+					("sheet-1", "SUPPLIERS SOA"),
+				).fetchall()
+			]
+
+		self.assertEqual(stored_keys, ["__row_2", "16538__row_3", "16538__row_4"])
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary
- make Sheets Receiver snapshot row keys stable when AP source rows have blank or duplicate invoice numbers
- prevent duplicate-key failures in `data_snapshots` from aborting AP syncs
- add a regression test covering blank and duplicate `invoice_no.` rows

## Verification
- python -m py_compile hrms/services/sheets_receiver/change_tracker.py hrms/tests/test_sheets_receiver_change_tracker.py hrms/services/sheets_receiver/config.py hrms/tests/test_sheets_receiver_config.py hrms/tests/test_sheets_receiver_processor.py
- python hrms/tests/test_sheets_receiver_change_tracker.py
- python hrms/tests/test_sheets_receiver_processor.py
- python hrms/tests/test_sheets_receiver_config.py
- pre-commit run --files hrms/services/sheets_receiver/change_tracker.py hrms/tests/test_sheets_receiver_change_tracker.py hrms/services/sheets_receiver/config.py hrms/tests/test_sheets_receiver_config.py