### PR TITLE
fix: close all-exception trips as partial

### DIFF
--- a/hrms/hr/doctype/bei_distribution_trip/bei_distribution_trip.py
+++ b/hrms/hr/doctype/bei_distribution_trip/bei_distribution_trip.py
@@ -7,59 +7,62 @@ from frappe.utils import now_datetime
 
 
 class BEIDistributionTrip(Document):
-    def validate(self):
-        self.validate_unique_route_date()
-        self.validate_stops()
-        self.update_status()
+	def validate(self):
+		self.validate_unique_route_date()
+		self.validate_stops()
+		self.update_status()
 
-    def validate_unique_route_date(self):
-        """G-069: Prevent duplicate trips for the same route + date."""
-        if not self.route_name or not self.trip_date:
-            return
-        existing = frappe.db.get_value(
-            "BEI Distribution Trip",
-            {"route_name": self.route_name, "trip_date": self.trip_date, "name": ["!=", self.name]},
-            "name"
-        )
-        if existing:
-            frappe.throw(
-                f"A trip already exists for route '{self.route_name}' on {self.trip_date}: {existing}",
-                frappe.DuplicateEntryError
-            )
+	def validate_unique_route_date(self):
+		"""G-069: Prevent duplicate trips for the same route + date."""
+		if not self.route_name or not self.trip_date:
+			return
+		existing = frappe.db.get_value(
+			"BEI Distribution Trip",
+			{"route_name": self.route_name, "trip_date": self.trip_date, "name": ["!=", self.name]},
+			"name",
+		)
+		if existing:
+			frappe.throw(
+				f"A trip already exists for route '{self.route_name}' on {self.trip_date}: {existing}",
+				frappe.DuplicateEntryError,
+			)
 
-    def validate_stops(self):
-        if not self.stops:
-            frappe.throw("At least one delivery stop is required")
-        # Auto-number stops if not set
-        for idx, stop in enumerate(self.stops, 1):
-            if not stop.stop_order:
-                stop.stop_order = idx
+	def validate_stops(self):
+		if not self.stops:
+			frappe.throw("At least one delivery stop is required")
+		# Auto-number stops if not set
+		for idx, stop in enumerate(self.stops, 1):
+			if not stop.stop_order:
+				stop.stop_order = idx
 
-    def update_status(self):
-        if not self.stops:
-            return
+	def update_status(self):
+		if not self.stops:
+			return
 
-        delivered = sum(1 for s in self.stops if s.status == "Delivered")
-        total = len(self.stops)
+		delivered = sum(1 for s in self.stops if s.status == "Delivered")
+		processed = sum(1 for s in self.stops if s.status != "Pending")
+		total = len(self.stops)
 
-        if delivered == total:
-            self.status = "Completed"
-        elif delivered > 0:
-            self.status = "Partial"
-        elif self.departure_time:
-            self.status = "In Transit"
+		if delivered == total:
+			self.status = "Completed"
+		elif processed == total:
+			self.status = "Partial"
+		elif delivered > 0:
+			self.status = "Partial"
+		elif self.departure_time:
+			self.status = "In Transit"
 
-    def confirm_departure(self):
-        self.departure_time = now_datetime()
-        self.status = "In Transit"
-        self.save()
+	def confirm_departure(self):
+		self.departure_time = now_datetime()
+		self.status = "In Transit"
+		self.save()
 
-    def confirm_stop_delivery(self, stop_idx, signature, signed_by):
-        if stop_idx < len(self.stops):
-            stop = self.stops[stop_idx]
-            stop.status = "Delivered"
-            stop.arrival_time = now_datetime()
-            stop.signature = signature
-            stop.signed_by = signed_by
-            self.update_status()
-            self.save()
+	def confirm_stop_delivery(self, stop_idx, signature, signed_by):
+		if stop_idx < len(self.stops):
+			stop = self.stops[stop_idx]
+			stop.status = "Delivered"
+			stop.arrival_time = now_datetime()
+			stop.signature = signature
+			stop.signed_by = signed_by
+			self.update_status()
+			self.save()

--- a/hrms/tests/test_distribution_trip_status.py
+++ b/hrms/tests/test_distribution_trip_status.py
@@ -1,0 +1,75 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+def _install_frappe_stubs():
+	frappe = types.ModuleType("frappe")
+	frappe.db = types.SimpleNamespace(get_value=lambda *args, **kwargs: None)
+	frappe.throw = lambda msg, *args, **kwargs: (_ for _ in ()).throw(RuntimeError(msg))
+
+	model_mod = types.ModuleType("frappe.model")
+	document_mod = types.ModuleType("frappe.model.document")
+
+	class Document:
+		pass
+
+	document_mod.Document = Document
+
+	utils = types.ModuleType("frappe.utils")
+	utils.now_datetime = lambda: "2026-03-10 12:00:00"
+
+	sys.modules["frappe"] = frappe
+	sys.modules["frappe.model"] = model_mod
+	sys.modules["frappe.model.document"] = document_mod
+	sys.modules["frappe.utils"] = utils
+
+
+def _load_doctype_module():
+	_install_frappe_stubs()
+	file_path = (
+		pathlib.Path(__file__).resolve().parents[1]
+		/ "hr"
+		/ "doctype"
+		/ "bei_distribution_trip"
+		/ "bei_distribution_trip.py"
+	)
+	spec = importlib.util.spec_from_file_location("distribution_trip_doctype_under_test", file_path)
+	module = importlib.util.module_from_spec(spec)
+	assert spec and spec.loader
+	spec.loader.exec_module(module)
+	return module
+
+
+def _stop(status):
+	return types.SimpleNamespace(status=status)
+
+
+class TestDistributionTripStatus(unittest.TestCase):
+	def test_all_exception_stops_mark_trip_partial(self):
+		module = _load_doctype_module()
+		doc = module.BEIDistributionTrip()
+		doc.departure_time = "2026-03-10 11:45:00"
+		doc.status = "In Transit"
+		doc.stops = [_stop("Store Closed"), _stop("Refused")]
+
+		doc.update_status()
+
+		self.assertEqual(doc.status, "Partial")
+
+	def test_exception_with_pending_stop_stays_in_transit(self):
+		module = _load_doctype_module()
+		doc = module.BEIDistributionTrip()
+		doc.departure_time = "2026-03-10 11:45:00"
+		doc.status = "In Transit"
+		doc.stops = [_stop("Store Closed"), _stop("Pending")]
+
+		doc.update_status()
+
+		self.assertEqual(doc.status, "In Transit")
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary
- treat fully processed all-exception trips as Partial in the BEI Distribution Trip controller
- preserve In Transit while pending stops still remain
- add a focused regression test for the all-exception and mixed pending/exception cases

## Verification
- python hrms/tests/test_distribution_trip_status.py
- python hrms/tests/test_trip_driver_estimated_minutes_s10.py
- python -m py_compile hrms/hr/doctype/bei_distribution_trip/bei_distribution_trip.py
- python -m ruff format --check hrms/hr/doctype/bei_distribution_trip/bei_distribution_trip.py hrms/tests/test_distribution_trip_status.py