### PR TITLE
fix: add daily procurement baseline sync

### DIFF
--- a/hrms/services/sheets_receiver/main.py
+++ b/hrms/services/sheets_receiver/main.py
@@ -37,11 +37,12 @@ import signal
 import sys
 import threading
 import time
-from datetime import datetime
+from datetime import UTC, datetime, time as dt_time
+from zoneinfo import ZoneInfo
 
 import schedule
 
-from .config import get_config, get_watched_sheets
+from .config import get_config, get_sheet_config, get_watched_sheets
 from .models import get_db
 from .sheets_client import get_sheets_client
 from .processor import get_processor
@@ -58,6 +59,18 @@ logging.basicConfig(
     ]
 )
 logger = logging.getLogger(__name__)
+
+PHT_TIMEZONE = ZoneInfo("Asia/Manila")
+DAILY_BASELINE_TRIGGER = "daily_baseline"
+DAILY_BASELINE_PHT_TIME = dt_time(hour=8, minute=0)
+DAILY_BASELINE_SHEET_KEYS = (
+    "ap_opening_balance",
+    "supplier_soa",
+    "procurement_suppliers",
+    "procurement_requisitions",
+    "procurement_purchase_orders",
+    "procurement_goods_receipts",
+)
 
 
 def setup_file_logging():
@@ -102,6 +115,72 @@ def scheduled_sync_job():
         processor.sync_all_sheets(trigger='scheduled', force=False)
     except Exception as e:
         logger.error(f"Scheduled sync failed: {e}")
+
+
+def _normalize_now_utc(now_utc: datetime | None = None) -> datetime:
+    """Normalize a timestamp to timezone-aware UTC."""
+    if now_utc is None:
+        return datetime.now(UTC)
+    if now_utc.tzinfo is None:
+        return now_utc.replace(tzinfo=UTC)
+    return now_utc.astimezone(UTC)
+
+
+def get_daily_baseline_sheet_keys() -> tuple[str, ...]:
+    """Return the sheet keys that must be force-synced at 8:00 AM PHT."""
+    return DAILY_BASELINE_SHEET_KEYS
+
+
+def run_daily_baseline_sync_if_due(now_utc: datetime | None = None):
+    """
+    Force-sync AP and Procurement baseline sheets once per PHT day after 8:00 AM.
+
+    This does not rely on the host/container timezone. It checks whether each target
+    sheet already has a successful `daily_baseline` sync logged for the current PHT
+    day and only re-syncs missing sheets.
+    """
+    normalized_now_utc = _normalize_now_utc(now_utc)
+    now_pht = normalized_now_utc.astimezone(PHT_TIMEZONE)
+
+    if now_pht.time() < DAILY_BASELINE_PHT_TIME:
+        return []
+
+    pht_day_start = datetime.combine(now_pht.date(), dt_time.min, tzinfo=PHT_TIMEZONE)
+    pht_day_start_utc = pht_day_start.astimezone(UTC)
+
+    db = get_db()
+    processor = get_processor()
+    results = []
+
+    for sheet_key in get_daily_baseline_sheet_keys():
+        sheet_config = get_sheet_config(sheet_key)
+        if not sheet_config or not sheet_config.enabled:
+            logger.warning(f"Daily baseline sync skipped missing/disabled sheet config: {sheet_key}")
+            continue
+
+        already_synced = db.has_successful_sync_since(
+            sheet_config.spreadsheet_id,
+            sheet_config.sheet_name,
+            DAILY_BASELINE_TRIGGER,
+            pht_day_start_utc,
+        )
+        if already_synced:
+            continue
+
+        logger.info(
+            "Running daily baseline force sync for %s (%s)",
+            getattr(sheet_config, "name", sheet_key),
+            sheet_key,
+        )
+        results.append(
+            processor.sync_sheet(
+                sheet_config,
+                trigger=DAILY_BASELINE_TRIGGER,
+                force=True,
+            )
+        )
+
+    return results
 
 
 # =============================================================================
@@ -243,46 +322,54 @@ def daily_summary_job():
         logger.error(f"Daily summary job failed: {e}")
 
 
-def run_scheduler():
-    """Run the scheduler in a background thread."""
-    config = get_config()
-
+def configure_scheduled_jobs(schedule_module=schedule):
+    """Register all recurring jobs on the provided schedule module."""
     # ==========================================================================
     # Sheets Processing (Original)
     # ==========================================================================
 
     # Renew sheet watches every hour (they expire after 24h)
-    schedule.every(1).hour.do(renew_watches_job)
+    schedule_module.every(1).hour.do(renew_watches_job)
 
     # Backup sync every 6 hours (in case webhooks missed)
-    schedule.every(6).hours.do(scheduled_sync_job)
+    schedule_module.every(6).hours.do(scheduled_sync_job)
+
+    # Deterministic AP + Procurement baseline refresh at 8:00 AM PHT.
+    # Runs through a once-per-day gate so it is safe across restarts.
+    schedule_module.every(1).minutes.do(run_daily_baseline_sync_if_due)
 
     # ==========================================================================
     # POS File Processing (Automatic - No Manual Intervention)
     # ==========================================================================
 
     # Process pending files every 2 minutes (fast turnaround)
-    schedule.every(2).minutes.do(process_pending_files_job)
+    schedule_module.every(2).minutes.do(process_pending_files_job)
 
     # Retry failed files every 15 minutes (give time for transient issues)
-    schedule.every(15).minutes.do(retry_failed_files_job)
+    schedule_module.every(15).minutes.do(retry_failed_files_job)
 
     # Scan all folders every 30 minutes (backup to webhooks)
-    schedule.every(30).minutes.do(scan_for_new_files_job)
+    schedule_module.every(30).minutes.do(scan_for_new_files_job)
 
     # Renew folder watches every hour (they expire after 24h)
-    schedule.every(1).hour.do(renew_folder_watches_job)
+    schedule_module.every(1).hour.do(renew_folder_watches_job)
 
     # ==========================================================================
     # Notifications & Reporting
     # ==========================================================================
 
     # Daily summary at 7 AM Philippines time (23:00 UTC)
-    schedule.every().day.at("23:00").do(daily_summary_job)
+    schedule_module.every().day.at("23:00").do(daily_summary_job)
+
+
+def run_scheduler():
+    """Run the scheduler in a background thread."""
+    configure_scheduled_jobs()
 
     logger.info("Scheduler started with jobs:")
     logger.info("  - Sheet watch renewal: every 1 hour")
     logger.info("  - Sheet backup sync: every 6 hours")
+    logger.info("  - Daily AP/procurement baseline sync gate: every 1 minute, target 8 AM PHT")
     logger.info("  - POS file processing: every 2 minutes")
     logger.info("  - Failed file retry: every 15 minutes")
     logger.info("  - Folder scan (backup): every 30 minutes")
@@ -345,6 +432,12 @@ def initial_setup():
         processor.sync_all_sheets(trigger='startup', force=False)
     except Exception as e:
         logger.error(f"Initial sheet sync failed: {e}")
+
+    logger.info("Checking whether daily AP/procurement baseline sync is due...")
+    try:
+        run_daily_baseline_sync_if_due()
+    except Exception as e:
+        logger.error(f"Daily baseline sync check failed: {e}")
 
     # Initial scan for POS files
     logger.info("Performing initial POS folder scan...")

--- a/hrms/services/sheets_receiver/main.py
+++ b/hrms/services/sheets_receiver/main.py
@@ -37,26 +37,25 @@ import signal
 import sys
 import threading
 import time
-from datetime import UTC, datetime, time as dt_time
+from datetime import UTC, datetime
+from datetime import time as dt_time
 from zoneinfo import ZoneInfo
 
 import schedule
 
 from .config import get_config, get_sheet_config, get_watched_sheets
-from .models import get_db
-from .sheets_client import get_sheets_client
-from .processor import get_processor
-from .webhook import run_server
 from .file_processor import get_file_processor
 from .folder_watcher import get_folder_watcher
+from .models import get_db
+from .processor import get_processor
+from .sheets_client import get_sheets_client
+from .webhook import run_server
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
+	level=logging.INFO,
+	format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+	handlers=[logging.StreamHandler(sys.stdout)],
 )
 logger = logging.getLogger(__name__)
 
@@ -64,438 +63,432 @@ PHT_TIMEZONE = ZoneInfo("Asia/Manila")
 DAILY_BASELINE_TRIGGER = "daily_baseline"
 DAILY_BASELINE_PHT_TIME = dt_time(hour=8, minute=0)
 DAILY_BASELINE_SHEET_KEYS = (
-    "ap_opening_balance",
-    "supplier_soa",
-    "procurement_suppliers",
-    "procurement_requisitions",
-    "procurement_purchase_orders",
-    "procurement_goods_receipts",
+	"ap_opening_balance",
+	"supplier_soa",
+	"procurement_suppliers",
+	"procurement_requisitions",
+	"procurement_purchase_orders",
+	"procurement_goods_receipts",
 )
 
 
 def setup_file_logging():
-    """Set up file logging."""
-    config = get_config()
+	"""Set up file logging."""
+	config = get_config()
 
-    # Ensure log directory exists
-    from pathlib import Path
-    Path(config.log_file).parent.mkdir(parents=True, exist_ok=True)
+	# Ensure log directory exists
+	from pathlib import Path
 
-    file_handler = logging.FileHandler(config.log_file)
-    file_handler.setLevel(getattr(logging, config.log_level))
-    file_handler.setFormatter(logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    ))
+	Path(config.log_file).parent.mkdir(parents=True, exist_ok=True)
 
-    logging.getLogger().addHandler(file_handler)
+	file_handler = logging.FileHandler(config.log_file)
+	file_handler.setLevel(getattr(logging, config.log_level))
+	file_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+
+	logging.getLogger().addHandler(file_handler)
 
 
 def renew_watches_job():
-    """Scheduled job to renew expiring watches."""
-    logger.info("Running watch renewal job...")
-    try:
-        client = get_sheets_client()
-        renewed = client.renew_expiring_watches(hours_before=2)
-        if renewed:
-            logger.info(f"Renewed {len(renewed)} watches")
-    except Exception as e:
-        logger.error(f"Watch renewal failed: {e}")
+	"""Scheduled job to renew expiring watches."""
+	logger.info("Running watch renewal job...")
+	try:
+		client = get_sheets_client()
+		renewed = client.renew_expiring_watches(hours_before=2)
+		if renewed:
+			logger.info(f"Renewed {len(renewed)} watches")
+	except Exception as e:
+		logger.error(f"Watch renewal failed: {e}")
 
 
 def scheduled_sync_job():
-    """
-    Scheduled job to sync all sheets.
+	"""
+	Scheduled job to sync all sheets.
 
-    This is a backup in case webhooks are missed.
-    Runs less frequently since webhooks should catch most changes.
-    """
-    logger.info("Running scheduled sync job...")
-    try:
-        processor = get_processor()
-        processor.sync_all_sheets(trigger='scheduled', force=False)
-    except Exception as e:
-        logger.error(f"Scheduled sync failed: {e}")
+	This is a backup in case webhooks are missed.
+	Runs less frequently since webhooks should catch most changes.
+	"""
+	logger.info("Running scheduled sync job...")
+	try:
+		processor = get_processor()
+		processor.sync_all_sheets(trigger="scheduled", force=False)
+	except Exception as e:
+		logger.error(f"Scheduled sync failed: {e}")
 
 
 def _normalize_now_utc(now_utc: datetime | None = None) -> datetime:
-    """Normalize a timestamp to timezone-aware UTC."""
-    if now_utc is None:
-        return datetime.now(UTC)
-    if now_utc.tzinfo is None:
-        return now_utc.replace(tzinfo=UTC)
-    return now_utc.astimezone(UTC)
+	"""Normalize a timestamp to timezone-aware UTC."""
+	if now_utc is None:
+		return datetime.now(UTC)
+	if now_utc.tzinfo is None:
+		return now_utc.replace(tzinfo=UTC)
+	return now_utc.astimezone(UTC)
 
 
 def get_daily_baseline_sheet_keys() -> tuple[str, ...]:
