### PR TITLE
fix: resume shadow sync from unsynced stores

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -1818,6 +1818,7 @@ def watch_store_inventory_shadow_sync_health(
 	run_date_value = _safe_date(run_date) or nowdate()
 	stale_after = max(cint(stale_after_minutes), 1)
 	cooldown = max(cint(cooldown_minutes), 1)
+	registry_file = store_inventory_shadow_sync_builder.get_runtime_registry_path()
 	state_file = (
 		Path(state_path) if state_path else store_inventory_shadow_sync_builder.get_runtime_state_path()
 	)
@@ -1835,6 +1836,53 @@ def watch_store_inventory_shadow_sync_health(
 			"reason": "run_date_mismatch",
 			"run_date": run_date_value,
 			"recorded_run_date": recorded_run_date,
+		}
+
+	try:
+		registry_rows = store_inventory_shadow_sync_builder.load_store_registry(registry_file)
+	except Exception:
+		registry_rows = []
+
+	importable_states = getattr(store_inventory_shadow_sync_builder, "IMPORTABLE_STATES", {"shadow_sync"})
+	enabled_rows = [
+		row
+		for row in registry_rows
+		if getattr(row, "sheet_sync_enabled", False) and getattr(row, "state", "") in importable_states
+	]
+	completed_rows = [
+		row
+		for row in enabled_rows
+		if _safe_date(getattr(row, "last_inventory_date", "")) == run_date_value
+		and bool(getattr(row, "last_success_at", ""))
+	]
+	if enabled_rows and len(completed_rows) == len(enabled_rows):
+		completed_at = _runtime_timestamp()
+		for row in completed_rows:
+			if getattr(row, "last_error", ""):
+				row.last_error = ""
+		try:
+			store_inventory_shadow_sync_builder.save_store_registry(registry_rows, registry_file)
+		except Exception:
+			pass
+		runtime_state["last_run"] = {
+			"status": "completed",
+			"run_date": run_date_value,
+			"generated_at": last_run.get("generated_at") or completed_at,
+			"updated_at": completed_at,
+			"imported_stores": len(completed_rows),
+			"skipped_unchanged": 0,
+			"failed_stores": 0,
+			"recovery_enqueued_at": "",
+			"current_store_code": "",
+			"current_store_name": "",
+			"current_stage": "completed",
+		}
+		store_inventory_shadow_sync_builder.save_runtime_state(runtime_state, state_file)
+		return {
+			"queued": False,
+			"reason": "already_complete",
+			"run_date": run_date_value,
+			"completed_stores": len(completed_rows),
 		}
 
 	now_value = now_datetime()

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -35,7 +35,12 @@ def _install_fake_hrms():
 	store_inventory_mod.get_runtime_state_path = lambda: (
 		ROOT / "tmp" / "store_inventory_shadow_sync_state.json"
 	)
+	store_inventory_mod.get_runtime_registry_path = lambda: (
+		ROOT / "tmp" / "store_inventory_shadow_sync_registry.csv"
+	)
 	store_inventory_mod.load_runtime_state = lambda *args, **kwargs: {"stores": {}, "last_run": {}}
+	store_inventory_mod.load_store_registry = lambda *args, **kwargs: []
+	store_inventory_mod.save_store_registry = lambda *args, **kwargs: None
 	store_inventory_mod.save_runtime_state = lambda *args, **kwargs: None
 	sys.modules["hrms.utils.store_inventory_shadow_sync"] = store_inventory_mod
 	utils_pkg.store_inventory_shadow_sync = store_inventory_mod
@@ -222,6 +227,72 @@ class TestErpSyncRuntime(unittest.TestCase):
 		self.assertFalse(result["queued"])
 		self.assertEqual(result["reason"], "not_stale")
 		erp_sync.frappe.enqueue.assert_not_called()
+
+	def test_watch_store_inventory_shadow_sync_health_marks_completed_when_registry_already_synced(self):
+		runtime_state = {
+			"stores": {},
+			"last_run": {
+				"status": "in_progress",
+				"run_date": "2026-01-01",
+				"generated_at": "2026-01-01T07:00:00",
+				"updated_at": "2026-01-01T07:10:00",
+				"recovery_enqueued_at": "2026-01-01T07:20:00",
+			},
+		}
+		registry_rows = [
+			types.SimpleNamespace(
+				store_code="AFT",
+				sheet_sync_enabled=True,
+				state="shadow_sync",
+				last_inventory_date="2026-01-01",
+				last_success_at="2026-01-01T07:30:00",
+			),
+			types.SimpleNamespace(
+				store_code="AMM",
+				sheet_sync_enabled=True,
+				state="shadow_sync",
+				last_inventory_date="2026-01-01",
+				last_success_at="2026-01-01T07:31:00",
+			),
+		]
+		erp_sync.frappe.enqueue = MagicMock()
+
+		with (
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"load_runtime_state",
+				return_value=runtime_state,
+			),
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"load_store_registry",
+				return_value=registry_rows,
+			),
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"save_runtime_state",
+				MagicMock(),
+			) as save_state_mock,
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"save_store_registry",
+				MagicMock(),
+			) as save_registry_mock,
+		):
+			result = erp_sync.watch_store_inventory_shadow_sync_health(
+				run_date="2026-01-01",
+				stale_after_minutes=20,
+				cooldown_minutes=20,
+			)
+
+		self.assertFalse(result["queued"])
+		self.assertEqual(result["reason"], "already_complete")
+		self.assertEqual(runtime_state["last_run"]["status"], "completed")
+		self.assertEqual(runtime_state["last_run"]["failed_stores"], 0)
+		self.assertEqual(runtime_state["last_run"]["current_stage"], "completed")
+		erp_sync.frappe.enqueue.assert_not_called()
+		save_registry_mock.assert_called_once()
+		save_state_mock.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_store_inventory_shadow_sync.py
+++ b/hrms/tests/test_store_inventory_shadow_sync.py
@@ -445,6 +445,123 @@ class TestStoreInventoryShadowSync(unittest.TestCase):
 		self.assertEqual(captured_last_runs[5]["current_store_code"], "AMM")
 		self.assertIn("updated_at", captured_last_runs[-1])
 
