### PR TITLE
feat: whitelist supplier invoice exceptions for AP sync

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -7,6 +7,7 @@ and sync it to ERPNext DocTypes.
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -22,6 +23,7 @@ from hrms.utils.standard_buying_bridge import apply_standard_buying_context
 _FIELD_CACHE: dict[tuple, bool] = {}
 ROOT_TYPES = {"Asset", "Liability", "Equity", "Income", "Expense"}
 AP_OPENING_ITEM_CODE = "ERP-SYNC-AP-OPENING"
+AP_INTERNAL_REF_PREFIX = "XINV"
 SYNC_ALLOWED_ROLES = {
 	"System Manager",
 	"Accounts Manager",
@@ -33,6 +35,7 @@ STORE_DEMAND_SNAPSHOT_AUTO_PREFIX = "scheduled_store_demand_snapshot"
 STORE_INVENTORY_SHADOW_SYNC_SHEET_NAME = "Store Inventory Shadow Sync"
 STORE_INVENTORY_SHADOW_SYNC_AUTO_PREFIX = "scheduled_store_inventory_shadow_sync"
 STORE_INVENTORY_SHADOW_BATCH_PREFIX = "SHADOW"
+PO_REFERENCE_RE = re.compile(r"^\s*(?:PO|PURCHASE\s*ORDER)\s*[-#:/]?\s*[A-Z0-9-]+\s*$", re.IGNORECASE)
 
 
 def _parse_rows(data: Any) -> list[dict[str, Any]]:
@@ -493,6 +496,130 @@ def _ensure_supplier(supplier_name: str) -> str:
 		if _is_duplicate_error(exc):
 			return frappe.db.get_value("Supplier", {"supplier_name": supplier_name}, "name")
 		raise
+
+
+def _get_bei_supplier_invoice_exception_config(
+	supplier_input: str | None, frappe_supplier: str | None = None
+) -> dict[str, Any]:
+	"""Resolve missing-invoice exception controls from BEI Supplier."""
+	supplier_name = (supplier_input or "").strip()
+	bei_supplier_name = None
+
+	if frappe_supplier:
+		bei_supplier_name = frappe.db.get_value("BEI Supplier", {"frappe_supplier": frappe_supplier}, "name")
+
+	if not bei_supplier_name and supplier_name and frappe.db.exists("BEI Supplier", supplier_name):
+		bei_supplier_name = supplier_name
+
+	if not bei_supplier_name and supplier_name:
+		bei_supplier_name = frappe.db.get_value("BEI Supplier", {"supplier_name": supplier_name}, "name")
+
+	if not bei_supplier_name:
+		return {
+			"bei_supplier": None,
+			"allowed": False,
+			"reason": "",
+		}
+
+	return {
+		"bei_supplier": bei_supplier_name,
+		"allowed": bool(
+			cint(frappe.db.get_value("BEI Supplier", bei_supplier_name, "allow_missing_supplier_invoice") or 0)
+		),
+		"reason": frappe.db.get_value("BEI Supplier", bei_supplier_name, "missing_supplier_invoice_reason")
+		or "",
+	}
+
+
+def _looks_like_po_reference(value: Any) -> bool:
+	text = str(value or "").strip()
+	if not text:
+		return False
+	return bool(PO_REFERENCE_RE.match(text))
+
+
+def _normalize_internal_ap_token(value: Any) -> str:
+	text = "".join(ch for ch in str(value or "").upper() if ch.isalnum())
+	return text[:40]
+
+
+def _build_internal_ap_ref(
+	row: dict[str, Any], sheet_name: str, checksum: str, supplier_name: str
+) -> str:
+	raw_reference = _first_non_empty(row, "purchase_order", "po_reference", "po_no", "po_number", "po")
+	if not raw_reference:
+		reference_candidate = _first_non_empty(row, "reference")
+		if _looks_like_po_reference(reference_candidate):
+			raw_reference = reference_candidate
+
+	po_token = _normalize_internal_ap_token(raw_reference)
+	if po_token:
+		if po_token.startswith("PURCHASEORDER"):
+			po_token = po_token[len("PURCHASEORDER") :]
+		elif po_token.startswith("PO") and len(po_token) > 2:
+			po_token = po_token[2:]
+		return f"{AP_INTERNAL_REF_PREFIX}-PO-{po_token}"
+
+	posting_date = (
+		_safe_date(_first_non_empty(row, "posting_date", "invoice_date", "date", "date_entry")) or nowdate()
+	).replace("-", "")
+	amount = _safe_float(_first_non_empty(row, "outstanding_balance", "balance", "outstanding", "amount"))
+	digest = hashlib.sha1(
+		f"{sheet_name}|{checksum}|{supplier_name}|{posting_date}|{amount}".encode()
+	).hexdigest()[:10].upper()
+	return f"{AP_INTERNAL_REF_PREFIX}-SOA-{posting_date}-{digest}"
+
+
+def _purchase_invoice_exception_field_values(
+	*, missing_supplier_invoice: bool, internal_ap_ref: str | None, exception_reason: str | None
+) -> dict[str, Any]:
+	values: dict[str, Any] = {}
+	field_values = {
+		"custom_missing_supplier_invoice": 1 if missing_supplier_invoice else 0,
+		"custom_internal_ap_ref": internal_ap_ref or "",
+		"custom_invoice_exception_reason": exception_reason or "",
+		"custom_no_input_vat_support": 1 if missing_supplier_invoice else 0,
+	}
+	for fieldname, value in field_values.items():
+		if _doctype_has_field("Purchase Invoice", fieldname):
+			values[fieldname] = value
+	return values
+
+
+def _lookup_existing_purchase_invoice(
+	*,
+	supplier: str,
+	company: str,
+	invoice_no: str | None = None,
+	internal_ap_ref: str | None = None,
+) -> str | None:
+	if invoice_no:
+		existing = frappe.db.get_value(
+			"Purchase Invoice",
+			{
+				"supplier": supplier,
+				"bill_no": invoice_no,
+				"company": company,
+				"docstatus": ["<", 2],
+			},
+			"name",
+		)
+		if existing:
+			return existing
+
+	if internal_ap_ref and _doctype_has_field("Purchase Invoice", "custom_internal_ap_ref"):
+		return frappe.db.get_value(
+			"Purchase Invoice",
+			{
+				"supplier": supplier,
+				"custom_internal_ap_ref": internal_ap_ref,
+				"company": company,
+				"docstatus": ["<", 2],
+			},
+			"name",
+		)
+
+	return None
 
 
 def _default_expense_account(company: str) -> str | None:
@@ -1306,8 +1433,11 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 		savepoint: str | None = None
 		try:
 			supplier_input = _first_non_empty(row, "supplier", "supplier_name")
-			invoice_no = _first_non_empty(row, "invoice_no", "invoice_no.", "reference", "bill_no")
-			if not supplier_input or not invoice_no:
+			raw_reference = _first_non_empty(row, "reference")
+			invoice_no = _first_non_empty(row, "invoice_no", "invoice_no.", "bill_no")
+			if not invoice_no and raw_reference and not _looks_like_po_reference(raw_reference):
+				invoice_no = raw_reference
+			if not supplier_input:
 				results["rows_failed"] += 1
 				results["errors"].append("Missing supplier or invoice_no in AP opening row")
 				continue
@@ -1316,19 +1446,9 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 				_first_non_empty(row, "outstanding_balance", "balance", "outstanding", "amount")
 			)
 			company = _normalize_company(_first_non_empty(row, "company", "billed_to"))
