### PR TITLE
fix: stabilize shadow sync watchdog heartbeats

### DIFF
--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -53,9 +53,6 @@ def _install_fake_hrms():
 
 
 def _install_fake_frappe():
-	if "frappe" in sys.modules:
-		return
-
 	frappe = types.ModuleType("frappe")
 	utils = types.ModuleType("frappe.utils")
 

--- a/hrms/tests/test_store_inventory_shadow_sync.py
+++ b/hrms/tests/test_store_inventory_shadow_sync.py
@@ -1,9 +1,10 @@
+import copy
 import importlib.util
 import sys
 import tempfile
 import types
 import unittest
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -41,6 +42,19 @@ spec.loader.exec_module(shadow_sync)
 
 
 class TestStoreInventoryShadowSync(unittest.TestCase):
+	def test_now_ts_uses_frappe_site_time_when_available(self):
+		original_utils = getattr(shadow_sync.frappe, "utils", None)
+		shadow_sync.frappe.utils = types.SimpleNamespace(
+			now_datetime=lambda: datetime(2026, 3, 11, 16, 45, 12)
+		)
+		try:
+			self.assertEqual(shadow_sync._now_ts(), "2026-03-11T16:45:12")
+		finally:
+			if original_utils is None:
+				delattr(shadow_sync.frappe, "utils")
+			else:
+				shadow_sync.frappe.utils = original_utils
+
 	def test_ensure_required_master_data_reuses_existing_warehouse_name_match(self):
 		store = shadow_sync.StoreSyncConfig(
 			store_code="NAIA",
@@ -314,6 +328,8 @@ class TestStoreInventoryShadowSync(unittest.TestCase):
 		hrms.api = fake_api
 		sys.modules["hrms.api"] = fake_api
 		sys.modules["hrms.api.erp_sync"] = fake_erp_sync
+		captured_last_runs = []
+		captured_summaries = []
 
 		try:
 			with tempfile.TemporaryDirectory() as tmp_dir:
@@ -372,7 +388,14 @@ class TestStoreInventoryShadowSync(unittest.TestCase):
 							},
 						],
 					),
