### PR TITLE
fix: guard department email lookup for billing sends

### DIFF
--- a/hrms/api/soa.py
+++ b/hrms/api/soa.py
@@ -17,6 +17,13 @@ SOA_READ_ROLES = {
 }
 
 
+def _get_department_email(department_name: str | None) -> str | None:
+	if not department_name or not frappe.db.has_column("Department", "department_email"):
+		return None
+
+	return frappe.db.get_value("Department", department_name, "department_email")
+
+
 def _check_soa_read_access() -> None:
 	roles = set(frappe.get_roles(frappe.session.user))
 	if not roles.intersection(SOA_READ_ROLES):
@@ -334,7 +341,7 @@ def send_soa_to_store(soa_name: str) -> dict[str, Any]:
 
 	# Get recipients
 	recipients = []
-	dept_email = frappe.db.get_value("Department", soa.store, "department_email")
+	dept_email = _get_department_email(soa.store)
 	if dept_email:
 		recipients.append(dept_email)
 

--- a/hrms/hr/doctype/bei_billing_schedule/bei_billing_schedule.py
+++ b/hrms/hr/doctype/bei_billing_schedule/bei_billing_schedule.py
@@ -35,6 +35,13 @@ NAMING_SERIES = {
 DEFAULT_NAMING_SERIES = "BILL-MF-.YYYY.-.#####"
 
 
+def _get_department_email(department_name):
+	if not department_name or not frappe.db.has_column("Department", "department_email"):
+		return None
+
+	return frappe.db.get_value("Department", department_name, "department_email")
+
+
 def _get_account_by_number(account_number, company=None):
 	"""Get full Frappe account name from account_number."""
 	return frappe.db.get_value(
@@ -310,7 +317,7 @@ class BEIBillingSchedule(Document):
 
 		# Get store manager email from Department
 		recipients = []
-		dept = frappe.db.get_value("Department", self.store, "department_email")
+		dept = _get_department_email(self.store)
 		if dept:
 			recipients.append(dept)
 


### PR DESCRIPTION
## Summary
- guard SOA send against missing Department.department_email column
- apply the same guard to billing statement send flow

## Verification
- pre-commit run --files hrms/api/soa.py hrms/hr/doctype/bei_billing_schedule/bei_billing_schedule.py
- python -m py_compile hrms/api/soa.py hrms/hr/doctype/bei_billing_schedule/bei_billing_schedule.py