### PR TITLE
fix: resolve pick list source warehouse from route

### DIFF
--- a/hrms/api/picking.py
+++ b/hrms/api/picking.py
@@ -7,13 +7,37 @@ Handles warehouse picking workflow: order approved -> items picked -> loaded -> 
 """
 
 import frappe
-from hrms.utils.bei_config import get_company
 from frappe import _
-from frappe.utils import nowdate, now_datetime, flt
+from frappe.utils import flt, now_datetime, nowdate
 
+from hrms.utils.bei_config import get_company
 
 # P0-10: Import centralized RBAC role sets
-from hrms.utils.scm_roles import SCM_PICKING_ROLES, check_scm_permission as _check_picking_permission
+from hrms.utils.scm_roles import SCM_PICKING_ROLES
+from hrms.utils.scm_roles import check_scm_permission as _check_picking_permission
+
+
+def _resolve_trip_source_warehouse(trip):
+	"""Resolve the source warehouse for a trip across route-linked schema variants."""
+	source_warehouse = getattr(trip, "warehouse", None) or getattr(trip, "source_warehouse", None)
+	if source_warehouse:
+		return source_warehouse
+
+	linked_route = getattr(trip, "route", None)
+	if linked_route:
+		source_warehouse = frappe.db.get_value("BEI Route", linked_route, "source_warehouse")
+		if source_warehouse:
+			return source_warehouse
+
+	route_name = getattr(trip, "route_name", None)
+	if route_name:
+		source_warehouse = frappe.db.get_value(
+			"BEI Route", {"route_name": route_name}, "source_warehouse"
+		)
+		if source_warehouse:
+			return source_warehouse
+
+	return frappe.db.get_value("Warehouse", {"is_group": 0, "disabled": 0}, "name")
 
 
 @frappe.whitelist()
@@ -76,11 +100,8 @@ def generate_pick_list(trip_name):
     if not item_map:
         frappe.throw(_("No items found in approved Store Orders for trip {0}").format(trip_name))
 
-    # Determine source warehouse from trip
-    source_warehouse = getattr(trip, "warehouse", None) or getattr(trip, "source_warehouse", None)
-    if not source_warehouse:
-        # Fallback: try to get commissary/main warehouse
-        source_warehouse = frappe.db.get_value("Warehouse", {"is_group": 0, "disabled": 0}, "name")
+    # Determine source warehouse from trip or its linked route.
+    source_warehouse = _resolve_trip_source_warehouse(trip)
 
     frappe.db.savepoint("generate_pick_list")
     try:

--- a/hrms/api/picking.py
+++ b/hrms/api/picking.py
@@ -31,9 +31,7 @@ def _resolve_trip_source_warehouse(trip):
 
 	route_name = getattr(trip, "route_name", None)
 	if route_name:
-		source_warehouse = frappe.db.get_value(
-			"BEI Route", {"route_name": route_name}, "source_warehouse"
-		)
+		source_warehouse = frappe.db.get_value("BEI Route", {"route_name": route_name}, "source_warehouse")
 		if source_warehouse:
 			return source_warehouse
 
@@ -42,312 +40,306 @@ def _resolve_trip_source_warehouse(trip):
 
 @frappe.whitelist()
 def generate_pick_list(trip_name):
-    """
-    Auto-create pick list from trip's approved BEI Store Orders.
-    Groups items by store. Returns existing pick list if already created.
-    """
-    _check_picking_permission(SCM_PICKING_ROLES, "generate pick lists")
+	"""
+	Auto-create pick list from trip's approved BEI Store Orders.
+	Groups items by store. Returns existing pick list if already created.
+	"""
+	_check_picking_permission(SCM_PICKING_ROLES, "generate pick lists")
 
-    # Check if a pick list already exists for this trip
-    existing = frappe.db.get_value("BEI Pick List", {"trip": trip_name}, "name")
-    if existing:
-        return {"pick_list": existing, "message": _("Pick list already exists for this trip")}
+	# Check if a pick list already exists for this trip
+	existing = frappe.db.get_value("BEI Pick List", {"trip": trip_name}, "name")
+	if existing:
+		return {"pick_list": existing, "message": _("Pick list already exists for this trip")}
 
-    # Get the trip to find warehouse
-    trip = frappe.get_doc("BEI Distribution Trip", trip_name)
+	# Get the trip to find warehouse
+	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
 
-    # Get all approved store orders linked to this trip
-    store_orders = frappe.get_all(
-        "BEI Store Order",
-        filters={"trip": trip_name, "status": ["in", ["Approved", "Dispatched"]]},
-        fields=["name", "store", "status"]
-    )
+	# Get all approved store orders linked to this trip
+	store_orders = frappe.get_all(
+		"BEI Store Order",
+		filters={"trip": trip_name, "status": ["in", ["Approved", "Dispatched"]]},
+		fields=["name", "store", "status"],
+	)
 
-    if not store_orders:
-        frappe.throw(
-            _("No approved Store Orders found for trip {0}").format(trip_name)
-        )
+	if not store_orders:
+		frappe.throw(_("No approved Store Orders found for trip {0}").format(trip_name))
 
-    # Collect all items from all approved store orders, grouped by store+item
-    item_map = {}  # key: (store, item_code) -> {qty, uom, store}
+	# Collect all items from all approved store orders, grouped by store+item
+	item_map = {}  # key: (store, item_code) -> {qty, uom, store}
 
-    # Batch-fetch all items from all store orders in a single query (avoid N+1)
-    so_names = [so.name for so in store_orders]
-    so_store_map = {so.name: so.store for so in store_orders}
+	# Batch-fetch all items from all store orders in a single query (avoid N+1)
+	so_names = [so.name for so in store_orders]
+	so_store_map = {so.name: so.store for so in store_orders}
 
-    all_so_items = frappe.get_all(
-        "BEI Store Order Item",
-        filters={"parent": ["in", so_names]},
-        fields=["parent", "item_code", "item_name", "qty_requested", "uom"]
-    )
+	all_so_items = frappe.get_all(
+		"BEI Store Order Item",
+		filters={"parent": ["in", so_names]},
+		fields=["parent", "item_code", "item_name", "qty_requested", "uom"],
+	)
 
-    for item in all_so_items:
-        store = so_store_map[item.parent]
-        key = (store, item.item_code)
-        if key in item_map:
-            item_map[key]["qty_ordered"] += flt(item.qty_requested, 3)
-        else:
-            item_map[key] = {
-                "store": store,
-                "item_code": item.item_code,
-                "item_name": item.item_name,
-                "qty_ordered": flt(item.qty_requested, 3),
-                "uom": item.uom or "",
-                "qty_picked": 0,
-                "picked": 0
-            }
+	for item in all_so_items:
+		store = so_store_map[item.parent]
+		key = (store, item.item_code)
+		if key in item_map:
+			item_map[key]["qty_ordered"] += flt(item.qty_requested, 3)
+		else:
+			item_map[key] = {
+				"store": store,
+				"item_code": item.item_code,
+				"item_name": item.item_name,
+				"qty_ordered": flt(item.qty_requested, 3),
+				"uom": item.uom or "",
+				"qty_picked": 0,
+				"picked": 0,
+			}
 
-    if not item_map:
-        frappe.throw(_("No items found in approved Store Orders for trip {0}").format(trip_name))
+	if not item_map:
+		frappe.throw(_("No items found in approved Store Orders for trip {0}").format(trip_name))
 
-    # Determine source warehouse from trip or its linked route.
-    source_warehouse = _resolve_trip_source_warehouse(trip)
+	# Determine source warehouse from trip or its linked route.
+	source_warehouse = _resolve_trip_source_warehouse(trip)
 
-    frappe.db.savepoint("generate_pick_list")
-    try:
-        pick_list = frappe.get_doc({
-            "doctype": "BEI Pick List",
-            "trip": trip_name,
-            "warehouse": source_warehouse,
-            "pick_date": nowdate(),
-            "status": "Pending",
-            "items": list(item_map.values())
-        })
-        pick_list.insert(ignore_permissions=True)
+	frappe.db.savepoint("generate_pick_list")
+	try:
+		pick_list = frappe.get_doc(
+			{
+				"doctype": "BEI Pick List",
+				"trip": trip_name,
+				"warehouse": source_warehouse,
+				"pick_date": nowdate(),
+				"status": "Pending",
+				"items": list(item_map.values()),
+			}
+		)
+		pick_list.insert(ignore_permissions=True)
 
-        return {
-            "pick_list": pick_list.name,
-            "item_count": len(item_map),
-            "message": _("Pick list {0} created with {1} items").format(
-                pick_list.name, len(item_map)
-            )
-        }
-    except Exception:
-        frappe.db.rollback(save_point="generate_pick_list")
-        raise
+		return {
+			"pick_list": pick_list.name,
+			"item_count": len(item_map),
+			"message": _("Pick list {0} created with {1} items").format(pick_list.name, len(item_map)),
+		}
+	except Exception:
+		frappe.db.rollback(save_point="generate_pick_list")
+		raise
 
 
 @frappe.whitelist()
 def get_pick_list(trip_name):
-    """Fetch pick list with all items for a given trip."""
-    _check_picking_permission(SCM_PICKING_ROLES, "view pick lists")
+	"""Fetch pick list with all items for a given trip."""
+	_check_picking_permission(SCM_PICKING_ROLES, "view pick lists")
 
-    pick_list_name = frappe.db.get_value("BEI Pick List", {"trip": trip_name}, "name")
-    if not pick_list_name:
-        return {"pick_list": None, "message": _("No pick list found for trip {0}").format(trip_name)}
+	pick_list_name = frappe.db.get_value("BEI Pick List", {"trip": trip_name}, "name")
+	if not pick_list_name:
+		return {"pick_list": None, "message": _("No pick list found for trip {0}").format(trip_name)}
 
-    pick_list = frappe.get_doc("BEI Pick List", pick_list_name)
+	pick_list = frappe.get_doc("BEI Pick List", pick_list_name)
 
-    items = [
-        {
-            "idx": item.idx,
-            "store": item.store,
-            "item_code": item.item_code,
-            "item_name": item.item_name,
-            "qty_ordered": flt(item.qty_ordered, 3),
-            "qty_picked": flt(item.qty_picked, 3),
-            "uom": item.uom,
-            "bin_location": item.bin_location,
-            "picked": item.picked
-        }
-        for item in pick_list.items
-    ]
+	items = [
+		{
+			"idx": item.idx,
+			"store": item.store,
+			"item_code": item.item_code,
+			"item_name": item.item_name,
+			"qty_ordered": flt(item.qty_ordered, 3),
+			"qty_picked": flt(item.qty_picked, 3),
+			"uom": item.uom,
+			"bin_location": item.bin_location,
+			"picked": item.picked,
+		}
+		for item in pick_list.items
+	]
 
-    total_items = len(items)
-    picked_items = sum(1 for i in items if i["picked"])
+	total_items = len(items)
+	picked_items = sum(1 for i in items if i["picked"])
 
-    return {
-        "pick_list": {
-            "name": pick_list.name,
-            "trip": pick_list.trip,
-            "warehouse": pick_list.warehouse,
-            "pick_date": pick_list.pick_date,
-            "status": pick_list.status,
-            "picked_by": pick_list.picked_by,
-            "verified_by": pick_list.verified_by,
-            "packed_at": pick_list.packed_at,
-            "loaded_at": pick_list.loaded_at,
-            "total_items": total_items,
-            "picked_items": picked_items,
-            "items": items
-        }
-    }
+	return {
+		"pick_list": {
+			"name": pick_list.name,
+			"trip": pick_list.trip,
+			"warehouse": pick_list.warehouse,
+			"pick_date": pick_list.pick_date,
+			"status": pick_list.status,
+			"picked_by": pick_list.picked_by,
+			"verified_by": pick_list.verified_by,
+			"packed_at": pick_list.packed_at,
+			"loaded_at": pick_list.loaded_at,
+			"total_items": total_items,
+			"picked_items": picked_items,
+			"items": items,
+		}
+	}
 
 
 @frappe.whitelist()
 def update_pick_item(pick_list_name, item_idx, qty_picked):
-    """
-    Picker updates the actual qty picked for a specific item.
-    Sets item.picked = 1 when qty_picked >= 0.
-    """
-    _check_picking_permission(SCM_PICKING_ROLES, "update pick items")
+	"""
+	Picker updates the actual qty picked for a specific item.
+	Sets item.picked = 1 when qty_picked >= 0.
+	"""
+	_check_picking_permission(SCM_PICKING_ROLES, "update pick items")
 
-    qty_picked = flt(qty_picked, 3)
-    if qty_picked < 0:
-        frappe.throw(_("qty_picked cannot be negative"))
+	qty_picked = flt(qty_picked, 3)
+	if qty_picked < 0:
+		frappe.throw(_("qty_picked cannot be negative"))
 
-    item_idx = int(item_idx)
+	item_idx = int(item_idx)
 
-    pick_list = frappe.get_doc("BEI Pick List", pick_list_name)
+	pick_list = frappe.get_doc("BEI Pick List", pick_list_name)
 
-    if pick_list.status == "Loaded":
-        frappe.throw(_("Cannot update items on a Loaded pick list"))
+	if pick_list.status == "Loaded":
+		frappe.throw(_("Cannot update items on a Loaded pick list"))
 
-    # Find the item by idx
-    target_item = None
-    for item in pick_list.items:
-        if item.idx == item_idx:
-            target_item = item
-            break
+	# Find the item by idx
+	target_item = None
+	for item in pick_list.items:
+		if item.idx == item_idx:
+			target_item = item
+			break
 
-    if not target_item:
-        frappe.throw(_("Item at index {0} not found in pick list {1}").format(
-            item_idx, pick_list_name
-        ))
+	if not target_item:
+		frappe.throw(_("Item at index {0} not found in pick list {1}").format(item_idx, pick_list_name))
 
-    target_item.qty_picked = qty_picked
-    target_item.picked = 1
+	target_item.qty_picked = qty_picked
+	target_item.picked = 1
 
-    # Advance status to In Progress if still Pending
-    if pick_list.status == "Pending":
-        pick_list.status = "In Progress"
+	# Advance status to In Progress if still Pending
+	if pick_list.status == "Pending":
+		pick_list.status = "In Progress"
 
-    pick_list.save(ignore_permissions=True)
+	pick_list.save(ignore_permissions=True)
 
-    return {
-        "success": True,
-        "item_idx": item_idx,
-        "qty_picked": qty_picked,
-        "status": pick_list.status,
-        "message": _("Item updated")
-    }
+	return {
+		"success": True,
+		"item_idx": item_idx,
+		"qty_picked": qty_picked,
+		"status": pick_list.status,
+		"message": _("Item updated"),
+	}
 
 
 @frappe.whitelist()
 def complete_picking(pick_list_name):
-    """
-    Mark pick list as Packed after all items have been picked.
-    Validates that every item has picked=1 before proceeding.
-    """
-    _check_picking_permission(SCM_PICKING_ROLES, "complete picking")
+	"""
+	Mark pick list as Packed after all items have been picked.
+	Validates that every item has picked=1 before proceeding.
+	"""
+	_check_picking_permission(SCM_PICKING_ROLES, "complete picking")
 
-    pick_list = frappe.get_doc("BEI Pick List", pick_list_name)
+	pick_list = frappe.get_doc("BEI Pick List", pick_list_name)
 
-    if pick_list.status not in ["Pending", "In Progress"]:
-        frappe.throw(
-            _("Pick list must be Pending or In Progress to complete picking. Current: {0}").format(
-                pick_list.status
-            )
-        )
+	if pick_list.status not in ["Pending", "In Progress"]:
+		frappe.throw(
+			_("Pick list must be Pending or In Progress to complete picking. Current: {0}").format(
+				pick_list.status
+			)
+		)
 
-    # Validate all items have been picked
-    unpicked = [
-        item.item_code for item in pick_list.items if not item.picked
-    ]
-    if unpicked:
-        frappe.throw(
-            _("The following items have not been picked yet: {0}").format(
-                ", ".join(unpicked)
-            )
-        )
+	# Validate all items have been picked
+	unpicked = [item.item_code for item in pick_list.items if not item.picked]
+	if unpicked:
+		frappe.throw(_("The following items have not been picked yet: {0}").format(", ".join(unpicked)))
 
-    pick_list.status = "Packed"
-    pick_list.packed_at = now_datetime()
-    pick_list.save(ignore_permissions=True)
+	pick_list.status = "Packed"
+	pick_list.packed_at = now_datetime()
+	pick_list.save(ignore_permissions=True)
 
-    return {
-        "success": True,
-        "status": "Packed",
-        "packed_at": str(pick_list.packed_at),
-        "message": _("Pick list {0} marked as Packed").format(pick_list_name)
-    }
+	return {
+		"success": True,
+		"status": "Packed",
+		"packed_at": str(pick_list.packed_at),
+		"message": _("Pick list {0} marked as Packed").format(pick_list_name),
+	}
 
 
 @frappe.whitelist()
 def confirm_loaded(pick_list_name):
-    """
-    Mark pick list as Loaded (driver confirms items on truck).
-    P0-1 fix: Creates one Material Transfer Stock Entry PER STOP (not per pick list),
-    because each stop has a different target warehouse. Previously used Material Issue
-    which permanently removed items from inventory with no destination.
-    """
-    _check_picking_permission(SCM_PICKING_ROLES, "confirm loaded")
+	"""
+	Mark pick list as Loaded (driver confirms items on truck).
+	P0-1 fix: Creates one Material Transfer Stock Entry PER STOP (not per pick list),
+	because each stop has a different target warehouse. Previously used Material Issue
+	which permanently removed items from inventory with no destination.
+	"""
+	_check_picking_permission(SCM_PICKING_ROLES, "confirm loaded")
 
-    pick_list = frappe.get_doc("BEI Pick List", pick_list_name)
+	pick_list = frappe.get_doc("BEI Pick List", pick_list_name)
 
-    if pick_list.status != "Packed":
-        frappe.throw(
-            _("Pick list must be Packed before confirming load. Current: {0}").format(
-                pick_list.status
-            )
-        )
+	if pick_list.status != "Packed":
+		frappe.throw(
+			_("Pick list must be Packed before confirming load. Current: {0}").format(pick_list.status)
+		)
 
-    if not pick_list.warehouse:
-        frappe.throw(_("Pick list has no source warehouse set"))
+	if not pick_list.warehouse:
+		frappe.throw(_("Pick list has no source warehouse set"))
 
-    # Group picked items by store (target warehouse) for per-stop Stock Entries
-    items_by_store = {}
-    for item in pick_list.items:
-        qty = flt(item.qty_picked, 3)
-        if qty <= 0:
-            continue
-        store = item.store or ""
-        if store not in items_by_store:
-            items_by_store[store] = []
-        items_by_store[store].append({
-            "item_code": item.item_code,
-            "qty": qty,
-            "s_warehouse": pick_list.warehouse,
-            "t_warehouse": store,
-            "uom": item.uom or frappe.db.get_value("Item", item.item_code, "stock_uom") or "Nos"
-        })
+	# Group picked items by store (target warehouse) for per-stop Stock Entries
+	items_by_store = {}
+	for item in pick_list.items:
+		qty = flt(item.qty_picked, 3)
+		if qty <= 0:
+			continue
+		store = item.store or ""
+		if store not in items_by_store:
+			items_by_store[store] = []
+		items_by_store[store].append(
+			{
+				"item_code": item.item_code,
+				"qty": qty,
+				"s_warehouse": pick_list.warehouse,
+				"t_warehouse": store,
+				"uom": item.uom or frappe.db.get_value("Item", item.item_code, "stock_uom") or "Nos",
+			}
+		)
 
-    if not items_by_store:
-        frappe.throw(_("No items with picked quantity > 0 to transfer"))
+	if not items_by_store:
+		frappe.throw(_("No items with picked quantity > 0 to transfer"))
 
-    frappe.db.savepoint("confirm_loaded")
-    try:
-        stock_entries = []
-        for target_warehouse, se_items in items_by_store.items():
-            if not target_warehouse:
-                frappe.throw(
-                    _("Pick list item(s) missing store/destination warehouse. "
-                      "Ensure all items have the 'store' field set.")
-                )
+	frappe.db.savepoint("confirm_loaded")
+	try:
+		stock_entries = []
+		for target_warehouse, se_items in items_by_store.items():
+			if not target_warehouse:
+				frappe.throw(
+					_(
+						"Pick list item(s) missing store/destination warehouse. "
+						"Ensure all items have the 'store' field set."
+					)
+				)
 
-            stock_entry = frappe.get_doc({
-                "doctype": "Stock Entry",
-                "stock_entry_type": "Material Transfer",
-                "from_warehouse": pick_list.warehouse,
-                "to_warehouse": target_warehouse,
-                "posting_date": nowdate(),
-                "posting_time": frappe.utils.nowtime(),
-                "company": get_company(),
-                "remarks": _("Pick List {0} - Trip {1} - Store {2}").format(
-                    pick_list_name, pick_list.trip, target_warehouse
-                ),
-                "items": se_items
-            })
+			stock_entry = frappe.get_doc(
+				{
+					"doctype": "Stock Entry",
+					"stock_entry_type": "Material Transfer",
+					"from_warehouse": pick_list.warehouse,
+					"to_warehouse": target_warehouse,
+					"posting_date": nowdate(),
+					"posting_time": frappe.utils.nowtime(),
+					"company": get_company(),
+					"remarks": _("Pick List {0} - Trip {1} - Store {2}").format(
+						pick_list_name, pick_list.trip, target_warehouse
+					),
+					"items": se_items,
+				}
+			)
 
-            stock_entry.insert(ignore_permissions=True)
-            stock_entry.submit()
-            stock_entries.append(stock_entry.name)
+			stock_entry.insert(ignore_permissions=True)
+			stock_entry.submit()
+			stock_entries.append(stock_entry.name)
 
-        pick_list.status = "Loaded"
-        pick_list.loaded_at = now_datetime()
-        pick_list.save(ignore_permissions=True)
+		pick_list.status = "Loaded"
+		pick_list.loaded_at = now_datetime()
+		pick_list.save(ignore_permissions=True)
 
-        return {
-            "success": True,
-            "status": "Loaded",
-            "loaded_at": str(pick_list.loaded_at),
-            "stock_entries": stock_entries,
-            "stock_entry": stock_entries[0] if stock_entries else None,
-            "message": _("Pick list {0} confirmed as Loaded. {1} Stock Entry(s) created.").format(
-                pick_list_name, len(stock_entries)
-            )
-        }
+		return {
+			"success": True,
+			"status": "Loaded",
+			"loaded_at": str(pick_list.loaded_at),
+			"stock_entries": stock_entries,
+			"stock_entry": stock_entries[0] if stock_entries else None,
+			"message": _("Pick list {0} confirmed as Loaded. {1} Stock Entry(s) created.").format(
+				pick_list_name, len(stock_entries)
+			),
+		}
 
-    except Exception:
-        frappe.db.rollback(save_point="confirm_loaded")
-        raise
+	except Exception:
+		frappe.db.rollback(save_point="confirm_loaded")
+		raise

--- a/hrms/api/picking.py
+++ b/hrms/api/picking.py
@@ -6,6 +6,8 @@ BEI Pick List API
 Handles warehouse picking workflow: order approved -> items picked -> loaded -> trip departs
 """
 
