### PR TITLE
fix: align inventory warehouse names with live frappe

### DIFF
--- a/hrms/services/sheets_receiver/transforms.py
+++ b/hrms/services/sheets_receiver/transforms.py
@@ -13,11 +13,11 @@ from typing import Any
 INVENTORY_SUMMARY_MATRIX_TRANSFORMER = "inventory_summary_matrix"
 
 INVENTORY_SUMMARY_WAREHOUSE_MAP = {
-	"3MD": "3MD Logistics - Camangyanan - BEI",
-	"JENTEC": "Jentec Storage Inc. - BEI",
-	"RCS": "Royal Cold Storage - Taytay - BEI",
-	"PINNACLE": "Pinnacle Cold Storage - BEI",
-	"SHAW": "Shaw BLVD - BEI",
+	"3MD": "3MD Logistics – Camangyanan",
+	"JENTEC": "Jentec Storage Inc.",
+	"RCS": "Royal Cold Storage – Taytay (RCS)",
+	"PINNACLE": "Pinnacle Cold Storage Solutions",
+	"SHAW": "Shaw BLVD",
 }
 
 _INVENTORY_SECTION_MARKERS = {"DRY", "COLD", "FROZEN", "CHILLED"}

--- a/hrms/tests/test_sheets_receiver_transforms.py
+++ b/hrms/tests/test_sheets_receiver_transforms.py
@@ -53,16 +53,16 @@ class TestSheetsReceiverTransforms(unittest.TestCase):
 
 		self.assertEqual(len(rows), 10)
 		self.assertEqual(rows[0]["inventory_key"], "3MD::PM001")
-		self.assertEqual(rows[0]["warehouse"], "3MD Logistics - Camangyanan - BEI")
+		self.assertEqual(rows[0]["warehouse"], "3MD Logistics – Camangyanan")
 		self.assertEqual(rows[0]["qty"], 73.0)
-		self.assertEqual(rows[1]["warehouse"], "Jentec Storage Inc. - BEI")
+		self.assertEqual(rows[1]["warehouse"], "Jentec Storage Inc.")
 		self.assertEqual(rows[1]["qty"], 0.0)
-		self.assertEqual(rows[3]["warehouse"], "Pinnacle Cold Storage - BEI")
+		self.assertEqual(rows[3]["warehouse"], "Pinnacle Cold Storage Solutions")
 		self.assertEqual(rows[3]["qty"], 23.0)
-		self.assertEqual(rows[4]["warehouse"], "Shaw BLVD - BEI")
+		self.assertEqual(rows[4]["warehouse"], "Shaw BLVD")
 		self.assertEqual(rows[4]["qty"], 0.0)
 		self.assertEqual(rows[5]["inventory_key"], "3MD::RM015")
-		self.assertEqual(rows[7]["warehouse"], "Royal Cold Storage - Taytay - BEI")
+		self.assertEqual(rows[7]["warehouse"], "Royal Cold Storage – Taytay (RCS)")
 		self.assertEqual(rows[7]["qty"], 0.0)
 
 	def test_inventory_summary_matrix_raises_when_expected_warehouses_are_missing(self):


### PR DESCRIPTION
## Summary
- map Ian inventory warehouse outputs to the live Frappe warehouse names
- keep the 8 AM baseline and matrix pivot flow unchanged
- fix the production warehouse resolution failure that caused all 630 inventory rows to fail

## Verification
- python -m pre_commit run --files hrms/services/sheets_receiver/transforms.py hrms/tests/test_sheets_receiver_transforms.py
- python hrms/tests/test_sheets_receiver_transforms.py
- python hrms/tests/test_sheets_receiver_processor.py
- python hrms/tests/test_sheets_receiver_main.py
- python hrms/tests/test_sheets_receiver_config.py
- python -m py_compile hrms/services/sheets_receiver/transforms.py hrms/tests/test_sheets_receiver_transforms.py hrms/tests/test_sheets_receiver_processor.py hrms/tests/test_sheets_receiver_main.py hrms/tests/test_sheets_receiver_config.py