### PR TITLE
fix: normalize billing goods value quantity columns

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -763,9 +763,24 @@ def _get_order_goods_value(store_order: str | None):
 	"""Calculate the total goods value from a store order's line items."""
 	if not store_order:
 		return 0
+
+	qty_fields = []
+	for fieldname in ("qty", "qty_delivered", "qty_approved", "qty_requested"):
+		if _has_column("BEI Store Order Item", fieldname):
+			qty_fields.append(fieldname)
+
+	if not qty_fields:
+		return 0
+
+	if qty_fields[0] == "qty":
+		qty_expr = "qty"
+	else:
+		non_zero_candidates = [f"NULLIF({fieldname}, 0)" for fieldname in qty_fields[:-1]]
+		qty_expr = f"COALESCE({', '.join(non_zero_candidates + [qty_fields[-1], '0'])})"
+
 	result = frappe.db.sql(
-		"""
-        SELECT COALESCE(SUM(qty * unit_price), 0)
+		f"""
+        SELECT COALESCE(SUM(({qty_expr}) * unit_price), 0)
         FROM `tabBEI Store Order Item`
         WHERE parent = %s
     """,


### PR DESCRIPTION
## Summary\n- make delivery billing goods value calculation schema-safe across legacy and current store-order-item quantity columns\n- prefer delivered/approved/requested quantities when legacy qty is absent\n- unblock S027 billing delivery billing generation on production\n\n## Verification\n- python -m compileall hrms/api/dispatch.py\n- live S027 billing run exposed production Error Log: unknown column qty in _get_order_goods_value()\n