### PR TITLE
feat: add scheduled AP and procurement baseline sync support

### DIFF
--- a/hrms/services/sheets_receiver/ap_exception_reports.py
+++ b/hrms/services/sheets_receiver/ap_exception_reports.py
@@ -213,7 +213,9 @@ def extract_missing_invoice_rows(raw_values: list[list[Any]]) -> list[dict[str, 
 	return rows
 
 
-def _build_summary(rows: list[dict[str, Any]], latest_sync: SyncLog | None, generated_at: datetime) -> dict[str, Any]:
+def _build_summary(
+	rows: list[dict[str, Any]], latest_sync: SyncLog | None, generated_at: datetime
+) -> dict[str, Any]:
 	total_amount = sum(Decimal(str(row["amount"] or 0)) for row in rows)
 	total_payment = sum(Decimal(str(row["payment"] or 0)) for row in rows)
 	total_outstanding = sum(Decimal(str(row["outstanding_balance"] or 0)) for row in rows)
@@ -310,7 +312,9 @@ def _write_markdown(
 
 
 def _style_cell(cell, *, bold: bool = False, fill_color: str = BEI_CREAM, wrap: bool = False) -> None:
-	cell.font = Font(name="Calibri", size=10, bold=bold, color=TEXT_WHITE if fill_color == BEI_GREEN else TEXT_DARK)
+	cell.font = Font(
+		name="Calibri", size=10, bold=bold, color=TEXT_WHITE if fill_color == BEI_GREEN else TEXT_DARK
+	)
 	cell.fill = PatternFill("solid", fgColor=fill_color)
 	cell.alignment = Alignment(vertical="center", wrap_text=wrap)
 	cell.border = THIN_BORDER

--- a/hrms/services/sheets_receiver/ap_exception_reports.py
+++ b/hrms/services/sheets_receiver/ap_exception_reports.py
@@ -1,0 +1,498 @@
+"""
+AP exception report generation for the live SUPPLIERS SOA workbook.
+
+Builds a daily/actionable accounting workbook from the authoritative sheet
+instead of relying on a hand-maintained local copy.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import shutil
+from collections import Counter
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+from openpyxl.utils import get_column_letter
+
+from .config import get_config, get_sheet_config
+from .models import SyncLog, get_db
+from .sheets_client import get_sheets_client
+
+logger = logging.getLogger(__name__)
+
+FIELDNAMES = [
+	"sheet_row",
+	"date_entry",
+	"entered_by",
+	"billed_to",
+	"acctg_status",
+	"fin_status",
+	"invoice_no",
+	"invoice_date",
+	"terms",
+	"supplier_name",
+	"category",
+	"particulars",
+	"rfp_id",
+	"status",
+	"payment_date",
+	"amount",
+	"payment",
+	"outstanding_balance",
+	"due_date",
+	"aging_days",
+	"missing_supplier",
+	"missing_invoice_no",
+	"recommended_action",
+]
+
+HEADER_ALIASES = {
+	"date_entry": ("date_entry", "date"),
+	"entered_by": ("entered_by",),
+	"billed_to": ("billed_to",),
+	"acctg_status": ("acctg_status",),
+	"fin_status": ("fin_status",),
+	"invoice_no": ("invoice_no", "invoice_no.", "invoice_number"),
+	"invoice_date": ("invoice_date",),
+	"terms": ("terms",),
+	"supplier_name": ("supplier", "supplier_name"),
+	"category": ("category",),
+	"particulars": ("particulars",),
+	"rfp_id": ("rfp_id", "rfp"),
+	"status": ("status",),
+	"payment_date": ("payment_date",),
+	"amount": ("amount",),
+	"payment": ("payment",),
+	"outstanding_balance": ("outstanding_balance", "outstanding"),
+	"due_date": ("due_date",),
+	"aging_days": ("aging_days", "aging"),
+}
+
+HEADER_FALLBACK_INDEX = {
+	"date_entry": 0,
+	"entered_by": 1,
+	"billed_to": 2,
+	"acctg_status": 3,
+	"fin_status": 4,
+	"invoice_no": 6,
+	"invoice_date": 7,
+	"terms": 8,
+	"supplier_name": 9,
+	"category": 10,
+	"particulars": 11,
+	"rfp_id": 12,
+	"status": 13,
+	"payment_date": 14,
+	"amount": 15,
+	"payment": 16,
+	"outstanding_balance": 17,
+	"due_date": 18,
+	"aging_days": 19,
+}
+
+BEI_GREEN = "04400A"
+BEI_GOLD = "C8900A"
+BEI_CREAM = "F9F5EB"
+BEI_GREEN_TINT = "E6ECE7"
+BEI_BORDER = "D4D0C8"
+TEXT_DARK = "1A1A1A"
+TEXT_WHITE = "FFFFFF"
+PHP_ACCOUNTING = '₱#,##0.00_);[Red](₱#,##0.00);₱"-"??_)'
+THIN_BORDER = Border(
+	left=Side(style="thin", color=BEI_BORDER),
+	right=Side(style="thin", color=BEI_BORDER),
+	top=Side(style="thin", color=BEI_BORDER),
+	bottom=Side(style="thin", color=BEI_BORDER),
+)
+
+
+def _normalize_header(value: Any) -> str:
+	return str(value or "").strip().lower().replace(".", "").replace(" ", "_")
+
+
+def _clean_text(value: Any) -> str:
+	return str(value or "").strip()
+
+
+def _parse_decimal(value: Any) -> Decimal:
+	text = _clean_text(value).replace(",", "")
+	if text in {"", "-", "-   ", "-   -"}:
+		return Decimal("0")
+	text = text.replace("-   ", "").replace("₱", "")
+	try:
+		return Decimal(text)
+	except InvalidOperation:
+		return Decimal("0")
+
+
+def _parse_int(value: Any) -> int | None:
+	text = _clean_text(value).replace(",", "")
+	if not text:
+		return None
+	try:
+		return int(float(text))
+	except ValueError:
+		return None
+
+
+def _decimal_to_number(value: Decimal) -> int | float:
+	if value == value.to_integral():
+		return int(value)
+	return float(value)
+
+
+def _resolve_value(row: list[Any], header_indexes: dict[str, int], canonical_name: str) -> Any:
+	index = header_indexes.get(canonical_name)
+	if index is None:
+		index = HEADER_FALLBACK_INDEX[canonical_name]
+	if index >= len(row):
+		return ""
+	return row[index]
+
+
+def extract_missing_invoice_rows(raw_values: list[list[Any]]) -> list[dict[str, Any]]:
+	"""Extract rows with blank invoice numbers from raw SUPPLIERS SOA values."""
+	if len(raw_values) < 2:
+		return []
+
+	headers = [_normalize_header(value) for value in raw_values[1]]
+	header_indexes: dict[str, int] = {}
+	for canonical_name, aliases in HEADER_ALIASES.items():
+		for alias in aliases:
+			normalized = _normalize_header(alias)
+			if normalized in headers:
+				header_indexes[canonical_name] = headers.index(normalized)
+				break
+
+	rows: list[dict[str, Any]] = []
+	for sheet_row_number, raw_row in enumerate(raw_values[2:], start=3):
+		invoice_no = _clean_text(_resolve_value(raw_row, header_indexes, "invoice_no"))
+		if invoice_no:
+			continue
+
+		supplier_name = _clean_text(_resolve_value(raw_row, header_indexes, "supplier_name"))
+		amount = _parse_decimal(_resolve_value(raw_row, header_indexes, "amount"))
+		payment = _parse_decimal(_resolve_value(raw_row, header_indexes, "payment"))
+		outstanding_balance = _parse_decimal(_resolve_value(raw_row, header_indexes, "outstanding_balance"))
+
+		rows.append(
+			{
+				"sheet_row": sheet_row_number,
+				"date_entry": _clean_text(_resolve_value(raw_row, header_indexes, "date_entry")),
+				"entered_by": _clean_text(_resolve_value(raw_row, header_indexes, "entered_by")),
+				"billed_to": _clean_text(_resolve_value(raw_row, header_indexes, "billed_to")),
+				"acctg_status": _clean_text(_resolve_value(raw_row, header_indexes, "acctg_status")),
+				"fin_status": _clean_text(_resolve_value(raw_row, header_indexes, "fin_status")),
+				"invoice_no": "",
+				"invoice_date": _clean_text(_resolve_value(raw_row, header_indexes, "invoice_date")),
+				"terms": _parse_int(_resolve_value(raw_row, header_indexes, "terms")),
+				"supplier_name": supplier_name,
+				"category": _clean_text(_resolve_value(raw_row, header_indexes, "category")),
+				"particulars": _clean_text(_resolve_value(raw_row, header_indexes, "particulars")),
+				"rfp_id": _clean_text(_resolve_value(raw_row, header_indexes, "rfp_id")),
+				"status": _clean_text(_resolve_value(raw_row, header_indexes, "status")),
+				"payment_date": _clean_text(_resolve_value(raw_row, header_indexes, "payment_date")),
+				"amount": _decimal_to_number(amount),
+				"payment": _decimal_to_number(payment),
+				"outstanding_balance": _decimal_to_number(outstanding_balance),
+				"due_date": _clean_text(_resolve_value(raw_row, header_indexes, "due_date")),
+				"aging_days": _parse_int(_resolve_value(raw_row, header_indexes, "aging_days")),
+				"missing_supplier": not supplier_name,
+				"missing_invoice_no": True,
+				"recommended_action": "Fill in invoice number before AP sync rerun",
+			}
+		)
+
+	return rows
+
+
+def _build_summary(rows: list[dict[str, Any]], latest_sync: SyncLog | None, generated_at: datetime) -> dict[str, Any]:
+	total_amount = sum(Decimal(str(row["amount"] or 0)) for row in rows)
+	total_payment = sum(Decimal(str(row["payment"] or 0)) for row in rows)
+	total_outstanding = sum(Decimal(str(row["outstanding_balance"] or 0)) for row in rows)
+	supplier_counts = Counter(row["supplier_name"] or "(missing supplier)" for row in rows)
+	receiver_rows_failed = latest_sync.rows_failed if latest_sync else None
+	return {
+		"generated_at_utc": generated_at.astimezone(UTC).isoformat(),
+		"live_blocked_rows": len(rows),
+		"affected_suppliers": len(supplier_counts),
+		"rows_missing_supplier": sum(1 for row in rows if row["missing_supplier"]),
+		"rows_missing_invoice_no": sum(1 for row in rows if row["missing_invoice_no"]),
+		"total_amount": _decimal_to_number(total_amount),
+		"total_payment": _decimal_to_number(total_payment),
+		"total_outstanding_balance": _decimal_to_number(total_outstanding),
+		"receiver_rows_failed": receiver_rows_failed,
+		"receiver_discrepancy": (
+			abs(receiver_rows_failed - len(rows)) if receiver_rows_failed is not None else None
+		),
+		"latest_sync_log_id": latest_sync.id if latest_sync else None,
+		"latest_sync_created_at": latest_sync.created_at.isoformat() if latest_sync else None,
+		"suppliers": dict(sorted(supplier_counts.items())),
+	}
+
+
+def build_team_message(summary: dict[str, Any]) -> list[str]:
+	"""Return the copy-ready accounting message lines for the current exception list."""
+	return [
+		"Team, we validated the live AP workbook today and found rows in SUPPLIERS SOA that cannot sync into Frappe yet.",
+		"",
+		f"There are {summary['live_blocked_rows']} rows that need invoice numbers completed across {summary['affected_suppliers']} suppliers.",
+		(
+			f"The latest AP sync failed on {summary['receiver_rows_failed']} rows, and the current live workbook now shows "
+			f"{summary['live_blocked_rows']} rows missing INVOICE NO."
+			if summary["receiver_rows_failed"] is not None
+			else f"The current live workbook now shows {summary['live_blocked_rows']} rows missing INVOICE NO."
+		),
+		"",
+		"Please update the INVOICE NO. field directly in the SUPPLIERS SOA tab for the rows listed in this workbook.",
+		"Do not change amount, payment, outstanding balance, supplier name, or dates unless the source document itself is wrong.",
+		"If a row should not remain in SUPPLIERS SOA because it is already fully paid or entered by mistake, mark it for review before deleting anything.",
+		"",
+		"Once all invoice numbers are filled, reply in the group so we can rerun AP sync and verify that the blocked rows clear in Frappe.",
+	]
+
+
+def _write_csv(rows: list[dict[str, Any]], destination: Path) -> None:
+	with destination.open("w", encoding="utf-8", newline="") as handle:
+		writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+		writer.writeheader()
+		for row in rows:
+			writer.writerow(row)
+
+
+def _write_json(payload: dict[str, Any], destination: Path) -> None:
+	destination.write_text(json.dumps(payload, indent=2, sort_keys=True, default=str), encoding="utf-8")
+
+
+def _write_markdown(
+	*,
+	destination: Path,
+	summary: dict[str, Any],
+	message_lines: list[str],
+	rows: list[dict[str, Any]],
+) -> None:
+	lines = [
+		"# AP Missing Invoice Exception Report",
+		"",
+		f"- Generated (UTC): `{summary['generated_at_utc']}`",
+		f"- Live blocked rows: `{summary['live_blocked_rows']}`",
+		f"- Affected suppliers: `{summary['affected_suppliers']}`",
+		f"- Total amount: `{summary['total_amount']}`",
+		f"- Total payment: `{summary['total_payment']}`",
+		f"- Total outstanding balance: `{summary['total_outstanding_balance']}`",
+	]
+	if summary["receiver_rows_failed"] is not None:
+		lines.extend(
+			[
+				f"- Latest receiver `rows_failed`: `{summary['receiver_rows_failed']}`",
+				f"- Workbook vs receiver discrepancy: `{summary['receiver_discrepancy']}`",
+			]
+		)
+	lines.extend(["", "## Accounting Message", ""])
+	lines.extend([f"- {line}" if line else "" for line in message_lines])
+	lines.extend(["", "## Supplier Breakdown", ""])
+	for supplier_name, count in summary["suppliers"].items():
+		lines.append(f"- `{supplier_name}`: `{count}`")
+	lines.extend(["", "## Sample Rows", ""])
+	for row in rows[:10]:
+		lines.append(
+			f"- Row `{row['sheet_row']}` | Supplier `{row['supplier_name'] or '(missing supplier)'}` | "
+			f"Amount `{row['amount']}` | Outstanding `{row['outstanding_balance']}`"
+		)
+	destination.write_text("\n".join(lines).strip() + "\n", encoding="utf-8")
+
+
+def _style_cell(cell, *, bold: bool = False, fill_color: str = BEI_CREAM, wrap: bool = False) -> None:
+	cell.font = Font(name="Calibri", size=10, bold=bold, color=TEXT_WHITE if fill_color == BEI_GREEN else TEXT_DARK)
+	cell.fill = PatternFill("solid", fgColor=fill_color)
+	cell.alignment = Alignment(vertical="center", wrap_text=wrap)
+	cell.border = THIN_BORDER
+
+
+def _autosize(ws) -> None:
+	for column_cells in ws.columns:
+		column_letter = get_column_letter(column_cells[0].column)
+		width = 10
+		for cell in column_cells:
+			width = max(width, len(str(cell.value or "")) + 2)
+		ws.column_dimensions[column_letter].width = min(width, 42)
+
+
+def _write_workbook(
+	*,
+	destination: Path,
+	summary: dict[str, Any],
+	message_lines: list[str],
+	rows: list[dict[str, Any]],
+) -> None:
+	workbook = Workbook()
+	summary_ws = workbook.active
+	summary_ws.title = "Summary"
+	message_ws = workbook.create_sheet("Team Message")
+	rows_ws = workbook.create_sheet("Missing Invoice Rows")
+
+	summary_ws["A1"] = "AP Exception Summary"
+	_style_cell(summary_ws["A1"], bold=True, fill_color=BEI_GREEN)
+	summary_ws.merge_cells("A1:C1")
+	summary_ws["A2"] = "Live SUPPLIERS SOA rows currently blocked from AP sync."
+	_style_cell(summary_ws["A2"], fill_color=BEI_CREAM)
+	summary_ws.merge_cells("A2:C2")
+
+	summary_metrics = [
+		("Generated (UTC)", summary["generated_at_utc"]),
+		("Live blocked rows", summary["live_blocked_rows"]),
+		("Affected suppliers", summary["affected_suppliers"]),
+		("Rows missing supplier", summary["rows_missing_supplier"]),
+		("Rows missing invoice number", summary["rows_missing_invoice_no"]),
+		("Latest receiver rows_failed", summary["receiver_rows_failed"]),
+		("Workbook vs receiver discrepancy", summary["receiver_discrepancy"]),
+		("Total amount", summary["total_amount"]),
+		("Total payment", summary["total_payment"]),
+		("Total outstanding balance", summary["total_outstanding_balance"]),
+	]
+	for column, header in enumerate(("Metric", "Value", "Notes"), start=1):
+		cell = summary_ws.cell(row=4, column=column, value=header)
+		_style_cell(cell, bold=True, fill_color=BEI_GOLD)
+	for row_index, (label, value) in enumerate(summary_metrics, start=5):
+		summary_ws.cell(row=row_index, column=1, value=label)
+		summary_ws.cell(row=row_index, column=2, value=value)
+		summary_ws.cell(
+			row=row_index,
+			column=3,
+			value="Receiver comparison" if "receiver" in label.lower() else "",
+		)
+		for column in range(1, 4):
+			_style_cell(
+				summary_ws.cell(row=row_index, column=column),
+				fill_color=BEI_GREEN_TINT if row_index % 2 == 0 else BEI_CREAM,
+			)
+	for row_index in (12, 13, 14):
+		summary_ws.cell(row=row_index, column=2).number_format = PHP_ACCOUNTING
+
+	message_ws["A1"] = "Accounting Team Message"
+	_style_cell(message_ws["A1"], bold=True, fill_color=BEI_GREEN)
+	message_ws.merge_cells("A1:C1")
+	for row_index, line in enumerate(message_lines, start=3):
+		message_ws.cell(row=row_index, column=1, value=line)
+		message_ws.merge_cells(start_row=row_index, start_column=1, end_row=row_index, end_column=3)
+		_style_cell(message_ws.cell(row=row_index, column=1), fill_color=BEI_CREAM, wrap=True)
+
+	for column_index, header in enumerate(FIELDNAMES, start=1):
+		cell = rows_ws.cell(row=1, column=column_index, value=header)
+		_style_cell(cell, bold=True, fill_color=BEI_GOLD)
+	for row_index, row in enumerate(rows, start=2):
+		for column_index, field_name in enumerate(FIELDNAMES, start=1):
+			cell = rows_ws.cell(row=row_index, column=column_index, value=row.get(field_name))
+			_style_cell(cell, fill_color=BEI_GREEN_TINT if row_index % 2 == 0 else BEI_CREAM)
+			if field_name in {"amount", "payment", "outstanding_balance"}:
+				cell.number_format = PHP_ACCOUNTING
+			elif field_name in {"missing_supplier", "missing_invoice_no"}:
+				cell.value = "True" if row.get(field_name) else "False"
+
+	summary_ws.freeze_panes = "A5"
+	rows_ws.freeze_panes = "A2"
+	_autosize(summary_ws)
+	_autosize(message_ws)
+	_autosize(rows_ws)
+	workbook.save(destination)
+
+
+def _update_latest_copies(timestamped_paths: dict[str, Path], output_dir: Path) -> dict[str, Path]:
+	latest_paths: dict[str, Path] = {}
+	for suffix, timestamped_path in timestamped_paths.items():
+		latest_path = output_dir / f"ap_missing_invoice_report_latest.{suffix}"
+		shutil.copyfile(timestamped_path, latest_path)
+		latest_paths[suffix] = latest_path
+	return latest_paths
+
+
+def generate_ap_exception_report(
+	*,
+	sheets_client=None,
+	db=None,
+	output_dir: str | Path | None = None,
+	generated_at: datetime | None = None,
+) -> dict[str, Any]:
+	"""Generate current AP missing-invoice exception artifacts from live Google Sheets data."""
+	config = get_config()
+	sheets_client = sheets_client or get_sheets_client()
+	db = db or get_db()
+	generated_at = (generated_at or datetime.now(UTC)).astimezone(UTC)
+	sheet_config = get_sheet_config("ap_opening_balance")
+	if sheet_config is None:
+		raise RuntimeError("Missing sheet config for ap_opening_balance")
+
+	range_name = f"{sheet_config.sheet_name}!A:Z"
+	raw_values = (
+		sheets_client.sheets.spreadsheets()
+		.values()
+		.get(
+			spreadsheetId=sheet_config.spreadsheet_id,
+			range=range_name,
+			dateTimeRenderOption="FORMATTED_STRING",
+		)
+		.execute()
+		.get("values", [])
+	)
+	rows = extract_missing_invoice_rows(raw_values)
+	latest_sync = db.get_latest_sync(
+		sheet_config.spreadsheet_id,
+		sheet_config.sheet_name,
+		status="success",
+	)
+	summary = _build_summary(rows, latest_sync, generated_at)
+	message_lines = build_team_message(summary)
+
+	report_dir = Path(output_dir or config.ap_exception_report_dir)
+	report_dir.mkdir(parents=True, exist_ok=True)
+	timestamp = generated_at.strftime("%Y%m%d_%H%M%S")
+	base_path = report_dir / f"ap_missing_invoice_report_{timestamp}"
+	timestamped_paths = {
+		"csv": base_path.with_suffix(".csv"),
+		"json": base_path.with_suffix(".json"),
+		"md": base_path.with_suffix(".md"),
+		"xlsx": base_path.with_suffix(".xlsx"),
+	}
+
+	_write_csv(rows, timestamped_paths["csv"])
+	_write_json(
+		{
+			"summary": summary,
+			"team_message_lines": message_lines,
+			"rows": rows,
+		},
+		timestamped_paths["json"],
+	)
+	_write_markdown(
+		destination=timestamped_paths["md"],
+		summary=summary,
+		message_lines=message_lines,
+		rows=rows,
+	)
+	_write_workbook(
+		destination=timestamped_paths["xlsx"],
+		summary=summary,
+		message_lines=message_lines,
+		rows=rows,
+	)
+	latest_paths = _update_latest_copies(timestamped_paths, report_dir)
+
+	result = {
+		"summary": summary,
+		"team_message_lines": message_lines,
+		"timestamped_files": {key: str(path) for key, path in timestamped_paths.items()},
+		"latest_files": {key: str(path) for key, path in latest_paths.items()},
+	}
+	logger.info(
+		"Generated AP exception report with %s blocked rows at %s",
+		summary["live_blocked_rows"],
+		timestamped_paths["xlsx"],
+	)
+	return result

--- a/hrms/services/sheets_receiver/ap_exception_reports.py
+++ b/hrms/services/sheets_receiver/ap_exception_reports.py
@@ -247,8 +247,7 @@ def build_team_message(summary: dict[str, Any]) -> list[str]:
 		"",
 		f"There are {summary['live_blocked_rows']} rows that need invoice numbers completed across {summary['affected_suppliers']} suppliers.",
 		(
-			f"The latest AP sync failed on {summary['receiver_rows_failed']} rows, and the current live workbook now shows "
-			f"{summary['live_blocked_rows']} rows missing INVOICE NO."
+			f"The latest AP sync failed on {summary['receiver_rows_failed']} rows, and the current live workbook now shows {summary['live_blocked_rows']} rows missing INVOICE NO."
 			if summary["receiver_rows_failed"] is not None
 			else f"The current live workbook now shows {summary['live_blocked_rows']} rows missing INVOICE NO."
 		),

--- a/hrms/services/sheets_receiver/config.py
+++ b/hrms/services/sheets_receiver/config.py
@@ -9,13 +9,12 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
-
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 
 
 def _env_flag(name: str, default: bool) -> bool:
 	"""Parse a boolean environment variable with a sensible default."""
-	return (os.environ.get(name, str(default)).strip().lower() in _TRUE_VALUES)
+	return os.environ.get(name, str(default)).strip().lower() in _TRUE_VALUES
 
 
 def _env_int(name: str, default: int) -> int:

--- a/hrms/services/sheets_receiver/config.py
+++ b/hrms/services/sheets_receiver/config.py
@@ -10,6 +10,31 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _env_flag(name: str, default: bool) -> bool:
+	"""Parse a boolean environment variable with a sensible default."""
+	return (os.environ.get(name, str(default)).strip().lower() in _TRUE_VALUES)
+
+
+def _env_int(name: str, default: int) -> int:
+	"""Parse an integer environment variable with fallback."""
+	try:
+		return int(os.environ.get(name, str(default)).strip())
+	except (TypeError, ValueError):
+		return default
+
+
+def _env_csv(name: str, default: tuple[str, ...]) -> tuple[str, ...]:
+	"""Parse a comma-separated environment variable into a normalized tuple."""
+	raw_value = os.environ.get(name)
+	if raw_value is None:
+		return default
+	parsed = [item.strip() for item in raw_value.split(",") if item.strip()]
+	return tuple(parsed) if parsed else default
+
+
 @dataclass
 class FolderConfig:
 	"""Configuration for a watched folder."""
@@ -90,6 +115,23 @@ class ServiceConfig:
 	log_level: str = field(default_factory=lambda: os.environ.get("LOG_LEVEL", "INFO"))
 	log_file: str = field(
 		default_factory=lambda: os.environ.get("SHEETS_RECEIVER_LOG", "/app/logs/sheets_receiver.log")
+	)
+	baseline_test_interval_minutes: int = field(
+		default_factory=lambda: _env_int("BASELINE_TEST_INTERVAL_MINUTES", 0)
+	)
+	generate_ap_exception_reports: bool = field(
+		default_factory=lambda: _env_flag("GENERATE_AP_EXCEPTION_REPORTS", True)
+	)
+	ap_exception_report_dir: str = field(
+		default_factory=lambda: os.environ.get(
+			"AP_EXCEPTION_REPORT_DIR", "/app/data/reports/ap_exception_reports"
+		)
+	)
+	suppress_critical_alert_triggers: tuple[str, ...] = field(
+		default_factory=lambda: _env_csv(
+			"SHEETS_RECEIVER_SUPPRESS_CRITICAL_ALERT_TRIGGERS",
+			("startup", "manual", "interval_baseline"),
+		)
 	)
 
 

--- a/hrms/services/sheets_receiver/deploy/docker-compose.yml
+++ b/hrms/services/sheets_receiver/deploy/docker-compose.yml
@@ -29,6 +29,12 @@ services:
       # Logging
       LOG_LEVEL: INFO
 
+      # Baseline sync orchestration / testing
+      BASELINE_TEST_INTERVAL_MINUTES: ${BASELINE_TEST_INTERVAL_MINUTES:-0}
+      GENERATE_AP_EXCEPTION_REPORTS: ${GENERATE_AP_EXCEPTION_REPORTS:-true}
+      AP_EXCEPTION_REPORT_DIR: ${AP_EXCEPTION_REPORT_DIR:-/app/data/reports/ap_exception_reports}
+      SHEETS_RECEIVER_SUPPRESS_CRITICAL_ALERT_TRIGGERS: ${SHEETS_RECEIVER_SUPPRESS_CRITICAL_ALERT_TRIGGERS:-startup,manual,interval_baseline}
+
     volumes:
       # Google service account (copy from main credentials folder)
       - ./credentials:/app/credentials:ro

--- a/hrms/services/sheets_receiver/main.py
+++ b/hrms/services/sheets_receiver/main.py
@@ -43,6 +43,7 @@ from zoneinfo import ZoneInfo
 
 import schedule
 
+from .ap_exception_reports import generate_ap_exception_report
 from .config import get_config, get_sheet_config, get_watched_sheets
 from .file_processor import get_file_processor
 from .folder_watcher import get_folder_watcher
@@ -61,6 +62,7 @@ logger = logging.getLogger(__name__)
 
 PHT_TIMEZONE = ZoneInfo("Asia/Manila")
 DAILY_BASELINE_TRIGGER = "daily_baseline"
+INTERVAL_BASELINE_TRIGGER = "interval_baseline"
 DAILY_BASELINE_PHT_TIME = dt_time(hour=8, minute=0)
 DAILY_BASELINE_SHEET_KEYS = (
 	"ap_opening_balance",
@@ -129,6 +131,83 @@ def get_daily_baseline_sheet_keys() -> tuple[str, ...]:
 	return DAILY_BASELINE_SHEET_KEYS
 
 
+def _maybe_generate_ap_exception_report(trigger: str) -> dict | None:
+	"""Generate the current AP exception workbook when enabled."""
+	config = get_config()
+	if not config.generate_ap_exception_reports:
+		return None
+
+	try:
+		report = generate_ap_exception_report(output_dir=config.ap_exception_report_dir)
+		logger.info(
+			"AP exception report generated after %s sync: %s",
+			trigger,
+			report["latest_files"].get("xlsx"),
+		)
+		return report
+	except Exception as e:
+		logger.error(f"AP exception report generation failed after {trigger}: {e}")
+		return None
+
+
+def _run_baseline_sync(
+	*,
+	trigger: str,
+	force: bool,
+	now_utc: datetime | None = None,
+	enforce_daily_gate: bool,
+) -> list:
+	"""Run the AP + Procurement baseline sync set with optional daily gate enforcement."""
+	normalized_now_utc = _normalize_now_utc(now_utc)
+	now_pht = normalized_now_utc.astimezone(PHT_TIMEZONE)
+
+	if enforce_daily_gate and now_pht.time() < DAILY_BASELINE_PHT_TIME:
+		return []
+
+	config = get_config()
+	db = get_db()
+	processor = get_processor()
+	results = []
+
+	pht_day_start = datetime.combine(now_pht.date(), dt_time.min, tzinfo=PHT_TIMEZONE)
+	pht_day_start_utc = pht_day_start.astimezone(UTC)
+
+	for sheet_key in get_daily_baseline_sheet_keys():
+		sheet_config = get_sheet_config(sheet_key)
+		if not sheet_config or not sheet_config.enabled:
+			logger.warning(f"Daily baseline sync skipped missing/disabled sheet config: {sheet_key}")
+			continue
+
+		if enforce_daily_gate:
+			already_synced = db.has_successful_sync_since(
+				sheet_config.spreadsheet_id,
+				sheet_config.sheet_name,
+				DAILY_BASELINE_TRIGGER,
+				pht_day_start_utc,
+			)
+			if already_synced:
+				continue
+
+		logger.info(
+			"Running %s force sync for %s (%s)",
+			trigger,
+			getattr(sheet_config, "name", sheet_key),
+			sheet_key,
+		)
+		results.append(
+			processor.sync_sheet(
+				sheet_config,
+				trigger=trigger,
+				force=force,
+			)
+		)
+
+	if results and config.generate_ap_exception_reports:
+		_maybe_generate_ap_exception_report(trigger)
+
+	return results
+
+
 def run_daily_baseline_sync_if_due(now_utc: datetime | None = None):
 	"""
 	Force-sync AP and Procurement baseline sheets once per PHT day after 8:00 AM.
@@ -137,48 +216,24 @@ def run_daily_baseline_sync_if_due(now_utc: datetime | None = None):
 	sheet already has a successful `daily_baseline` sync logged for the current PHT
 	day and only re-syncs missing sheets.
 	"""
-	normalized_now_utc = _normalize_now_utc(now_utc)
-	now_pht = normalized_now_utc.astimezone(PHT_TIMEZONE)
+	return _run_baseline_sync(
+		trigger=DAILY_BASELINE_TRIGGER,
+		force=True,
+		now_utc=now_utc,
+		enforce_daily_gate=True,
+	)
 
-	if now_pht.time() < DAILY_BASELINE_PHT_TIME:
+
+def run_interval_baseline_sync_job():
+	"""Optional short-interval force sync for migration shadow-run testing."""
+	config = get_config()
+	if config.baseline_test_interval_minutes <= 0:
 		return []
-
-	pht_day_start = datetime.combine(now_pht.date(), dt_time.min, tzinfo=PHT_TIMEZONE)
-	pht_day_start_utc = pht_day_start.astimezone(UTC)
-
-	db = get_db()
-	processor = get_processor()
-	results = []
-
-	for sheet_key in get_daily_baseline_sheet_keys():
-		sheet_config = get_sheet_config(sheet_key)
-		if not sheet_config or not sheet_config.enabled:
-			logger.warning(f"Daily baseline sync skipped missing/disabled sheet config: {sheet_key}")
-			continue
-
-		already_synced = db.has_successful_sync_since(
-			sheet_config.spreadsheet_id,
-			sheet_config.sheet_name,
-			DAILY_BASELINE_TRIGGER,
-			pht_day_start_utc,
-		)
-		if already_synced:
-			continue
-
-		logger.info(
-			"Running daily baseline force sync for %s (%s)",
-			getattr(sheet_config, "name", sheet_key),
-			sheet_key,
-		)
-		results.append(
-			processor.sync_sheet(
-				sheet_config,
-				trigger=DAILY_BASELINE_TRIGGER,
-				force=True,
-			)
-		)
-
-	return results
+	return _run_baseline_sync(
+		trigger=INTERVAL_BASELINE_TRIGGER,
+		force=True,
+		enforce_daily_gate=False,
+	)
 
 
 # =============================================================================
@@ -321,6 +376,7 @@ def daily_summary_job():
 
 def configure_scheduled_jobs(schedule_module=schedule):
 	"""Register all recurring jobs on the provided schedule module."""
+	config = get_config()
 	# ==========================================================================
 	# Sheets Processing (Original)
 	# ==========================================================================
@@ -334,6 +390,10 @@ def configure_scheduled_jobs(schedule_module=schedule):
 	# Deterministic AP + Procurement baseline refresh at 8:00 AM PHT.
 	# Runs through a once-per-day gate so it is safe across restarts.
 	schedule_module.every(1).minutes.do(run_daily_baseline_sync_if_due)
+	if config.baseline_test_interval_minutes > 0:
+		schedule_module.every(config.baseline_test_interval_minutes).minutes.do(
+			run_interval_baseline_sync_job
+		)
 
 	# ==========================================================================
 	# POS File Processing (Automatic - No Manual Intervention)
@@ -362,11 +422,17 @@ def configure_scheduled_jobs(schedule_module=schedule):
 def run_scheduler():
 	"""Run the scheduler in a background thread."""
 	configure_scheduled_jobs()
+	config = get_config()
 
 	logger.info("Scheduler started with jobs:")
 	logger.info("  - Sheet watch renewal: every 1 hour")
 	logger.info("  - Sheet backup sync: every 6 hours")
 	logger.info("  - Daily AP/procurement baseline sync gate: every 1 minute, target 8 AM PHT")
+	if config.baseline_test_interval_minutes > 0:
+		logger.info(
+			"  - Interval AP/procurement baseline sync: every %s minutes (test mode)",
+			config.baseline_test_interval_minutes,
+		)
 	logger.info("  - POS file processing: every 2 minutes")
 	logger.info("  - Failed file retry: every 15 minutes")
 	logger.info("  - Folder scan (backup): every 30 minutes")

--- a/hrms/services/sheets_receiver/models.py
+++ b/hrms/services/sheets_receiver/models.py
@@ -354,6 +354,49 @@ class Database:
 				for row in rows
 			]
 
+	def get_latest_sync(
+		self,
+		spreadsheet_id: str,
+		sheet_name: str,
+		*,
+		status: str | None = None,
+		trigger: str | None = None,
+	) -> SyncLog | None:
+		"""Return the most recent sync log for a sheet, optionally filtered by status/trigger."""
+		query = [
+			"SELECT * FROM sync_logs WHERE spreadsheet_id = ? AND sheet_name = ?",
+		]
+		params: list[Any] = [spreadsheet_id, sheet_name]
+		if status:
+			query.append("AND status = ?")
+			params.append(status)
+		if trigger:
+			query.append("AND trigger = ?")
+			params.append(trigger)
+		query.append("ORDER BY created_at DESC LIMIT 1")
+
+		with self._connection() as conn:
+			row = conn.execute(" ".join(query), params).fetchone()
+			if not row:
+				return None
+
+			return SyncLog(
+				id=row["id"],
+				spreadsheet_id=row["spreadsheet_id"],
+				spreadsheet_name=row["spreadsheet_name"],
+				sheet_name=row["sheet_name"],
+				trigger=row["trigger"],
+				status=row["status"],
+				rows_processed=row["rows_processed"],
+				rows_created=row["rows_created"],
+				rows_updated=row["rows_updated"],
+				rows_failed=row["rows_failed"],
+				error_message=row["error_message"],
+				duration_seconds=row["duration_seconds"],
+				data_checksum=row["data_checksum"],
+				created_at=datetime.fromisoformat(row["created_at"]),
+			)
+
 	def has_successful_sync_since(
 		self,
 		spreadsheet_id: str,

--- a/hrms/services/sheets_receiver/processor.py
+++ b/hrms/services/sheets_receiver/processor.py
@@ -57,6 +57,15 @@ class ChangeProcessor:
 		)
 		return any(marker in alert_text for marker in critical_markers)
 
+	def _critical_alerts_suppressed_for_trigger(self, trigger: str) -> bool:
+		"""Return True when the current sync trigger should not emit chat alerts."""
+		suppressed = {
+			str(value).strip()
+			for value in getattr(self.config, "suppress_critical_alert_triggers", ())
+			if str(value).strip()
+		}
+		return trigger in suppressed
+
 	def _send_critical_sync_alert(
 		self,
 		*,
@@ -70,6 +79,14 @@ class ChangeProcessor:
 	) -> None:
 		"""Send critical sync alerts to Google Chat (non-blocking)."""
 		if not (reasons or rows_failed or errors or critical_alerts):
+			return
+		if self._critical_alerts_suppressed_for_trigger(trigger):
+			logger.info(
+				"Critical sync alert suppressed for %s/%s trigger=%s",
+				sheet_config.name,
+				sheet_config.sheet_name,
+				trigger,
+			)
 			return
 
 		try:

--- a/hrms/tests/test_sheets_receiver_ap_exception_reports.py
+++ b/hrms/tests/test_sheets_receiver_ap_exception_reports.py
@@ -1,0 +1,264 @@
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_dependencies():
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.services" not in sys.modules:
+		services_pkg = types.ModuleType("hrms.services")
+		services_pkg.__path__ = []
+		sys.modules["hrms.services"] = services_pkg
+
+	if "hrms.services.sheets_receiver" not in sys.modules:
+		sheets_pkg = types.ModuleType("hrms.services.sheets_receiver")
+		sheets_pkg.__path__ = []
+		sys.modules["hrms.services.sheets_receiver"] = sheets_pkg
+
+	config_mod = types.ModuleType("hrms.services.sheets_receiver.config")
+	config_mod.get_config = lambda: types.SimpleNamespace(ap_exception_report_dir=".")
+	config_mod.get_sheet_config = lambda _key: None
+	sys.modules["hrms.services.sheets_receiver.config"] = config_mod
+
+	models_mod = types.ModuleType("hrms.services.sheets_receiver.models")
+	models_mod.SyncLog = types.SimpleNamespace
+	models_mod.get_db = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.models"] = models_mod
+
+	sheets_client_mod = types.ModuleType("hrms.services.sheets_receiver.sheets_client")
+	sheets_client_mod.get_sheets_client = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.sheets_client"] = sheets_client_mod
+
+
+_install_fake_dependencies()
+report_spec = importlib.util.spec_from_file_location(
+	"hrms.services.sheets_receiver.ap_exception_reports_under_test",
+	ROOT / "hrms" / "services" / "sheets_receiver" / "ap_exception_reports.py",
+)
+report_mod = importlib.util.module_from_spec(report_spec)
+report_spec.loader.exec_module(report_mod)
+
+
+class TestSheetsReceiverApExceptionReports(unittest.TestCase):
+	def test_extract_missing_invoice_rows_uses_header_row_two(self):
+		raw_values = [
+			["Summary block", "", "", ""],
+			[
+				"DATE ENTRY",
+				"ENTERED BY",
+				"BILLED TO",
+				"ACCTG STATUS",
+				"FIN STATUS",
+				"NO.",
+				"INVOICE NO.",
+				"INVOICE DATE",
+				"TERMS",
+				"SUPPLIER",
+				"CATEGORY",
+				"PARTICULARS",
+				"RFP ID",
+				"STATUS",
+				"PAYMENT DATE",
+				"AMOUNT",
+				"PAYMENT",
+				"OUTSTANDING BALANCE",
+				"DUE DATE",
+				"AGING DAYS",
+			],
+			[
+				"2026-03-10",
+				"Alyssa",
+				"Stores - BEI",
+				"OPEN",
+				"OPEN",
+				"1",
+				"",
+				"2026-03-05",
+				"30",
+				"ALYANA CHUA",
+				"Supplies",
+				"Office supplies",
+				"RFP-1",
+				"UNPAID",
+				"",
+				"1500",
+				"0",
+				"1500",
+				"2026-04-04",
+				"5",
+			],
+			[
+				"2026-03-10",
+				"Alyssa",
+				"Stores - BEI",
+				"OPEN",
+				"OPEN",
+				"2",
+				"INV-001",
+				"2026-03-05",
+				"30",
+				"MAC SIGNS",
+				"Signage",
+				"Poster",
+				"RFP-2",
+				"UNPAID",
+				"",
+				"2500",
+				"500",
+				"2000",
+				"2026-04-04",
+				"5",
+			],
+		]
+
+		rows = report_mod.extract_missing_invoice_rows(raw_values)
+
+		self.assertEqual(len(rows), 1)
+		self.assertEqual(rows[0]["sheet_row"], 3)
+		self.assertEqual(rows[0]["supplier_name"], "ALYANA CHUA")
+		self.assertEqual(rows[0]["amount"], 1500)
+		self.assertTrue(rows[0]["missing_invoice_no"])
+
+	def test_generate_ap_exception_report_writes_expected_artifacts(self):
+		raw_values = [
+			["Summary block", "", "", ""],
+			[
+				"DATE ENTRY",
+				"ENTERED BY",
+				"BILLED TO",
+				"ACCTG STATUS",
+				"FIN STATUS",
+				"NO.",
+				"INVOICE NO.",
+				"INVOICE DATE",
+				"TERMS",
+				"SUPPLIER",
+				"CATEGORY",
+				"PARTICULARS",
+				"RFP ID",
+				"STATUS",
+				"PAYMENT DATE",
+				"AMOUNT",
+				"PAYMENT",
+				"OUTSTANDING BALANCE",
+				"DUE DATE",
+				"AGING DAYS",
+			],
+			[
+				"2026-03-10",
+				"Alyssa",
+				"Stores - BEI",
+				"OPEN",
+				"OPEN",
+				"1",
+				"",
+				"2026-03-05",
+				"30",
+				"ALYANA CHUA",
+				"Supplies",
+				"Office supplies",
+				"RFP-1",
+				"UNPAID",
+				"",
+				"1500",
+				"0",
+				"1500",
+				"2026-04-04",
+				"5",
+			],
+			[
+				"2026-03-10",
+				"Alyssa",
+				"Stores - BEI",
+				"OPEN",
+				"OPEN",
+				"2",
+				"",
+				"2026-03-06",
+				"15",
+				"MAC SIGNS",
+				"Signage",
+				"Poster",
+				"RFP-2",
+				"UNPAID",
+				"",
+				"2500",
+				"500",
+				"2000",
+				"2026-03-21",
+				"4",
+			],
+		]
+
+		class _FakeGetRequest:
+			def execute(self):
+				return {"values": raw_values}
+
+		class _FakeValuesService:
+			def get(self, **_kwargs):
+				return _FakeGetRequest()
+
+		class _FakeSpreadsheetsService:
+			def values(self):
+				return _FakeValuesService()
+
+		class _FakeSheetsService:
+			def spreadsheets(self):
+				return _FakeSpreadsheetsService()
+
+		fake_client = types.SimpleNamespace(sheets=_FakeSheetsService())
+		fake_db = types.SimpleNamespace(
+			get_latest_sync=lambda *_args, **_kwargs: types.SimpleNamespace(
+				id=77,
+				rows_failed=3,
+				created_at=datetime(2026, 3, 10, 0, 0, tzinfo=UTC),
+			)
+		)
+		report_mod.get_sheet_config = lambda _key: types.SimpleNamespace(
+			spreadsheet_id="sheet-123",
+			sheet_name="SUPPLIERS SOA",
+		)
+		report_mod.get_config = lambda: types.SimpleNamespace(ap_exception_report_dir=".")
+
+		with tempfile.TemporaryDirectory() as tmpdir:
+			result = report_mod.generate_ap_exception_report(
+				sheets_client=fake_client,
+				db=fake_db,
+				output_dir=tmpdir,
+				generated_at=datetime(2026, 3, 10, 1, 2, 3, tzinfo=UTC),
+			)
+
+			self.assertEqual(result["summary"]["live_blocked_rows"], 2)
+			self.assertEqual(result["summary"]["affected_suppliers"], 2)
+			self.assertEqual(result["summary"]["receiver_rows_failed"], 3)
+			for file_path in result["timestamped_files"].values():
+				self.assertTrue(Path(file_path).exists(), file_path)
+			for file_path in result["latest_files"].values():
+				self.assertTrue(Path(file_path).exists(), file_path)
+
+			workbook = load_workbook(result["latest_files"]["xlsx"])
+			self.assertEqual(
+				workbook.sheetnames,
+				["Summary", "Team Message", "Missing Invoice Rows"],
+			)
+			rows_ws = workbook["Missing Invoice Rows"]
+			self.assertEqual(rows_ws["A2"].value, 3)
+			self.assertEqual(rows_ws["J2"].value, "ALYANA CHUA")
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/hrms/tests/test_sheets_receiver_main.py
+++ b/hrms/tests/test_sheets_receiver_main.py
@@ -34,7 +34,11 @@ def _install_fake_sheets_receiver_dependencies():
 		sys.modules["hrms.services.sheets_receiver"] = sheets_pkg
 
 	config_mod = types.ModuleType("hrms.services.sheets_receiver.config")
-	config_mod.get_config = lambda: types.SimpleNamespace()
+	config_mod.get_config = lambda: types.SimpleNamespace(
+		baseline_test_interval_minutes=0,
+		generate_ap_exception_reports=False,
+		ap_exception_report_dir=".",
+	)
 	config_mod.get_watched_sheets = lambda: {}
 	config_mod.get_sheet_config = lambda _sheet_key: None
 	sys.modules["hrms.services.sheets_receiver.config"] = config_mod
@@ -58,6 +62,10 @@ def _install_fake_sheets_receiver_dependencies():
 	file_processor_mod = types.ModuleType("hrms.services.sheets_receiver.file_processor")
 	file_processor_mod.get_file_processor = lambda: types.SimpleNamespace()
 	sys.modules["hrms.services.sheets_receiver.file_processor"] = file_processor_mod
+
+	ap_reports_mod = types.ModuleType("hrms.services.sheets_receiver.ap_exception_reports")
+	ap_reports_mod.generate_ap_exception_report = lambda *args, **kwargs: {}
+	sys.modules["hrms.services.sheets_receiver.ap_exception_reports"] = ap_reports_mod
 
 	folder_watcher_mod = types.ModuleType("hrms.services.sheets_receiver.folder_watcher")
 	folder_watcher_mod.get_folder_watcher = lambda: types.SimpleNamespace()
@@ -166,6 +174,14 @@ class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
 		main_mod.get_db = MagicMock(return_value=self.db)
 		main_mod.get_processor = MagicMock(return_value=self.processor)
 		main_mod.get_sheet_config = MagicMock(side_effect=lambda sheet_key: self.sheet_configs.get(sheet_key))
+		main_mod.get_config = MagicMock(
+			return_value=types.SimpleNamespace(
+				baseline_test_interval_minutes=0,
+				generate_ap_exception_reports=False,
+				ap_exception_report_dir=".",
+			)
+		)
+		main_mod._maybe_generate_ap_exception_report = MagicMock()
 
 	def test_daily_baseline_sync_skips_before_8am_pht(self):
 		now_utc = datetime(2026, 3, 9, 23, 59, tzinfo=UTC)
@@ -206,6 +222,49 @@ class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
 
 		self.assertIn(
 			main_mod.run_daily_baseline_sync_if_due,
+			[job["func"] for job in fake_schedule.jobs],
+		)
+
+	def test_daily_baseline_sync_generates_ap_exception_report_when_enabled(self):
+		now_utc = datetime(2026, 3, 10, 0, 5, tzinfo=UTC)
+		main_mod.get_config.return_value = types.SimpleNamespace(
+			baseline_test_interval_minutes=0,
+			generate_ap_exception_reports=True,
+			ap_exception_report_dir=".",
+		)
+
+		results = main_mod.run_daily_baseline_sync_if_due(now_utc=now_utc)
+
+		self.assertEqual(len(results), 6)
+		main_mod._maybe_generate_ap_exception_report.assert_called_once_with("daily_baseline")
+
+	def test_interval_baseline_sync_runs_when_enabled(self):
+		main_mod.get_config.return_value = types.SimpleNamespace(
+			baseline_test_interval_minutes=5,
+			generate_ap_exception_reports=False,
+			ap_exception_report_dir=".",
+		)
+
+		results = main_mod.run_interval_baseline_sync_job()
+
+		self.assertEqual(len(results), 6)
+		self.assertEqual(self.processor.sync_sheet.call_count, 6)
+		for call in self.processor.sync_sheet.call_args_list:
+			self.assertEqual(call.kwargs["trigger"], "interval_baseline")
+			self.assertTrue(call.kwargs["force"])
+
+	def test_configure_scheduled_jobs_registers_interval_baseline_when_enabled(self):
+		fake_schedule = _FakeSchedule()
+		main_mod.get_config.return_value = types.SimpleNamespace(
+			baseline_test_interval_minutes=5,
+			generate_ap_exception_reports=False,
+			ap_exception_report_dir=".",
+		)
+
+		main_mod.configure_scheduled_jobs(schedule_module=fake_schedule)
+
+		self.assertIn(
+			main_mod.run_interval_baseline_sync_job,
 			[job["func"] for job in fake_schedule.jobs],
 		)
 

--- a/hrms/tests/test_sheets_receiver_processor.py
+++ b/hrms/tests/test_sheets_receiver_processor.py
@@ -117,6 +117,9 @@ class TestSheetsReceiverProcessorCriticalAlerts(unittest.TestCase):
 
 	def _make_processor(self):
 		processor = ChangeProcessor.__new__(ChangeProcessor)
+		processor.config = types.SimpleNamespace(
+			suppress_critical_alert_triggers=("startup", "manual", "interval_baseline")
+		)
 		processor.db = types.SimpleNamespace(
 			has_changed=MagicMock(return_value=True),
 			save_checksum=MagicMock(),
@@ -152,6 +155,13 @@ class TestSheetsReceiverProcessorCriticalAlerts(unittest.TestCase):
 		)
 		processor._send_critical_sync_alert = MagicMock()
 		return processor
+
+	def test_critical_alerts_suppressed_for_interval_baseline_trigger(self):
+		processor = self._make_processor()
+
+		self.assertTrue(processor._critical_alerts_suppressed_for_trigger("interval_baseline"))
+		self.assertTrue(processor._critical_alerts_suppressed_for_trigger("manual"))
+		self.assertFalse(processor._critical_alerts_suppressed_for_trigger("scheduled"))
 
 	def test_sync_sheet_emits_alert_for_critical_change_pattern(self):
 		processor = self._make_processor()


### PR DESCRIPTION
Automates the standalone Sheets Receiver baseline sync flow with AP exception report generation and tested interval controls.

no-docs: operational receiver scheduling and reporting change; live validation evidence captured in tmp/2026-03-10-sheets-receiver-interval-baseline-live-test.md.