+from typing import Any
+
 import frappe
 from frappe import _
 from frappe.utils import flt, now_datetime, nowdate
@@ -17,7 +19,7 @@ from hrms.utils.scm_roles import SCM_PICKING_ROLES
 from hrms.utils.scm_roles import check_scm_permission as _check_picking_permission
 
 
-def _resolve_trip_source_warehouse(trip):
+def _resolve_trip_source_warehouse(trip: Any):
 	"""Resolve the source warehouse for a trip across route-linked schema variants."""
 	source_warehouse = getattr(trip, "warehouse", None) or getattr(trip, "source_warehouse", None)
 	if source_warehouse:
@@ -39,7 +41,7 @@ def _resolve_trip_source_warehouse(trip):
 
 
 @frappe.whitelist()
-def generate_pick_list(trip_name):
+def generate_pick_list(trip_name: str):
 	"""
 	Auto-create pick list from trip's approved BEI Store Orders.
 	Groups items by store. Returns existing pick list if already created.
@@ -124,7 +126,7 @@ def generate_pick_list(trip_name):
 
 
 @frappe.whitelist()
-def get_pick_list(trip_name):
+def get_pick_list(trip_name: str):
 	"""Fetch pick list with all items for a given trip."""
 	_check_picking_permission(SCM_PICKING_ROLES, "view pick lists")
 
@@ -171,7 +173,7 @@ def get_pick_list(trip_name):
 
 
 @frappe.whitelist()
-def update_pick_item(pick_list_name, item_idx, qty_picked):
+def update_pick_item(pick_list_name: str, item_idx: int | str, qty_picked: float | str):
 	"""
 	Picker updates the actual qty picked for a specific item.
 	Sets item.picked = 1 when qty_picked >= 0.