-			dedupe_key = f"{company}|{supplier_input}|{invoice_no}"
-			if supplier_input and invoice_no and dedupe_key in seen_supplier_invoice_keys:
-				results["rows_updated"] += 1
-				continue
-			if supplier_input and invoice_no:
-				seen_supplier_invoice_keys.add(dedupe_key)
-
 			if amount <= 0:
 				results["rows_updated"] += 1
 				continue
-
-			savepoint = _make_savepoint("sync_ap", f"{sheet_name}|{checksum}|{dedupe_key}")
-			frappe.db.savepoint(savepoint)
 
 			posting_date = (
 				_safe_date(_first_non_empty(row, "posting_date", "invoice_date", "date", "date_entry"))
@@ -1337,15 +1457,33 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 			due_date = _safe_date(_first_non_empty(row, "due_date")) or posting_date
 
 			supplier = _ensure_supplier(str(supplier_input))
-			existing = frappe.db.get_value(
-				"Purchase Invoice",
-				{
-					"supplier": supplier,
-					"bill_no": invoice_no,
-					"company": company,
-					"docstatus": ["<", 2],
-				},
-				"name",
+			exception_config = _get_bei_supplier_invoice_exception_config(str(supplier_input), supplier)
+			internal_ap_ref = (
+				_build_internal_ap_ref(row, sheet_name, checksum, str(supplier_input))
+				if exception_config["allowed"]
+				else None
+			)
+			missing_supplier_invoice = not bool(invoice_no)
+			if missing_supplier_invoice and not exception_config["allowed"]:
+				results["rows_failed"] += 1
+				results["errors"].append("Missing supplier or invoice_no in AP opening row")
+				continue
+
+			lookup_key = internal_ap_ref if missing_supplier_invoice else invoice_no
+			dedupe_key = f"{company}|{supplier_input}|{lookup_key}"
+			if dedupe_key in seen_supplier_invoice_keys:
+				results["rows_updated"] += 1
+				continue
+			seen_supplier_invoice_keys.add(dedupe_key)
+
+			savepoint = _make_savepoint("sync_ap", f"{sheet_name}|{checksum}|{dedupe_key}")
+			frappe.db.savepoint(savepoint)
+
+			existing = _lookup_existing_purchase_invoice(
+				supplier=supplier,
+				company=company,
+				invoice_no=invoice_no,
+				internal_ap_ref=internal_ap_ref if exception_config["allowed"] else None,
 			)
 
 			if existing:
@@ -1358,11 +1496,22 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 					updates["bei_legal_entity"] = company
 				if _doctype_has_field("Purchase Invoice", "bei_store_label"):
 					updates["bei_store_label"] = _ap_opening_store_label(row) or "Stores - BEI"
-				sync_ref = _sync_ref("AP", sheet_name, checksum, f"{supplier}|{invoice_no}")
+				if invoice_no and _doctype_has_field("Purchase Invoice", "bill_no"):
+					updates["bill_no"] = invoice_no
+				updates.update(
+					_purchase_invoice_exception_field_values(
+						missing_supplier_invoice=missing_supplier_invoice,
+						internal_ap_ref=internal_ap_ref if exception_config["allowed"] else None,
+						exception_reason=exception_config["reason"],
+					)
+				)
+				sync_ref = _sync_ref("AP", sheet_name, checksum, f"{supplier}|{lookup_key}")
 				if _doctype_has_field("Purchase Invoice", "remarks"):
 					current_remarks = frappe.db.get_value("Purchase Invoice", existing, "remarks") or ""
 					if sync_ref not in current_remarks:
 						sync_note = f"[{sync_ref}] amount={amount}"
+						if missing_supplier_invoice and internal_ap_ref:
+							sync_note += f" internal_ref={internal_ap_ref} missing_supplier_invoice=1"
 						updates["remarks"] = f"{current_remarks}\n{sync_note}".strip()
 				if updates:
 					frappe.db.set_value("Purchase Invoice", existing, updates, update_modified=False)
@@ -1381,11 +1530,12 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 			if not payable_account:
 				raise ValueError(f"No payable account available for company {company}")
 
-			sync_ref = _sync_ref("AP", sheet_name, checksum, f"{supplier}|{invoice_no}")
+			sync_ref = _sync_ref("AP", sheet_name, checksum, f"{supplier}|{lookup_key}")
 			pi = frappe.new_doc("Purchase Invoice")
 			pi.company = company
 			pi.supplier = supplier
-			pi.bill_no = invoice_no
+			if invoice_no:
+				pi.bill_no = invoice_no
 			pi.bill_date = posting_date
 			pi.posting_date = posting_date
 			pi.due_date = due_date
@@ -1394,8 +1544,19 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 				pi.is_opening = "Yes"
 			if _doctype_has_field("Purchase Invoice", "credit_to"):
 				pi.credit_to = payable_account
+			for fieldname, value in _purchase_invoice_exception_field_values(
+				missing_supplier_invoice=missing_supplier_invoice,
+				internal_ap_ref=internal_ap_ref if exception_config["allowed"] else None,
+				exception_reason=exception_config["reason"],
+			).items():
+				setattr(pi, fieldname, value)
 			if _doctype_has_field("Purchase Invoice", "remarks"):
 				pi.remarks = f"ERP AP Opening Sync [{sync_ref}]"
+				if missing_supplier_invoice and internal_ap_ref:
+					pi.remarks += (
+						f"\nSupplier invoice missing; internal ref {internal_ap_ref}; "
+						f"reason: {exception_config['reason'] or 'Approved whitelist supplier exception'}"
+					)
 			apply_standard_buying_context(
 				pi,
 				store_label=_ap_opening_store_label(row),
@@ -1407,7 +1568,7 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 				"qty": 1,
 				"rate": amount,
 				"expense_account": expense_account,
-				"description": f"Opening balance sync for {invoice_no}",
+				"description": f"Opening balance sync for {invoice_no or internal_ap_ref}",
 			}
 			if cost_center:
 				item_row["cost_center"] = cost_center

--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -25,12 +25,34 @@ _BLOCKED_FIELDS = frozenset({
     "doctype", "name", "owner", "creation", "modified", "modified_by",
     "docstatus", "idx", "parent", "parenttype", "parentfield",
     "_user_tags", "_comments", "_assign", "_liked_by",
+    "allow_missing_supplier_invoice",
+    "missing_supplier_invoice_reason",
+    "missing_supplier_invoice_effective_date",
+    "missing_supplier_invoice_whitelisted_by",
 })
+_SUPPLIER_INVOICE_EXCEPTION_MANAGER_ROLES = {
+    "System Manager",
+    "Procurement Manager",
+    "Accounts Manager",
+}
 
 
 def _sanitize_doc_data(data):
     """Remove system/internal fields from user-supplied data before doc creation."""
     return {k: v for k, v in data.items() if k not in _BLOCKED_FIELDS}
+
+
+def _require_roles(allowed_roles: set[str], message: str) -> None:
+    """Enforce role-based access for sensitive procurement actions."""
+    user = frappe.session.user or "Guest"
+    if user == "Administrator":
+        return
+
+    user_roles = set(frappe.get_roles(user))
+    if user_roles.intersection(allowed_roles):
+        return
+
+    frappe.throw(message, frappe.PermissionError)
 
 
 def _resolve_supplier_identity(supplier: str) -> tuple[str, str]:
@@ -303,6 +325,38 @@ def update_supplier(name, data):
     supplier.save()
 
     return {"success": True, "message": _("Supplier updated")}
+
+
+@frappe.whitelist()
+def set_supplier_invoice_exception(name, allowed=1, reason=None):
+    """Whitelist a supplier for missing-invoice AP exception handling."""
+    _require_roles(
+        _SUPPLIER_INVOICE_EXCEPTION_MANAGER_ROLES,
+        _("You are not allowed to manage supplier invoice exceptions."),
+    )
+
+    supplier_name, _supplier_display_name = _resolve_supplier_identity(name)
+    supplier = frappe.get_doc("BEI Supplier", supplier_name)
+
+    is_allowed = 1 if cint(allowed) else 0
+    cleaned_reason = (reason or "").strip()
+    effective_date = nowdate() if is_allowed else None
+    whitelisted_by = frappe.session.user if is_allowed else None
+
+    supplier.allow_missing_supplier_invoice = is_allowed
+    supplier.missing_supplier_invoice_reason = cleaned_reason if is_allowed else ""
+    supplier.missing_supplier_invoice_effective_date = effective_date
+    supplier.missing_supplier_invoice_whitelisted_by = whitelisted_by
+    supplier.save(ignore_permissions=True)
+
+    return {
+        "success": True,
+        "name": supplier.name,
+        "allow_missing_supplier_invoice": bool(is_allowed),
+        "missing_supplier_invoice_effective_date": effective_date,
+        "missing_supplier_invoice_whitelisted_by": whitelisted_by,
+        "message": _("Supplier invoice exception updated."),
+    }
 
 
 @frappe.whitelist()

--- a/hrms/fixtures/custom_field.json
+++ b/hrms/fixtures/custom_field.json
@@ -154,5 +154,58 @@
         "label": "Store Order",
         "insert_after": "schedule_date",
         "description": "G-070: Link to the BEI Store Order that generated this Material Request"
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Purchase Invoice-custom_invoice_exception_section",
+        "dt": "Purchase Invoice",
+        "fieldname": "custom_invoice_exception_section",
+        "fieldtype": "Section Break",
+        "label": "Invoice Exception Controls",
+        "insert_after": "bill_no",
+        "collapsible": 1
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Purchase Invoice-custom_missing_supplier_invoice",
+        "dt": "Purchase Invoice",
+        "fieldname": "custom_missing_supplier_invoice",
+        "fieldtype": "Check",
+        "label": "Missing Supplier Invoice",
+        "insert_after": "custom_invoice_exception_section",
+        "read_only": 1,
+        "description": "Checked when BEI approved an exception because the supplier did not issue an invoice number"
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Purchase Invoice-custom_internal_ap_ref",
+        "dt": "Purchase Invoice",
+        "fieldname": "custom_internal_ap_ref",
+        "fieldtype": "Data",
+        "label": "Internal AP Reference",
+        "insert_after": "custom_missing_supplier_invoice",
+        "read_only": 1,
+        "description": "System-generated internal reference for approved missing-invoice supplier exceptions"
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Purchase Invoice-custom_invoice_exception_reason",
+        "dt": "Purchase Invoice",
+        "fieldname": "custom_invoice_exception_reason",
+        "fieldtype": "Small Text",
+        "label": "Invoice Exception Reason",
+        "insert_after": "custom_internal_ap_ref",
+        "read_only": 1
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Purchase Invoice-custom_no_input_vat_support",
+        "dt": "Purchase Invoice",
+        "fieldname": "custom_no_input_vat_support",
+        "fieldtype": "Check",
+        "label": "No Input VAT Support",
+        "insert_after": "custom_invoice_exception_reason",
+        "read_only": 1,
+        "description": "Checked while the supplier invoice exception remains unresolved"
     }
 ]