-    """Return the sheet keys that must be force-synced at 8:00 AM PHT."""
-    return DAILY_BASELINE_SHEET_KEYS
+	"""Return the sheet keys that must be force-synced at 8:00 AM PHT."""
+	return DAILY_BASELINE_SHEET_KEYS
 
 
 def run_daily_baseline_sync_if_due(now_utc: datetime | None = None):
-    """
-    Force-sync AP and Procurement baseline sheets once per PHT day after 8:00 AM.
+	"""
+	Force-sync AP and Procurement baseline sheets once per PHT day after 8:00 AM.
 
-    This does not rely on the host/container timezone. It checks whether each target
-    sheet already has a successful `daily_baseline` sync logged for the current PHT
-    day and only re-syncs missing sheets.
-    """
-    normalized_now_utc = _normalize_now_utc(now_utc)
-    now_pht = normalized_now_utc.astimezone(PHT_TIMEZONE)
+	This does not rely on the host/container timezone. It checks whether each target
+	sheet already has a successful `daily_baseline` sync logged for the current PHT
+	day and only re-syncs missing sheets.
+	"""
+	normalized_now_utc = _normalize_now_utc(now_utc)
+	now_pht = normalized_now_utc.astimezone(PHT_TIMEZONE)
 
-    if now_pht.time() < DAILY_BASELINE_PHT_TIME:
-        return []
+	if now_pht.time() < DAILY_BASELINE_PHT_TIME:
+		return []
 
-    pht_day_start = datetime.combine(now_pht.date(), dt_time.min, tzinfo=PHT_TIMEZONE)
-    pht_day_start_utc = pht_day_start.astimezone(UTC)
+	pht_day_start = datetime.combine(now_pht.date(), dt_time.min, tzinfo=PHT_TIMEZONE)
+	pht_day_start_utc = pht_day_start.astimezone(UTC)
 
-    db = get_db()
-    processor = get_processor()
-    results = []
+	db = get_db()
+	processor = get_processor()
+	results = []
 
-    for sheet_key in get_daily_baseline_sheet_keys():
-        sheet_config = get_sheet_config(sheet_key)
-        if not sheet_config or not sheet_config.enabled:
-            logger.warning(f"Daily baseline sync skipped missing/disabled sheet config: {sheet_key}")
-            continue
+	for sheet_key in get_daily_baseline_sheet_keys():
+		sheet_config = get_sheet_config(sheet_key)
+		if not sheet_config or not sheet_config.enabled:
+			logger.warning(f"Daily baseline sync skipped missing/disabled sheet config: {sheet_key}")
+			continue
 
-        already_synced = db.has_successful_sync_since(
-            sheet_config.spreadsheet_id,
-            sheet_config.sheet_name,
-            DAILY_BASELINE_TRIGGER,
-            pht_day_start_utc,
-        )
-        if already_synced:
-            continue
+		already_synced = db.has_successful_sync_since(
+			sheet_config.spreadsheet_id,
+			sheet_config.sheet_name,
+			DAILY_BASELINE_TRIGGER,
+			pht_day_start_utc,
+		)
+		if already_synced:
+			continue
 
-        logger.info(
-            "Running daily baseline force sync for %s (%s)",
-            getattr(sheet_config, "name", sheet_key),
-            sheet_key,
-        )
-        results.append(
-            processor.sync_sheet(
-                sheet_config,
-                trigger=DAILY_BASELINE_TRIGGER,
-                force=True,
-            )
-        )
+		logger.info(
+			"Running daily baseline force sync for %s (%s)",
+			getattr(sheet_config, "name", sheet_key),
+			sheet_key,
+		)
+		results.append(
+			processor.sync_sheet(
+				sheet_config,
+				trigger=DAILY_BASELINE_TRIGGER,
+				force=True,
+			)
+		)
 
-    return results
+	return results
 
 
 # =============================================================================
 # POS File Processing Jobs (Automatic - No Manual Intervention Required)
 # =============================================================================
 
+
 def process_pending_files_job():
-    """
-    Automatic job to process pending POS files from the queue.
+	"""
+	Automatic job to process pending POS files from the queue.
 
-    Runs every 2 minutes to pick up newly queued files.
-    Uses parallel processing (10 workers) for fast throughput.
-    """
-    try:
-        processor = get_file_processor()
-        db = get_db()
+	Runs every 2 minutes to pick up newly queued files.
+	Uses parallel processing (10 workers) for fast throughput.
+	"""
+	try:
+		processor = get_file_processor()
+		db = get_db()
 
-        # Get pending count first
-        pending_count = db.get_pending_count()
-        if pending_count == 0:
-            return  # Nothing to do, skip logging
+		# Get pending count first
+		pending_count = db.get_pending_count()
+		if pending_count == 0:
+			return  # Nothing to do, skip logging
 
-        logger.info(f"Processing {pending_count} pending files...")
+		logger.info(f"Processing {pending_count} pending files...")
 
-        # Process up to 50 files per batch with parallel processing
-        result = processor.process_pending_files(limit=50, parallel=True)
+		# Process up to 50 files per batch with parallel processing
+		result = processor.process_pending_files(limit=50, parallel=True)
 
-        if result['processed'] > 0 or result['failed'] > 0:
-            logger.info(
-                f"File processing complete: {result['processed']} processed, "
-                f"{result['failed']} failed, {result['total_records']} records extracted"
-            )
+		if result["processed"] > 0 or result["failed"] > 0:
+			logger.info(
+				f"File processing complete: {result['processed']} processed, "
+				f"{result['failed']} failed, {result['total_records']} records extracted"
+			)
 
-    except Exception as e:
-        logger.error(f"File processing job failed: {e}")
+	except Exception as e:
+		logger.error(f"File processing job failed: {e}")
 
 
 def retry_failed_files_job():
-    """
-    Automatic job to retry failed POS files.
+	"""
+	Automatic job to retry failed POS files.
 
-    Runs every 15 minutes to retry files that failed processing.
-    Only retries files that failed less than 3 times.
-    """
-    try:
-        db = get_db()
+	Runs every 15 minutes to retry files that failed processing.
+	Only retries files that failed less than 3 times.
+	"""
+	try:
+		db = get_db()
 
-        # Get failed files that haven't exceeded retry limit
-        failed_files = db.get_failed_files(max_retries=3)
-        if not failed_files:
-            return  # Nothing to retry
+		# Get failed files that haven't exceeded retry limit
+		failed_files = db.get_failed_files(max_retries=3)
+		if not failed_files:
+			return  # Nothing to retry
 
-        logger.info(f"Retrying {len(failed_files)} failed files...")
+		logger.info(f"Retrying {len(failed_files)} failed files...")
 
-        # Reset status to pending for retry
-        retry_count = 0
-        for entry in failed_files:
-            db.reset_for_retry(entry['file_id'])
-            retry_count += 1
+		# Reset status to pending for retry
+		retry_count = 0
+		for entry in failed_files:
+			db.reset_for_retry(entry["file_id"])
+			retry_count += 1
 
-        if retry_count > 0:
-            logger.info(f"Reset {retry_count} files for retry")
+		if retry_count > 0:
+			logger.info(f"Reset {retry_count} files for retry")
 
-            # Immediately process the reset files
-            processor = get_file_processor()
-            result = processor.process_pending_files(limit=retry_count, parallel=True)
-            logger.info(
-                f"Retry results: {result['processed']} succeeded, "
-                f"{result['failed']} still failing"
-            )
+			# Immediately process the reset files
+			processor = get_file_processor()
+			result = processor.process_pending_files(limit=retry_count, parallel=True)
+			logger.info(f"Retry results: {result['processed']} succeeded, {result['failed']} still failing")
 
-    except Exception as e:
-        logger.error(f"Failed files retry job failed: {e}")
+	except Exception as e:
+		logger.error(f"Failed files retry job failed: {e}")
 
 
 def scan_for_new_files_job():
-    """
-    Automatic job to scan all store folders for new files.
+	"""
+	Automatic job to scan all store folders for new files.
 
-    Runs every 30 minutes as a backup to webhook notifications.
-    Discovers new files that might have been missed by push notifications.
-    """
-    try:
-        watcher = get_folder_watcher()
-        logger.info("Scanning all store folders for new files...")
+	Runs every 30 minutes as a backup to webhook notifications.
+	Discovers new files that might have been missed by push notifications.
+	"""
+	try:
+		watcher = get_folder_watcher()
+		logger.info("Scanning all store folders for new files...")
 
-        result = watcher.scan_all_stores()
+		result = watcher.scan_all_stores()
 
-        if result['total_queued'] > 0:
-            logger.info(
-                f"Folder scan: {result['total_found']} files found, "
-                f"{result['total_queued']} queued for processing, "
-                f"{result['stores_with_files']} stores with new files"
-            )
-        else:
-            logger.debug("Folder scan: No new files found")
+		if result["total_queued"] > 0:
+			logger.info(
+				f"Folder scan: {result['total_found']} files found, "
+				f"{result['total_queued']} queued for processing, "
+				f"{result['stores_with_files']} stores with new files"
+			)
+		else:
+			logger.debug("Folder scan: No new files found")
 
-    except Exception as e:
-        logger.error(f"Folder scan job failed: {e}")
+	except Exception as e:
+		logger.error(f"Folder scan job failed: {e}")
 
 
 def renew_folder_watches_job():
-    """
-    Scheduled job to renew expiring folder watches.
+	"""
+	Scheduled job to renew expiring folder watches.
 
-    Folder watches expire after 24 hours. This runs hourly
-    to renew any watches expiring in the next 2 hours.
-    """
-    logger.info("Running folder watch renewal job...")
-    try:
-        watcher = get_folder_watcher()
-        renewed = watcher.renew_expiring_folder_watches(hours_before=2)
-        if renewed:
-            logger.info(f"Renewed {len(renewed)} folder watches")
-    except Exception as e:
-        logger.error(f"Folder watch renewal failed: {e}")
+	Folder watches expire after 24 hours. This runs hourly
+	to renew any watches expiring in the next 2 hours.
+	"""
+	logger.info("Running folder watch renewal job...")
+	try:
+		watcher = get_folder_watcher()
+		renewed = watcher.renew_expiring_folder_watches(hours_before=2)
+		if renewed:
+			logger.info(f"Renewed {len(renewed)} folder watches")
+	except Exception as e:
+		logger.error(f"Folder watch renewal failed: {e}")
 
 
 def daily_summary_job():
-    """
-    Scheduled job to send daily summary report via Google Chat.
+	"""
+	Scheduled job to send daily summary report via Google Chat.
 
-    Runs at 7 AM Philippines time (23:00 UTC previous day).
-    Reports on the previous day's file processing.
-    """
-    try:
-        from . import notifications
-        db = get_db()
+	Runs at 7 AM Philippines time (23:00 UTC previous day).
+	Reports on the previous day's file processing.
+	"""
+	try:
+		from . import notifications
 
-        logger.info("Sending daily POS file summary report...")
-        result = notifications.send_daily_summary(db)
+		db = get_db()
 
-        if result:
-            logger.info(f"Daily summary sent: {result}")
-        else:
-            logger.warning("Failed to send daily summary")
+		logger.info("Sending daily POS file summary report...")
+		result = notifications.send_daily_summary(db)
 
-    except Exception as e:
-        logger.error(f"Daily summary job failed: {e}")
+		if result:
+			logger.info(f"Daily summary sent: {result}")
+		else:
+			logger.warning("Failed to send daily summary")
+
+	except Exception as e:
+		logger.error(f"Daily summary job failed: {e}")
 
 
 def configure_scheduled_jobs(schedule_module=schedule):
