### PR TITLE
fix: guard billing read endpoints

### DIFF
--- a/hrms/api/billing.py
+++ b/hrms/api/billing.py
@@ -249,6 +249,8 @@ def get_delivery_rates(
 	status: str | None = None,
 ):
 	"""List delivery rates with optional filters."""
+	_check_rate_permission()
+
 	filters = {}
 	if store:
 		filters["store"] = store
@@ -358,6 +360,8 @@ def approve_rate(rate_name: str):
 @frappe.whitelist()
 def get_stores_without_rates():
 	"""Get stores that are missing active delivery rates."""
+	_check_rate_permission()
+
 	# All stores from BEI Store Type
 	all_stores = _get_store_type_records()
 
@@ -394,6 +398,8 @@ def get_stores_without_rates():
 @frappe.whitelist()
 def get_pending_billings(store: str | None = None, billing_type: str | None = None):
 	"""List billings pending Finance approval."""
+	_check_billing_permission("view pending billings")
+
 	filters = {"status": "Pending"}
 	if store:
 		filters["store"] = store

--- a/hrms/tests/test_billing_rate_approval_guard_s027.py
+++ b/hrms/tests/test_billing_rate_approval_guard_s027.py
@@ -160,6 +160,7 @@ class TestBillingRateApprovalGuardS027(unittest.TestCase):
 		billing.frappe.get_all = MagicMock(return_value=[types.SimpleNamespace(name="RATE-OLD-001")])
 		billing.frappe.local.db.set_value = MagicMock()
 		billing.frappe.get_roles = MagicMock(return_value=["Supply Chain Manager"])
+		billing.check_scm_permission = MagicMock()
 
 	def test_self_approval_is_blocked(self):
 		self.rate.set_by = "approver@bebang.ph"
@@ -211,6 +212,35 @@ class TestBillingRateApprovalGuardS027(unittest.TestCase):
 		self.assertTrue(result["success"])
 		self.assertEqual(result["status"], "Active")
 		self.assertEqual(self.rate.reviewed_by_role, "Supply Chain")
+
+	def test_get_delivery_rates_checks_rate_permission(self):
+		billing.frappe.get_all = MagicMock(return_value=[])
+
+		result = billing.get_delivery_rates()
+
+		self.assertEqual(result, [])
+		billing.check_scm_permission.assert_called_with(
+			billing.RATE_MANAGEMENT_ROLES, "manage delivery rates"
+		)
+
+	def test_get_pending_billings_checks_billing_permission(self):
+		billing.frappe.get_all = MagicMock(return_value=[])
+
+		result = billing.get_pending_billings()
+
+		self.assertEqual(result, [])
+		billing.check_scm_permission.assert_called_with(billing.SCM_BILLING_ROLES, "view pending billings")
+
+	def test_get_stores_without_rates_checks_rate_permission(self):
+		billing._get_store_type_records = MagicMock(return_value=[])
+		billing.frappe.local.db.sql = MagicMock(return_value=[])
+
+		result = billing.get_stores_without_rates()
+
+		self.assertEqual(result, [])
+		billing.check_scm_permission.assert_called_with(
+			billing.RATE_MANAGEMENT_ROLES, "manage delivery rates"
+		)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enforce backend permission checks on billing read endpoints used by the portal
- protect delivery rates, missing-rate scans, and pending billing reads from UI-only access drift
- extend the S027 billing regression suite for the read-side guards

## Verification
- pre-commit run --files hrms/api/billing.py hrms/tests/test_billing_rate_approval_guard_s027.py
- python -m py_compile hrms/api/billing.py hrms/tests/test_billing_rate_approval_guard_s027.py
- python hrms/tests/test_billing_rate_approval_guard_s027.py

## Context
After the warehouse RBAC fix deployed, the live S027 billing lane progressed to the crew negative probe and proved that `/api/billing?action=rates` was still readable by unauthorized users.