-					patch.object(shadow_sync, "_persist_shadow_sync_progress") as persist_mock,
+					patch.object(
+						shadow_sync,
+						"_persist_shadow_sync_progress",
+						side_effect=lambda **kwargs: (
+							captured_last_runs.append(copy.deepcopy(kwargs["runtime_state"]["last_run"])),
+							captured_summaries.append(copy.deepcopy(kwargs["summary"])),
+						),
+					) as persist_mock,
 				):
 					result = shadow_sync.run_store_inventory_shadow_sync(
 						run_date="2026-03-10",
@@ -398,13 +421,29 @@ class TestStoreInventoryShadowSync(unittest.TestCase):
 		self.assertEqual(result["status"], "completed")
 		self.assertEqual(result["imported_stores"], 2)
 		self.assertEqual(fake_erp_sync._sync_inventory_rows.call_count, 2)
-		self.assertEqual(persist_mock.call_count, 4)
-		self.assertEqual(persist_mock.call_args_list[0].kwargs["summary"]["status"], "in_progress")
-		self.assertEqual(persist_mock.call_args_list[-1].kwargs["summary"]["status"], "completed")
+		self.assertEqual(persist_mock.call_count, 10)
+		stages = [entry["current_stage"] for entry in captured_last_runs]
 		self.assertEqual(
-			persist_mock.call_args_list[0].kwargs["runtime_state"]["last_run"]["recovery_enqueued_at"], ""
+			stages,
+			[
+				"starting",
+				"exporting_workbook",
+				"extracting_inventory",
+				"syncing_inventory",
+				"completed_store",
+				"exporting_workbook",
+				"extracting_inventory",
+				"syncing_inventory",
+				"completed_store",
+				"completed",
+			],
 		)
-		self.assertIn("updated_at", persist_mock.call_args_list[-1].kwargs["runtime_state"]["last_run"])
+		self.assertEqual(captured_summaries[0]["status"], "in_progress")
+		self.assertEqual(captured_summaries[-1]["status"], "completed")
+		self.assertEqual(captured_last_runs[0]["recovery_enqueued_at"], "")
+		self.assertEqual(captured_last_runs[1]["current_store_code"], "AFT")
+		self.assertEqual(captured_last_runs[5]["current_store_code"], "AMM")
+		self.assertIn("updated_at", captured_last_runs[-1])
 
 
 if __name__ == "__main__":

--- a/hrms/utils/store_inventory_shadow_sync.py
+++ b/hrms/utils/store_inventory_shadow_sync.py
@@ -89,6 +89,8 @@ class InventoryLayout:
 
 
 def _now_ts() -> str:
+	if frappe and getattr(frappe, "utils", None) and hasattr(frappe.utils, "now_datetime"):
+		return frappe.utils.now_datetime().strftime("%Y-%m-%dT%H:%M:%S")
 	return datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 
 
@@ -676,7 +678,7 @@ def extract_store_inventory_payload(
 			continue
 
 		if _classify_section_row(code, items, description, uom):
-			section_name = code if _normalize_header(code) in SECTION_NAMES else code
+			section_name = code
 			continue
 
 		current_row = {
@@ -895,6 +897,32 @@ def _persist_shadow_sync_progress(
 	(run_root / "summary.md").write_text(_summary_markdown(summary), encoding="utf-8")
 
 
+def _set_last_run_state(
+	runtime_state: dict[str, Any],
+	*,
+	status: str,
+	run_date: str,
+	imported_stores: int,
+	skipped_unchanged: int,
+	failed_store_count: int,
+	current_store: StoreSyncConfig | None = None,
+	current_stage: str = "",
+) -> None:
+	runtime_state["last_run"] = {
+		"status": status,
+		"run_date": run_date,
+		"generated_at": _now_ts(),
+		"updated_at": _now_ts(),
+		"imported_stores": imported_stores,
+		"skipped_unchanged": skipped_unchanged,
+		"failed_stores": failed_store_count,
+		"recovery_enqueued_at": "",
+		"current_store_code": current_store.store_code if current_store else "",
+		"current_store_name": current_store.store_name if current_store else "",
+		"current_stage": current_stage,
+	}
+
+
 def run_store_inventory_shadow_sync(
 	*,
 	run_date: str | None = None,
@@ -949,46 +977,51 @@ def run_store_inventory_shadow_sync(
 
 	enabled_stores = len(eligible_stores)
 
-	runtime_state["last_run"] = {
-		"status": "in_progress",
-		"run_date": run_date_value.isoformat(),
-		"generated_at": _now_ts(),
-		"updated_at": _now_ts(),
-		"imported_stores": imported_stores,
-		"skipped_unchanged": skipped_unchanged,
-		"failed_stores": len(failed_stores),
-		"recovery_enqueued_at": "",
-	}
-	_persist_shadow_sync_progress(
-		registry_rows=store_registry,
-		registry_file=registry_file,
-		runtime_state=runtime_state,
-		state_file=state_file,
-		run_root=run_root,
-		summary=_build_shadow_sync_summary(
+	def persist_progress(*, current_store: StoreSyncConfig | None = None, current_stage: str = "") -> None:
+		_set_last_run_state(
+			runtime_state,
+			status="in_progress",
 			run_date=run_date_value.isoformat(),
-			registry_file=registry_file,
-			state_file=state_file,
-			run_root=run_root,
-			enabled_stores=enabled_stores,
 			imported_stores=imported_stores,
 			skipped_unchanged=skipped_unchanged,
-			skipped_non_shadow=skipped_non_shadow,
-			skipped_disabled=skipped_disabled,
-			payload_rows_all=payload_rows_all,
-			exception_rows_all=exception_rows_all,
-			rows_created=rows_created,
-			rows_updated=rows_updated,
-			rows_failed=rows_failed,
-			failed_stores=failed_stores,
-			bootstrap=bootstrap,
-			status="in_progress",
-		),
-	)
+			failed_store_count=len(failed_stores),
+			current_store=current_store,
+			current_stage=current_stage,
+		)
+		_persist_shadow_sync_progress(
+			registry_rows=store_registry,
+			registry_file=registry_file,
+			runtime_state=runtime_state,
+			state_file=state_file,
+			run_root=run_root,
+			summary=_build_shadow_sync_summary(
+				run_date=run_date_value.isoformat(),
+				registry_file=registry_file,
+				state_file=state_file,
+				run_root=run_root,
+				enabled_stores=enabled_stores,
+				imported_stores=imported_stores,
+				skipped_unchanged=skipped_unchanged,
+				skipped_non_shadow=skipped_non_shadow,
+				skipped_disabled=skipped_disabled,
+				payload_rows_all=payload_rows_all,
+				exception_rows_all=exception_rows_all,
+				rows_created=rows_created,
+				rows_updated=rows_updated,
+				rows_failed=rows_failed,
+				failed_stores=failed_stores,
+				bootstrap=bootstrap,
+				status="in_progress",
+			),
+		)
+
+	persist_progress(current_stage="starting")
 
 	for store in eligible_stores:
 		try:
+			persist_progress(current_store=store, current_stage="exporting_workbook")
 			workbook_path = export_store_workbook(store, downloads_dir, drive, sheets)
+			persist_progress(current_store=store, current_stage="extracting_inventory")
 			store_result = extract_store_inventory_payload(store, workbook_path, item_mapping, run_date_value)
 			payload_rows = store_result["payload_rows"]
 			exception_rows = store_result["exception_rows"]
@@ -999,9 +1032,11 @@ def run_store_inventory_shadow_sync(
 
 			if not force and store.last_checksum and store.last_checksum == store_result["checksum"]:
 				skipped_unchanged += 1
+				persist_progress(current_store=store, current_stage="completed_store")
 				continue
 
 			if payload_rows:
+				persist_progress(current_store=store, current_stage="syncing_inventory")
 				sync_result = erp_sync._sync_inventory_rows(
 					sheet_name=f"Store Inventory Shadow Sync {store.store_code}",
 					data=payload_rows,
@@ -1042,42 +1077,7 @@ def run_store_inventory_shadow_sync(
 				"last_error": store.last_error,
 			}
 
-		runtime_state["last_run"] = {
-			"status": "in_progress",
-			"run_date": run_date_value.isoformat(),
-			"generated_at": _now_ts(),
-			"updated_at": _now_ts(),
-			"imported_stores": imported_stores,
-			"skipped_unchanged": skipped_unchanged,
-			"failed_stores": len(failed_stores),
-			"recovery_enqueued_at": "",
-		}
-		_persist_shadow_sync_progress(
-			registry_rows=store_registry,
-			registry_file=registry_file,
-			runtime_state=runtime_state,
-			state_file=state_file,
-			run_root=run_root,
-			summary=_build_shadow_sync_summary(
-				run_date=run_date_value.isoformat(),
-				registry_file=registry_file,
-				state_file=state_file,
-				run_root=run_root,
-				enabled_stores=enabled_stores,
-				imported_stores=imported_stores,
-				skipped_unchanged=skipped_unchanged,
-				skipped_non_shadow=skipped_non_shadow,
-				skipped_disabled=skipped_disabled,
-				payload_rows_all=payload_rows_all,
-				exception_rows_all=exception_rows_all,
-				rows_created=rows_created,
-				rows_updated=rows_updated,
-				rows_failed=rows_failed,
-				failed_stores=failed_stores,
-				bootstrap=bootstrap,
-				status="in_progress",
-			),
-		)
+		persist_progress(current_store=store, current_stage="completed_store")
 
 	_write_csv(
 		run_root / "store_inventory_payload.csv",
@@ -1140,16 +1140,15 @@ def run_store_inventory_shadow_sync(
 		audit_rows_all,
 	)
 
-	runtime_state["last_run"] = {
-		"status": "completed",
-		"run_date": run_date_value.isoformat(),
-		"generated_at": _now_ts(),
-		"updated_at": _now_ts(),
-		"imported_stores": imported_stores,
-		"skipped_unchanged": skipped_unchanged,
-		"failed_stores": len(failed_stores),
-		"recovery_enqueued_at": "",
-	}
+	_set_last_run_state(
+		runtime_state,
+		status="completed",
+		run_date=run_date_value.isoformat(),
+		imported_stores=imported_stores,
+		skipped_unchanged=skipped_unchanged,
+		failed_store_count=len(failed_stores),
+		current_stage="completed",
+	)
 	summary = _build_shadow_sync_summary(
 		run_date=run_date_value.isoformat(),
 		registry_file=registry_file,

--- a/tmp/2026-03-11_shadow_sync_hardening_followup_note.md
+++ b/tmp/2026-03-11_shadow_sync_hardening_followup_note.md
@@ -1,0 +1,31 @@
+# 2026-03-11 Store Inventory Shadow Sync Hardening Follow-Up
+
+## Live issue found during production simulation
+
+The first hardening patch deployed successfully, but a live watchdog simulation exposed two remaining gaps:
+
+1. `store_inventory_shadow_sync.py` wrote `last_run.generated_at` / `updated_at` using plain `datetime.now()` from the container.
+2. `erp_sync.watch_store_inventory_shadow_sync_health()` compared those timestamps to `frappe.utils.now_datetime()`.
+
+Because production is interpreted in `Asia/Manila`, while the container-level `datetime.now()` behaved as UTC, the watchdog saw active runs as artificially older than they really were and could enqueue recovery too early.
+
+The same simulation also showed that the runtime heartbeat only moved after an entire store completed. That is too coarse for large workbook exports and extraction steps because a healthy but slow store can look stalled.
+
+## Follow-up fix
+
+- Make `_now_ts()` use `frappe.utils.now_datetime()` when Frappe is available.
+- Add stage-level heartbeats during:
+  - `starting`
+  - `exporting_workbook`
+  - `extracting_inventory`
+  - `syncing_inventory`
+  - `completed_store`
+  - final `completed`
+- Persist `current_store_code`, `current_store_name`, and `current_stage` into `last_run` for operational debugging.
+
+## Local verification
+
+- `pytest hrms/tests/test_store_inventory_shadow_sync.py -q` -> `6 passed`
+- `pytest hrms/tests/test_erp_sync_runtime.py -q` -> `5 passed`
+- `pytest hrms/tests/test_erp_sync.py -q` -> `38 passed`
+- `ruff check hrms/utils/store_inventory_shadow_sync.py hrms/tests/test_store_inventory_shadow_sync.py hrms/tests/test_erp_sync_runtime.py` -> `All checks passed`


### PR DESCRIPTION
## Summary
- align shadow sync progress timestamps with site time so watchdog age checks stay in one timezone
- persist store-stage heartbeats during export, extraction, and sync so slow stores do not look stalled
- capture the live production finding in a follow-up note and extend the targeted test coverage

## Testing
- python -m compileall hrms/utils/store_inventory_shadow_sync.py hrms/tests/test_store_inventory_shadow_sync.py hrms/tests/test_erp_sync_runtime.py
- $env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; pytest hrms/tests/test_store_inventory_shadow_sync.py -q
- $env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; pytest hrms/tests/test_erp_sync_runtime.py -q
- $env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; pytest hrms/tests/test_erp_sync.py -q
- ruff check hrms/utils/store_inventory_shadow_sync.py hrms/tests/test_store_inventory_shadow_sync.py hrms/tests/test_erp_sync_runtime.py