-    """Register all recurring jobs on the provided schedule module."""
-    # ==========================================================================
-    # Sheets Processing (Original)
-    # ==========================================================================
+	"""Register all recurring jobs on the provided schedule module."""
+	# ==========================================================================
+	# Sheets Processing (Original)
+	# ==========================================================================
 
-    # Renew sheet watches every hour (they expire after 24h)
-    schedule_module.every(1).hour.do(renew_watches_job)
+	# Renew sheet watches every hour (they expire after 24h)
+	schedule_module.every(1).hour.do(renew_watches_job)
 
-    # Backup sync every 6 hours (in case webhooks missed)
-    schedule_module.every(6).hours.do(scheduled_sync_job)
+	# Backup sync every 6 hours (in case webhooks missed)
+	schedule_module.every(6).hours.do(scheduled_sync_job)
 
-    # Deterministic AP + Procurement baseline refresh at 8:00 AM PHT.
-    # Runs through a once-per-day gate so it is safe across restarts.
-    schedule_module.every(1).minutes.do(run_daily_baseline_sync_if_due)
+	# Deterministic AP + Procurement baseline refresh at 8:00 AM PHT.
+	# Runs through a once-per-day gate so it is safe across restarts.
+	schedule_module.every(1).minutes.do(run_daily_baseline_sync_if_due)
 
-    # ==========================================================================
-    # POS File Processing (Automatic - No Manual Intervention)
-    # ==========================================================================
+	# ==========================================================================
+	# POS File Processing (Automatic - No Manual Intervention)
+	# ==========================================================================
 
-    # Process pending files every 2 minutes (fast turnaround)
-    schedule_module.every(2).minutes.do(process_pending_files_job)
+	# Process pending files every 2 minutes (fast turnaround)
+	schedule_module.every(2).minutes.do(process_pending_files_job)
 
-    # Retry failed files every 15 minutes (give time for transient issues)
-    schedule_module.every(15).minutes.do(retry_failed_files_job)
+	# Retry failed files every 15 minutes (give time for transient issues)
+	schedule_module.every(15).minutes.do(retry_failed_files_job)
 
-    # Scan all folders every 30 minutes (backup to webhooks)
-    schedule_module.every(30).minutes.do(scan_for_new_files_job)
+	# Scan all folders every 30 minutes (backup to webhooks)
+	schedule_module.every(30).minutes.do(scan_for_new_files_job)
 
-    # Renew folder watches every hour (they expire after 24h)
-    schedule_module.every(1).hour.do(renew_folder_watches_job)
+	# Renew folder watches every hour (they expire after 24h)
+	schedule_module.every(1).hour.do(renew_folder_watches_job)
 
-    # ==========================================================================
-    # Notifications & Reporting
-    # ==========================================================================
+	# ==========================================================================
+	# Notifications & Reporting
+	# ==========================================================================
 
-    # Daily summary at 7 AM Philippines time (23:00 UTC)
-    schedule_module.every().day.at("23:00").do(daily_summary_job)
+	# Daily summary at 7 AM Philippines time (23:00 UTC)
+	schedule_module.every().day.at("23:00").do(daily_summary_job)
 
 
 def run_scheduler():
-    """Run the scheduler in a background thread."""
-    configure_scheduled_jobs()
+	"""Run the scheduler in a background thread."""
+	configure_scheduled_jobs()
 
-    logger.info("Scheduler started with jobs:")
-    logger.info("  - Sheet watch renewal: every 1 hour")
-    logger.info("  - Sheet backup sync: every 6 hours")
-    logger.info("  - Daily AP/procurement baseline sync gate: every 1 minute, target 8 AM PHT")
-    logger.info("  - POS file processing: every 2 minutes")
-    logger.info("  - Failed file retry: every 15 minutes")
-    logger.info("  - Folder scan (backup): every 30 minutes")
-    logger.info("  - Folder watch renewal: every 1 hour")
-    logger.info("  - Daily summary report: 7 AM PHT (23:00 UTC)")
+	logger.info("Scheduler started with jobs:")
+	logger.info("  - Sheet watch renewal: every 1 hour")
+	logger.info("  - Sheet backup sync: every 6 hours")
+	logger.info("  - Daily AP/procurement baseline sync gate: every 1 minute, target 8 AM PHT")
+	logger.info("  - POS file processing: every 2 minutes")
+	logger.info("  - Failed file retry: every 15 minutes")
+	logger.info("  - Folder scan (backup): every 30 minutes")
+	logger.info("  - Folder watch renewal: every 1 hour")
+	logger.info("  - Daily summary report: 7 AM PHT (23:00 UTC)")
 
-    while True:
-        schedule.run_pending()
-        time.sleep(30)  # Check every 30 seconds for faster response
+	while True:
+		schedule.run_pending()
+		time.sleep(30)  # Check every 30 seconds for faster response
 
 
 def initial_setup():
-    """Perform initial setup on startup."""
-    logger.info("=" * 60)
-    logger.info("Sheets Receiver Service Starting")
-    logger.info("=" * 60)
+	"""Perform initial setup on startup."""
+	logger.info("=" * 60)
+	logger.info("Sheets Receiver Service Starting")
+	logger.info("=" * 60)
 
-    config = get_config()
+	config = get_config()
 
-    # Initialize database
-    logger.info("Initializing database...")
-    db = get_db()
+	# Initialize database
+	logger.info("Initializing database...")
+	db = get_db()
 
-    # Log configuration
-    logger.info(f"Frappe URL: {config.frappe_url}")
-    logger.info(f"Webhook URL: {config.public_webhook_url}")
-    logger.info(f"Webhook port: {config.webhook_port}")
+	# Log configuration
+	logger.info(f"Frappe URL: {config.frappe_url}")
+	logger.info(f"Webhook URL: {config.public_webhook_url}")
+	logger.info(f"Webhook port: {config.webhook_port}")
 
-    # Log watched sheets
-    sheets = get_watched_sheets()
-    logger.info(f"Watching {len(sheets)} sheets:")
-    for key, sheet in sheets.items():
-        logger.info(f"  - {sheet.name} ({sheet.spreadsheet_id})")
+	# Log watched sheets
+	sheets = get_watched_sheets()
+	logger.info(f"Watching {len(sheets)} sheets:")
+	for _key, sheet in sheets.items():
+		logger.info(f"  - {sheet.name} ({sheet.spreadsheet_id})")
 
-    # Set up sheet watches
-    logger.info("Setting up Google Drive watches for sheets...")
-    try:
-        client = get_sheets_client()
-        watches = client.setup_all_watches()
-        logger.info(f"Created/verified {len(watches)} sheet watches")
-    except Exception as e:
-        logger.error(f"Failed to set up sheet watches: {e}")
-        logger.warning("Service will continue without real-time notifications")
-        logger.warning("Using scheduled sync as fallback")
+	# Set up sheet watches
+	logger.info("Setting up Google Drive watches for sheets...")
+	try:
+		client = get_sheets_client()
+		watches = client.setup_all_watches()
+		logger.info(f"Created/verified {len(watches)} sheet watches")
+	except Exception as e:
+		logger.error(f"Failed to set up sheet watches: {e}")
+		logger.warning("Service will continue without real-time notifications")
+		logger.warning("Using scheduled sync as fallback")
 
-    # Set up folder watches for POS files
-    logger.info("Setting up Google Drive watches for POS folders...")
-    try:
-        watcher = get_folder_watcher()
-        folder_watches = watcher.setup_all_folder_watches()
-        logger.info(f"Created/verified {len(folder_watches)} folder watches")
-    except Exception as e:
-        logger.error(f"Failed to set up folder watches: {e}")
-        logger.warning("Using scheduled folder scan as fallback")
+	# Set up folder watches for POS files
+	logger.info("Setting up Google Drive watches for POS folders...")
+	try:
+		watcher = get_folder_watcher()
+		folder_watches = watcher.setup_all_folder_watches()
+		logger.info(f"Created/verified {len(folder_watches)} folder watches")
+	except Exception as e:
+		logger.error(f"Failed to set up folder watches: {e}")
+		logger.warning("Using scheduled folder scan as fallback")
 
-    # Initial sync for sheets
-    logger.info("Performing initial sheet sync check...")
-    try:
-        processor = get_processor()
-        processor.sync_all_sheets(trigger='startup', force=False)
-    except Exception as e:
-        logger.error(f"Initial sheet sync failed: {e}")
+	# Initial sync for sheets
+	logger.info("Performing initial sheet sync check...")
+	try:
+		processor = get_processor()
+		processor.sync_all_sheets(trigger="startup", force=False)
+	except Exception as e:
+		logger.error(f"Initial sheet sync failed: {e}")
 
-    logger.info("Checking whether daily AP/procurement baseline sync is due...")
-    try:
-        run_daily_baseline_sync_if_due()
-    except Exception as e:
-        logger.error(f"Daily baseline sync check failed: {e}")
+	logger.info("Checking whether daily AP/procurement baseline sync is due...")
+	try:
+		run_daily_baseline_sync_if_due()
+	except Exception as e:
+		logger.error(f"Daily baseline sync check failed: {e}")
 
-    # Initial scan for POS files
-    logger.info("Performing initial POS folder scan...")
-    try:
-        watcher = get_folder_watcher()
-        scan_result = watcher.scan_all_stores()
-        logger.info(
-            f"Initial scan: {scan_result['total_found']} files found, "
-            f"{scan_result['total_queued']} queued"
-        )
+	# Initial scan for POS files
+	logger.info("Performing initial POS folder scan...")
+	try:
+		watcher = get_folder_watcher()
+		scan_result = watcher.scan_all_stores()
+		logger.info(
+			f"Initial scan: {scan_result['total_found']} files found, {scan_result['total_queued']} queued"
+		)
 
-        # Process any pending files immediately
-        file_processor = get_file_processor()
-        pending_count = db.get_pending_count()
-        if pending_count > 0:
-            logger.info(f"Processing {pending_count} pending files on startup...")
-            result = file_processor.process_pending_files(limit=100, parallel=True)
-            logger.info(
-                f"Startup processing: {result['processed']} processed, "
-                f"{result['failed']} failed"
-            )
-    except Exception as e:
-        logger.error(f"Initial POS scan failed: {e}")
+		# Process any pending files immediately
+		file_processor = get_file_processor()
+		pending_count = db.get_pending_count()
+		if pending_count > 0:
+			logger.info(f"Processing {pending_count} pending files on startup...")
+			result = file_processor.process_pending_files(limit=100, parallel=True)
+			logger.info(f"Startup processing: {result['processed']} processed, {result['failed']} failed")
+	except Exception as e:
+		logger.error(f"Initial POS scan failed: {e}")
 
-    logger.info("Initial setup complete")
-    logger.info("=" * 60)
+	logger.info("Initial setup complete")
+	logger.info("=" * 60)
 
 
 def handle_shutdown(signum, frame):
-    """Handle shutdown signals gracefully."""
-    logger.info("Shutdown signal received, cleaning up...")
+	"""Handle shutdown signals gracefully."""
+	logger.info("Shutdown signal received, cleaning up...")
 
-    # Could stop watches here if needed
-    # (but they'll expire anyway after 24h)
+	# Could stop watches here if needed
+	# (but they'll expire anyway after 24h)
 
-    sys.exit(0)
+	sys.exit(0)
 
 
 def main():
-    """Main entry point."""
-    # Set up logging
-    setup_file_logging()
+	"""Main entry point."""
+	# Set up logging
+	setup_file_logging()
 
-    # Handle shutdown signals
-    signal.signal(signal.SIGTERM, handle_shutdown)
-    signal.signal(signal.SIGINT, handle_shutdown)
+	# Handle shutdown signals
+	signal.signal(signal.SIGTERM, handle_shutdown)
+	signal.signal(signal.SIGINT, handle_shutdown)
 