@@ -218,7 +220,7 @@ def update_pick_item(pick_list_name, item_idx, qty_picked):
 
 
 @frappe.whitelist()
-def complete_picking(pick_list_name):
+def complete_picking(pick_list_name: str):
 	"""
 	Mark pick list as Packed after all items have been picked.
 	Validates that every item has picked=1 before proceeding.
@@ -252,7 +254,7 @@ def complete_picking(pick_list_name):
 
 
 @frappe.whitelist()
-def confirm_loaded(pick_list_name):
+def confirm_loaded(pick_list_name: str):
 	"""
 	Mark pick list as Loaded (driver confirms items on truck).
 	P0-1 fix: Creates one Material Transfer Stock Entry PER STOP (not per pick list),

--- a/hrms/tests/test_l1_blocker_contracts_s27.py
+++ b/hrms/tests/test_l1_blocker_contracts_s27.py
@@ -137,6 +137,19 @@ def _install_store_deps():
 	)
 
 
+def _install_picking_deps():
+	_install_base_frappe()
+	_ensure_module("hrms")
+	_ensure_module("hrms.api")
+	_ensure_module("hrms.utils")
+	_ensure_module("hrms.utils.bei_config", get_company=lambda: "Bebang Enterprise Inc.")
+	_ensure_module(
+		"hrms.utils.scm_roles",
+		SCM_PICKING_ROLES=["System Manager"],
+		check_scm_permission=lambda roles, action: None,
+	)
+
+
 def _load_module(module_name: str, relative_path: str):
 	spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
 	module = importlib.util.module_from_spec(spec)
