### PR TITLE
fix: ignore shift assignment perms in labor plan publish

### DIFF
--- a/hrms/api/supervisor.py
+++ b/hrms/api/supervisor.py
@@ -384,6 +384,7 @@ def _get_work_date(week_start_date: str, day_of_week: str):
 def _get_shift_assignment_conflicts(employee: str, work_date: str, row_key: str, plan_name: str):
 	assignments = frappe.get_all(
 		"Shift Assignment",
+		ignore_permissions=True,
 		filters={
 			"employee": employee,
 			"docstatus": 1,
@@ -605,6 +606,7 @@ def publish_weekly_plan(plan_name: str):
 	current_keys = set()
 	existing_assignments = frappe.get_all(
 		"Shift Assignment",
+		ignore_permissions=True,
 		filters={
 			"custom_bei_schedule_source": SCHEDULE_SOURCE,
 			"custom_bei_weekly_labor_plan": plan.name,


### PR DESCRIPTION
## Summary
- run weekly labor plan publish bridge with system-level Shift Assignment reads
- unblock supervisors from publishing plans even though they do not have raw Shift Assignment doctype access
- keep assignment conflict checks and tagged assignment sync working inside the bridge

## Verification
- ruff format hrms/api/supervisor.py
- ruff check hrms/api/supervisor.py
- python -m py_compile hrms/api/supervisor.py
- live production reproduction showed supervisor publish was failing with Shift Assignment permission errors before this fix