--- a/hrms/hr/doctype/bei_supplier/bei_supplier.json
+++ b/hrms/hr/doctype/bei_supplier/bei_supplier.json
@@ -23,6 +23,12 @@
     "bir_2307",
     "sec_certificate",
     "business_permit",
+    "invoice_exception_section",
+    "allow_missing_supplier_invoice",
+    "missing_supplier_invoice_reason",
+    "column_break_invoice_exception",
+    "missing_supplier_invoice_effective_date",
+    "missing_supplier_invoice_whitelisted_by",
     "ewt_section",
     "ewt_applicable",
     "ewt_exempt",
@@ -145,6 +151,43 @@
       "fieldname": "business_permit",
       "fieldtype": "Attach",
       "label": "Business Permit"
+    },
+    {
+      "fieldname": "invoice_exception_section",
+      "fieldtype": "Section Break",
+      "label": "Invoice Exception Controls"
+    },
+    {
+      "default": "0",
+      "description": "Controlled server-side whitelist for suppliers allowed to sync AP rows without a supplier-issued invoice number",
+      "fieldname": "allow_missing_supplier_invoice",
+      "fieldtype": "Check",
+      "label": "Allow Missing Supplier Invoice",
+      "read_only": 1
+    },
+    {
+      "description": "Required business justification for the supplier invoice exception whitelist",
+      "fieldname": "missing_supplier_invoice_reason",
+      "fieldtype": "Small Text",
+      "label": "Invoice Exception Reason",
+      "read_only": 1
+    },
+    {
+      "fieldname": "column_break_invoice_exception",
+      "fieldtype": "Column Break"
+    },
+    {
+      "fieldname": "missing_supplier_invoice_effective_date",
+      "fieldtype": "Date",
+      "label": "Invoice Exception Effective Date",
+      "read_only": 1
+    },
+    {
+      "fieldname": "missing_supplier_invoice_whitelisted_by",
+      "fieldtype": "Link",
+      "label": "Invoice Exception Whitelisted By",
+      "options": "User",
+      "read_only": 1
     },
     {
       "fieldname": "ewt_section",

--- a/hrms/hr/doctype/bei_supplier/bei_supplier.py
+++ b/hrms/hr/doctype/bei_supplier/bei_supplier.py
@@ -5,6 +5,18 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+_INVOICE_EXCEPTION_FIELDS = (
+    "allow_missing_supplier_invoice",
+    "missing_supplier_invoice_reason",
+    "missing_supplier_invoice_effective_date",
+    "missing_supplier_invoice_whitelisted_by",
+)
+_INVOICE_EXCEPTION_MANAGER_ROLES = {
+    "System Manager",
+    "Procurement Manager",
+    "Accounts Manager",
+}
+
 
 class BEISupplier(Document):
     """
@@ -17,6 +29,7 @@ class BEISupplier(Document):
     def validate(self):
         self.validate_supplier_code()
         self.validate_required_documents()
+        self.validate_invoice_exception_control()
 
     def validate_supplier_code(self):
         """Ensure supplier code is unique and properly formatted."""
@@ -40,6 +53,36 @@ class BEISupplier(Document):
                     indicator="orange",
                     alert=True
                 )
+
+    def validate_invoice_exception_control(self):
+        """Only privileged roles may change supplier invoice exception controls."""
+        user = frappe.session.user or "Guest"
+        if user == "Administrator":
+            return
+
+        if self.is_new():
+            previous_values = {fieldname: None for fieldname in _INVOICE_EXCEPTION_FIELDS}
+        else:
+            previous_values = {
+                fieldname: frappe.db.get_value("BEI Supplier", self.name, fieldname)
+                for fieldname in _INVOICE_EXCEPTION_FIELDS
+            }
+
+        changed = any(
+            (getattr(self, fieldname, None) or "") != (previous_values.get(fieldname) or "")
+            for fieldname in _INVOICE_EXCEPTION_FIELDS
+        )
+        if not changed:
+            return
+
+        user_roles = set(frappe.get_roles(user))
+        if user_roles.intersection(_INVOICE_EXCEPTION_MANAGER_ROLES):
+            return
+
+        frappe.throw(
+            _("You are not allowed to change supplier invoice exception controls."),
+            frappe.PermissionError,
+        )
 
     def before_save(self):
         self.update_metrics()

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -818,6 +818,122 @@ class TestErpSync(unittest.TestCase):
 		self.assertEqual(created_docs[0].bill_no, "INV-OPEN")
 		self.assertEqual(created_docs[0].items[0]["rate"], 40)
 
+	def test_sync_ap_opening_generates_internal_ref_for_whitelisted_missing_invoice_supplier(self):
+		created_docs = []
+
+		def db_exists(doctype, name=None):
+			if doctype == "BEI Supplier" and name == "SUPP-EXC":
+				return "SUPP-EXC"
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "Purchase Invoice" and isinstance(filters, dict):
+				return None
+			if doctype == "BEI Supplier" and isinstance(filters, dict):
+				if filters.get("frappe_supplier") == "SUP-0001":
+					return "SUPP-EXC"
+				if filters.get("supplier_name") == "HOME SUPPLIER":
+					return "SUPP-EXC"
+			if doctype == "BEI Supplier" and filters == "SUPP-EXC":
+				values = {
+					"allow_missing_supplier_invoice": 1,
+					"missing_supplier_invoice_reason": "Approved home-based supplier",
+				}
+				return values.get(fieldname)
+			return None
+
+		def new_doc(doctype):
+			if doctype != "Purchase Invoice":
+				return _FakeDoc(doctype)
+
+			def on_insert(doc):
+				doc.name = f"PI-{len(created_docs) + 1:04d}"
+				created_docs.append(doc)
+
+			return _FakeDoc(doctype, on_insert=on_insert)
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.db.set_value = MagicMock()
+		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
+		erp_sync.frappe.log_error = MagicMock()
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		rows = [
+			{
+				"supplier_name": "HOME SUPPLIER",
+				"reference": "PO#12345",
+				"outstanding_balance": 40,
+				"invoice_date": "2026-01-05",
+				"due_date": "2026-01-20",
+				"billed_to": "BEBANG SHAW INC",
+			},
+		]
+
+		with (
+			patch.object(erp_sync, "_ensure_ap_opening_item", return_value="ERP-SYNC-AP-OPENING"),
+			patch.object(erp_sync, "_normalize_company", return_value="BEI"),
+			patch.object(erp_sync, "_ensure_supplier", return_value="SUP-0001"),
+			patch.object(erp_sync, "_default_expense_account", return_value="Expense - BEI"),
+			patch.object(erp_sync, "_default_payable_account", return_value="Payable - BEI"),
+			patch.object(erp_sync, "_default_cost_center", return_value="Main - BEI"),
+			patch.object(erp_sync, "_doctype_has_field", return_value=True),
+		):
+			result = erp_sync.sync_ap_opening("Supplier SOA", rows, "chk-ap-soa-exc-1")
+
+		self.assertEqual(result["rows_created"], 1)
+		self.assertEqual(result["rows_failed"], 0)
+		self.assertEqual(len(created_docs), 1)
+		self.assertFalse(hasattr(created_docs[0], "bill_no"))
+		self.assertEqual(created_docs[0].custom_missing_supplier_invoice, 1)
+		self.assertEqual(created_docs[0].custom_no_input_vat_support, 1)
+		self.assertEqual(created_docs[0].custom_invoice_exception_reason, "Approved home-based supplier")
+		self.assertEqual(created_docs[0].custom_internal_ap_ref, "XINV-PO-12345")
+		self.assertIn("internal ref XINV-PO-12345", created_docs[0].remarks)
+
+	def test_sync_ap_opening_rejects_missing_invoice_for_non_whitelisted_supplier(self):
+		def db_exists(doctype, name=None):
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Supplier" and isinstance(filters, dict):
+				return None
+			return None
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.db.set_value = MagicMock()
+		erp_sync.frappe.new_doc = MagicMock()
+		erp_sync.frappe.log_error = MagicMock()
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		rows = [
+			{
+				"supplier_name": "STRICT SUPPLIER",
+				"reference": "PO#67890",
+				"outstanding_balance": 40,
+				"invoice_date": "2026-01-05",
+				"due_date": "2026-01-20",
+				"billed_to": "BEBANG SHAW INC",
+			},
+		]
+
+		with (
+			patch.object(erp_sync, "_ensure_ap_opening_item", return_value="ERP-SYNC-AP-OPENING"),
+			patch.object(erp_sync, "_normalize_company", return_value="BEI"),
+			patch.object(erp_sync, "_ensure_supplier", return_value="SUP-0002"),
+			patch.object(erp_sync, "_default_expense_account", return_value="Expense - BEI"),
+			patch.object(erp_sync, "_default_payable_account", return_value="Payable - BEI"),
+			patch.object(erp_sync, "_default_cost_center", return_value="Main - BEI"),
+			patch.object(erp_sync, "_doctype_has_field", return_value=True),
+		):
+			result = erp_sync.sync_ap_opening("Supplier SOA", rows, "chk-ap-soa-exc-2")
+
+		self.assertEqual(result["rows_created"], 0)
+		self.assertEqual(result["rows_failed"], 1)
+		self.assertIn("Missing supplier or invoice_no in AP opening row", result["errors"])
+		erp_sync.frappe.new_doc.assert_not_called()
+
 	def test_sync_procurement_suppliers_creates_then_updates_by_supplier_code(self):
 		registry = {}
 		counters = {}

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -29,6 +29,12 @@ def _install_fake_hrms():
 	sys.modules["hrms.utils.store_order_demand_snapshot"] = store_snapshot_mod
 	utils_pkg.store_order_demand_snapshot = store_snapshot_mod
 
+	store_inventory_mod = types.ModuleType("hrms.utils.store_inventory_shadow_sync")
+	store_inventory_mod.DEFAULT_OUTPUT_ROOT = ROOT / "tmp"
+	store_inventory_mod.run_shadow_sync = lambda *args, **kwargs: {}
+	sys.modules["hrms.utils.store_inventory_shadow_sync"] = store_inventory_mod
+	utils_pkg.store_inventory_shadow_sync = store_inventory_mod
+
 	standard_buying_bridge_mod = types.ModuleType("hrms.utils.standard_buying_bridge")
 
 	def apply_standard_buying_context(doc, *, store_label=None, legal_entity=None):

--- a/hrms/tests/test_procurement_sprint02.py
+++ b/hrms/tests/test_procurement_sprint02.py
@@ -143,6 +143,78 @@ class TestProcurementSprint02(unittest.TestCase):
 		procurement.frappe.get_all = MagicMock(return_value=[])
 		procurement.frappe.get_doc = MagicMock()
 
+	def test_update_supplier_strips_invoice_exception_fields_from_general_update(self):
+		supplier = types.SimpleNamespace(
+			supplier_name="Supplier A",
+			allow_missing_supplier_invoice=0,
+			missing_supplier_invoice_reason="",
+			save=MagicMock(),
+		)
+		procurement.frappe.get_doc = MagicMock(return_value=supplier)
+
+		result = procurement.update_supplier(
+			"SUP-001",
+			{
+				"supplier_name": "Supplier A Updated",
+				"allow_missing_supplier_invoice": 1,
+				"missing_supplier_invoice_reason": "Should be blocked",
+			},
+		)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(supplier.supplier_name, "Supplier A Updated")
+		self.assertEqual(supplier.allow_missing_supplier_invoice, 0)
+		self.assertEqual(supplier.missing_supplier_invoice_reason, "")
+		supplier.save.assert_called_once()
+
+	def test_set_supplier_invoice_exception_requires_privileged_role(self):
+		procurement.frappe.session = types.SimpleNamespace(user="buyer@bebang.ph")
+		procurement.frappe.get_roles = MagicMock(return_value=["Procurement User"])
+
+		with self.assertRaises(procurement.frappe.PermissionError):
+			procurement.set_supplier_invoice_exception("SUP-001", allowed=1, reason="Legacy exception")
+
+	def test_set_supplier_invoice_exception_sets_whitelist_fields(self):
+		supplier = types.SimpleNamespace(
+			name="SUP-001",
+			allow_missing_supplier_invoice=0,
+			missing_supplier_invoice_reason="",
+			missing_supplier_invoice_effective_date=None,
+			missing_supplier_invoice_whitelisted_by=None,
+			save=MagicMock(),
+		)
+
+		def _db_exists(doctype, name=None):
+			if doctype == "BEI Supplier" and name == "SUP-001":
+				return True
+			return None
+
+		def _db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Supplier" and filters == "SUP-001" and fieldname == "supplier_name":
+				return "Supplier A"
+			return None
+
+		procurement.frappe.session = types.SimpleNamespace(user="accounts@bebang.ph")
+		procurement.frappe.get_roles = MagicMock(return_value=["Accounts Manager"])
+		procurement.frappe.db.exists = MagicMock(side_effect=_db_exists)
+		procurement.frappe.db.get_value = MagicMock(side_effect=_db_get_value)
+		procurement.frappe.get_doc = MagicMock(return_value=supplier)
+
+		result = procurement.set_supplier_invoice_exception(
+			"SUP-001", allowed=1, reason="Approved legacy home-based supplier"
+		)
+
+		self.assertTrue(result["success"])
+		self.assertTrue(result["allow_missing_supplier_invoice"])
+		self.assertEqual(supplier.allow_missing_supplier_invoice, 1)
+		self.assertEqual(
+			supplier.missing_supplier_invoice_reason,
+			"Approved legacy home-based supplier",
+		)
+		self.assertEqual(supplier.missing_supplier_invoice_whitelisted_by, "accounts@bebang.ph")
+		self.assertEqual(supplier.missing_supplier_invoice_effective_date, "2026-02-27")
+		supplier.save.assert_called_once_with(ignore_permissions=True)
+
 	def test_generate_form_2307_entry_uses_structured_doctype(self):
 		pay_req = types.SimpleNamespace(
 			supplier="SUP-001",


### PR DESCRIPTION
## Summary`n- whitelist-only supplier invoice exception flow for AP sync`n- generate internal XINV-* refs for approved missing-invoice suppliers`n- hard-fail non-whitelisted missing invoice rows`n- add supplier and Purchase Invoice audit fields plus tests`n`n## Verification`n- python hrms/tests/test_erp_sync.py`n- python hrms/tests/test_procurement_sprint02.py`n- python hrms/tests/test_erp_sync_runtime.py`n- python -m py_compile hrms/api/erp_sync.py hrms/api/procurement.py hrms/hr/doctype/bei_supplier/bei_supplier.py hrms/tests/test_procurement_sprint02.py hrms/tests/test_erp_sync.py hrms/tests/test_erp_sync_runtime.py