### PR TITLE
fix: disable manual store POS uploads

### DIFF
--- a/hrms/api/dashboard.py
+++ b/hrms/api/dashboard.py
@@ -6,213 +6,207 @@ Dashboard API
 Provides KPIs and metrics for store, area, and ops dashboards
 """
 
-import frappe
-from frappe import _
-from frappe.utils import nowdate, add_days
 import json
 
-
-@frappe.whitelist()
-def get_store_dashboard(store=None, period="week"):
-    """Get dashboard KPIs for a store."""
-    if not store:
-        return {"store": None, "period": period, "kpis": {}}
-
-    today = nowdate()
-    if period == "week":
-        start_date = add_days(today, -7)
-    elif period == "month":
-        start_date = add_days(today, -30)
-    else:
-        start_date = add_days(today, -7)
-
-    # Orders
-    orders = frappe.db.count(
-        "BEI Store Order",
-        filters={"store": store, "order_date": [">=", start_date]}
-    )
-    pending_orders = frappe.db.count(
-        "BEI Store Order",
-        filters={"store": store, "status": "Pending Approval"}
-    )
-
-    # FQI
-    fqi_count = frappe.db.count(
-        "BEI FQI Report",
-        filters={"store": store, "reported_at": [">=", start_date]}
-    )
-    open_fqi = frappe.db.count(
-        "BEI FQI Report",
-        filters={"store": store, "status": "Open"}
-    )
-
-    # Receiving
-    receiving_count = frappe.db.count(
-        "BEI Store Receiving",
-        filters={"store": store, "receiving_date": [">=", start_date]}
-    )
-
-    # Checklists
-    opening_count = frappe.db.count(
-        "BEI Store Opening Report",
-        filters={"store": store, "report_date": [">=", start_date]}
-    )
-    closing_count = frappe.db.count(
-        "BEI Store Closing Report",
-        filters={"store": store, "report_date": [">=", start_date]}
-    )
-
-    return {
-        "store": store,
-        "period": period,
-        "kpis": {
-            "total_orders": orders,
-            "pending_approvals": pending_orders,
-            "fqi_incidents": fqi_count,
-            "open_fqi": open_fqi,
-            "deliveries_received": receiving_count,
-            "opening_reports": opening_count,
-            "closing_reports": closing_count
-        }
-    }
+import frappe
+from frappe import _
+from frappe.utils import add_days, nowdate
 
 
 @frappe.whitelist()
-def get_area_dashboard(area_supervisor=None, period="week"):
-    """Get aggregated dashboard for area supervisor's stores."""
-    if not area_supervisor:
-        area_supervisor = frappe.session.user
+def get_store_dashboard(store: str | None = None, period: str = "week") -> dict:
+	"""Get dashboard KPIs for a store."""
+	if not store:
+		return {"store": None, "period": period, "kpis": {}}
 
-    # Get stores managed by this supervisor
-    try:
-        stores = frappe.get_all(
-            "Warehouse",
-            filters={"custom_area_supervisor": area_supervisor},
-            pluck="name"
-        )
-    except Exception:
-        # custom_area_supervisor field may not exist in this environment
-        stores = []
+	today = nowdate()
+	if period == "week":
+		start_date = add_days(today, -7)
+	elif period == "month":
+		start_date = add_days(today, -30)
+	else:
+		start_date = add_days(today, -7)
 
-    if not stores:
-        return {"stores": [], "kpis": {}}
+	# Orders
+	orders = frappe.db.count("BEI Store Order", filters={"store": store, "order_date": [">=", start_date]})
+	pending_orders = frappe.db.count(
+		"BEI Store Order", filters={"store": store, "status": "Pending Approval"}
+	)
 
-    today = nowdate()
-    start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
+	# FQI
+	fqi_count = frappe.db.count("BEI FQI Report", filters={"store": store, "reported_at": [">=", start_date]})
+	open_fqi = frappe.db.count("BEI FQI Report", filters={"store": store, "status": "Open"})
 
-    total_orders = 0
-    total_pending = 0
-    total_fqi = 0
+	# Receiving
+	receiving_count = frappe.db.count(
+		"BEI Store Receiving", filters={"store": store, "receiving_date": [">=", start_date]}
+	)
 