-    # Initial setup
-    initial_setup()
+	# Initial setup
+	initial_setup()
 
-    # Start scheduler in background thread
-    scheduler_thread = threading.Thread(target=run_scheduler, daemon=True)
-    scheduler_thread.start()
+	# Start scheduler in background thread
+	scheduler_thread = threading.Thread(target=run_scheduler, daemon=True)
+	scheduler_thread.start()
 
-    # Run webhook server (this blocks)
-    logger.info("Starting webhook server...")
-    run_server()
+	# Run webhook server (this blocks)
+	logger.info("Starting webhook server...")
+	run_server()
 
 
 if __name__ == "__main__":
-    main()
+	main()

--- a/hrms/services/sheets_receiver/models.py
+++ b/hrms/services/sheets_receiver/models.py
@@ -9,7 +9,7 @@ Uses SQLite for persistent storage of:
 
 import sqlite3
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Optional, List, Dict, Any
 from dataclasses import dataclass, asdict
@@ -342,6 +342,34 @@ class Database:
                 )
                 for row in rows
             ]
+
+    def has_successful_sync_since(
+        self,
+        spreadsheet_id: str,
+        sheet_name: str,
+        trigger: str,
+        since: datetime,
+    ) -> bool:
+        """Return True when a successful sync exists for the sheet since the given UTC timestamp."""
+        if since.tzinfo is not None:
+            since = since.astimezone(UTC).replace(tzinfo=None)
+
+        with self._connection() as conn:
+            row = conn.execute(
+                """
+                SELECT 1
+                FROM sync_logs
+                WHERE spreadsheet_id = ?
+                  AND sheet_name = ?
+                  AND trigger = ?
+                  AND status = 'success'
+                  AND created_at >= ?
+                LIMIT 1
+                """,
+                (spreadsheet_id, sheet_name, trigger, since.isoformat()),
+            ).fetchone()
+
+            return row is not None
 
     # Checksums
     def get_checksum(self, spreadsheet_id: str, sheet_name: str) -> Optional[str]:

--- a/hrms/services/sheets_receiver/models.py
+++ b/hrms/services/sheets_receiver/models.py
@@ -7,90 +7,93 @@ Uses SQLite for persistent storage of:
 - Data checksums (change detection)
 """
 
-import sqlite3
 import json
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Optional, List, Dict, Any
-from dataclasses import dataclass, asdict
-from contextlib import contextmanager
+from typing import Any
 
 from .config import get_config
 
 
 @dataclass
 class WatchChannel:
-    """Google Drive watch channel."""
-    channel_id: str
-    spreadsheet_id: str
-    spreadsheet_name: str
-    resource_id: str
-    expiration: datetime
-    created_at: datetime = None
+	"""Google Drive watch channel."""
 
-    def __post_init__(self):
-        if self.created_at is None:
-            self.created_at = datetime.utcnow()
+	channel_id: str
+	spreadsheet_id: str
+	spreadsheet_name: str
+	resource_id: str
+	expiration: datetime
+	created_at: datetime = None
 
-    @property
-    def is_expired(self) -> bool:
-        return datetime.utcnow() >= self.expiration
+	def __post_init__(self):
+		if self.created_at is None:
+			self.created_at = datetime.utcnow()
 
-    @property
-    def hours_until_expiry(self) -> float:
-        delta = self.expiration - datetime.utcnow()
-        return delta.total_seconds() / 3600
+	@property
+	def is_expired(self) -> bool:
+		return datetime.utcnow() >= self.expiration
+
+	@property
+	def hours_until_expiry(self) -> float:
+		delta = self.expiration - datetime.utcnow()
+		return delta.total_seconds() / 3600
 
 
 @dataclass
 class SyncLog:
-    """Record of a sync operation."""
-    id: int = None
-    spreadsheet_id: str = None
-    spreadsheet_name: str = None
-    sheet_name: str = None
-    trigger: str = None  # 'webhook', 'manual', 'scheduled'
-    status: str = None  # 'success', 'failed', 'skipped'
-    rows_processed: int = 0
-    rows_created: int = 0
-    rows_updated: int = 0
-    rows_failed: int = 0
-    error_message: str = None
-    duration_seconds: float = 0
-    data_checksum: str = None
-    created_at: datetime = None
+	"""Record of a sync operation."""
 
-    def __post_init__(self):
-        if self.created_at is None:
-            self.created_at = datetime.utcnow()
+	id: int = None
+	spreadsheet_id: str = None
+	spreadsheet_name: str = None
+	sheet_name: str = None
+	trigger: str = None  # 'webhook', 'manual', 'scheduled'
+	status: str = None  # 'success', 'failed', 'skipped'
+	rows_processed: int = 0
+	rows_created: int = 0
+	rows_updated: int = 0
+	rows_failed: int = 0
+	error_message: str = None
+	duration_seconds: float = 0
+	data_checksum: str = None
+	created_at: datetime = None
+
+	def __post_init__(self):
+		if self.created_at is None:
+			self.created_at = datetime.utcnow()
 
 
 @dataclass
 class DataChecksum:
-    """Checksum for change detection."""
-    spreadsheet_id: str
-    sheet_name: str
-    checksum: str
-    row_count: int
-    last_synced: datetime
+	"""Checksum for change detection."""
+
+	spreadsheet_id: str
+	sheet_name: str
+	checksum: str
+	row_count: int
+	last_synced: datetime
 
 
 class Database:
-    """SQLite database for Sheets Receiver."""
+	"""SQLite database for Sheets Receiver."""
 
-    def __init__(self, db_path: str = None):
-        config = get_config()
-        self.db_path = db_path or config.db_path
+	def __init__(self, db_path: str | None = None):
+		config = get_config()
+		self.db_path = db_path or config.db_path
 
-        # Ensure directory exists
-        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+		# Ensure directory exists
+		Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
 
-        self._init_db()
+		self._init_db()
 
-    def _init_db(self):
-        """Initialize database schema."""
-        with self._connection() as conn:
-            conn.executescript("""
+	def _init_db(self):
+		"""Initialize database schema."""
+		with self._connection() as conn:
+			conn.executescript("""
                 CREATE TABLE IF NOT EXISTS watch_channels (
                     channel_id TEXT PRIMARY KEY,
                     spreadsheet_id TEXT NOT NULL,
@@ -205,158 +208,166 @@ class Database:
                 ON notifications(file_id);
             """)
 
-            # Migration: Add retry_count column if it doesn't exist
-            try:
-                conn.execute("ALTER TABLE file_queue ADD COLUMN retry_count INTEGER DEFAULT 0")
-            except sqlite3.OperationalError:
-                pass  # Column already exists
+			# Migration: Add retry_count column if it doesn't exist
+			try:
+				conn.execute("ALTER TABLE file_queue ADD COLUMN retry_count INTEGER DEFAULT 0")
+			except sqlite3.OperationalError:
+				pass  # Column already exists
 
-    @contextmanager
-    def _connection(self):
-        """Context manager for database connection."""
-        conn = sqlite3.connect(self.db_path)
-        conn.row_factory = sqlite3.Row
-        try:
-            yield conn
-            conn.commit()
-        finally:
-            conn.close()
+	@contextmanager
+	def _connection(self):
+		"""Context manager for database connection."""
+		conn = sqlite3.connect(self.db_path)
+		conn.row_factory = sqlite3.Row
+		try:
+			yield conn
+			conn.commit()
+		finally:
+			conn.close()
 
-    # Watch Channels
-    def save_watch(self, watch: WatchChannel):
-        """Save or update a watch channel."""
-        with self._connection() as conn:
-            conn.execute("""
+	# Watch Channels
+	def save_watch(self, watch: WatchChannel):
+		"""Save or update a watch channel."""
+		with self._connection() as conn:
+			conn.execute(
+				"""
                 INSERT OR REPLACE INTO watch_channels
                 (channel_id, spreadsheet_id, spreadsheet_name, resource_id, expiration, created_at)
                 VALUES (?, ?, ?, ?, ?, ?)
-            """, (
-                watch.channel_id,
-                watch.spreadsheet_id,
-                watch.spreadsheet_name,
-                watch.resource_id,
-                watch.expiration.isoformat(),
-                watch.created_at.isoformat()
-            ))
+            """,
+				(
+					watch.channel_id,
+					watch.spreadsheet_id,
+					watch.spreadsheet_name,
+					watch.resource_id,
+					watch.expiration.isoformat(),
+					watch.created_at.isoformat(),
+				),
+			)
 
-    def get_watch(self, spreadsheet_id: str) -> Optional[WatchChannel]:
-        """Get watch channel by spreadsheet ID."""
-        with self._connection() as conn:
-            row = conn.execute(
-                "SELECT * FROM watch_channels WHERE spreadsheet_id = ?",
-                (spreadsheet_id,)
-            ).fetchone()
+	def get_watch(self, spreadsheet_id: str) -> WatchChannel | None:
+		"""Get watch channel by spreadsheet ID."""
+		with self._connection() as conn:
+			row = conn.execute(
+				"SELECT * FROM watch_channels WHERE spreadsheet_id = ?", (spreadsheet_id,)
+			).fetchone()
 
-            if row:
-                return WatchChannel(
-                    channel_id=row['channel_id'],
-                    spreadsheet_id=row['spreadsheet_id'],
-                    spreadsheet_name=row['spreadsheet_name'],
-                    resource_id=row['resource_id'],
-                    expiration=datetime.fromisoformat(row['expiration']),
-                    created_at=datetime.fromisoformat(row['created_at'])
-                )
-        return None
+			if row:
+				return WatchChannel(
+					channel_id=row["channel_id"],
+					spreadsheet_id=row["spreadsheet_id"],
+					spreadsheet_name=row["spreadsheet_name"],
+					resource_id=row["resource_id"],
+					expiration=datetime.fromisoformat(row["expiration"]),
+					created_at=datetime.fromisoformat(row["created_at"]),
+				)
+		return None
 
-    def get_expiring_watches(self, hours: int = 2) -> List[WatchChannel]:
-        """Get watches expiring within given hours."""
-        cutoff = datetime.utcnow()
-        with self._connection() as conn:
-            rows = conn.execute("""
+	def get_expiring_watches(self, hours: int = 2) -> list[WatchChannel]:
+		"""Get watches expiring within given hours."""
+		cutoff = datetime.utcnow()
+		with self._connection() as conn:
+			rows = conn.execute(
+				"""
                 SELECT * FROM watch_channels
                 WHERE expiration <= datetime(?, '+' || ? || ' hours')
-            """, (cutoff.isoformat(), hours)).fetchall()
+            """,
+				(cutoff.isoformat(), hours),
+			).fetchall()
 
-            return [
-                WatchChannel(
-                    channel_id=row['channel_id'],
-                    spreadsheet_id=row['spreadsheet_id'],
-                    spreadsheet_name=row['spreadsheet_name'],
-                    resource_id=row['resource_id'],
-                    expiration=datetime.fromisoformat(row['expiration']),
-                    created_at=datetime.fromisoformat(row['created_at'])
-                )
-                for row in rows
-            ]
+			return [
+				WatchChannel(
+					channel_id=row["channel_id"],
+					spreadsheet_id=row["spreadsheet_id"],
+					spreadsheet_name=row["spreadsheet_name"],
+					resource_id=row["resource_id"],
+					expiration=datetime.fromisoformat(row["expiration"]),
+					created_at=datetime.fromisoformat(row["created_at"]),
+				)
+				for row in rows
+			]
 
-    def delete_watch(self, channel_id: str):
-        """Delete a watch channel."""
-        with self._connection() as conn:
-            conn.execute(
-                "DELETE FROM watch_channels WHERE channel_id = ?",
-                (channel_id,)
-            )
+	def delete_watch(self, channel_id: str):
+		"""Delete a watch channel."""
+		with self._connection() as conn:
+			conn.execute("DELETE FROM watch_channels WHERE channel_id = ?", (channel_id,))
 
