### PR TITLE
fix: harden store inventory shadow sync recovery

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -5,6 +5,7 @@ These endpoints receive data from the Sheets Receiver service
 and sync it to ERPNext DocTypes.
 """
 
+import datetime
 import hashlib
 import json
 import re
@@ -34,9 +35,12 @@ STORE_DEMAND_SNAPSHOT_SHEET_NAME = "Store Demand Snapshot"
 STORE_DEMAND_SNAPSHOT_AUTO_PREFIX = "scheduled_store_demand_snapshot"
 STORE_INVENTORY_SHADOW_SYNC_SHEET_NAME = "Store Inventory Shadow Sync"
 STORE_INVENTORY_SHADOW_SYNC_AUTO_PREFIX = "scheduled_store_inventory_shadow_sync"
+STORE_INVENTORY_SHADOW_SYNC_RECOVERY_PREFIX = "scheduled_store_inventory_shadow_sync_recovery"
 STORE_INVENTORY_SHADOW_BATCH_PREFIX = "SHADOW"
 INVENTORY_BASELINE_SHEET_NAME = "Inventory"
 INVENTORY_BASELINE_BATCH_PREFIX = "INVBASE"
+STORE_INVENTORY_SHADOW_STALE_AFTER_MINUTES = 20
+STORE_INVENTORY_SHADOW_RECOVERY_COOLDOWN_MINUTES = 20
 PO_REFERENCE_RE = re.compile(r"^\s*(?:PO|PURCHASE\s*ORDER)\s*[-#:/]?\s*[A-Z0-9-]+\s*$", re.IGNORECASE)
 
 
@@ -233,6 +237,20 @@ def _store_demand_output_root() -> Path:
 
 def _store_demand_output_dir(snapshot_date: str) -> Path:
 	return _store_demand_output_root() / f"{snapshot_date}_store_order_demand_snapshot_auto"
+
+
+def _runtime_timestamp() -> str:
+	return now_datetime().strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _parse_runtime_timestamp(value: Any) -> Any | None:
+	text = str(value or "").strip()
+	if not text:
+		return None
+	try:
+		return datetime.datetime.strptime(text, "%Y-%m-%dT%H:%M:%S")
+	except ValueError:
+		return None
 
 
 def _log_sync_run_summary(title: str, payload: dict[str, Any]) -> None:
@@ -1035,10 +1053,10 @@ def _sync_inventory_rows(
 				["custom_sync_ref", "custom_last_sync_checksum"],
 			)
 			lookup_filters: dict[str, Any] = {"docstatus": ["<", 2]}
-			if has_remarks:
-				lookup_filters["remarks"] = ["like", f"%{sync_ref}%"]
-			elif token_field:
+			if token_field:
 				lookup_filters[token_field] = sync_ref
+			elif has_remarks:
+				lookup_filters["remarks"] = ["like", f"%{sync_ref}%"]
 			else:
 				lookup_filters = {}
 
@@ -1071,7 +1089,7 @@ def _sync_inventory_rows(
 					f"ERP Inventory Sync ({sync_ref}) "
 					f"sheet={sheet_name} warehouse={warehouse} rows={len(items)}"
 				)
-			elif token_field:
+			if token_field:
 				setattr(sr, token_field, sync_ref)
 
 			for item in items:
@@ -1778,6 +1796,7 @@ def enqueue_scheduled_store_inventory_shadow_sync(
 		"hrms.api.erp_sync.run_scheduled_store_inventory_shadow_sync",
 		queue="long",
 		job_id=job_id,
+		deduplicate=True,
 		run_date=run_date_value,
 		force=force_flag,
 	)
@@ -1787,6 +1806,87 @@ def enqueue_scheduled_store_inventory_shadow_sync(
 		"run_date": run_date_value,
 		"force": force_flag,
 	}
+
+
+def watch_store_inventory_shadow_sync_health(
+	run_date: str | None = None,
+	stale_after_minutes: int = STORE_INVENTORY_SHADOW_STALE_AFTER_MINUTES,
+	cooldown_minutes: int = STORE_INVENTORY_SHADOW_RECOVERY_COOLDOWN_MINUTES,
+	state_path: str | None = None,
+) -> dict[str, Any]:
+	"""Resume the daily shadow sync when the tracked run is stale mid-flight."""
+	run_date_value = _safe_date(run_date) or nowdate()
+	stale_after = max(cint(stale_after_minutes), 1)
+	cooldown = max(cint(cooldown_minutes), 1)
+	state_file = (
+		Path(state_path) if state_path else store_inventory_shadow_sync_builder.get_runtime_state_path()
+	)
+	runtime_state = store_inventory_shadow_sync_builder.load_runtime_state(state_file)
+	last_run = runtime_state.get("last_run") or {}
+	status = str(last_run.get("status") or "").strip().lower()
+	recorded_run_date = _safe_date(last_run.get("run_date"))
+
+	if status != "in_progress":
+		return {"queued": False, "reason": "not_in_progress", "run_date": run_date_value}
+
+	if recorded_run_date != run_date_value:
+		return {
+			"queued": False,
+			"reason": "run_date_mismatch",
+			"run_date": run_date_value,
+			"recorded_run_date": recorded_run_date,
+		}
+
+	now_value = now_datetime()
+	progress_ts = _parse_runtime_timestamp(last_run.get("updated_at")) or _parse_runtime_timestamp(
+		last_run.get("generated_at")
+	)
+	if not progress_ts:
+		return {"queued": False, "reason": "missing_progress_timestamp", "run_date": run_date_value}
+
+	age_minutes = (now_value - progress_ts).total_seconds() / 60.0
+	if age_minutes < stale_after:
+		return {
+			"queued": False,
+			"reason": "not_stale",
+			"run_date": run_date_value,
+			"age_minutes": round(age_minutes, 2),
+			"stale_after_minutes": stale_after,
+		}
+
+	recovery_enqueued_at = _parse_runtime_timestamp(last_run.get("recovery_enqueued_at"))
+	if recovery_enqueued_at:
+		cooldown_age = (now_value - recovery_enqueued_at).total_seconds() / 60.0
+		if cooldown_age < cooldown:
+			return {
+				"queued": False,
+				"reason": "recovery_cooldown",
+				"run_date": run_date_value,
+				"cooldown_remaining_minutes": round(cooldown - cooldown_age, 2),
+			}
+
+	job_id = f"{STORE_INVENTORY_SHADOW_SYNC_RECOVERY_PREFIX}:{run_date_value}"
+	frappe.enqueue(
+		"hrms.api.erp_sync.run_scheduled_store_inventory_shadow_sync",
+		queue="long",
+		job_id=job_id,
+		deduplicate=True,
+		run_date=run_date_value,
+		force=False,
+	)
+	last_run["recovery_enqueued_at"] = _runtime_timestamp()
+	store_inventory_shadow_sync_builder.save_runtime_state(runtime_state, state_file)
+
+	result = {
+		"queued": True,
+		"reason": "stale_in_progress_run",
+		"job_id": job_id,
+		"run_date": run_date_value,
+		"age_minutes": round(age_minutes, 2),
+		"stale_after_minutes": stale_after,
+	}
+	_log_sync_run_summary("Store Inventory Shadow Sync Watchdog", result)
+	return result
 
 
 def run_scheduled_store_inventory_shadow_sync(

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -381,6 +381,10 @@ scheduler_events = {
 			"hrms.api.erp_sync.enqueue_scheduled_store_inventory_shadow_sync",
 			"hrms.api.erp_sync.enqueue_scheduled_store_demand_snapshot_sync",
 		],
+		# Store inventory shadow sync watchdog: resume stale in-progress runs after deploy interruptions
+		"*/10 * * * *": [
+			"hrms.api.erp_sync.watch_store_inventory_shadow_sync_health",
+		],
 		# Discount audit workbook: 12:50 AM PHT after Supabase alert refresh at 12:35 AM PHT
 		"42 16 * * *": ["hrms.api.discount_abuse.scheduled_refresh_discount_benchmark_snapshots"],
 		# Discount audit workbook: 12:50 AM PHT after benchmark refresh

--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -46,3 +46,4 @@ hrms.patches.v16_0.backfill_store_area_supervisor_mapping #2026-03-02
 hrms.patches.v16_0.add_cycle_count_unique_index #2026-02-19
 hrms.patches.v16_0.drop_cycle_count_unique_index #2026-02-20
 hrms.patches.v16_0.ensure_statement_of_account_doctype #2026-03-10
+hrms.patches.v16_0.add_stock_reconciliation_sync_ref_field #2026-03-11

--- a/hrms/patches/v16_0/add_stock_reconciliation_sync_ref_field.py
+++ b/hrms/patches/v16_0/add_stock_reconciliation_sync_ref_field.py
@@ -1,0 +1,20 @@
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	custom_fields = {
+		"Stock Reconciliation": [
+			{
+				"fieldname": "custom_sync_ref",
+				"fieldtype": "Data",
+				"label": "Sync Reference",
+				"insert_after": "expense_account",
+				"hidden": 1,
+				"read_only": 1,
+				"no_copy": 1,
+				"description": "Idempotency token for ERP sync retries and shadow sync recovery.",
+			}
+		]
+	}
+
+	create_custom_fields(custom_fields)

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -314,6 +314,18 @@ def get_custom_fields():
 				"insert_after": "column_break_3",
 			},
 		],
+		"Stock Reconciliation": [
+			{
+				"fieldname": "custom_sync_ref",
+				"fieldtype": "Data",
+				"label": _("Sync Reference"),
+				"insert_after": "expense_account",
+				"hidden": 1,
+				"read_only": 1,
+				"no_copy": 1,
+				"description": _("Idempotency token for ERP sync retries and shadow sync recovery."),
+			},
+		],
 		"Terms and Conditions": [
 			{
 				"default": "1",

--- a/hrms/setup.py
+++ b/hrms/setup.py
@@ -733,12 +733,8 @@ def create_user_type(user_type, data):
 			raise
 
 		# Cross-version compatibility: older role perms can fail stricter dependency checks.
-		frappe.db.sql(
-			"UPDATE `tabDocPerm` SET `create` = 1 WHERE `amend` = 1 AND `create` = 0"
-		)
-		frappe.db.sql(
-			"UPDATE `tabCustom DocPerm` SET `create` = 1 WHERE `amend` = 1 AND `create` = 0"
-		)
+		frappe.db.sql("UPDATE `tabDocPerm` SET `create` = 1 WHERE `amend` = 1 AND `create` = 0")
+		frappe.db.sql("UPDATE `tabCustom DocPerm` SET `create` = 1 WHERE `amend` = 1 AND `create` = 0")
 		frappe.db.commit()
 		doc.save(ignore_permissions=True)
 

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -268,9 +268,7 @@ class TestErpSync(unittest.TestCase):
 		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
 		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
 		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
-		erp_sync.frappe.get_meta = MagicMock(
-			return_value=types.SimpleNamespace(has_field=meta_has_field)
-		)
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=meta_has_field))
 
 		with patch.object(erp_sync, "_normalize_company", return_value="BEI"):
 			first = erp_sync.sync_inventory(
@@ -304,7 +302,11 @@ class TestErpSync(unittest.TestCase):
 			return None
 
 		def db_get_value(doctype, filters=None, fieldname=None):
-			if doctype == "Stock Reconciliation" and isinstance(filters, dict) and "custom_sync_ref" in filters:
+			if (
+				doctype == "Stock Reconciliation"
+				and isinstance(filters, dict)
+				and "custom_sync_ref" in filters
+			):
 				return "SR-0001" if filters["custom_sync_ref"] in created_sync_refs else None
 			if doctype == "Account" and isinstance(filters, dict):
 				return "Stock Adjustment - BEI"
@@ -330,9 +332,7 @@ class TestErpSync(unittest.TestCase):
 		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
 		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
 		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
-		erp_sync.frappe.get_meta = MagicMock(
-			return_value=types.SimpleNamespace(has_field=meta_has_field)
-		)
+		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=meta_has_field))
 
 		with patch.object(erp_sync, "_normalize_company", return_value="BEI"):
 			first = erp_sync.sync_inventory(
@@ -468,9 +468,7 @@ class TestErpSync(unittest.TestCase):
 		with patch.object(erp_sync, "_normalize_company", return_value="BEI"):
 			result = erp_sync._sync_inventory_rows(
 				sheet_name="Inventory",
-				data=[
-					{"item_code": "FG001", "warehouse": "3MD Logistics – Camangyanan", "qty": 5}
-				],
+				data=[{"item_code": "FG001", "warehouse": "3MD Logistics – Camangyanan", "qty": 5}],
 				checksum="chk-baseline-batch",
 				require_auth=False,
 			)

--- a/hrms/tests/test_erp_sync.py
+++ b/hrms/tests/test_erp_sync.py
@@ -262,10 +262,15 @@ class TestErpSync(unittest.TestCase):
 
 			return _FakeDoc(doctype, on_insert=on_insert)
 
+		def meta_has_field(fieldname):
+			return fieldname not in {"custom_sync_ref", "custom_last_sync_checksum"}
+
 		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
 		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
 		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
-		erp_sync.frappe.get_meta = MagicMock(return_value=types.SimpleNamespace(has_field=lambda field: True))
+		erp_sync.frappe.get_meta = MagicMock(
+			return_value=types.SimpleNamespace(has_field=meta_has_field)
+		)
 
 		with patch.object(erp_sync, "_normalize_company", return_value="BEI"):
 			first = erp_sync.sync_inventory(
@@ -288,6 +293,63 @@ class TestErpSync(unittest.TestCase):
 		self.assertEqual(first["rows_created"], 2)
 		self.assertEqual(second["rows_updated"], 2)
 		self.assertEqual(len(created_docs), 1)
+
+	def test_sync_inventory_is_idempotent_by_custom_sync_ref_when_remarks_missing(self):
+		created_sync_refs = set()
+		created_docs = []
+
+		def db_exists(doctype, name=None):
+			if doctype in ("Item", "Warehouse", "Company"):
+				return name or True
+			return None
+
+		def db_get_value(doctype, filters=None, fieldname=None):
+			if doctype == "Stock Reconciliation" and isinstance(filters, dict) and "custom_sync_ref" in filters:
+				return "SR-0001" if filters["custom_sync_ref"] in created_sync_refs else None
+			if doctype == "Account" and isinstance(filters, dict):
+				return "Stock Adjustment - BEI"
+			if doctype == "Company" and filters == "BEI" and fieldname == "cost_center":
+				return "Main - BEI"
+			return None
+
+		def new_doc(doctype):
+			if doctype != "Stock Reconciliation":
+				return _FakeDoc(doctype)
+
+			def on_insert(doc):
+				doc.name = f"SR-{len(created_docs) + 1:04d}"
+				created_docs.append(doc)
+				if getattr(doc, "custom_sync_ref", None):
+					created_sync_refs.add(doc.custom_sync_ref)
+
+			return _FakeDoc(doctype, on_insert=on_insert)
+
+		def meta_has_field(fieldname):
+			return fieldname != "remarks"
+
+		erp_sync.frappe.db.exists = MagicMock(side_effect=db_exists)
+		erp_sync.frappe.db.get_value = MagicMock(side_effect=db_get_value)
+		erp_sync.frappe.new_doc = MagicMock(side_effect=new_doc)
+		erp_sync.frappe.get_meta = MagicMock(
+			return_value=types.SimpleNamespace(has_field=meta_has_field)
+		)
+
+		with patch.object(erp_sync, "_normalize_company", return_value="BEI"):
+			first = erp_sync.sync_inventory(
+				sheet_name="Inventory",
+				data=[{"item_code": "ITM-001", "warehouse": "Stores - BEI", "qty": 5}],
+				checksum="chk-token-1",
+			)
+			second = erp_sync.sync_inventory(
+				sheet_name="Inventory",
+				data=[{"item_code": "ITM-001", "warehouse": "Stores - BEI", "qty": 5}],
+				checksum="chk-token-1",
+			)
+
+		self.assertEqual(first["rows_created"], 1)
+		self.assertEqual(second["rows_updated"], 1)
+		self.assertEqual(len(created_docs), 1)
+		self.assertTrue(created_docs[0].custom_sync_ref.startswith("INV:"))
 
 	def test_sync_inventory_shadow_sync_uses_stable_batch_placeholder(self):
 		created_sync_refs = set()
@@ -883,6 +945,7 @@ class TestErpSync(unittest.TestCase):
 			"hrms.api.erp_sync.run_scheduled_store_inventory_shadow_sync",
 			queue="long",
 			job_id="scheduled_store_inventory_shadow_sync:2026-03-10",
+			deduplicate=True,
 			run_date="2026-03-10",
 			force=True,
 		)

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -32,6 +32,9 @@ def _install_fake_hrms():
 	store_inventory_mod = types.ModuleType("hrms.utils.store_inventory_shadow_sync")
 	store_inventory_mod.DEFAULT_OUTPUT_ROOT = ROOT / "tmp"
 	store_inventory_mod.run_shadow_sync = lambda *args, **kwargs: {}
+	store_inventory_mod.get_runtime_state_path = lambda: ROOT / "tmp" / "store_inventory_shadow_sync_state.json"
+	store_inventory_mod.load_runtime_state = lambda *args, **kwargs: {"stores": {}, "last_run": {}}
+	store_inventory_mod.save_runtime_state = lambda *args, **kwargs: None
 	sys.modules["hrms.utils.store_inventory_shadow_sync"] = store_inventory_mod
 	utils_pkg.store_inventory_shadow_sync = store_inventory_mod
 
@@ -148,6 +151,80 @@ class TestErpSyncRuntime(unittest.TestCase):
 
 		sync_ap_opening.assert_called_once_with(sheet_name="Supplier SOA", data=rows, checksum="runtime-2")
 		self.assertEqual(result, expected)
+
+	def test_watch_store_inventory_shadow_sync_health_queues_recovery_for_stale_run(self):
+		runtime_state = {
+			"stores": {},
+			"last_run": {
+				"status": "in_progress",
+				"run_date": "2026-01-01",
+				"generated_at": "2026-01-01T07:30:00",
+				"updated_at": "2026-01-01T07:35:00",
+			},
+		}
+		erp_sync.frappe.enqueue = MagicMock()
+		erp_sync.frappe.log_error = MagicMock()
+
+		with (
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"load_runtime_state",
+				return_value=runtime_state,
+			),
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"save_runtime_state",
+				MagicMock(),
+			) as save_state_mock,
+		):
+			result = erp_sync.watch_store_inventory_shadow_sync_health(
+				run_date="2026-01-01",
+				stale_after_minutes=20,
+				cooldown_minutes=20,
+				state_path=str(ROOT / "tmp" / "shadow-state.json"),
+			)
+
+		self.assertTrue(result["queued"])
+		self.assertEqual(
+			result["job_id"], "scheduled_store_inventory_shadow_sync_recovery:2026-01-01"
+		)
+		erp_sync.frappe.enqueue.assert_called_once_with(
+			"hrms.api.erp_sync.run_scheduled_store_inventory_shadow_sync",
+			queue="long",
+			job_id="scheduled_store_inventory_shadow_sync_recovery:2026-01-01",
+			deduplicate=True,
+			run_date="2026-01-01",
+			force=False,
+		)
+		self.assertIn("recovery_enqueued_at", runtime_state["last_run"])
+		save_state_mock.assert_called_once()
+
+	def test_watch_store_inventory_shadow_sync_health_skips_fresh_run(self):
+		runtime_state = {
+			"stores": {},
+			"last_run": {
+				"status": "in_progress",
+				"run_date": "2026-01-01",
+				"generated_at": "2026-01-01T07:55:00",
+				"updated_at": "2026-01-01T07:55:00",
+			},
+		}
+		erp_sync.frappe.enqueue = MagicMock()
+
+		with patch.object(
+			erp_sync.store_inventory_shadow_sync_builder,
+			"load_runtime_state",
+			return_value=runtime_state,
+		):
+			result = erp_sync.watch_store_inventory_shadow_sync_health(
+				run_date="2026-01-01",
+				stale_after_minutes=20,
+				cooldown_minutes=20,
+			)
+
+		self.assertFalse(result["queued"])
+		self.assertEqual(result["reason"], "not_stale")
+		erp_sync.frappe.enqueue.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -32,7 +32,9 @@ def _install_fake_hrms():
 	store_inventory_mod = types.ModuleType("hrms.utils.store_inventory_shadow_sync")
 	store_inventory_mod.DEFAULT_OUTPUT_ROOT = ROOT / "tmp"
 	store_inventory_mod.run_shadow_sync = lambda *args, **kwargs: {}
-	store_inventory_mod.get_runtime_state_path = lambda: ROOT / "tmp" / "store_inventory_shadow_sync_state.json"
+	store_inventory_mod.get_runtime_state_path = lambda: (
+		ROOT / "tmp" / "store_inventory_shadow_sync_state.json"
+	)
 	store_inventory_mod.load_runtime_state = lambda *args, **kwargs: {"stores": {}, "last_run": {}}
 	store_inventory_mod.save_runtime_state = lambda *args, **kwargs: None
 	sys.modules["hrms.utils.store_inventory_shadow_sync"] = store_inventory_mod
@@ -185,9 +187,7 @@ class TestErpSyncRuntime(unittest.TestCase):
 			)
 
 		self.assertTrue(result["queued"])
-		self.assertEqual(
-			result["job_id"], "scheduled_store_inventory_shadow_sync_recovery:2026-01-01"
-		)
+		self.assertEqual(result["job_id"], "scheduled_store_inventory_shadow_sync_recovery:2026-01-01")
 		erp_sync.frappe.enqueue.assert_called_once_with(
 			"hrms.api.erp_sync.run_scheduled_store_inventory_shadow_sync",
 			queue="long",

--- a/hrms/tests/test_store_inventory_shadow_sync.py
+++ b/hrms/tests/test_store_inventory_shadow_sync.py
@@ -3,9 +3,9 @@ import sys
 import tempfile
 import types
 import unittest
-from unittest.mock import MagicMock, patch
 from datetime import date
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from openpyxl import Workbook
 

--- a/hrms/tests/test_store_inventory_shadow_sync.py
+++ b/hrms/tests/test_store_inventory_shadow_sync.py
@@ -271,10 +271,13 @@ class TestStoreInventoryShadowSync(unittest.TestCase):
 			seen_destinations.append(dest)
 			dest.write_bytes(b"workbook-bytes")
 
-		with tempfile.TemporaryDirectory() as tmp_dir, patch.object(
-			shadow_sync,
-			"_export_workbook_via_drive",
-			side_effect=fake_drive_export,
+		with (
+			tempfile.TemporaryDirectory() as tmp_dir,
+			patch.object(
+				shadow_sync,
+				"_export_workbook_via_drive",
+				side_effect=fake_drive_export,
+			),
 		):
 			result = shadow_sync.export_store_workbook(config, Path(tmp_dir), drive=None, sheets=None)
 			self.assertEqual(seen_destinations[0].suffixes[-2:], [".xlsx", ".part"])
@@ -401,9 +404,7 @@ class TestStoreInventoryShadowSync(unittest.TestCase):
 		self.assertEqual(
 			persist_mock.call_args_list[0].kwargs["runtime_state"]["last_run"]["recovery_enqueued_at"], ""
 		)
-		self.assertIn(
-			"updated_at", persist_mock.call_args_list[-1].kwargs["runtime_state"]["last_run"]
-		)
+		self.assertIn("updated_at", persist_mock.call_args_list[-1].kwargs["runtime_state"]["last_run"])
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_store_inventory_shadow_sync.py
+++ b/hrms/tests/test_store_inventory_shadow_sync.py
@@ -398,6 +398,12 @@ class TestStoreInventoryShadowSync(unittest.TestCase):
 		self.assertEqual(persist_mock.call_count, 4)
 		self.assertEqual(persist_mock.call_args_list[0].kwargs["summary"]["status"], "in_progress")
 		self.assertEqual(persist_mock.call_args_list[-1].kwargs["summary"]["status"], "completed")
+		self.assertEqual(
+			persist_mock.call_args_list[0].kwargs["runtime_state"]["last_run"]["recovery_enqueued_at"], ""
+		)
+		self.assertIn(
+			"updated_at", persist_mock.call_args_list[-1].kwargs["runtime_state"]["last_run"]
+		)
 
 
 if __name__ == "__main__":

--- a/hrms/utils/store_inventory_shadow_sync.py
+++ b/hrms/utils/store_inventory_shadow_sync.py
@@ -953,9 +953,11 @@ def run_store_inventory_shadow_sync(
 		"status": "in_progress",
 		"run_date": run_date_value.isoformat(),
 		"generated_at": _now_ts(),
+		"updated_at": _now_ts(),
 		"imported_stores": imported_stores,
 		"skipped_unchanged": skipped_unchanged,
 		"failed_stores": len(failed_stores),
+		"recovery_enqueued_at": "",
 	}
 	_persist_shadow_sync_progress(
 		registry_rows=store_registry,
@@ -1044,9 +1046,11 @@ def run_store_inventory_shadow_sync(
 			"status": "in_progress",
 			"run_date": run_date_value.isoformat(),
 			"generated_at": _now_ts(),
+			"updated_at": _now_ts(),
 			"imported_stores": imported_stores,
 			"skipped_unchanged": skipped_unchanged,
 			"failed_stores": len(failed_stores),
+			"recovery_enqueued_at": "",
 		}
 		_persist_shadow_sync_progress(
 			registry_rows=store_registry,
@@ -1140,9 +1144,11 @@ def run_store_inventory_shadow_sync(
 		"status": "completed",
 		"run_date": run_date_value.isoformat(),
 		"generated_at": _now_ts(),
+		"updated_at": _now_ts(),
 		"imported_stores": imported_stores,
 		"skipped_unchanged": skipped_unchanged,
 		"failed_stores": len(failed_stores),
+		"recovery_enqueued_at": "",
 	}
 	summary = _build_shadow_sync_summary(
 		run_date=run_date_value.isoformat(),


### PR DESCRIPTION
## Summary
- add a watchdog that resumes stale in-progress store inventory shadow sync runs after deploy interruptions
- persist heartbeat metadata during the shadow sync and add a Stock Reconciliation sync token for idempotent retries
- cover the recovery and idempotency paths with automated tests

## Testing
- python -m py_compile hrms/api/erp_sync.py hrms/utils/store_inventory_shadow_sync.py hrms/setup.py hrms/patches/v16_0/add_stock_reconciliation_sync_ref_field.py hrms/tests/test_erp_sync.py hrms/tests/test_erp_sync_runtime.py hrms/tests/test_store_inventory_shadow_sync.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest hrms/tests/test_erp_sync.py hrms/tests/test_erp_sync_runtime.py hrms/tests/test_store_inventory_shadow_sync.py -q