### PR TITLE
fix: align billing warehouse rate permissions

### DIFF
--- a/hrms/api/billing.py
+++ b/hrms/api/billing.py
@@ -28,6 +28,16 @@ def _check_rate_permission():
 	check_scm_permission(RATE_MANAGEMENT_ROLES, "manage delivery rates")
 
 
+def _get_rate_actor_role(user: str | None = None) -> str | None:
+	"""Map runtime roles to the billing rate workflow department label."""
+	user_roles = set(frappe.get_roles(user or frappe.session.user) or [])
+	if "Accounts Manager" in user_roles:
+		return "Finance"
+	if "Supply Chain Manager" in user_roles:
+		return "Supply Chain"
+	return None
+
+
 def on_billing_schedule_validate(doc, method=None):
 	"""Doc-event hardening for BEI Billing Schedule validation.
 
@@ -314,6 +324,14 @@ def approve_rate(rate_name: str):
 	if rate.status != "Pending Review":
 		frappe.throw(_("Only rates with 'Pending Review' status can be approved"))
 
+	reviewer = frappe.session.user
+	reviewer_role = _get_rate_actor_role(reviewer)
+	if rate.set_by and rate.set_by == reviewer:
+		frappe.throw(_("Cannot approve your own rate"))
+
+	if reviewer_role and rate.set_by_role and reviewer_role == rate.set_by_role:
+		frappe.throw(_("Delivery rates must be approved by the other department"))
+
 	# Expire existing active rate for same store+cargo_type
 	existing_active = frappe.get_all(
 		"BEI Delivery Rate",
@@ -329,12 +347,9 @@ def approve_rate(rate_name: str):
 
 	# Activate new rate
 	rate.status = "Active"
-	rate.reviewed_by = frappe.session.user
-	user_roles = frappe.get_roles(frappe.session.user)
-	if "Accounts Manager" in user_roles:
-		rate.reviewed_by_role = "Finance"
-	elif "Supply Chain Manager" in user_roles:
-		rate.reviewed_by_role = "Supply Chain"
+	rate.reviewed_by = reviewer
+	if reviewer_role:
+		rate.reviewed_by_role = reviewer_role
 	rate.reviewed_at = now_datetime()
 	rate.save()
 	return {"success": True, "status": rate.status}

--- a/hrms/api/billing.py
+++ b/hrms/api/billing.py
@@ -33,7 +33,7 @@ def _get_rate_actor_role(user: str | None = None) -> str | None:
 	user_roles = set(frappe.get_roles(user or frappe.session.user) or [])
 	if "Accounts Manager" in user_roles:
 		return "Finance"
-	if "Supply Chain Manager" in user_roles:
+	if user_roles.intersection({"Supply Chain Manager", "Warehouse Manager", "Warehouse User"}):
 		return "Supply Chain"
 	return None
 

--- a/hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.json
+++ b/hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.json
@@ -167,6 +167,17 @@
    "write": 1
   },
   {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Warehouse User",
+   "share": 1,
+   "write": 1
+  },
+  {
    "export": 1,
    "print": 1,
    "read": 1,

--- a/hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.py
+++ b/hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.py
@@ -1,17 +1,20 @@
 import frappe
-from frappe.model.document import Document
 from frappe import _
+from frappe.model.document import Document
 
 
 class BEIDeliveryRate(Document):
 	def validate(self):
 		if self.status == "Active":
-			existing = frappe.db.exists("BEI Delivery Rate", {
-				"store": self.store,
-				"cargo_type": self.cargo_type,
-				"status": "Active",
-				"name": ["!=", self.name]
-			})
+			existing = frappe.db.exists(
+				"BEI Delivery Rate",
+				{
+					"store": self.store,
+					"cargo_type": self.cargo_type,
+					"status": "Active",
+					"name": ["!=", self.name],
+				},
+			)
 			if existing:
 				frappe.throw(
 					_("An active rate already exists for {0} - {1}: {2}").format(
@@ -25,5 +28,7 @@ class BEIDeliveryRate(Document):
 			user_roles = frappe.get_roles(frappe.session.user)
 			if "Accounts Manager" in user_roles:
 				self.set_by_role = "Finance"
-			elif "Supply Chain Manager" in user_roles:
+			elif {"Supply Chain Manager", "Warehouse Manager", "Warehouse User"}.intersection(
+				set(user_roles or [])
+			):
 				self.set_by_role = "Supply Chain"

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -45,3 +45,4 @@ hrms.patches.v16_0.seed_warehouse_department_mapping
 hrms.patches.v16_0.backfill_store_area_supervisor_mapping #2026-03-02
 hrms.patches.v16_0.add_cycle_count_unique_index #2026-02-19
 hrms.patches.v16_0.drop_cycle_count_unique_index #2026-02-20
+hrms.patches.v16_0.ensure_statement_of_account_doctype #2026-03-10

--- a/hrms/patches/v16_0/ensure_statement_of_account_doctype.py
+++ b/hrms/patches/v16_0/ensure_statement_of_account_doctype.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from __future__ import annotations
+
+import os
+
+import frappe
+from frappe.modules.import_file import import_file_by_path
+from frappe.modules.utils import get_module_path
+
+
+def _import_standard_doctype(docname: str) -> None:
+	path = os.path.join(get_module_path("hr"), "doctype", docname, f"{docname}.json")
+	original_in_fixtures = getattr(frappe.flags, "in_fixtures", False)
+
+	try:
+		frappe.flags.in_patch = True
+		frappe.flags.in_fixtures = True
+		import_file_by_path(path, force=True)
+	finally:
+		frappe.flags.in_fixtures = original_in_fixtures
+
+
+def execute():
+	"""Ensure the SOA parent/child DocTypes exist after older deploys missed the parent registry row."""
+	_import_standard_doctype("bei_soa_line_item")
+	_import_standard_doctype("bei_statement_of_account")
+	frappe.clear_cache()

--- a/hrms/tests/test_billing_rate_approval_guard_s027.py
+++ b/hrms/tests/test_billing_rate_approval_guard_s027.py
@@ -11,6 +11,17 @@ if str(ROOT) not in sys.path:
 	sys.path.insert(0, str(ROOT))
 
 
+class _LocalProxy:
+	def __init__(self, getter):
+		object.__setattr__(self, "_getter", getter)
+
+	def __getattr__(self, name):
+		return getattr(object.__getattribute__(self, "_getter")(), name)
+
+	def __setattr__(self, name, value):
+		setattr(object.__getattribute__(self, "_getter")(), name, value)
+
+
 def _install_fake_modules():
 	if "frappe" not in sys.modules:
 		frappe = types.ModuleType("frappe")
@@ -45,12 +56,13 @@ def _install_fake_modules():
 	frappe.whitelist = whitelist
 	frappe._ = lambda text: text
 	frappe.throw = _throw
-	frappe.session = types.SimpleNamespace(user="approver@bebang.ph")
+	frappe.local = types.SimpleNamespace()
+	frappe.local.session = types.SimpleNamespace(user="approver@bebang.ph")
 	frappe.get_roles = lambda user=None: ["System Manager"]
 	frappe.log_error = lambda *args, **kwargs: None
 	frappe.has_permission = lambda *args, **kwargs: True
 	frappe.format_value = lambda value, _type=None: f"{float(value):.2f}"
-	frappe.db = types.SimpleNamespace(
+	frappe.local.db = types.SimpleNamespace(
 		sql=lambda *args, **kwargs: [],
 		get_value=lambda *args, **kwargs: None,
 		set_value=lambda *args, **kwargs: None,
@@ -58,6 +70,8 @@ def _install_fake_modules():
 		release_savepoint=lambda *args, **kwargs: None,
 		rollback=lambda *args, **kwargs: None,
 	)
+	frappe.__dict__["session"] = _LocalProxy(lambda: frappe.local.session)
+	frappe.__dict__["db"] = _LocalProxy(lambda: frappe.local.db)
 
 	utils.flt = lambda value, precision=None: float(value or 0)
 	utils.now_datetime = lambda: datetime.datetime(2026, 3, 10, 10, 0, 0)
@@ -131,10 +145,10 @@ class _RateDoc:
 class TestBillingRateApprovalGuardS027(unittest.TestCase):
 	def setUp(self):
 		self.rate = _RateDoc()
-		billing.frappe.session.user = "approver@bebang.ph"
+		billing.frappe.local.session.user = "approver@bebang.ph"
 		billing.frappe.get_doc = MagicMock(return_value=self.rate)
 		billing.frappe.get_all = MagicMock(return_value=[types.SimpleNamespace(name="RATE-OLD-001")])
-		billing.frappe.db.set_value = MagicMock()
+		billing.frappe.local.db.set_value = MagicMock()
 		billing.frappe.get_roles = MagicMock(return_value=["Supply Chain Manager"])
 
 	def test_self_approval_is_blocked(self):

--- a/hrms/tests/test_billing_rate_approval_guard_s027.py
+++ b/hrms/tests/test_billing_rate_approval_guard_s027.py
@@ -1,0 +1,182 @@
+import datetime
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_modules():
+	if "frappe" not in sys.modules:
+		frappe = types.ModuleType("frappe")
+		sys.modules["frappe"] = frappe
+	else:
+		frappe = sys.modules["frappe"]
+
+	if "frappe.utils" not in sys.modules:
+		utils = types.ModuleType("frappe.utils")
+		sys.modules["frappe.utils"] = utils
+	else:
+		utils = sys.modules["frappe.utils"]
+
+	def whitelist(*args, **kwargs):
+		def decorator(fn):
+			return fn
+
+		return decorator
+
+	def _throw(message, exc=None):
+		if isinstance(exc, type) and issubclass(exc, Exception):
+			raise exc(message)
+		raise Exception(message)
+
+	if not hasattr(frappe, "ValidationError"):
+		frappe.ValidationError = type("ValidationError", (Exception,), {})
+	if not hasattr(frappe, "PermissionError"):
+		frappe.PermissionError = type("PermissionError", (Exception,), {})
+	if not hasattr(frappe, "DoesNotExistError"):
+		frappe.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
+
+	frappe.whitelist = whitelist
+	frappe._ = lambda text: text
+	frappe.throw = _throw
+	frappe.session = types.SimpleNamespace(user="approver@bebang.ph")
+	frappe.get_roles = lambda user=None: ["System Manager"]
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.has_permission = lambda *args, **kwargs: True
+	frappe.format_value = lambda value, _type=None: f"{float(value):.2f}"
+	frappe.db = types.SimpleNamespace(
+		sql=lambda *args, **kwargs: [],
+		get_value=lambda *args, **kwargs: None,
+		set_value=lambda *args, **kwargs: None,
+		savepoint=lambda *args, **kwargs: None,
+		release_savepoint=lambda *args, **kwargs: None,
+		rollback=lambda *args, **kwargs: None,
+	)
+
+	utils.flt = lambda value, precision=None: float(value or 0)
+	utils.now_datetime = lambda: datetime.datetime(2026, 3, 10, 10, 0, 0)
+	utils.nowdate = lambda: "2026-03-10"
+	utils.get_first_day = lambda value: value
+	utils.get_last_day = lambda value: value
+	utils.getdate = lambda value=None: datetime.date.fromisoformat(str(value or "2026-03-10")[:10])
+	frappe.utils = utils
+
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.utils" not in sys.modules:
+		hrms_utils_pkg = types.ModuleType("hrms.utils")
+		hrms_utils_pkg.__path__ = []
+		sys.modules["hrms.utils"] = hrms_utils_pkg
+
+	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.get_company = lambda: "Bebang Enterprise Inc."
+	sys.modules["hrms.utils.bei_config"] = bei_config
+
+	store_type_mod = types.ModuleType("hrms.hr.doctype.bei_store_type.bei_store_type")
+	store_type_mod.resolve_store_type = (
+		lambda store_type=None, store_type_category=None: store_type or store_type_category
+	)
+	sys.modules["hrms.hr.doctype.bei_store_type.bei_store_type"] = store_type_mod
+
+	scm_roles = types.ModuleType("hrms.utils.scm_roles")
+	scm_roles.RATE_MANAGEMENT_ROLES = ["Accounts Manager", "Supply Chain Manager", "System Manager"]
+	scm_roles.SCM_BILLING_ROLES = ["Accounts Manager", "Supply Chain Manager", "System Manager"]
+	scm_roles.check_scm_permission = lambda roles, action=None: None
+	sys.modules["hrms.utils.scm_roles"] = scm_roles
+
+
+_install_fake_modules()
+
+billing_spec = importlib.util.spec_from_file_location(
+	"billing_under_test",
+	ROOT / "hrms" / "api" / "billing.py",
+)
+billing = importlib.util.module_from_spec(billing_spec)
+assert billing_spec and billing_spec.loader
+billing_spec.loader.exec_module(billing)
+
+
+class _RateDoc:
+	def __init__(
+		self,
+		*,
+		name="RATE-0001",
+		store="TEST-STORE-BGC - BEI",
+		cargo_type="Dry Goods",
+		status="Pending Review",
+		set_by="creator@bebang.ph",
+		set_by_role="Finance",
+	):
+		self.name = name
+		self.store = store
+		self.cargo_type = cargo_type
+		self.status = status
+		self.set_by = set_by
+		self.set_by_role = set_by_role
+		self.reviewed_by = None
+		self.reviewed_by_role = None
+		self.reviewed_at = None
+		self.save = MagicMock()
+
+
+class TestBillingRateApprovalGuardS027(unittest.TestCase):
+	def setUp(self):
+		self.rate = _RateDoc()
+		billing.frappe.session.user = "approver@bebang.ph"
+		billing.frappe.get_doc = MagicMock(return_value=self.rate)
+		billing.frappe.get_all = MagicMock(return_value=[types.SimpleNamespace(name="RATE-OLD-001")])
+		billing.frappe.db.set_value = MagicMock()
+		billing.frappe.get_roles = MagicMock(return_value=["Supply Chain Manager"])
+
+	def test_self_approval_is_blocked(self):
+		self.rate.set_by = "approver@bebang.ph"
+
+		with self.assertRaisesRegex(Exception, "Cannot approve your own rate"):
+			billing.approve_rate(self.rate.name)
+
+		billing.frappe.db.set_value.assert_not_called()
+		self.rate.save.assert_not_called()
+
+	def test_same_department_approval_is_blocked(self):
+		billing.frappe.get_roles = MagicMock(return_value=["Accounts Manager"])
+		self.rate.set_by = "finance.creator@bebang.ph"
+		self.rate.set_by_role = "Finance"
+
+		with self.assertRaisesRegex(Exception, "approved by the other department"):
+			billing.approve_rate(self.rate.name)
+
+		billing.frappe.db.set_value.assert_not_called()
+		self.rate.save.assert_not_called()
+
+	def test_cross_department_approval_activates_rate_and_expires_prior_active(self):
+		billing.frappe.get_roles = MagicMock(return_value=["Supply Chain Manager"])
+		self.rate.set_by = "finance.creator@bebang.ph"
+		self.rate.set_by_role = "Finance"
+
+		result = billing.approve_rate(self.rate.name)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(result["status"], "Active")
+		self.assertEqual(self.rate.status, "Active")
+		self.assertEqual(self.rate.reviewed_by, "approver@bebang.ph")
+		self.assertEqual(self.rate.reviewed_by_role, "Supply Chain")
+		billing.frappe.db.set_value.assert_called_once_with(
+			"BEI Delivery Rate",
+			"RATE-OLD-001",
+			"status",
+			"Expired",
+		)
+		self.rate.save.assert_called_once()
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/hrms/tests/test_billing_rate_approval_guard_s027.py
+++ b/hrms/tests/test_billing_rate_approval_guard_s027.py
@@ -102,8 +102,18 @@ def _install_fake_modules():
 	sys.modules["hrms.hr.doctype.bei_store_type.bei_store_type"] = store_type_mod
 
 	scm_roles = types.ModuleType("hrms.utils.scm_roles")
-	scm_roles.RATE_MANAGEMENT_ROLES = ["Accounts Manager", "Supply Chain Manager", "System Manager"]
-	scm_roles.SCM_BILLING_ROLES = ["Accounts Manager", "Supply Chain Manager", "System Manager"]
+	scm_roles.RATE_MANAGEMENT_ROLES = [
+		"Accounts Manager",
+		"Supply Chain Manager",
+		"Warehouse User",
+		"System Manager",
+	]
+	scm_roles.SCM_BILLING_ROLES = [
+		"Accounts Manager",
+		"Supply Chain Manager",
+		"Warehouse User",
+		"System Manager",
+	]
 	scm_roles.check_scm_permission = lambda roles, action=None: None
 	sys.modules["hrms.utils.scm_roles"] = scm_roles
 
@@ -190,6 +200,17 @@ class TestBillingRateApprovalGuardS027(unittest.TestCase):
 			"Expired",
 		)
 		self.rate.save.assert_called_once()
+
+	def test_warehouse_user_is_treated_as_supply_chain_for_approval(self):
+		billing.frappe.get_roles = MagicMock(return_value=["Warehouse User"])
+		self.rate.set_by = "finance.creator@bebang.ph"
+		self.rate.set_by_role = "Finance"
+
+		result = billing.approve_rate(self.rate.name)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(result["status"], "Active")
+		self.assertEqual(self.rate.reviewed_by_role, "Supply Chain")
 
 
 if __name__ == "__main__":

--- a/hrms/utils/scm_roles.py
+++ b/hrms/utils/scm_roles.py
@@ -11,7 +11,6 @@ Usage:
 import frappe
 from frappe import _
 
-
 # ============================================================
 # SCM Role Sets
 # ============================================================
@@ -27,23 +26,39 @@ SCM_PICKING_ROLES = {"Warehouse Manager", "Warehouse Staff", "Logistics Coordina
 # Ordering (ordering.py)
 ORDERING_STORE_ROLES = {"Store Staff", "Store Supervisor", "Store OIC", "System Manager"}
 ORDERING_WAREHOUSE_ROLES = {
-    "Area Supervisor",
-    "Regional Manager",
-    "HR Manager",
-    "Warehouse Manager",
-    "System Manager",
+	"Area Supervisor",
+	"Regional Manager",
+	"HR Manager",
+	"Warehouse Manager",
+	"System Manager",
 }
 ORDERING_APPROVAL_ROLES = {
-    "Area Supervisor",
-    "Regional Manager",
-    "HR Manager",
-    "Warehouse Manager",
-    "System Manager",
+	"Area Supervisor",
+	"Regional Manager",
+	"HR Manager",
+	"Warehouse Manager",
+	"System Manager",
 }
 
 # Billing (billing.py)
-RATE_MANAGEMENT_ROLES = {"Accounts Manager", "Supply Chain Manager", "System Manager"}
-SCM_BILLING_ROLES = {"Warehouse Manager", "Logistics Coordinator", "HR Manager", "System Manager"}
+RATE_MANAGEMENT_ROLES = {
+	"Accounts Manager",
+	"Supply Chain Manager",
+	"Warehouse Manager",
+	"Warehouse User",
+	"System Manager",
+}
+SCM_BILLING_ROLES = {
+	"Accounts Manager",
+	"Supply Chain Manager",
+	"Warehouse Manager",
+	"Warehouse User",
+	"Logistics Coordinator",
+	"HQ User",
+	"HQ Finance",
+	"HR Manager",
+	"System Manager",
+}
 
 # Inventory (inventory.py)
 SCM_INVENTORY_ROLES = {"Warehouse Manager", "Warehouse Staff", "Logistics Coordinator", "System Manager"}
@@ -60,19 +75,17 @@ SCM_APPROVAL_ROLES = {"Warehouse Manager", "Supply Chain Manager", "HR Manager",
 # Shared Permission Check
 # ============================================================
 
+
 def check_scm_permission(allowed_roles, action="access this resource"):
-    """Check if current user has any of the allowed roles.
+	"""Check if current user has any of the allowed roles.
 
-    Args:
-        allowed_roles: Set of role names that grant access
-        action: Description of the action for the error message
+	Args:
+	    allowed_roles: Set of role names that grant access
+	    action: Description of the action for the error message
 
-    Raises:
-        frappe.PermissionError: If user has none of the allowed roles
-    """
-    user_roles = set(frappe.get_roles(frappe.session.user))
-    if not user_roles.intersection(allowed_roles):
-        frappe.throw(
-            _("You do not have permission to {0}").format(action),
-            frappe.PermissionError
-        )
+	Raises:
+	    frappe.PermissionError: If user has none of the allowed roles
+	"""
+	user_roles = set(frappe.get_roles(frappe.session.user))
+	if not user_roles.intersection(allowed_roles):
+		frappe.throw(_("You do not have permission to {0}").format(action), frappe.PermissionError)


### PR DESCRIPTION
## Summary
- allow Warehouse User through billing rate-management RBAC
- map warehouse billing actors to the Supply Chain approval side
- add Delivery Rate DocType permissions for Warehouse User
- extend the S027 approval regression to cover warehouse-user approval

## Verification
- pre-commit run --files hrms/utils/scm_roles.py hrms/api/billing.py hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.py hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.json hrms/tests/test_billing_rate_approval_guard_s027.py
- python -m py_compile hrms/utils/scm_roles.py hrms/api/billing.py hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.py hrms/tests/test_billing_rate_approval_guard_s027.py
- python hrms/tests/test_billing_rate_approval_guard_s027.py

## Context
S027 billing live Playwright proved the warehouse approval lane was failing with:
`403 You do not have permission to manage delivery rates`