### PR TITLE
fix: bridge AP opening invoices into standard buying fields

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -16,6 +16,7 @@ from frappe import _
 from frappe.utils import cint, flt, getdate, now_datetime, nowdate
 
 from hrms.utils import store_order_demand_snapshot as store_demand_snapshot_builder
+from hrms.utils.standard_buying_bridge import apply_standard_buying_context
 
 _FIELD_CACHE: dict[tuple, bool] = {}
 ROOT_TYPES = {"Asset", "Liability", "Equity", "Income", "Expense"}
@@ -75,6 +76,10 @@ def _is_duplicate_error(exc: Exception) -> bool:
 		return True
 	message = str(exc).lower()
 	return "duplicate" in message and "entry" in message
+
+
+def _ap_opening_store_label(row: dict[str, Any]) -> str | None:
+	return _first_non_empty(row, "bei_store_label", "store_label", "warehouse", "store", "branch")
 
 
 def _sync_ref(prefix: str, sheet_name: str, checksum: str, row_key: str) -> str:
@@ -1249,6 +1254,10 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 					updates["due_date"] = due_date
 				if _doctype_has_field("Purchase Invoice", "bill_date"):
 					updates["bill_date"] = posting_date
+				if _doctype_has_field("Purchase Invoice", "bei_legal_entity"):
+					updates["bei_legal_entity"] = company
+				if _doctype_has_field("Purchase Invoice", "bei_store_label"):
+					updates["bei_store_label"] = _ap_opening_store_label(row) or "Stores - BEI"
 				sync_ref = _sync_ref("AP", sheet_name, checksum, f"{supplier}|{invoice_no}")
 				if _doctype_has_field("Purchase Invoice", "remarks"):
 					current_remarks = frappe.db.get_value("Purchase Invoice", existing, "remarks") or ""
@@ -1287,6 +1296,11 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 				pi.credit_to = payable_account
 			if _doctype_has_field("Purchase Invoice", "remarks"):
 				pi.remarks = f"ERP AP Opening Sync [{sync_ref}]"
+			apply_standard_buying_context(
+				pi,
+				store_label=_ap_opening_store_label(row),
+				legal_entity=company,
+			)
 
 			item_row = {
 				"item_code": opening_item,

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -555,6 +555,7 @@ class TestErpSync(unittest.TestCase):
 			"invoice_no": "INV-001",
 			"amount": 24500.0,
 			"due_date": "2026-02-15",
+			"billed_to": "BEBANG SHAW INC",
 		}
 
 		with (
@@ -572,7 +573,12 @@ class TestErpSync(unittest.TestCase):
 		self.assertEqual(first["rows_created"], 1)
 		self.assertEqual(second["rows_updated"], 1)
 		self.assertEqual(len(created_docs), 1)
+		self.assertEqual(created_docs[0].bei_legal_entity, "BEI")
+		self.assertEqual(created_docs[0].bei_store_label, "Stores - BEI")
 		erp_sync.frappe.db.set_value.assert_called_once()
+		update_fields = erp_sync.frappe.db.set_value.call_args[0][2]
+		self.assertEqual(update_fields["bei_legal_entity"], "BEI")
+		self.assertEqual(update_fields["bei_store_label"], "Stores - BEI")
 
 	def test_sync_supplier_soa_aliases_sync_ap_opening(self):
 		rows = [{"supplier": "Acme Supply", "invoice_no": "INV-001"}]

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -29,6 +29,17 @@ def _install_fake_hrms():
 	sys.modules["hrms.utils.store_order_demand_snapshot"] = store_snapshot_mod
 	utils_pkg.store_order_demand_snapshot = store_snapshot_mod
 
+	standard_buying_bridge_mod = types.ModuleType("hrms.utils.standard_buying_bridge")
+
+	def apply_standard_buying_context(doc, *, store_label=None, legal_entity=None):
+		if legal_entity:
+			doc.set("bei_legal_entity", legal_entity)
+		doc.set("bei_store_label", store_label or "Stores - BEI")
+
+	standard_buying_bridge_mod.apply_standard_buying_context = apply_standard_buying_context
+	sys.modules["hrms.utils.standard_buying_bridge"] = standard_buying_bridge_mod
+	utils_pkg.standard_buying_bridge = standard_buying_bridge_mod
+
 
 def _install_fake_frappe():
 	if "frappe" in sys.modules:


### PR DESCRIPTION
## Summary
- populate AP opening Purchase Invoices with BEI legal entity and store bridge fields
- backfill those bridge fields on update reruns as well
- extend ERP sync tests and runtime harness coverage for the standard buying bridge import

## Verification
- python hrms\\tests\\test_erp_sync.py
- python hrms\\tests\\test_erp_sync_runtime.py
- python hrms\\tests\\test_sheets_receiver_processor.py
- python -m py_compile hrms\\api\\erp_sync.py hrms\\tests\\test_erp_sync.py hrms\\tests\\test_erp_sync_runtime.py
- ruff check hrms\\api\\erp_sync.py hrms\\tests\\test_erp_sync.py hrms\\tests\\test_erp_sync_runtime.py