-    # Sync Logs
-    def log_sync(self, log: SyncLog) -> int:
-        """Log a sync operation. Returns log ID."""
-        with self._connection() as conn:
-            cursor = conn.execute("""
+	# Sync Logs
+	def log_sync(self, log: SyncLog) -> int:
+		"""Log a sync operation. Returns log ID."""
+		with self._connection() as conn:
+			cursor = conn.execute(
+				"""
                 INSERT INTO sync_logs
                 (spreadsheet_id, spreadsheet_name, sheet_name, trigger, status,
                  rows_processed, rows_created, rows_updated, rows_failed,
                  error_message, duration_seconds, data_checksum, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (
-                log.spreadsheet_id,
-                log.spreadsheet_name,
-                log.sheet_name,
-                log.trigger,
-                log.status,
-                log.rows_processed,
-                log.rows_created,
-                log.rows_updated,
-                log.rows_failed,
-                log.error_message,
-                log.duration_seconds,
-                log.data_checksum,
-                log.created_at.isoformat()
-            ))
-            return cursor.lastrowid
+            """,
+				(
+					log.spreadsheet_id,
+					log.spreadsheet_name,
+					log.sheet_name,
+					log.trigger,
+					log.status,
+					log.rows_processed,
+					log.rows_created,
+					log.rows_updated,
+					log.rows_failed,
+					log.error_message,
+					log.duration_seconds,
+					log.data_checksum,
+					log.created_at.isoformat(),
+				),
+			)
+			return cursor.lastrowid
 
-    def get_recent_syncs(self, limit: int = 50) -> List[SyncLog]:
-        """Get recent sync logs."""
-        with self._connection() as conn:
-            rows = conn.execute("""
+	def get_recent_syncs(self, limit: int = 50) -> list[SyncLog]:
+		"""Get recent sync logs."""
+		with self._connection() as conn:
+			rows = conn.execute(
+				"""
                 SELECT * FROM sync_logs
                 ORDER BY created_at DESC
                 LIMIT ?
-            """, (limit,)).fetchall()
+            """,
+				(limit,),
+			).fetchall()
 
-            return [
-                SyncLog(
-                    id=row['id'],
-                    spreadsheet_id=row['spreadsheet_id'],
-                    spreadsheet_name=row['spreadsheet_name'],
-                    sheet_name=row['sheet_name'],
-                    trigger=row['trigger'],
-                    status=row['status'],
-                    rows_processed=row['rows_processed'],
-                    rows_created=row['rows_created'],
-                    rows_updated=row['rows_updated'],
-                    rows_failed=row['rows_failed'],
-                    error_message=row['error_message'],
-                    duration_seconds=row['duration_seconds'],
-                    data_checksum=row['data_checksum'],
-                    created_at=datetime.fromisoformat(row['created_at'])
-                )
-                for row in rows
-            ]
+			return [
+				SyncLog(
+					id=row["id"],
+					spreadsheet_id=row["spreadsheet_id"],
+					spreadsheet_name=row["spreadsheet_name"],
+					sheet_name=row["sheet_name"],
+					trigger=row["trigger"],
+					status=row["status"],
+					rows_processed=row["rows_processed"],
+					rows_created=row["rows_created"],
+					rows_updated=row["rows_updated"],
+					rows_failed=row["rows_failed"],
+					error_message=row["error_message"],
+					duration_seconds=row["duration_seconds"],
+					data_checksum=row["data_checksum"],
+					created_at=datetime.fromisoformat(row["created_at"]),
+				)
+				for row in rows
+			]
 
-    def has_successful_sync_since(
-        self,
-        spreadsheet_id: str,
-        sheet_name: str,
-        trigger: str,
-        since: datetime,
-    ) -> bool:
-        """Return True when a successful sync exists for the sheet since the given UTC timestamp."""
-        if since.tzinfo is not None:
-            since = since.astimezone(UTC).replace(tzinfo=None)
+	def has_successful_sync_since(
+		self,
+		spreadsheet_id: str,
+		sheet_name: str,
+		trigger: str,
+		since: datetime,
+	) -> bool:
+		"""Return True when a successful sync exists for the sheet since the given UTC timestamp."""
+		if since.tzinfo is not None:
+			since = since.astimezone(UTC).replace(tzinfo=None)
 
-        with self._connection() as conn:
-            row = conn.execute(
-                """
+		with self._connection() as conn:
+			row = conn.execute(
+				"""
                 SELECT 1
                 FROM sync_logs
                 WHERE spreadsheet_id = ?
@@ -366,539 +377,573 @@ class Database:
                   AND created_at >= ?
                 LIMIT 1
                 """,
-                (spreadsheet_id, sheet_name, trigger, since.isoformat()),
-            ).fetchone()
+				(spreadsheet_id, sheet_name, trigger, since.isoformat()),
+			).fetchone()
 
-            return row is not None
+			return row is not None
 
-    # Checksums
-    def get_checksum(self, spreadsheet_id: str, sheet_name: str) -> Optional[str]:
-        """Get stored checksum for a sheet."""
-        with self._connection() as conn:
-            row = conn.execute("""
+	# Checksums
+	def get_checksum(self, spreadsheet_id: str, sheet_name: str) -> str | None:
+		"""Get stored checksum for a sheet."""
+		with self._connection() as conn:
+			row = conn.execute(
+				"""
                 SELECT checksum FROM data_checksums
                 WHERE spreadsheet_id = ? AND sheet_name = ?
-            """, (spreadsheet_id, sheet_name)).fetchone()
+            """,
+				(spreadsheet_id, sheet_name),
+			).fetchone()
 
-            return row['checksum'] if row else None
+			return row["checksum"] if row else None
 
-    def save_checksum(self, spreadsheet_id: str, sheet_name: str, checksum: str, row_count: int):
-        """Save checksum after successful sync."""
-        with self._connection() as conn:
-            conn.execute("""
+	def save_checksum(self, spreadsheet_id: str, sheet_name: str, checksum: str, row_count: int):
+		"""Save checksum after successful sync."""
+		with self._connection() as conn:
+			conn.execute(
+				"""
                 INSERT OR REPLACE INTO data_checksums
                 (spreadsheet_id, sheet_name, checksum, row_count, last_synced)
                 VALUES (?, ?, ?, ?, ?)
-            """, (spreadsheet_id, sheet_name, checksum, row_count, datetime.utcnow().isoformat()))
+            """,
+				(spreadsheet_id, sheet_name, checksum, row_count, datetime.utcnow().isoformat()),
+			)
 
-    def has_changed(self, spreadsheet_id: str, sheet_name: str, new_checksum: str) -> bool:
-        """Check if data has changed since last sync."""
-        stored = self.get_checksum(spreadsheet_id, sheet_name)
-        return stored != new_checksum
+	def has_changed(self, spreadsheet_id: str, sheet_name: str, new_checksum: str) -> bool:
+		"""Check if data has changed since last sync."""
+		stored = self.get_checksum(spreadsheet_id, sheet_name)
+		return stored != new_checksum
 
-    # =========================================================================
-    # Folder Watches (POS file processing)
-    # =========================================================================
+	# =========================================================================
+	# Folder Watches (POS file processing)
+	# =========================================================================
 
-    def save_folder_watch(self, watch: Dict[str, Any]):
-        """Save or update a folder watch channel."""
-        with self._connection() as conn:
-            expiration = watch['expiration']
-            if isinstance(expiration, datetime):
-                expiration = expiration.isoformat()
+	def save_folder_watch(self, watch: dict[str, Any]):
+		"""Save or update a folder watch channel."""
+		with self._connection() as conn:
+			expiration = watch["expiration"]
+			if isinstance(expiration, datetime):
+				expiration = expiration.isoformat()
 
-            created_at = watch.get('created_at', datetime.utcnow())
-            if isinstance(created_at, datetime):
-                created_at = created_at.isoformat()
+			created_at = watch.get("created_at", datetime.utcnow())
+			if isinstance(created_at, datetime):
+				created_at = created_at.isoformat()
 
-            conn.execute("""
+			conn.execute(
+				"""
                 INSERT OR REPLACE INTO folder_watches
                 (channel_id, folder_id, folder_name, store_code, resource_id, expiration, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?)
-            """, (
-                watch['channel_id'],
-                watch['folder_id'],
-                watch.get('folder_name'),
-                watch.get('store_code'),
-                watch.get('resource_id'),
-                expiration,
-                created_at
-            ))
+            """,
+				(
+					watch["channel_id"],
+					watch["folder_id"],
+					watch.get("folder_name"),
+					watch.get("store_code"),
+					watch.get("resource_id"),
+					expiration,
+					created_at,
+				),
+			)
 
-    def get_folder_watch(self, folder_id: str) -> Optional[Dict[str, Any]]:
-        """Get folder watch by folder ID."""
-        with self._connection() as conn:
-            row = conn.execute(
-                "SELECT * FROM folder_watches WHERE folder_id = ?",
-                (folder_id,)
-            ).fetchone()
+	def get_folder_watch(self, folder_id: str) -> dict[str, Any] | None:
+		"""Get folder watch by folder ID."""
+		with self._connection() as conn:
+			row = conn.execute("SELECT * FROM folder_watches WHERE folder_id = ?", (folder_id,)).fetchone()
 
-            if row:
-                return {
-                    'channel_id': row['channel_id'],
-                    'folder_id': row['folder_id'],
-                    'folder_name': row['folder_name'],
-                    'store_code': row['store_code'],
-                    'resource_id': row['resource_id'],
-                    'expiration': datetime.fromisoformat(row['expiration']),
-                    'created_at': datetime.fromisoformat(row['created_at'])
-                }
-        return None
+			if row:
+				return {
+					"channel_id": row["channel_id"],
+					"folder_id": row["folder_id"],
+					"folder_name": row["folder_name"],
+					"store_code": row["store_code"],
+					"resource_id": row["resource_id"],
+					"expiration": datetime.fromisoformat(row["expiration"]),
+					"created_at": datetime.fromisoformat(row["created_at"]),
+				}
+		return None
 
-    def get_folder_watch_by_channel(self, channel_id: str) -> Optional[Dict[str, Any]]:
-        """Get folder watch by channel ID."""
-        with self._connection() as conn:
-            row = conn.execute(
-                "SELECT * FROM folder_watches WHERE channel_id = ?",
-                (channel_id,)
-            ).fetchone()
+	def get_folder_watch_by_channel(self, channel_id: str) -> dict[str, Any] | None:
+		"""Get folder watch by channel ID."""
+		with self._connection() as conn:
+			row = conn.execute("SELECT * FROM folder_watches WHERE channel_id = ?", (channel_id,)).fetchone()
 
-            if row:
-                return {
-                    'channel_id': row['channel_id'],
-                    'folder_id': row['folder_id'],
-                    'folder_name': row['folder_name'],
-                    'store_code': row['store_code'],
-                    'resource_id': row['resource_id'],
-                    'expiration': datetime.fromisoformat(row['expiration']),
-                    'created_at': datetime.fromisoformat(row['created_at'])
-                }
-        return None
+			if row:
+				return {
+					"channel_id": row["channel_id"],
+					"folder_id": row["folder_id"],
+					"folder_name": row["folder_name"],
+					"store_code": row["store_code"],
+					"resource_id": row["resource_id"],
+					"expiration": datetime.fromisoformat(row["expiration"]),
+					"created_at": datetime.fromisoformat(row["created_at"]),
+				}
+		return None
 