+	def test_run_store_inventory_shadow_sync_skips_store_already_synced_today(self):
+		completed_store = shadow_sync.StoreSyncConfig(
+			store_code="AFT",
+			store_name="Store One",
+			spreadsheet_id="sheet-1",
+			warehouse_name="Store One",
+			warehouse_docname="Store One - BEI",
+			last_checksum="checksum-1",
+			last_success_at="2026-03-10T08:00:00",
+			last_error="transient export failure",
+			last_import_rows=103,
+			last_inventory_date="2026-03-10",
+		)
+		pending_store = shadow_sync.StoreSyncConfig(
+			store_code="AMM",
+			store_name="Store Two",
+			spreadsheet_id="sheet-2",
+			warehouse_name="Store Two",
+			warehouse_docname="Store Two - BEI",
+		)
+		fake_erp_sync = types.ModuleType("hrms.api.erp_sync")
+		fake_erp_sync._sync_inventory_rows = MagicMock(
+			return_value={"rows_created": 1, "rows_updated": 0, "rows_failed": 0, "errors": []}
+		)
+		fake_api = types.ModuleType("hrms.api")
+		fake_api.erp_sync = fake_erp_sync
+
+		import hrms
+
+		original_api = getattr(hrms, "api", None)
+		original_api_module = sys.modules.get("hrms.api")
+		original_erp_sync_module = sys.modules.get("hrms.api.erp_sync")
+		hrms.api = fake_api
+		sys.modules["hrms.api"] = fake_api
+		sys.modules["hrms.api.erp_sync"] = fake_erp_sync
+		captured_states = []
+
+		try:
+			with tempfile.TemporaryDirectory() as tmp_dir:
+				tmp_path = Path(tmp_dir)
+				with (
+					patch.object(
+						shadow_sync,
+						"load_store_registry",
+						return_value=[completed_store, pending_store],
+					),
+					patch.object(shadow_sync, "load_item_mapping", return_value={}),
+					patch.object(shadow_sync, "ensure_required_master_data", return_value={}),
+					patch.object(shadow_sync, "_build_google_services", return_value=(None, None)),
+					patch.object(
+						shadow_sync,
+						"export_store_workbook",
+						return_value=tmp_path / "two.xlsx",
+					) as export_mock,
+					patch.object(
+						shadow_sync,
+						"extract_store_inventory_payload",
+						return_value={
+							"payload_rows": [
+								{
+									"store_code": "AMM",
+									"store_name": "Store Two",
+									"warehouse": "Store Two - BEI",
+									"item_code": "ITEM-2",
+									"qty": 2,
+									"qty_source": "encode",
+									"inventory_date": "2026-03-10",
+									"spreadsheet_id": "sheet-2",
+									"source_row": 4,
+									"workbook_path": str(tmp_path / "two.xlsx"),
+								}
+							],
+							"exception_rows": [],
+							"audit_rows": [],
+							"checksum": "checksum-2",
+						},
+					),
+					patch.object(
+						shadow_sync,
+						"_persist_shadow_sync_progress",
+						side_effect=lambda **kwargs: captured_states.append(
+							copy.deepcopy(kwargs["runtime_state"])
+						),
+					),
+				):
+					result = shadow_sync.run_store_inventory_shadow_sync(
+						run_date="2026-03-10",
+						force=False,
+						output_dir=str(tmp_path / "run"),
+						registry_path=str(tmp_path / "registry.csv"),
+						state_path=str(tmp_path / "state.json"),
+					)
+		finally:
+			if original_api is None:
+				delattr(hrms, "api")
+			else:
+				hrms.api = original_api
+			if original_api_module is None:
+				sys.modules.pop("hrms.api", None)
+			else:
+				sys.modules["hrms.api"] = original_api_module
+			if original_erp_sync_module is None:
+				sys.modules.pop("hrms.api.erp_sync", None)
+			else:
+				sys.modules["hrms.api.erp_sync"] = original_erp_sync_module
+
+		self.assertEqual(result["status"], "completed")
+		self.assertEqual(result["imported_stores"], 1)
+		self.assertEqual(result["skipped_unchanged"], 1)
+		self.assertEqual(export_mock.call_count, 1)
+		self.assertEqual(fake_erp_sync._sync_inventory_rows.call_count, 1)
+		self.assertEqual(completed_store.last_error, "")
+		self.assertEqual(
+			captured_states[0]["stores"]["AFT"]["last_error"],
+			"",
+		)
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/hrms/utils/store_inventory_shadow_sync.py
+++ b/hrms/utils/store_inventory_shadow_sync.py
@@ -923,6 +923,20 @@ def _set_last_run_state(
 	}
 
 