-    for store in stores:
-        total_orders += frappe.db.count(
-            "BEI Store Order",
-            filters={"store": store, "order_date": [">=", start_date]}
-        )
-        total_pending += frappe.db.count(
-            "BEI Store Order",
-            filters={"store": store, "status": "Pending Approval"}
-        )
-        total_fqi += frappe.db.count(
-            "BEI FQI Report",
-            filters={"store": store, "reported_at": [">=", start_date]}
-        )
+	# Checklists
+	opening_count = frappe.db.count(
+		"BEI Store Opening Report", filters={"store": store, "report_date": [">=", start_date]}
+	)
+	closing_count = frappe.db.count(
+		"BEI Store Closing Report", filters={"store": store, "report_date": [">=", start_date]}
+	)
 
-    return {
-        "stores": stores,
-        "store_count": len(stores),
-        "kpis": {
-            "total_orders": total_orders,
-            "pending_approvals": total_pending,
-            "total_fqi": total_fqi
-        }
-    }
-
-
-@frappe.whitelist()
-def get_ops_dashboard(period="week"):
-    """Get company-wide operations dashboard."""
-    today = nowdate()
-    start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
-
-    return {
-        "period": period,
-        "kpis": {
-            "total_orders": frappe.db.count("BEI Store Order", filters={"order_date": [">=", start_date]}),
-            "pending_approvals": frappe.db.count("BEI Store Order", filters={"status": "Pending Approval"}),
-            "total_fqi": frappe.db.count("BEI FQI Report", filters={"reported_at": [">=", start_date]}),
-            "open_fqi": frappe.db.count("BEI FQI Report", filters={"status": "Open"}),
-            "trips_today": frappe.db.count("BEI Distribution Trip", filters={"trip_date": today}),
-            "support_tickets_open": frappe.db.count("BEI Support Ticket", filters={"status": "Open"})
-        }
-    }
+	return {
+		"store": store,
+		"period": period,
+		"kpis": {
+			"total_orders": orders,
+			"pending_approvals": pending_orders,
+			"fqi_incidents": fqi_count,
+			"open_fqi": open_fqi,
+			"deliveries_received": receiving_count,
+			"opening_reports": opening_count,
+			"closing_reports": closing_count,
+		},
+	}
 
 
 @frappe.whitelist()
-def get_sales_trend(store=None, period="week"):
-    """Get sales trend from POS uploads."""
-    if not store:
-        return {"trend": []}
-    today = nowdate()
-    start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
+def get_area_dashboard(area_supervisor: str | None = None, period: str = "week") -> dict:
+	"""Get aggregated dashboard for area supervisor's stores."""
+	if not area_supervisor:
+		area_supervisor = frappe.session.user
 
-    data = frappe.get_all(
-        "BEI POS Upload",
-        filters={"store": store, "pos_date": [">=", start_date]},
-        fields=["pos_date", "gross_sales", "net_sales", "transaction_count"],
-        order_by="pos_date asc"
-    )
-    return {"trend": data}
+	# Get stores managed by this supervisor
+	try:
+		stores = frappe.get_all(
+			"Warehouse", filters={"custom_area_supervisor": area_supervisor}, pluck="name"
+		)
+	except Exception:
+		# custom_area_supervisor field may not exist in this environment
+		stores = []
+
+	if not stores:
+		return {"stores": [], "kpis": {}}
+
+	today = nowdate()
+	start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
+
+	total_orders = 0
+	total_pending = 0
+	total_fqi = 0
+
+	for store in stores:
+		total_orders += frappe.db.count(
+			"BEI Store Order", filters={"store": store, "order_date": [">=", start_date]}
+		)
+		total_pending += frappe.db.count(
+			"BEI Store Order", filters={"store": store, "status": "Pending Approval"}
+		)
+		total_fqi += frappe.db.count(
+			"BEI FQI Report", filters={"store": store, "reported_at": [">=", start_date]}
+		)
+
+	return {
+		"stores": stores,
+		"store_count": len(stores),
+		"kpis": {"total_orders": total_orders, "pending_approvals": total_pending, "total_fqi": total_fqi},
+	}
 
 
 @frappe.whitelist()
-def get_fqi_trend(store=None, period="week"):
-    """Get FQI incident trend."""
-    today = nowdate()
-    start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
+def get_ops_dashboard(period: str = "week") -> dict:
+	"""Get company-wide operations dashboard."""
+	today = nowdate()
+	start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
 
