### PR TITLE
fix: allow SCM trip creation with linked driver and vehicle

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -1105,7 +1105,8 @@ def create_route(
 				},
 			)
 
-	route.insert()
+	_enable_role_gated_write(route)
+	route.insert(ignore_permissions=True)
 	return {"success": True, "route": route.name}
 
 
@@ -1147,7 +1148,8 @@ def update_route(route_name: str, updates: dict[str, Any] | str | None = None):
 				},
 			)
 
-	route.save()
+	_enable_role_gated_write(route)
+	route.save(ignore_permissions=True)
 	return {"success": True, "route": route.name}
 
 
@@ -1158,7 +1160,8 @@ def delete_route(route_name: str):
 
 	route = frappe.get_doc("BEI Route", route_name)
 	route.active = 0
-	route.save()
+	_enable_role_gated_write(route)
+	route.save(ignore_permissions=True)
 	return {"success": True, "message": f"Route {route_name} deactivated"}
 
 
@@ -1233,6 +1236,15 @@ def _build_stop_preview(route: Any, trip_date: str):
 			}
 		)
 	return stops
+
+
+def _enable_role_gated_write(doc: Any):
+	"""Use explicit SCM role checks as the write gate for route/trip mutations."""
+	if getattr(doc, "flags", None) is None:
+		doc.flags = type("_DispatchDocFlags", (), {})()
+	doc.flags.ignore_permissions = True
+	doc.flags.ignore_user_permissions = True
+	return doc
 
 
 @frappe.whitelist()
@@ -1357,7 +1369,8 @@ def create_trip_from_route(
 		if stop_data.get("store_order"):
 			trip.stops[idx].store_order = stop_data["store_order"]
 
-	trip.insert()
+	_enable_role_gated_write(trip)
+	trip.insert(ignore_permissions=True)
 
 	# Update linked BEI Store Orders to "In Transit"
 	_set_store_orders_in_transit(stops)
@@ -1398,7 +1411,8 @@ def duplicate_route(route_name: str, new_name: str):
 			},
 		)
 
-	new_route.insert()
+	_enable_role_gated_write(new_route)
+	new_route.insert(ignore_permissions=True)
 	return {"success": True, "route": new_route.name}
 
 
@@ -1422,7 +1436,8 @@ def reorder_stops(route_name: str, stop_order_map: dict[str, int] | str):
 		stop.idx = idx
 		stop.stop_order = idx
 
-	route.save()
+	_enable_role_gated_write(route)
+	route.save(ignore_permissions=True)
 	return {"success": True, "route": route.name}
 
 

--- a/hrms/tests/test_trip_driver_estimated_minutes_s10.py
+++ b/hrms/tests/test_trip_driver_estimated_minutes_s10.py
@@ -131,9 +131,12 @@ class _TripDoc:
 		self.vehicle = None
 		self.vehicle_plate = None
 		self.cargo_type = None
+		self.flags = None
+		self.insert_kwargs = None
 		self.stops = [types.SimpleNamespace(store_order="", idx=i + 1) for i, _ in enumerate(stops)]
 
-	def insert(self):
+	def insert(self, **kwargs):
+		self.insert_kwargs = kwargs
 		return None
 
 
@@ -182,7 +185,8 @@ class TestTripDriverEstimatedMinutesS10(unittest.TestCase):
 			captured["stops"] = stops
 			captured["trip_date"] = trip_date
 			captured["route_name"] = route_name
-			return _TripDoc(stops)
+			captured["trip"] = _TripDoc(stops)
+			return captured["trip"]
 
 		dispatch.frappe.get_doc = MagicMock(return_value=route)
 		dispatch.frappe.db.get_value = MagicMock(side_effect=_get_value)
@@ -216,6 +220,15 @@ class TestTripDriverEstimatedMinutesS10(unittest.TestCase):
 		self.assertEqual(captured["stops"][1]["store"], "STORE-A - BEI")
 		self.assertEqual(captured["stops"][1]["stop_order"], 2)
 		self.assertEqual(captured["stops"][1]["estimated_minutes"], 11)
+		self.assertTrue(captured["trip"].flags.ignore_permissions)
+		self.assertTrue(captured["trip"].flags.ignore_user_permissions)
+		self.assertEqual(captured["trip"].insert_kwargs, {"ignore_permissions": True})
+
+	def test_enable_role_gated_write_sets_ignore_user_permissions(self):
+		doc = types.SimpleNamespace(flags=None)
+		dispatch._enable_role_gated_write(doc)
+		self.assertTrue(doc.flags.ignore_permissions)
+		self.assertTrue(doc.flags.ignore_user_permissions)
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_trip_driver_estimated_minutes_s10.py
+++ b/hrms/tests/test_trip_driver_estimated_minutes_s10.py
@@ -200,8 +200,9 @@ class TestTripDriverEstimatedMinutesS10(unittest.TestCase):
 			]
 		)
 
-		with patch.object(dispatch, "_build_trip_doc", side_effect=_build_trip_doc), patch.object(
-			dispatch, "_set_store_orders_in_transit", return_value=None
+		with (
+			patch.object(dispatch, "_build_trip_doc", side_effect=_build_trip_doc),
+			patch.object(dispatch, "_set_store_orders_in_transit", return_value=None),
 		):
 			result = dispatch.create_trip_from_route(
 				route_name="ROUTE-S10",


### PR DESCRIPTION
## Summary
- allow SCM route/trip writes to rely on explicit SCM role gates instead of linked document user-permission leakage
- apply the role-gated write path to route create/update/delete/duplicate/reorder and trip creation
- add regression coverage for create_trip_from_route preserving stop order while inserting with ignore permissions

## Verification
- python -m py_compile hrms/api/dispatch.py
- python hrms/tests/test_trip_driver_estimated_minutes_s10.py
- note: pytest entrypoint is blocked locally by a machine-level logfire/opentelemetry plugin import mismatch