-    def get_expiring_folder_watches(self, hours: int = 2) -> List[Dict[str, Any]]:
-        """Get folder watches expiring within given hours."""
-        cutoff = datetime.utcnow()
-        with self._connection() as conn:
-            rows = conn.execute("""
+	def get_expiring_folder_watches(self, hours: int = 2) -> list[dict[str, Any]]:
+		"""Get folder watches expiring within given hours."""
+		cutoff = datetime.utcnow()
+		with self._connection() as conn:
+			rows = conn.execute(
+				"""
                 SELECT * FROM folder_watches
                 WHERE expiration <= datetime(?, '+' || ? || ' hours')
-            """, (cutoff.isoformat(), hours)).fetchall()
+            """,
+				(cutoff.isoformat(), hours),
+			).fetchall()
 
-            return [
-                {
-                    'channel_id': row['channel_id'],
-                    'folder_id': row['folder_id'],
-                    'folder_name': row['folder_name'],
-                    'store_code': row['store_code'],
-                    'resource_id': row['resource_id'],
-                    'expiration': datetime.fromisoformat(row['expiration']),
-                    'created_at': datetime.fromisoformat(row['created_at'])
-                }
-                for row in rows
-            ]
+			return [
+				{
+					"channel_id": row["channel_id"],
+					"folder_id": row["folder_id"],
+					"folder_name": row["folder_name"],
+					"store_code": row["store_code"],
+					"resource_id": row["resource_id"],
+					"expiration": datetime.fromisoformat(row["expiration"]),
+					"created_at": datetime.fromisoformat(row["created_at"]),
+				}
+				for row in rows
+			]
 
-    def delete_folder_watch(self, channel_id: str):
-        """Delete a folder watch channel."""
-        with self._connection() as conn:
-            conn.execute(
-                "DELETE FROM folder_watches WHERE channel_id = ?",
-                (channel_id,)
-            )
+	def delete_folder_watch(self, channel_id: str):
+		"""Delete a folder watch channel."""
+		with self._connection() as conn:
+			conn.execute("DELETE FROM folder_watches WHERE channel_id = ?", (channel_id,))
 
-    def get_all_folder_watches(self) -> List[Dict[str, Any]]:
-        """Get all folder watches."""
-        with self._connection() as conn:
-            rows = conn.execute("SELECT * FROM folder_watches").fetchall()
+	def get_all_folder_watches(self) -> list[dict[str, Any]]:
+		"""Get all folder watches."""
+		with self._connection() as conn:
+			rows = conn.execute("SELECT * FROM folder_watches").fetchall()
 
-            return [
-                {
-                    'channel_id': row['channel_id'],
-                    'folder_id': row['folder_id'],
-                    'folder_name': row['folder_name'],
-                    'store_code': row['store_code'],
-                    'resource_id': row['resource_id'],
-                    'expiration': datetime.fromisoformat(row['expiration']),
-                    'created_at': datetime.fromisoformat(row['created_at'])
-                }
-                for row in rows
-            ]
+			return [
+				{
+					"channel_id": row["channel_id"],
+					"folder_id": row["folder_id"],
+					"folder_name": row["folder_name"],
+					"store_code": row["store_code"],
+					"resource_id": row["resource_id"],
+					"expiration": datetime.fromisoformat(row["expiration"]),
+					"created_at": datetime.fromisoformat(row["created_at"]),
+				}
+				for row in rows
+			]
 
-    # =========================================================================
-    # File Queue (POS file processing)
-    # =========================================================================
+	# =========================================================================
+	# File Queue (POS file processing)
+	# =========================================================================
 
-    def queue_file(self, file_info: Dict[str, Any], store_code: str = None):
-        """Add a file to the processing queue."""
-        with self._connection() as conn:
-            conn.execute("""
+	def queue_file(self, file_info: dict[str, Any], store_code: str | None = None):
+		"""Add a file to the processing queue."""
+		with self._connection() as conn:
+			conn.execute(
+				"""
                 INSERT OR IGNORE INTO file_queue
                 (file_id, file_name, folder_id, store_code, mime_type, file_size,
                  md5_checksum, status, detected_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)
-            """, (
-                file_info['id'],
-                file_info['name'],
-                file_info.get('parents', [''])[0] if 'parents' in file_info else file_info.get('folder_id', ''),
-                store_code,
-                file_info.get('mimeType'),
-                file_info.get('size'),
-                file_info.get('md5Checksum'),
-                datetime.utcnow().isoformat()
-            ))
+            """,
+				(
+					file_info["id"],
+					file_info["name"],
+					file_info.get("parents", [""])[0]
+					if "parents" in file_info
+					else file_info.get("folder_id", ""),
+					store_code,
+					file_info.get("mimeType"),
+					file_info.get("size"),
+					file_info.get("md5Checksum"),
+					datetime.utcnow().isoformat(),
+				),
+			)
 
-    def get_pending_files(self, limit: int = 10) -> List[Dict[str, Any]]:
-        """Get files pending processing."""
-        with self._connection() as conn:
-            rows = conn.execute("""
+	def get_pending_files(self, limit: int = 10) -> list[dict[str, Any]]:
+		"""Get files pending processing."""
+		with self._connection() as conn:
+			rows = conn.execute(
+				"""
                 SELECT * FROM file_queue
                 WHERE status = 'pending'
                 ORDER BY detected_at ASC
                 LIMIT ?
-            """, (limit,)).fetchall()
+            """,
+				(limit,),
+			).fetchall()
 
-            return [dict(row) for row in rows]
+			return [dict(row) for row in rows]
 
-    def update_file_status(
-        self,
-        file_id: str,
-        status: str,
-        record_count: int = 0,
-        report_type: str = None,
-        error: str = None
-    ):
-        """Update file processing status."""
-        with self._connection() as conn:
-            if status == 'completed':
-                conn.execute("""
+	def update_file_status(
+		self,
+		file_id: str,
+		status: str,
+		record_count: int = 0,
+		report_type: str | None = None,
+		error: str | None = None,
+	):
+		"""Update file processing status."""
+		with self._connection() as conn:
+			if status == "completed":
+				conn.execute(
+					"""
                     UPDATE file_queue
                     SET status = ?, processed_at = ?, record_count = ?, report_type = ?
                     WHERE file_id = ?
-                """, (status, datetime.utcnow().isoformat(), record_count, report_type, file_id))
-            elif status == 'failed':
-                conn.execute("""
+                """,
+					(status, datetime.utcnow().isoformat(), record_count, report_type, file_id),
+				)
+			elif status == "failed":
+				conn.execute(
+					"""
                     UPDATE file_queue
                     SET status = ?, error_message = ?
                     WHERE file_id = ?
-                """, (status, error, file_id))
-            else:
-                conn.execute("""
+                """,
+					(status, error, file_id),
+				)
+			else:
+				conn.execute(
+					"""
                     UPDATE file_queue SET status = ? WHERE file_id = ?
-                """, (status, file_id))
+                """,
+					(status, file_id),
+				)
 
-    def is_file_processed(self, file_id: str) -> bool:
-        """Check if a file has already been processed."""
-        with self._connection() as conn:
-            row = conn.execute("""
+	def is_file_processed(self, file_id: str) -> bool:
+		"""Check if a file has already been processed."""
+		with self._connection() as conn:
+			row = conn.execute(
+				"""
                 SELECT 1 FROM processed_files WHERE file_id = ?
                 UNION
                 SELECT 1 FROM file_queue WHERE file_id = ? AND status IN ('completed', 'processing')
-            """, (file_id, file_id)).fetchone()
+            """,
+				(file_id, file_id),
+			).fetchone()
 
-            return row is not None
+			return row is not None
 
-    def mark_file_processed(
-        self,
-        file_id: str,
-        file_name: str,
-        folder_id: str,
-        store_code: str,
-        md5_checksum: str,
-        record_count: int,
-        report_type: str,
-        extracted_data: Dict = None
-    ):
-        """Record a processed file."""
-        with self._connection() as conn:
-            conn.execute("""
+	def mark_file_processed(
+		self,
+		file_id: str,
+		file_name: str,
+		folder_id: str,
+		store_code: str,
+		md5_checksum: str,
+		record_count: int,
+		report_type: str,
+		extracted_data: dict[str, Any] | None = None,
+	):
+		"""Record a processed file."""
+		with self._connection() as conn:
+			conn.execute(
+				"""
                 INSERT OR REPLACE INTO processed_files
                 (file_id, file_name, folder_id, store_code, md5_checksum,
                  processed_at, record_count, report_type, extracted_data)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """, (
-                file_id,
-                file_name,
-                folder_id,
-                store_code,
-                md5_checksum,
-                datetime.utcnow().isoformat(),
-                record_count,
-                report_type,
-                json.dumps(extracted_data) if extracted_data else None
-            ))
+            """,
+				(
+					file_id,
+					file_name,
+					folder_id,
+					store_code,
+					md5_checksum,
+					datetime.utcnow().isoformat(),
+					record_count,
+					report_type,
+					json.dumps(extracted_data) if extracted_data else None,
+				),
+			)
 
-    def get_processed_files(
-        self,
-        store_code: str = None,
-        since: datetime = None,
-        limit: int = 100
-    ) -> List[Dict[str, Any]]:
-        """Get list of processed files."""
-        with self._connection() as conn:
-            query = "SELECT * FROM processed_files WHERE 1=1"
-            params = []
+	def get_processed_files(
+		self, store_code: str | None = None, since: datetime | None = None, limit: int = 100
+	) -> list[dict[str, Any]]:
+		"""Get list of processed files."""
+		with self._connection() as conn:
+			query = "SELECT * FROM processed_files WHERE 1=1"
+			params = []
 
-            if store_code:
-                query += " AND store_code = ?"
-                params.append(store_code)
+			if store_code:
+				query += " AND store_code = ?"
+				params.append(store_code)
 
-            if since:
-                query += " AND processed_at >= ?"
-                params.append(since.isoformat())
+			if since:
+				query += " AND processed_at >= ?"
+				params.append(since.isoformat())
 
-            query += " ORDER BY processed_at DESC LIMIT ?"
-            params.append(limit)
+			query += " ORDER BY processed_at DESC LIMIT ?"
+			params.append(limit)
 
-            rows = conn.execute(query, params).fetchall()
-            return [dict(row) for row in rows]
+			rows = conn.execute(query, params).fetchall()
+			return [dict(row) for row in rows]
 
-    def get_file_queue_summary(self) -> Dict[str, int]:
-        """Get summary counts of file queue by status."""
-        with self._connection() as conn:
-            rows = conn.execute("""
+	def get_file_queue_summary(self) -> dict[str, int]:
+		"""Get summary counts of file queue by status."""
+		with self._connection() as conn:
+			rows = conn.execute("""
                 SELECT status, COUNT(*) as count
                 FROM file_queue
                 GROUP BY status
             """).fetchall()
 
-            return {row['status']: row['count'] for row in rows}
+			return {row["status"]: row["count"] for row in rows}
 
-    def get_pending_count(self) -> int:
-        """Get count of pending files."""
-        with self._connection() as conn:
-            row = conn.execute("""
+	def get_pending_count(self) -> int:
+		"""Get count of pending files."""
+		with self._connection() as conn:
+			row = conn.execute("""
                 SELECT COUNT(*) as count FROM file_queue WHERE status = 'pending'
             """).fetchone()
-            return row['count'] if row else 0
+			return row["count"] if row else 0
 
-    def get_failed_files(self, max_retries: int = 3) -> List[Dict[str, Any]]:
-        """
-        Get failed files that haven't exceeded retry limit.
+	def get_failed_files(self, max_retries: int = 3) -> list[dict[str, Any]]:
+		"""
+		Get failed files that haven't exceeded retry limit.
 
-        Args:
-            max_retries: Maximum number of retries before giving up
+		Args:
+		    max_retries: Maximum number of retries before giving up
 
-        Returns:
-            List of failed file entries
-        """
-        with self._connection() as conn:
-            rows = conn.execute("""
+		Returns:
+		    List of failed file entries
+		"""
+		with self._connection() as conn:
+			rows = conn.execute(
+				"""
                 SELECT * FROM file_queue
                 WHERE status = 'failed'
                 AND (retry_count IS NULL OR retry_count < ?)
                 ORDER BY detected_at ASC
-            """, (max_retries,)).fetchall()
+            """,
+				(max_retries,),
+			).fetchall()
 