-    filters = {"reported_at": [">=", start_date]}
-    if store:
-        filters["store"] = store
+	return {
+		"period": period,
+		"kpis": {
+			"total_orders": frappe.db.count("BEI Store Order", filters={"order_date": [">=", start_date]}),
+			"pending_approvals": frappe.db.count("BEI Store Order", filters={"status": "Pending Approval"}),
+			"total_fqi": frappe.db.count("BEI FQI Report", filters={"reported_at": [">=", start_date]}),
+			"open_fqi": frappe.db.count("BEI FQI Report", filters={"status": "Open"}),
+			"trips_today": frappe.db.count("BEI Distribution Trip", filters={"trip_date": today}),
+			"support_tickets_open": frappe.db.count("BEI Support Ticket", filters={"status": "Open"}),
+		},
+	}
 
-    # Group by issue type
-    if store:
-        sql = """
+
+@frappe.whitelist()
+def get_sales_trend(store: str | None = None, period: str = "week") -> dict:
+	"""Get sales trend from the API-backed daily sales source with legacy fallback."""
+	if not store:
+		return {"trend": []}
+	today = nowdate()
+	start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
+
+	data = frappe.get_all(
+		"BEI Store Sales Day",
+		filters={"store": store, "business_date": [">=", start_date]},
+		fields=[
+			"business_date as pos_date",
+			"gross_sales",
+			"net_sales",
+			"cups_sold as transaction_count",
+			"source_system",
+		],
+		order_by="business_date asc",
+	)
+	if data:
+		return {"trend": data, "source": "BEI Store Sales Day"}
+
+	legacy_data = frappe.get_all(
+		"BEI POS Upload",
+		filters={"store": store, "pos_date": [">=", start_date]},
+		fields=["pos_date", "gross_sales", "net_sales", "transaction_count"],
+		order_by="pos_date asc",
+	)
+	return {"trend": legacy_data, "source": "BEI POS Upload"}
+
+
+@frappe.whitelist()
+def get_fqi_trend(store: str | None = None, period: str = "week") -> dict:
+	"""Get FQI incident trend."""
+	today = nowdate()
+	start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
+
+	filters = {"reported_at": [">=", start_date]}
+	if store:
+		filters["store"] = store
+
+	# Group by issue type
+	if store:
+		sql = """
             SELECT issue_type, COUNT(*) as count
             FROM `tabBEI FQI Report`
             WHERE reported_at >= %s AND store = %s
             GROUP BY issue_type
         """
-        by_type = frappe.db.sql(sql, [start_date, store], as_dict=True)
-    else:
-        sql = """
+		by_type = frappe.db.sql(sql, [start_date, store], as_dict=True)
+	else:
+		sql = """
             SELECT issue_type, COUNT(*) as count
             FROM `tabBEI FQI Report`
             WHERE reported_at >= %s
             GROUP BY issue_type
         """
-        by_type = frappe.db.sql(sql, [start_date], as_dict=True)
+		by_type = frappe.db.sql(sql, [start_date], as_dict=True)
 
-    return {"by_type": by_type}
+	return {"by_type": by_type}
 
 
 @frappe.whitelist()
-def get_order_fulfillment_rate(store=None, period="week"):
-    """Get order fulfillment statistics."""
-    today = nowdate()
-    start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
+def get_order_fulfillment_rate(store: str | None = None, period: str = "week") -> dict:
+	"""Get order fulfillment statistics."""
+	today = nowdate()
+	start_date = add_days(today, -7) if period == "week" else add_days(today, -30)
 
-    filters = {"order_date": [">=", start_date]}
-    if store:
-        filters["store"] = store
+	filters = {"order_date": [">=", start_date]}
+	if store:
+		filters["store"] = store
 
-    total = frappe.db.count("BEI Store Order", filters=filters)
+	total = frappe.db.count("BEI Store Order", filters=filters)
 
-    delivered_filters = {**filters, "status": "Delivered"}
-    delivered = frappe.db.count("BEI Store Order", filters=delivered_filters)
+	delivered_filters = {**filters, "status": "Delivered"}
+	delivered = frappe.db.count("BEI Store Order", filters=delivered_filters)
 
