### PR TITLE
fix: include non-submittable trips in 3pl reconciliation

### DIFF
--- a/hrms/api/billing.py
+++ b/hrms/api/billing.py
@@ -156,7 +156,7 @@ def _get_3pl_trip_query():
         LEFT JOIN `tabBEI Trip Stop` ds ON ds.parent = dt.name
         WHERE dt.trip_date BETWEEN %(start_date)s AND %(end_date)s
           AND COALESCE(dt.vehicle_owner, '') = %(partner)s
-          AND dt.docstatus = 1
+          AND dt.docstatus < 2
         GROUP BY dt.name
         ORDER BY dt.trip_date ASC
         """
@@ -177,7 +177,7 @@ def _get_3pl_trip_query():
     LEFT JOIN `tabBEI Trip Stop` ds ON ds.parent = dt.name
     WHERE dt.trip_date BETWEEN %(start_date)s AND %(end_date)s
       AND COALESCE(veh.threepl_partner, '') = %(partner)s
-      AND dt.docstatus = 1
+      AND dt.docstatus < 2
     GROUP BY dt.name
     ORDER BY dt.trip_date ASC
     """
@@ -190,7 +190,7 @@ def _get_3pl_trip_count_query():
         SELECT dt.vehicle_owner AS partner, COUNT(*) AS cnt
         FROM `tabBEI Distribution Trip` dt
         WHERE dt.trip_date BETWEEN %s AND %s
-          AND dt.docstatus = 1
+          AND dt.docstatus < 2
           AND COALESCE(dt.vehicle_owner, '') != ''
         GROUP BY dt.vehicle_owner
         """
@@ -200,7 +200,7 @@ def _get_3pl_trip_count_query():
     FROM `tabBEI Distribution Trip` dt
     LEFT JOIN `tabBEI Vehicle` veh ON veh.name = dt.vehicle
     WHERE dt.trip_date BETWEEN %s AND %s
-      AND dt.docstatus = 1
+      AND dt.docstatus < 2
       AND COALESCE(veh.threepl_partner, '') != ''
     GROUP BY veh.threepl_partner
     """

--- a/hrms/tests/test_l1_blocker_contracts_s27.py
+++ b/hrms/tests/test_l1_blocker_contracts_s27.py
@@ -169,6 +169,7 @@ class TestL1BlockerContractsS27(unittest.TestCase):
 		self.assertIn("0 AS is_weekend_trip", query)
 		self.assertNotIn("dt.overtime_hours", query)
 		self.assertIn("GROUP_CONCAT(DISTINCT ds.store SEPARATOR ', ') AS stores", query)
+		self.assertIn("dt.docstatus < 2", query)
 		self.assertNotIn("ds.department", query)
 
 	def test_billing_trip_query_falls_back_to_legacy_trip_stop_department(self):
@@ -179,7 +180,17 @@ class TestL1BlockerContractsS27(unittest.TestCase):
 		query = billing._get_3pl_trip_query()
 
 		self.assertIn("GROUP_CONCAT(DISTINCT ds.department SEPARATOR ', ') AS stores", query)
+		self.assertIn("dt.docstatus < 2", query)
 		self.assertNotIn("ds.store", query)
+
+	def test_billing_trip_count_query_includes_non_submittable_trip_rows(self):
+		_install_billing_deps()
+		billing = _load_module("billing_s27_trip_count_under_test", "hrms/api/billing.py")
+
+		billing.frappe.db.has_column = lambda doctype, fieldname: False
+		query = billing._get_3pl_trip_count_query()
+
+		self.assertIn("dt.docstatus < 2", query)
 
 	def test_dispatch_maps_cell_number_back_to_cell_phone(self):
 		_install_dispatch_deps()


### PR DESCRIPTION
## Summary
- include live BEI Distribution Trip rows in 3PL reconciliation even though the DocType is non-submittable
- keep reconciliation trip counts aligned with the same non-cancelled trip contract
- extend the S027 blocker contract tests to lock the docstatus guard

## Root Cause
- `generate_3pl_reconciliation` and `_get_3pl_trip_count_query()` filtered trips with `dt.docstatus = 1`
- `BEI Distribution Trip` is a non-submittable DocType, so live rows stay at `docstatus = 0`
- result: reconciliation candidate discovery was impossible in production

## Testing
- python -m ruff check hrms/api/billing.py hrms/tests/test_l1_blocker_contracts_s27.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_l1_blocker_contracts_s27.py