### PR TITLE
fix: make 3pl trip stop labels schema-safe

### DIFF
--- a/hrms/api/billing.py
+++ b/hrms/api/billing.py
@@ -124,11 +124,21 @@ def _trip_optional_field_sql(fieldname: str, trip_alias: str = "dt", default: st
 	return default
 
 
+def _trip_stop_store_sql(stop_alias: str = "ds", default: str = "''") -> str:
+	"""Resolve the live trip-stop label column across schema variants."""
+	if _has_column("BEI Trip Stop", "store"):
+		return f"{stop_alias}.store"
+	if _has_column("BEI Trip Stop", "department"):
+		return f"{stop_alias}.department"
+	return default
+
+
 def _get_3pl_trip_query():
 	"""Return a static SQL query matching the runtime trip-partner schema."""
 	overtime_sql = _trip_optional_field_sql("overtime_hours")
 	holiday_sql = _trip_optional_field_sql("is_holiday_trip")
 	weekend_sql = _trip_optional_field_sql("is_weekend_trip")
+	store_sql = _trip_stop_store_sql()
 
 	if _has_column("BEI Distribution Trip", "vehicle_owner"):
 		return f"""
@@ -141,7 +151,7 @@ def _get_3pl_trip_query():
             {overtime_sql} AS overtime_hours,
             {holiday_sql} AS is_holiday_trip,
             {weekend_sql} AS is_weekend_trip,
-            GROUP_CONCAT(DISTINCT ds.department SEPARATOR ', ') AS stores
+            GROUP_CONCAT(DISTINCT {store_sql} SEPARATOR ', ') AS stores
         FROM `tabBEI Distribution Trip` dt
         LEFT JOIN `tabBEI Trip Stop` ds ON ds.parent = dt.name
         WHERE dt.trip_date BETWEEN %(start_date)s AND %(end_date)s
@@ -161,7 +171,7 @@ def _get_3pl_trip_query():
         {overtime_sql} AS overtime_hours,
         {holiday_sql} AS is_holiday_trip,
         {weekend_sql} AS is_weekend_trip,
-        GROUP_CONCAT(DISTINCT ds.department SEPARATOR ', ') AS stores
+        GROUP_CONCAT(DISTINCT {store_sql} SEPARATOR ', ') AS stores
     FROM `tabBEI Distribution Trip` dt
     LEFT JOIN `tabBEI Vehicle` veh ON veh.name = dt.vehicle
     LEFT JOIN `tabBEI Trip Stop` ds ON ds.parent = dt.name

--- a/hrms/tests/test_l1_blocker_contracts_s27.py
+++ b/hrms/tests/test_l1_blocker_contracts_s27.py
@@ -161,9 +161,7 @@ class TestL1BlockerContractsS27(unittest.TestCase):
 		_install_billing_deps()
 		billing = _load_module("billing_s27_query_under_test", "hrms/api/billing.py")
 
-		billing.frappe.db.has_column = (
-			lambda doctype, fieldname: fieldname in {"vehicle_owner", "store"}
-		)
+		billing.frappe.db.has_column = lambda doctype, fieldname: fieldname in {"vehicle_owner", "store"}
 		query = billing._get_3pl_trip_query()
 
 		self.assertIn("0 AS overtime_hours", query)
@@ -177,9 +175,7 @@ class TestL1BlockerContractsS27(unittest.TestCase):
 		_install_billing_deps()
 		billing = _load_module("billing_s27_trip_stop_under_test", "hrms/api/billing.py")
 
-		billing.frappe.db.has_column = (
-			lambda doctype, fieldname: fieldname in {"vehicle_owner", "department"}
-		)
+		billing.frappe.db.has_column = lambda doctype, fieldname: fieldname in {"vehicle_owner", "department"}
 		query = billing._get_3pl_trip_query()
 
 		self.assertIn("GROUP_CONCAT(DISTINCT ds.department SEPARATOR ', ') AS stores", query)

--- a/hrms/tests/test_l1_blocker_contracts_s27.py
+++ b/hrms/tests/test_l1_blocker_contracts_s27.py
@@ -161,13 +161,29 @@ class TestL1BlockerContractsS27(unittest.TestCase):
 		_install_billing_deps()
 		billing = _load_module("billing_s27_query_under_test", "hrms/api/billing.py")
 
-		billing.frappe.db.has_column = lambda doctype, fieldname: fieldname == "vehicle_owner"
+		billing.frappe.db.has_column = (
+			lambda doctype, fieldname: fieldname in {"vehicle_owner", "store"}
+		)
 		query = billing._get_3pl_trip_query()
 
 		self.assertIn("0 AS overtime_hours", query)
 		self.assertIn("0 AS is_holiday_trip", query)
 		self.assertIn("0 AS is_weekend_trip", query)
 		self.assertNotIn("dt.overtime_hours", query)
+		self.assertIn("GROUP_CONCAT(DISTINCT ds.store SEPARATOR ', ') AS stores", query)
+		self.assertNotIn("ds.department", query)
+
+	def test_billing_trip_query_falls_back_to_legacy_trip_stop_department(self):
+		_install_billing_deps()
+		billing = _load_module("billing_s27_trip_stop_under_test", "hrms/api/billing.py")
+
+		billing.frappe.db.has_column = (
+			lambda doctype, fieldname: fieldname in {"vehicle_owner", "department"}
+		)
+		query = billing._get_3pl_trip_query()
+
+		self.assertIn("GROUP_CONCAT(DISTINCT ds.department SEPARATOR ', ') AS stores", query)
+		self.assertNotIn("ds.store", query)
 
 	def test_dispatch_maps_cell_number_back_to_cell_phone(self):
 		_install_dispatch_deps()


### PR DESCRIPTION
## Summary
- make 3PL reconciliation use the live BEI Trip Stop label column safely across store/department schema variants
- keep the new trip stop label lookup aligned with the earlier trip optional-field fallbacks
- extend the S027 blocker contract tests for both current and legacy trip stop schemas

## Testing
- python -m ruff check hrms/api/billing.py hrms/tests/test_l1_blocker_contracts_s27.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_l1_blocker_contracts_s27.py