-    return {
-        "total_orders": total,
-        "delivered": delivered,
-        "fulfillment_rate": round((delivered / total * 100), 1) if total > 0 else 0
-    }
+	return {
+		"total_orders": total,
+		"delivered": delivered,
+		"fulfillment_rate": round((delivered / total * 100), 1) if total > 0 else 0,
+	}

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -3011,6 +3011,12 @@ def upload_pos_data(
 	    notes: Optional notes
 	    skip_date_validation: Skip date validation (for back-dated uploads with supervisor approval)
 	"""
+	frappe.throw(
+		_(
+			"Manual POS uploads are disabled. Sales now sync automatically via API. "
+			"Use Closing Report for X/Z-reading evidence, cash control, and POS-down exceptions."
+		)
+	)
 	validate_store_ops_role()
 
 	if not store:

--- a/hrms/tests/test_store_pos_upload_contract.py
+++ b/hrms/tests/test_store_pos_upload_contract.py
@@ -114,52 +114,34 @@ class TestStorePosUploadContract(unittest.TestCase):
 		self.assertEqual(captured["attached_to_field"], "sales_summary")
 		self.assertEqual(captured["content"], b"spreadsheet-bytes")
 
-	def test_upload_pos_data_sets_mismatch_flag_and_uses_generic_file_saver(self):
-		set_value_calls = []
-		saved_fields = []
-		doc = _FakePosUploadDoc()
+	def test_upload_pos_data_is_hard_disabled(self):
 		payload = base64.b64encode(b"xlsx-bytes").decode()
+		new_doc_calls = []
+		saved_fields = []
 
 		store.validate_store_ops_role = lambda: None
 		store.resolve_warehouse = lambda value: value
-		store.frappe.new_doc = lambda doctype: doc
-		store.frappe.db.set_value = lambda doctype, name, fieldname, value: set_value_calls.append(
-			(doctype, name, fieldname, value)
-		)
+		store.frappe.new_doc = lambda doctype: new_doc_calls.append(doctype) or _FakePosUploadDoc()
 		store.save_base64_file = lambda _data, _doctype, fieldname="attachment", default_ext="bin": (
 			saved_fields.append((fieldname, default_ext)) or f"/files/{fieldname}.{default_ext}"
 		)
 
-		result = store.upload_pos_data(
-			store="Araneta Gateway - Bebang Enterprise Inc.",
-			pos_date="2026-03-10",
-			pos_system="MOSAIC",
-			discount_report=payload,
-			transaction_report=payload,
-			product_mix=payload,
-			daily_sales_revenue=payload,
-			sales_summary=payload,
-			notes="regression test",
-		)
+		with self.assertRaises(Exception) as ctx:
+			store.upload_pos_data(
+				store="Araneta Gateway - Bebang Enterprise Inc.",
+				pos_date="2026-03-10",
+				pos_system="MOSAIC",
+				discount_report=payload,
+				transaction_report=payload,
+				product_mix=payload,
+				daily_sales_revenue=payload,
+				sales_summary=payload,
+				notes="regression test",
+			)
 
-		self.assertTrue(result["success"])
-		self.assertTrue(result["date_mismatch"])
-		self.assertEqual(result["name"], "POS-TEST-0001")
-		self.assertTrue(doc.inserted)
-		self.assertEqual(
-			saved_fields,
-			[
-				("discount_report", "xlsx"),
-				("transaction_report", "xlsx"),
-				("product_mix", "xlsx"),
-				("daily_sales_revenue", "xlsx"),
-				("sales_summary", "xlsx"),
-			],
-		)
-		self.assertEqual(
-			set_value_calls,
-			[("BEI POS Upload", "POS-TEST-0001", "has_date_mismatch", 1)],
-		)
+		self.assertIn("Manual POS uploads are disabled", str(ctx.exception))
+		self.assertEqual(new_doc_calls, [])
+		self.assertEqual(saved_fields, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- hard-disable manual store POS uploads in Frappe
- switch sales trend and Blip sales reads to prefer API-backed daily sales data
- add regression coverage for the disabled upload contract

## Verification
- python -m py_compile hrms\api\store.py hrms\api\dashboard.py hrms\api\blip.py hrms\tests\test_store_pos_upload_contract.py
- local Frappe runtime tests unavailable on this machine because the standalone Python environment does not include frappe