### PR TITLE
fix: make 3pl reconciliation schema-safe

### DIFF
--- a/hrms/api/billing.py
+++ b/hrms/api/billing.py
@@ -117,19 +117,30 @@ def _trip_vehicle_join_sql(trip_alias: str = "dt", vehicle_alias: str = "veh") -
 	return f" LEFT JOIN `tabBEI Vehicle` {vehicle_alias} ON {vehicle_alias}.name = {trip_alias}.vehicle"
 
 
+def _trip_optional_field_sql(fieldname: str, trip_alias: str = "dt", default: str = "0") -> str:
+	"""Select optional trip columns safely across schema revisions."""
+	if _has_column("BEI Distribution Trip", fieldname):
+		return f"{trip_alias}.{fieldname}"
+	return default
+
+
 def _get_3pl_trip_query():
 	"""Return a static SQL query matching the runtime trip-partner schema."""
+	overtime_sql = _trip_optional_field_sql("overtime_hours")
+	holiday_sql = _trip_optional_field_sql("is_holiday_trip")
+	weekend_sql = _trip_optional_field_sql("is_weekend_trip")
+
 	if _has_column("BEI Distribution Trip", "vehicle_owner"):
-		return """
+		return f"""
         SELECT
             dt.name AS trip_name,
             dt.trip_date AS date,
             dt.route AS zone,
             dt.cargo_type,
             dt.vehicle_owner AS partner,
-            dt.overtime_hours,
-            dt.is_holiday_trip,
-            dt.is_weekend_trip,
+            {overtime_sql} AS overtime_hours,
+            {holiday_sql} AS is_holiday_trip,
+            {weekend_sql} AS is_weekend_trip,
             GROUP_CONCAT(DISTINCT ds.department SEPARATOR ', ') AS stores
         FROM `tabBEI Distribution Trip` dt
         LEFT JOIN `tabBEI Trip Stop` ds ON ds.parent = dt.name
@@ -140,16 +151,16 @@ def _get_3pl_trip_query():
         ORDER BY dt.trip_date ASC
         """
 
-	return """
+	return f"""
     SELECT
         dt.name AS trip_name,
         dt.trip_date AS date,
         dt.route AS zone,
         dt.cargo_type,
         veh.threepl_partner AS partner,
-        dt.overtime_hours,
-        dt.is_holiday_trip,
-        dt.is_weekend_trip,
+        {overtime_sql} AS overtime_hours,
+        {holiday_sql} AS is_holiday_trip,
+        {weekend_sql} AS is_weekend_trip,
         GROUP_CONCAT(DISTINCT ds.department SEPARATOR ', ') AS stores
     FROM `tabBEI Distribution Trip` dt
     LEFT JOIN `tabBEI Vehicle` veh ON veh.name = dt.vehicle

--- a/hrms/tests/test_l1_blocker_contracts_s27.py
+++ b/hrms/tests/test_l1_blocker_contracts_s27.py
@@ -22,6 +22,12 @@ def _install_base_frappe():
 	else:
 		utils = sys.modules["frappe.utils"]
 
+	if "frappe.exceptions" not in sys.modules:
+		exceptions = types.ModuleType("frappe.exceptions")
+		sys.modules["frappe.exceptions"] = exceptions
+	else:
+		exceptions = sys.modules["frappe.exceptions"]
+
 	def whitelist(*args, **kwargs):
 		def decorator(fn):
 			return fn
@@ -35,6 +41,7 @@ def _install_base_frappe():
 	frappe.PermissionError = type("PermissionError", (Exception,), {})
 	frappe.ValidationError = type("ValidationError", (Exception,), {})
 	frappe.DoesNotExistError = type("DoesNotExistError", (Exception,), {})
+	exceptions.TimestampMismatchError = type("TimestampMismatchError", (Exception,), {})
 	frappe.local = types.SimpleNamespace(
 		session=types.SimpleNamespace(user="tester@bebang.ph"),
 		db=types.SimpleNamespace(
@@ -149,6 +156,18 @@ class TestL1BlockerContractsS27(unittest.TestCase):
 		billing.frappe.db.has_column = lambda doctype, fieldname: fieldname == "vehicle_owner"
 		self.assertEqual(billing._trip_partner_field_sql(), "dt.vehicle_owner")
 		self.assertEqual(billing._trip_vehicle_join_sql(), "")
+
+	def test_billing_trip_query_uses_zero_for_missing_optional_trip_columns(self):
+		_install_billing_deps()
+		billing = _load_module("billing_s27_query_under_test", "hrms/api/billing.py")
+
+		billing.frappe.db.has_column = lambda doctype, fieldname: fieldname == "vehicle_owner"
+		query = billing._get_3pl_trip_query()
+
+		self.assertIn("0 AS overtime_hours", query)
+		self.assertIn("0 AS is_holiday_trip", query)
+		self.assertIn("0 AS is_weekend_trip", query)
+		self.assertNotIn("dt.overtime_hours", query)
 
 	def test_dispatch_maps_cell_number_back_to_cell_phone(self):
 		_install_dispatch_deps()


### PR DESCRIPTION
## Summary
- make the 3PL reconciliation trip query tolerate missing optional trip columns
- default missing overtime and holiday flags to zero instead of hard-failing SQL
- add a lightweight blocker test for the schema-safe query contract

## Verification
- python -m ruff check hrms/api/billing.py hrms/tests/test_l1_blocker_contracts_s27.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_l1_blocker_contracts_s27.py