+def _store_runtime_row(store: StoreSyncConfig) -> dict[str, Any]:
+	return {
+		"last_checksum": store.last_checksum,
+		"last_success_at": store.last_success_at,
+		"last_import_rows": store.last_import_rows,
+		"last_inventory_date": store.last_inventory_date,
+		"last_error": store.last_error,
+	}
+
+
+def _store_completed_for_run_date(store: StoreSyncConfig, run_date_value: date) -> bool:
+	return bool(store.last_success_at) and store.last_inventory_date == run_date_value.isoformat()
+
+
 def run_store_inventory_shadow_sync(
 	*,
 	run_date: str | None = None,
@@ -972,6 +986,12 @@ def run_store_inventory_shadow_sync(
 			continue
 		if store.state not in IMPORTABLE_STATES:
 			skipped_non_shadow += 1
+			continue
+		if not force and _store_completed_for_run_date(store, run_date_value):
+			skipped_unchanged += 1
+			if store.last_error:
+				store.last_error = ""
+			runtime_state.setdefault("stores", {})[store.store_code] = _store_runtime_row(store)
 			continue
 		eligible_stores.append(store)
 
@@ -1058,24 +1078,12 @@ def run_store_inventory_shadow_sync(
 			store.last_success_at = _now_ts()
 			store.last_import_rows = len(payload_rows)
 			store.last_inventory_date = run_date_value.isoformat()
-			runtime_state.setdefault("stores", {})[store.store_code] = {
-				"last_checksum": store.last_checksum,
-				"last_success_at": store.last_success_at,
-				"last_import_rows": store.last_import_rows,
-				"last_inventory_date": store.last_inventory_date,
-				"last_error": store.last_error,
-			}
+			runtime_state.setdefault("stores", {})[store.store_code] = _store_runtime_row(store)
 
 		except Exception as exc:
 			store.last_error = str(exc)
 			failed_stores.append({"store_code": store.store_code, "error": str(exc)})
-			runtime_state.setdefault("stores", {})[store.store_code] = {
-				"last_checksum": store.last_checksum,
-				"last_success_at": store.last_success_at,
-				"last_import_rows": store.last_import_rows,
-				"last_inventory_date": store.last_inventory_date,
-				"last_error": store.last_error,
-			}
+			runtime_state.setdefault("stores", {})[store.store_code] = _store_runtime_row(store)
 
 		persist_progress(current_store=store, current_stage="completed_store")
 


### PR DESCRIPTION
## Summary
- skip stores that already landed the current run date before re-exporting them
- let the watchdog close stale in-progress runs when the registry already shows all enabled stores completed
- clear stale per-store errors during recovery finalization and cover the behavior with unit tests

## Testing
- python -m compileall hrms/utils/store_inventory_shadow_sync.py hrms/api/erp_sync.py hrms/tests/test_store_inventory_shadow_sync.py hrms/tests/test_erp_sync_runtime.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_store_inventory_shadow_sync.py hrms/tests/test_erp_sync_runtime.py hrms/tests/test_erp_sync.py -q
- ruff check hrms/utils/store_inventory_shadow_sync.py hrms/api/erp_sync.py hrms/tests/test_store_inventory_shadow_sync.py hrms/tests/test_erp_sync_runtime.py