### PR TITLE
fix: normalize AP null invoice tokens

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -603,7 +603,9 @@ def _get_bei_supplier_invoice_exception_config(
 	return {
 		"bei_supplier": bei_supplier_name,
 		"allowed": bool(
-			cint(frappe.db.get_value("BEI Supplier", bei_supplier_name, "allow_missing_supplier_invoice") or 0)
+			cint(
+				frappe.db.get_value("BEI Supplier", bei_supplier_name, "allow_missing_supplier_invoice") or 0
+			)
 		),
 		"reason": frappe.db.get_value("BEI Supplier", bei_supplier_name, "missing_supplier_invoice_reason")
 		or "",
@@ -622,9 +624,7 @@ def _normalize_internal_ap_token(value: Any) -> str:
 	return text[:40]
 
 
-def _build_internal_ap_ref(
-	row: dict[str, Any], sheet_name: str, checksum: str, supplier_name: str
-) -> str:
+def _build_internal_ap_ref(row: dict[str, Any], sheet_name: str, checksum: str, supplier_name: str) -> str:
 	raw_reference = _first_non_empty(row, "purchase_order", "po_reference", "po_no", "po_number", "po")
 	if not raw_reference:
 		reference_candidate = _first_non_empty(row, "reference")
@@ -643,9 +643,11 @@ def _build_internal_ap_ref(
 		_safe_date(_first_non_empty(row, "posting_date", "invoice_date", "date", "date_entry")) or nowdate()
 	).replace("-", "")
 	amount = _safe_float(_first_non_empty(row, "outstanding_balance", "balance", "outstanding", "amount"))
-	digest = hashlib.sha1(
-		f"{sheet_name}|{checksum}|{supplier_name}|{posting_date}|{amount}".encode()
-	).hexdigest()[:10].upper()
+	digest = (
+		hashlib.sha1(f"{sheet_name}|{checksum}|{supplier_name}|{posting_date}|{amount}".encode())
+		.hexdigest()[:10]
+		.upper()
+	)
 	return f"{AP_INTERNAL_REF_PREFIX}-SOA-{posting_date}-{digest}"
 
 
@@ -1015,7 +1017,9 @@ def _sync_inventory_rows(
 			cost_center = _default_cost_center(sr.company)
 			if _doctype_has_field("Stock Reconciliation", "expense_account"):
 				if not expense_account:
-					frappe.throw(_("No stock adjustment expense account configured for company {0}").format(sr.company))
+					frappe.throw(
+						_("No stock adjustment expense account configured for company {0}").format(sr.company)
+					)
 				sr.expense_account = expense_account
 			if _doctype_has_field("Stock Reconciliation", "cost_center") and cost_center:
 				sr.cost_center = cost_center
@@ -1534,9 +1538,9 @@ def sync_ap_opening(sheet_name: str, data: list[dict], checksum: str, **kwargs) 
 	for row in rows:
 		savepoint: str | None = None
 		try:
-			supplier_input = _first_non_empty(row, "supplier", "supplier_name")
-			raw_reference = _first_non_empty(row, "reference")
-			invoice_no = _first_non_empty(row, "invoice_no", "invoice_no.", "bill_no")
+			supplier_input = _normalize_sheet_text(_first_non_empty(row, "supplier", "supplier_name"))
+			raw_reference = _normalize_sheet_text(_first_non_empty(row, "reference"))
+			invoice_no = _normalize_sheet_text(_first_non_empty(row, "invoice_no", "invoice_no.", "bill_no"))
 			if not invoice_no and raw_reference and not _looks_like_po_reference(raw_reference):
 				invoice_no = raw_reference
 			if not supplier_input:

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -68,8 +68,8 @@ def _install_fake_frappe():
 	utils.nowdate = lambda: "2026-01-01"
 	utils.flt = lambda value, precision=None: round(float(value or 0), precision or 2)
 	utils.cint = lambda value: int(float(value or 0))
-	utils.getdate = (
-		lambda value=None: datetime.date.fromisoformat(str(value)) if value else datetime.date(2026, 1, 1)
+	utils.getdate = lambda value=None: (
+		datetime.date.fromisoformat(str(value)) if value else datetime.date(2026, 1, 1)
 	)
 
 	sys.modules["frappe"] = frappe
@@ -320,6 +320,7 @@ class TestErpSync(unittest.TestCase):
 
 		def new_doc(doctype):
 			if doctype == "Batch":
+
 				def on_insert(doc):
 					doc.name = doc.batch_id
 					created_batches.add(doc.batch_id)
@@ -681,7 +682,7 @@ class TestErpSync(unittest.TestCase):
 		self.assertEqual(result["sync_result"]["rows_created"], 1)
 		log_error_mock.assert_called_once()
 		self.assertEqual(log_error_mock.call_args.kwargs["title"], "Scheduled Store Demand Snapshot Sync")
-		self.assertIn("\"snapshot_rows\": 1", log_error_mock.call_args.kwargs["message"])
+		self.assertIn('"snapshot_rows": 1', log_error_mock.call_args.kwargs["message"])
 
 	def test_enqueue_scheduled_store_inventory_shadow_sync_queues_daily_job(self):
 		erp_sync.frappe.enqueue = MagicMock()
@@ -731,7 +732,7 @@ class TestErpSync(unittest.TestCase):
 		self.assertEqual(result["rows_created"], 3200)
 		log_error_mock.assert_called_once()
 		self.assertEqual(log_error_mock.call_args.kwargs["title"], "Scheduled Store Inventory Shadow Sync")
-		self.assertIn("\"rows_created\": 3200", log_error_mock.call_args.kwargs["message"])
+		self.assertIn('"rows_created": 3200', log_error_mock.call_args.kwargs["message"])
 
 	def test_resolve_warehouse_accepts_warehouse_name_lookup(self):
 		def db_exists(doctype, name=None):
@@ -1050,6 +1051,78 @@ class TestErpSync(unittest.TestCase):
 		self.assertEqual(created_docs[0].custom_missing_supplier_invoice, 1)
 		self.assertEqual(created_docs[0].custom_no_input_vat_support, 1)
 		self.assertEqual(created_docs[0].custom_invoice_exception_reason, "Approved home-based supplier")
+		self.assertEqual(created_docs[0].custom_internal_ap_ref, "XINV-PO-12345")
+		self.assertIn("internal ref XINV-PO-12345", created_docs[0].remarks)
+
+	def test_sync_ap_opening_treats_none_invoice_token_as_missing_for_whitelisted_supplier(self):
+		created_docs = []
+
+		def db_exists(doctype, name=None):
+			if doctype == "BEI Supplier" and name == "SUPP-EXC":
+				return "SUPP-EXC"
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "Purchase Invoice" and isinstance(filters, dict):
+				return None
+			if doctype == "BEI Supplier" and isinstance(filters, dict):
+				if filters.get("frappe_supplier") == "SUP-0001":
+					return "SUPP-EXC"
+				if filters.get("supplier_name") == "HOME SUPPLIER":
+					return "SUPP-EXC"
+			if doctype == "BEI Supplier" and filters == "SUPP-EXC":
+				values = {
+					"allow_missing_supplier_invoice": 1,
+					"missing_supplier_invoice_reason": "Approved home-based supplier",
+				}
+				return values.get(fieldname)
+			return None
+
+		def new_doc(doctype):
+			if doctype != "Purchase Invoice":
+				return _FakeDoc(doctype)
+
+			def on_insert(doc):
+				doc.name = f"PI-{len(created_docs) + 1:04d}"
+				created_docs.append(doc)
+
+			return _FakeDoc(doctype, on_insert=on_insert)
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.db.set_value = MagicMock()
+		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
+		erp_sync.frappe.log_error = MagicMock()
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+
+		rows = [
+			{
+				"supplier_name": "HOME SUPPLIER",
+				"invoice_no.": "None",
+				"reference": "PO#12345",
+				"outstanding_balance": 40,
+				"invoice_date": "2026-01-05",
+				"due_date": "2026-01-20",
+				"billed_to": "BEBANG SHAW INC",
+			},
+		]
+
+		with (
+			patch.object(erp_sync, "_ensure_ap_opening_item", return_value="ERP-SYNC-AP-OPENING"),
+			patch.object(erp_sync, "_normalize_company", return_value="BEI"),
+			patch.object(erp_sync, "_ensure_supplier", return_value="SUP-0001"),
+			patch.object(erp_sync, "_default_expense_account", return_value="Expense - BEI"),
+			patch.object(erp_sync, "_default_payable_account", return_value="Payable - BEI"),
+			patch.object(erp_sync, "_default_cost_center", return_value="Main - BEI"),
+			patch.object(erp_sync, "_doctype_has_field", return_value=True),
+		):
+			result = erp_sync.sync_ap_opening("Supplier SOA", rows, "chk-ap-soa-exc-3")
+
+		self.assertEqual(result["rows_created"], 1)
+		self.assertEqual(result["rows_failed"], 0)
+		self.assertEqual(len(created_docs), 1)
+		self.assertFalse(hasattr(created_docs[0], "bill_no"))
+		self.assertEqual(created_docs[0].custom_missing_supplier_invoice, 1)
 		self.assertEqual(created_docs[0].custom_internal_ap_ref, "XINV-PO-12345")
 		self.assertIn("internal ref XINV-PO-12345", created_docs[0].remarks)
 


### PR DESCRIPTION
## Summary\n- treat AP opening supplier and invoice values through the sheet null-token normalizer\n- route literal \None\ invoice cells into the existing whitelist exception path instead of treating them as real bill numbers\n- add regression coverage for Finance's current \None\ invoice pattern\n\n## Testing\n- python hrms/tests/test_erp_sync.py\n- python -m py_compile hrms/api/erp_sync.py hrms/tests/test_erp_sync.py