-            return [dict(row) for row in rows]
+			return [dict(row) for row in rows]
 
-    def reset_for_retry(self, file_id: str):
-        """
-        Reset a failed file's status to pending for retry.
+	def reset_for_retry(self, file_id: str):
+		"""
+		Reset a failed file's status to pending for retry.
 
-        Increments the retry_count and clears error_message.
-        """
-        with self._connection() as conn:
-            conn.execute("""
+		Increments the retry_count and clears error_message.
+		"""
+		with self._connection() as conn:
+			conn.execute(
+				"""
                 UPDATE file_queue
                 SET status = 'pending',
                     retry_count = COALESCE(retry_count, 0) + 1,
                     error_message = NULL
                 WHERE file_id = ?
-            """, (file_id,))
+            """,
+				(file_id,),
+			)
 
-    def get_processing_stats(self) -> Dict[str, Any]:
-        """
-        Get comprehensive processing statistics.
+	def get_processing_stats(self) -> dict[str, Any]:
+		"""
+		Get comprehensive processing statistics.
 
-        Returns:
-            Dict with counts, recent activity, and performance metrics
-        """
-        with self._connection() as conn:
-            # Status counts
-            status_rows = conn.execute("""
+		Returns:
+		    Dict with counts, recent activity, and performance metrics
+		"""
+		with self._connection() as conn:
+			# Status counts
+			status_rows = conn.execute("""
                 SELECT status, COUNT(*) as count
                 FROM file_queue
                 GROUP BY status
             """).fetchall()
-            status_counts = {row['status']: row['count'] for row in status_rows}
+			status_counts = {row["status"]: row["count"] for row in status_rows}
 
-            # Total records extracted
-            record_row = conn.execute("""
+			# Total records extracted
+			record_row = conn.execute("""
                 SELECT SUM(record_count) as total_records
                 FROM processed_files
             """).fetchone()
-            total_records = record_row['total_records'] or 0
+			total_records = record_row["total_records"] or 0
 
-            # Files processed in last hour
-            recent_row = conn.execute("""
+			# Files processed in last hour
+			recent_row = conn.execute("""
                 SELECT COUNT(*) as count
                 FROM processed_files
                 WHERE processed_at >= datetime('now', '-1 hour')
             """).fetchone()
-            last_hour = recent_row['count'] if recent_row else 0
+			last_hour = recent_row["count"] if recent_row else 0
 
-            # Files processed today
-            today_row = conn.execute("""
+			# Files processed today
+			today_row = conn.execute("""
                 SELECT COUNT(*) as count
                 FROM processed_files
                 WHERE date(processed_at) = date('now')
             """).fetchone()
-            today = today_row['count'] if today_row else 0
+			today = today_row["count"] if today_row else 0
 
-            return {
-                'pending': status_counts.get('pending', 0),
-                'processing': status_counts.get('processing', 0),
-                'completed': status_counts.get('completed', 0),
-                'failed': status_counts.get('failed', 0),
-                'total_records': total_records,
-                'processed_last_hour': last_hour,
-                'processed_today': today
-            }
+			return {
+				"pending": status_counts.get("pending", 0),
+				"processing": status_counts.get("processing", 0),
+				"completed": status_counts.get("completed", 0),
+				"failed": status_counts.get("failed", 0),
+				"total_records": total_records,
+				"processed_last_hour": last_hour,
+				"processed_today": today,
+			}
 
-    def log_notification(
-        self,
-        message_id: str,
-        message_type: str,
-        message_preview: str,
-        file_id: Optional[str] = None,
-        store_code: Optional[str] = None
-    ) -> int:
-        """
-        Log a sent notification to the database.
+	def log_notification(
+		self,
+		message_id: str,
+		message_type: str,
+		message_preview: str,
+		file_id: str | None = None,
+		store_code: str | None = None,
+	) -> int:
+		"""
+		Log a sent notification to the database.
 
-        Args:
-            message_id: Google Chat message ID (e.g., "spaces/XXX/messages/YYY")
-            message_type: Type of notification (daily_summary, wrong_format, processing_failure, batch_failure)
-            message_preview: First 100 chars of message for identification
-            file_id: Associated file ID (if file-specific notification)
-            store_code: Store code (if applicable)
+		Args:
+		    message_id: Google Chat message ID (e.g., "spaces/XXX/messages/YYY")
+		    message_type: Type of notification (daily_summary, wrong_format, processing_failure, batch_failure)
+		    message_preview: First 100 chars of message for identification
+		    file_id: Associated file ID (if file-specific notification)
+		    store_code: Store code (if applicable)
 
-        Returns:
-            Notification ID
-        """
-        with self._connection() as conn:
-            cursor = conn.execute("""
+		Returns:
+		    Notification ID
+		"""
+		with self._connection() as conn:
+			cursor = conn.execute(
+				"""
                 INSERT INTO notifications (
                     message_id, message_type, file_id, store_code,
                     sent_at, message_preview
                 ) VALUES (?, ?, ?, ?, ?, ?)
-            """, (
-                message_id,
-                message_type,
-                file_id,
-                store_code,
-                datetime.utcnow().isoformat(),
-                message_preview[:100] if message_preview else None
-            ))
-            return cursor.lastrowid
+            """,
+				(
+					message_id,
+					message_type,
+					file_id,
+					store_code,
+					datetime.utcnow().isoformat(),
+					message_preview[:100] if message_preview else None,
+				),
+			)
+			return cursor.lastrowid
 
-    def get_notification_by_message_id(self, message_id: str) -> Optional[Dict[str, Any]]:
-        """Get notification record by Google Chat message ID."""
-        with self._connection() as conn:
-            row = conn.execute("""
+	def get_notification_by_message_id(self, message_id: str) -> dict[str, Any] | None:
+		"""Get notification record by Google Chat message ID."""
+		with self._connection() as conn:
+			row = conn.execute(
+				"""
                 SELECT * FROM notifications WHERE message_id = ?
-            """, (message_id,)).fetchone()
-            return dict(row) if row else None
+            """,
+				(message_id,),
+			).fetchone()
+			return dict(row) if row else None
 
-    def search_notifications(
-        self,
-        store_code: Optional[str] = None,
-        message_type: Optional[str] = None,
-        since: Optional[datetime] = None,
-        limit: int = 50
-    ) -> List[Dict[str, Any]]:
-        """
-        Search notifications by criteria.
+	def search_notifications(
+		self,
+		store_code: str | None = None,
+		message_type: str | None = None,
+		since: datetime | None = None,
+		limit: int = 50,
+	) -> list[dict[str, Any]]:
+		"""
+		Search notifications by criteria.
 
-        Args:
-            store_code: Filter by store code
-            message_type: Filter by notification type
-            since: Filter by sent date
-            limit: Maximum results
+		Args:
+		    store_code: Filter by store code
+		    message_type: Filter by notification type
+		    since: Filter by sent date
+		    limit: Maximum results
 
-        Returns:
-            List of notification records
-        """
-        with self._connection() as conn:
-            query = "SELECT * FROM notifications WHERE deleted_at IS NULL"
-            params = []
+		Returns:
+		    List of notification records
+		"""
+		with self._connection() as conn:
+			query = "SELECT * FROM notifications WHERE deleted_at IS NULL"
+			params = []
 
-            if store_code:
-                query += " AND store_code = ?"
-                params.append(store_code)
+			if store_code:
+				query += " AND store_code = ?"
+				params.append(store_code)
 
-            if message_type:
-                query += " AND message_type = ?"
-                params.append(message_type)
+			if message_type:
+				query += " AND message_type = ?"
+				params.append(message_type)
 
-            if since:
-                query += " AND sent_at >= ?"
-                params.append(since.isoformat())
+			if since:
+				query += " AND sent_at >= ?"
+				params.append(since.isoformat())
 
-            query += " ORDER BY sent_at DESC LIMIT ?"
-            params.append(limit)
+			query += " ORDER BY sent_at DESC LIMIT ?"
+			params.append(limit)
 
-            rows = conn.execute(query, params).fetchall()
-            return [dict(row) for row in rows]
+			rows = conn.execute(query, params).fetchall()
+			return [dict(row) for row in rows]
 
-    def mark_notification_deleted(self, message_id: str) -> bool:
-        """
-        Mark notification as deleted.
+	def mark_notification_deleted(self, message_id: str) -> bool:
+		"""
+		Mark notification as deleted.
 
-        Args:
-            message_id: Google Chat message ID
+		Args:
+		    message_id: Google Chat message ID
 
-        Returns:
-            True if notification was found and marked deleted
-        """
-        with self._connection() as conn:
-            cursor = conn.execute("""
+		Returns:
+		    True if notification was found and marked deleted
+		"""
+		with self._connection() as conn:
+			cursor = conn.execute(
+				"""
                 UPDATE notifications
                 SET deleted_at = ?
                 WHERE message_id = ? AND deleted_at IS NULL
-            """, (datetime.utcnow().isoformat(), message_id))
-            return cursor.rowcount > 0
+            """,
+				(datetime.utcnow().isoformat(), message_id),
+			)
+			return cursor.rowcount > 0
 
-    def find_notification_by_content(
-        self,
-        store_name: Optional[str] = None,
-        file_name: Optional[str] = None,
-        date_str: Optional[str] = None
-    ) -> List[Dict[str, Any]]:
-        """
-        Find notifications by content (for screenshot-based search).
+	def find_notification_by_content(
+		self, store_name: str | None = None, file_name: str | None = None, date_str: str | None = None
+	) -> list[dict[str, Any]]:
+		"""
+		Find notifications by content (for screenshot-based search).
 
-        Args:
-            store_name: Store name to search for
-            file_name: File name to search for
-            date_str: Date string from message (e.g., "2026-02-02")
+		Args:
+		    store_name: Store name to search for
+		    file_name: File name to search for
+		    date_str: Date string from message (e.g., "2026-02-02")
 