@@ -260,6 +273,33 @@ class TestL1BlockerContractsS27(unittest.TestCase):
 		self.assertEqual(result["inventory_variance_total"], 0)
 		self.assertEqual(result["cashier_signoff"], 1)
 		self.assertEqual(result["production_signoff"], 0)
+
+	def test_picking_resolves_source_warehouse_from_linked_route(self):
+		_install_picking_deps()
+		picking = _load_module("picking_s27_under_test", "hrms/api/picking.py")
+
+		def fake_get_value(doctype, filters, fieldname=None, as_dict=False):
+			if doctype == "BEI Route":
+				if filters == "BEI-ROUTE-0001":
+					return "TEST-COMMISSARY - BEI"
+				if filters == {"route_name": "S027 Pick Route"}:
+					return "TEST-COMMISSARY - BEI"
+			if doctype == "Warehouse":
+				return "UNEXPECTED-WAREHOUSE"
+			return None
+
+		picking.frappe.db.get_value = fake_get_value
+
+		trip = types.SimpleNamespace(
+			warehouse="",
+			source_warehouse="",
+			route="BEI-ROUTE-0001",
+			route_name="S027 Pick Route",
+		)
+		self.assertEqual(picking._resolve_trip_source_warehouse(trip), "TEST-COMMISSARY - BEI")
+
+		trip.route = ""
+		self.assertEqual(picking._resolve_trip_source_warehouse(trip), "TEST-COMMISSARY - BEI")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- resolve pick list source warehouse from the linked route when trips do not persist warehouse fields
- preserve the existing warehouse fallback only after route resolution fails
- cover the route-linked source warehouse contract in the S027 blocker unit tests

## Verification
- python -m ruff check hrms/api/picking.py hrms/tests/test_l1_blocker_contracts_s27.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_l1_blocker_contracts_s27.py