### PR TITLE
fix: align billing warehouse rate permissions

### DIFF
--- a/hrms/api/billing.py
+++ b/hrms/api/billing.py
@@ -33,7 +33,7 @@ def _get_rate_actor_role(user: str | None = None) -> str | None:
 	user_roles = set(frappe.get_roles(user or frappe.session.user) or [])
 	if "Accounts Manager" in user_roles:
 		return "Finance"
-	if "Supply Chain Manager" in user_roles:
+	if user_roles.intersection({"Supply Chain Manager", "Warehouse Manager", "Warehouse User"}):
 		return "Supply Chain"
 	return None
 

--- a/hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.json
+++ b/hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.json
@@ -167,6 +167,17 @@
    "write": 1
   },
   {
+   "create": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Warehouse User",
+   "share": 1,
+   "write": 1
+  },
+  {
    "export": 1,
    "print": 1,
    "read": 1,

--- a/hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.py
+++ b/hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.py
@@ -1,17 +1,20 @@
 import frappe
-from frappe.model.document import Document
 from frappe import _
+from frappe.model.document import Document
 
 
 class BEIDeliveryRate(Document):
 	def validate(self):
 		if self.status == "Active":
-			existing = frappe.db.exists("BEI Delivery Rate", {
-				"store": self.store,
-				"cargo_type": self.cargo_type,
-				"status": "Active",
-				"name": ["!=", self.name]
-			})
+			existing = frappe.db.exists(
+				"BEI Delivery Rate",
+				{
+					"store": self.store,
+					"cargo_type": self.cargo_type,
+					"status": "Active",
+					"name": ["!=", self.name],
+				},
+			)
 			if existing:
 				frappe.throw(
 					_("An active rate already exists for {0} - {1}: {2}").format(
@@ -25,5 +28,7 @@ class BEIDeliveryRate(Document):
 			user_roles = frappe.get_roles(frappe.session.user)
 			if "Accounts Manager" in user_roles:
 				self.set_by_role = "Finance"
-			elif "Supply Chain Manager" in user_roles:
+			elif {"Supply Chain Manager", "Warehouse Manager", "Warehouse User"}.intersection(
+				set(user_roles or [])
+			):
 				self.set_by_role = "Supply Chain"

--- a/hrms/tests/test_billing_rate_approval_guard_s027.py
+++ b/hrms/tests/test_billing_rate_approval_guard_s027.py
@@ -102,8 +102,18 @@ def _install_fake_modules():
 	sys.modules["hrms.hr.doctype.bei_store_type.bei_store_type"] = store_type_mod
 
 	scm_roles = types.ModuleType("hrms.utils.scm_roles")
-	scm_roles.RATE_MANAGEMENT_ROLES = ["Accounts Manager", "Supply Chain Manager", "System Manager"]
-	scm_roles.SCM_BILLING_ROLES = ["Accounts Manager", "Supply Chain Manager", "System Manager"]
+	scm_roles.RATE_MANAGEMENT_ROLES = [
+		"Accounts Manager",
+		"Supply Chain Manager",
+		"Warehouse User",
+		"System Manager",
+	]
+	scm_roles.SCM_BILLING_ROLES = [
+		"Accounts Manager",
+		"Supply Chain Manager",
+		"Warehouse User",
+		"System Manager",
+	]
 	scm_roles.check_scm_permission = lambda roles, action=None: None
 	sys.modules["hrms.utils.scm_roles"] = scm_roles
 
@@ -190,6 +200,17 @@ class TestBillingRateApprovalGuardS027(unittest.TestCase):
 			"Expired",
 		)
 		self.rate.save.assert_called_once()
+
+	def test_warehouse_user_is_treated_as_supply_chain_for_approval(self):
+		billing.frappe.get_roles = MagicMock(return_value=["Warehouse User"])
+		self.rate.set_by = "finance.creator@bebang.ph"
+		self.rate.set_by_role = "Finance"
+
+		result = billing.approve_rate(self.rate.name)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(result["status"], "Active")
+		self.assertEqual(self.rate.reviewed_by_role, "Supply Chain")
 
 
 if __name__ == "__main__":

--- a/hrms/utils/scm_roles.py
+++ b/hrms/utils/scm_roles.py
@@ -11,7 +11,6 @@ Usage:
 import frappe
 from frappe import _
 
-
 # ============================================================
 # SCM Role Sets
 # ============================================================
@@ -27,23 +26,39 @@ SCM_PICKING_ROLES = {"Warehouse Manager", "Warehouse Staff", "Logistics Coordina
 # Ordering (ordering.py)
 ORDERING_STORE_ROLES = {"Store Staff", "Store Supervisor", "Store OIC", "System Manager"}
 ORDERING_WAREHOUSE_ROLES = {
-    "Area Supervisor",
-    "Regional Manager",
-    "HR Manager",
-    "Warehouse Manager",
-    "System Manager",
+	"Area Supervisor",
+	"Regional Manager",
+	"HR Manager",
+	"Warehouse Manager",
+	"System Manager",
 }
 ORDERING_APPROVAL_ROLES = {
-    "Area Supervisor",
-    "Regional Manager",
-    "HR Manager",
-    "Warehouse Manager",
-    "System Manager",
+	"Area Supervisor",
+	"Regional Manager",
+	"HR Manager",
+	"Warehouse Manager",
+	"System Manager",
 }
 
 # Billing (billing.py)
-RATE_MANAGEMENT_ROLES = {"Accounts Manager", "Supply Chain Manager", "System Manager"}
-SCM_BILLING_ROLES = {"Warehouse Manager", "Logistics Coordinator", "HR Manager", "System Manager"}
+RATE_MANAGEMENT_ROLES = {
+	"Accounts Manager",
+	"Supply Chain Manager",
+	"Warehouse Manager",
+	"Warehouse User",
+	"System Manager",
+}
+SCM_BILLING_ROLES = {
+	"Accounts Manager",
+	"Supply Chain Manager",
+	"Warehouse Manager",
+	"Warehouse User",
+	"Logistics Coordinator",
+	"HQ User",
+	"HQ Finance",
+	"HR Manager",
+	"System Manager",
+}
 
 # Inventory (inventory.py)
 SCM_INVENTORY_ROLES = {"Warehouse Manager", "Warehouse Staff", "Logistics Coordinator", "System Manager"}
@@ -60,19 +75,17 @@ SCM_APPROVAL_ROLES = {"Warehouse Manager", "Supply Chain Manager", "HR Manager",
 # Shared Permission Check
 # ============================================================
 
+
 def check_scm_permission(allowed_roles, action="access this resource"):
-    """Check if current user has any of the allowed roles.
+	"""Check if current user has any of the allowed roles.
 
-    Args:
-        allowed_roles: Set of role names that grant access
-        action: Description of the action for the error message
+	Args:
+	    allowed_roles: Set of role names that grant access
+	    action: Description of the action for the error message
 
-    Raises:
-        frappe.PermissionError: If user has none of the allowed roles
-    """
-    user_roles = set(frappe.get_roles(frappe.session.user))
-    if not user_roles.intersection(allowed_roles):
-        frappe.throw(
-            _("You do not have permission to {0}").format(action),
-            frappe.PermissionError
-        )
+	Raises:
+	    frappe.PermissionError: If user has none of the allowed roles
+	"""
+	user_roles = set(frappe.get_roles(frappe.session.user))
+	if not user_roles.intersection(allowed_roles):
+		frappe.throw(_("You do not have permission to {0}").format(action), frappe.PermissionError)


### PR DESCRIPTION
## Summary
- allow Warehouse User through billing rate-management RBAC
- map warehouse billing actors to the Supply Chain approval side
- add Delivery Rate DocType permissions for Warehouse User
- extend the S027 approval regression to cover warehouse-user approval

## Verification
- pre-commit run --files hrms/utils/scm_roles.py hrms/api/billing.py hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.py hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.json hrms/tests/test_billing_rate_approval_guard_s027.py
- python -m py_compile hrms/utils/scm_roles.py hrms/api/billing.py hrms/hr/doctype/bei_delivery_rate/bei_delivery_rate.py hrms/tests/test_billing_rate_approval_guard_s027.py
- python hrms/tests/test_billing_rate_approval_guard_s027.py

## Context
S027 billing live Playwright proved the warehouse approval lane was failing with:
`403 You do not have permission to manage delivery rates`