-        Returns:
-            List of matching notifications
-        """
-        with self._connection() as conn:
-            query = """
+		Returns:
+		    List of matching notifications
+		"""
+		with self._connection() as conn:
+			query = """
                 SELECT * FROM notifications
                 WHERE deleted_at IS NULL
             """
-            params = []
+			params = []
 
-            if store_name:
-                # Convert "Bf Homes" to "bf_homes" for matching
-                store_code = store_name.lower().replace(' ', '_')
-                query += " AND LOWER(REPLACE(store_code, '_', ' ')) LIKE ?"
-                params.append(f"%{store_name.lower()}%")
+			if store_name:
+				# Convert "Bf Homes" to "bf_homes" for matching
+				query += " AND LOWER(REPLACE(store_code, '_', ' ')) LIKE ?"
+				params.append(f"%{store_name.lower()}%")
 
-            if file_name:
-                query += " AND message_preview LIKE ?"
-                params.append(f"%{file_name}%")
+			if file_name:
+				query += " AND message_preview LIKE ?"
+				params.append(f"%{file_name}%")
 
-            if date_str:
-                query += " AND sent_at LIKE ?"
-                params.append(f"{date_str}%")
+			if date_str:
+				query += " AND sent_at LIKE ?"
+				params.append(f"{date_str}%")
 
-            query += " ORDER BY sent_at DESC LIMIT 10"
+			query += " ORDER BY sent_at DESC LIMIT 10"
 
-            rows = conn.execute(query, params).fetchall()
-            return [dict(row) for row in rows]
+			rows = conn.execute(query, params).fetchall()
+			return [dict(row) for row in rows]
 
 
 # Singleton instance
-_db: Optional[Database] = None
+_db: Database | None = None
 
 
 def get_db() -> Database:
-    """Get database instance."""
-    global _db
-    if _db is None:
-        _db = Database()
-    return _db
+	"""Get database instance."""
+	global _db
+	if _db is None:
+		_db = Database()
+	return _db

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -11,6 +11,25 @@ if str(ROOT) not in sys.path:
 	sys.path.insert(0, str(ROOT))
 
 
+def _install_fake_hrms():
+	if "hrms" in sys.modules:
+		return
+
+	hrms_pkg = types.ModuleType("hrms")
+	hrms_pkg.__path__ = []
+	sys.modules["hrms"] = hrms_pkg
+
+	utils_pkg = types.ModuleType("hrms.utils")
+	utils_pkg.__path__ = []
+	sys.modules["hrms.utils"] = utils_pkg
+
+	store_snapshot_mod = types.ModuleType("hrms.utils.store_order_demand_snapshot")
+	store_snapshot_mod.DEFAULT_DESTINATION_DIR = ROOT / "tmp"
+	store_snapshot_mod.run_snapshot = lambda *args, **kwargs: {}
+	sys.modules["hrms.utils.store_order_demand_snapshot"] = store_snapshot_mod
+	utils_pkg.store_order_demand_snapshot = store_snapshot_mod
+
+
 def _install_fake_frappe():
 	if "frappe" in sys.modules:
 		return
@@ -64,6 +83,7 @@ def _install_fake_frappe():
 
 
 _install_fake_frappe()
+_install_fake_hrms()
 erp_sync_spec = importlib.util.spec_from_file_location(
 	"erp_sync_runtime_under_test",
 	ROOT / "hrms" / "api" / "erp_sync.py",

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -74,8 +74,8 @@ def _install_fake_frappe():
 	utils.nowdate = lambda: "2026-01-01"
 	utils.flt = lambda value: float(value or 0)
 	utils.cint = lambda value: int(float(value or 0))
-	utils.getdate = (
-		lambda value=None: datetime.date.fromisoformat(str(value)) if value else datetime.date(2026, 1, 1)
+	utils.getdate = lambda value=None: (
+		datetime.date.fromisoformat(str(value)) if value else datetime.date(2026, 1, 1)
 	)
 
 	sys.modules["frappe"] = frappe

--- a/hrms/tests/test_sheets_receiver_main.py
+++ b/hrms/tests/test_sheets_receiver_main.py
@@ -126,7 +126,9 @@ class _FakeSchedule:
 
 class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
 	def setUp(self):
-		self.processor = types.SimpleNamespace(sync_sheet=MagicMock(side_effect=lambda *args, **kwargs: kwargs))
+		self.processor = types.SimpleNamespace(
+			sync_sheet=MagicMock(side_effect=lambda *args, **kwargs: kwargs)
+		)
 		self.db = types.SimpleNamespace(has_successful_sync_since=MagicMock(return_value=False))
 		self.sheet_configs = {
 			"ap_opening_balance": types.SimpleNamespace(
@@ -187,8 +189,8 @@ class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
 
 	def test_daily_baseline_sync_skips_sheets_already_synced_today(self):
 		now_utc = datetime(2026, 3, 10, 0, 5, tzinfo=UTC)
-		self.db.has_successful_sync_since.side_effect = (
-			lambda spreadsheet_id, sheet_name, trigger, since: sheet_name == "SUPPLIERS SOA"
+		self.db.has_successful_sync_since.side_effect = lambda spreadsheet_id, sheet_name, trigger, since: (
+			sheet_name == "SUPPLIERS SOA"
 		)
 
 		results = main_mod.run_daily_baseline_sync_if_due(now_utc=now_utc)

--- a/hrms/tests/test_sheets_receiver_main.py
+++ b/hrms/tests/test_sheets_receiver_main.py
@@ -1,0 +1,212 @@
+import importlib.util
+import sys
+import types
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_sheets_receiver_dependencies():
+	if "schedule" not in sys.modules:
+		schedule_mod = types.ModuleType("schedule")
+		schedule_mod.every = lambda *_args, **_kwargs: None
+		schedule_mod.run_pending = lambda: None
+		sys.modules["schedule"] = schedule_mod
+
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.services" not in sys.modules:
+		services_pkg = types.ModuleType("hrms.services")
+		services_pkg.__path__ = []
+		sys.modules["hrms.services"] = services_pkg
+
+	if "hrms.services.sheets_receiver" not in sys.modules:
+		sheets_pkg = types.ModuleType("hrms.services.sheets_receiver")
+		sheets_pkg.__path__ = []
+		sys.modules["hrms.services.sheets_receiver"] = sheets_pkg
+
+	config_mod = types.ModuleType("hrms.services.sheets_receiver.config")
+	config_mod.get_config = lambda: types.SimpleNamespace()
+	config_mod.get_watched_sheets = lambda: {}
+	config_mod.get_sheet_config = lambda _sheet_key: None
+	sys.modules["hrms.services.sheets_receiver.config"] = config_mod
+
+	models_mod = types.ModuleType("hrms.services.sheets_receiver.models")
+	models_mod.get_db = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.models"] = models_mod
+
+	sheets_client_mod = types.ModuleType("hrms.services.sheets_receiver.sheets_client")
+	sheets_client_mod.get_sheets_client = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.sheets_client"] = sheets_client_mod
+
+	processor_mod = types.ModuleType("hrms.services.sheets_receiver.processor")
+	processor_mod.get_processor = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.processor"] = processor_mod
+
+	webhook_mod = types.ModuleType("hrms.services.sheets_receiver.webhook")
+	webhook_mod.run_server = lambda *_args, **_kwargs: None
+	sys.modules["hrms.services.sheets_receiver.webhook"] = webhook_mod
+
+	file_processor_mod = types.ModuleType("hrms.services.sheets_receiver.file_processor")
+	file_processor_mod.get_file_processor = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.file_processor"] = file_processor_mod
+
+	folder_watcher_mod = types.ModuleType("hrms.services.sheets_receiver.folder_watcher")
+	folder_watcher_mod.get_folder_watcher = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.folder_watcher"] = folder_watcher_mod
+
+
+_install_fake_sheets_receiver_dependencies()
+main_spec = importlib.util.spec_from_file_location(
+	"hrms.services.sheets_receiver.main_under_test",
+	ROOT / "hrms" / "services" / "sheets_receiver" / "main.py",
+)
+main_mod = importlib.util.module_from_spec(main_spec)
+main_spec.loader.exec_module(main_mod)
+
+
+class _FakeScheduledJob:
+	def __init__(self, schedule_module, interval):
+		self._schedule_module = schedule_module
+		self.interval = interval
+		self.unit = None
+		self.at_time = None
+
+	@property
+	def hour(self):
+		self.unit = "hour"
+		return self
+
+	@property
+	def hours(self):
+		self.unit = "hours"
+		return self
+
+	@property
+	def minutes(self):
+		self.unit = "minutes"
+		return self
+
+	@property
+	def day(self):
+		self.unit = "day"
+		return self
+
+	def at(self, time_value):
+		self.at_time = time_value
+		return self
+
+	def do(self, func):
+		self._schedule_module.jobs.append(
+			{
+				"interval": self.interval,
+				"unit": self.unit,
+				"at": self.at_time,
+				"func": func,
+			}
+		)
+		return self
+
+
+class _FakeSchedule:
+	def __init__(self):
+		self.jobs = []
+
+	def every(self, interval=None):
+		return _FakeScheduledJob(self, interval)
+
+
+class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
+	def setUp(self):
+		self.processor = types.SimpleNamespace(sync_sheet=MagicMock(side_effect=lambda *args, **kwargs: kwargs))
+		self.db = types.SimpleNamespace(has_successful_sync_since=MagicMock(return_value=False))
+		self.sheet_configs = {
+			"ap_opening_balance": types.SimpleNamespace(
+				spreadsheet_id="ap-book",
+				sheet_name="05 - AP Opening Balance (PHP 24.4M)",
+				enabled=True,
+			),
+			"supplier_soa": types.SimpleNamespace(
+				spreadsheet_id="ap-book",
+				sheet_name="SUPPLIERS SOA",
+				enabled=True,
+			),
+			"procurement_suppliers": types.SimpleNamespace(
+				spreadsheet_id="proc-book",
+				sheet_name="Suppliers",
+				enabled=True,
+			),
+			"procurement_requisitions": types.SimpleNamespace(
+				spreadsheet_id="proc-book",
+				sheet_name="Purchase Requisitions",
+				enabled=True,
+			),
+			"procurement_purchase_orders": types.SimpleNamespace(
+				spreadsheet_id="proc-book",
+				sheet_name="Purchase Order",
+				enabled=True,
+			),
+			"procurement_goods_receipts": types.SimpleNamespace(
+				spreadsheet_id="proc-book",
+				sheet_name="Goods Receipts",
+				enabled=True,
+			),
+		}
+
+		main_mod.get_db = MagicMock(return_value=self.db)
+		main_mod.get_processor = MagicMock(return_value=self.processor)
+		main_mod.get_sheet_config = MagicMock(side_effect=lambda sheet_key: self.sheet_configs.get(sheet_key))
+
+	def test_daily_baseline_sync_skips_before_8am_pht(self):
+		now_utc = datetime(2026, 3, 9, 23, 59, tzinfo=UTC)
+
+		results = main_mod.run_daily_baseline_sync_if_due(now_utc=now_utc)
+
+		self.assertEqual(results, [])
+		self.processor.sync_sheet.assert_not_called()
+		self.db.has_successful_sync_since.assert_not_called()
+
+	def test_daily_baseline_sync_runs_force_sync_for_target_sheets_after_8am_pht(self):
+		now_utc = datetime(2026, 3, 10, 0, 5, tzinfo=UTC)
+
+		results = main_mod.run_daily_baseline_sync_if_due(now_utc=now_utc)
+
+		self.assertEqual(len(results), 6)
+		self.assertEqual(self.processor.sync_sheet.call_count, 6)
+		for call in self.processor.sync_sheet.call_args_list:
+			self.assertEqual(call.kwargs["trigger"], "daily_baseline")
+			self.assertTrue(call.kwargs["force"])
+
+	def test_daily_baseline_sync_skips_sheets_already_synced_today(self):
+		now_utc = datetime(2026, 3, 10, 0, 5, tzinfo=UTC)
+		self.db.has_successful_sync_since.side_effect = (
+			lambda spreadsheet_id, sheet_name, trigger, since: sheet_name == "SUPPLIERS SOA"
+		)
+
+		results = main_mod.run_daily_baseline_sync_if_due(now_utc=now_utc)
+
+		self.assertEqual(len(results), 5)
+		synced_sheet_names = [call.args[0].sheet_name for call in self.processor.sync_sheet.call_args_list]
+		self.assertNotIn("SUPPLIERS SOA", synced_sheet_names)
+
+	def test_configure_scheduled_jobs_registers_daily_baseline_check(self):
+		fake_schedule = _FakeSchedule()
+
+		main_mod.configure_scheduled_jobs(schedule_module=fake_schedule)
+
+		self.assertIn(
+			main_mod.run_daily_baseline_sync_if_due,
+			[job["func"] for job in fake_schedule.jobs],
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary
- add a deterministic 8:00 AM PHT daily baseline force-sync for AP and procurement sheets
- make the receiver scheduler registration testable and restart-safe using sync log checks
- add receiver scheduler coverage and repair the current erp_sync runtime test harness

## Verification
- python hrms/tests/test_sheets_receiver_main.py
- python hrms/tests/test_sheets_receiver_processor.py
- python hrms/tests/test_erp_sync.py
- python hrms/tests/test_erp_sync_runtime.py
- python -m py_compile hrms/services/sheets_receiver/main.py hrms/services/sheets_receiver/models.py hrms/tests/test_sheets_receiver_main.py hrms/tests/test_erp_sync_runtime.py