### PR TITLE
fix: keep sheets receiver healthy during startup

### DIFF
--- a/hrms/services/sheets_receiver/main.py
+++ b/hrms/services/sheets_receiver/main.py
@@ -570,6 +570,14 @@ def initial_setup():
 	logger.info("=" * 60)
 
 
+def run_initial_setup_background():
+	"""Run expensive startup setup without blocking the webhook server."""
+	try:
+		initial_setup()
+	except Exception:
+		logger.exception("Background initial setup failed")
+
+
 def handle_shutdown(signum, frame):
 	"""Handle shutdown signals gracefully."""
 	logger.info("Shutdown signal received, cleaning up...")
@@ -589,8 +597,10 @@ def main():
 	signal.signal(signal.SIGTERM, handle_shutdown)
 	signal.signal(signal.SIGINT, handle_shutdown)
 
-	# Initial setup
-	initial_setup()
+	# Keep startup health checks responsive by running the heavy Google setup,
+	# initial syncs, and POS scans in the background.
+	initial_setup_thread = threading.Thread(target=run_initial_setup_background, daemon=True)
+	initial_setup_thread.start()
 
 	# Keep the 8AM baseline independent from the shared schedule loop so it cannot
 	# be delayed by long-running watch-renewal or file-processing work.

--- a/hrms/tests/test_sheets_receiver_main.py
+++ b/hrms/tests/test_sheets_receiver_main.py
@@ -303,5 +303,69 @@ class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
 		mock_run.assert_not_called()
 
 
+class TestSheetsReceiverStartup(unittest.TestCase):
+	def test_main_starts_webhook_server_without_waiting_for_initial_setup(self):
+		started_threads = []
+
+		class _FakeThread:
+			def __init__(self, *, target, daemon):
+				self.target = target
+				self.daemon = daemon
+				self.started = False
+
+			def start(self):
+				self.started = True
+				started_threads.append(self)
+
+		original_setup_file_logging = main_mod.setup_file_logging
+		original_signal = main_mod.signal.signal
+		original_run_initial_setup_background = main_mod.run_initial_setup_background
+		original_run_daily_baseline_loop = main_mod.run_daily_baseline_loop
+		original_run_scheduler = main_mod.run_scheduler
+		original_run_server = main_mod.run_server
+		original_thread = main_mod.threading.Thread
+
+		setup_file_logging = MagicMock()
+		signal_handler = MagicMock()
+		run_initial_setup_background = MagicMock()
+		run_daily_baseline_loop = MagicMock()
+		run_scheduler = MagicMock()
+		run_server = MagicMock()
+
+		main_mod.setup_file_logging = setup_file_logging
+		main_mod.signal.signal = signal_handler
+		main_mod.run_initial_setup_background = run_initial_setup_background
+		main_mod.run_daily_baseline_loop = run_daily_baseline_loop
+		main_mod.run_scheduler = run_scheduler
+		main_mod.run_server = run_server
+		main_mod.threading.Thread = _FakeThread
+
+		try:
+			main_mod.main()
+		finally:
+			main_mod.setup_file_logging = original_setup_file_logging
+			main_mod.signal.signal = original_signal
+			main_mod.run_initial_setup_background = original_run_initial_setup_background
+			main_mod.run_daily_baseline_loop = original_run_daily_baseline_loop
+			main_mod.run_scheduler = original_run_scheduler
+			main_mod.run_server = original_run_server
+			main_mod.threading.Thread = original_thread
+
+		setup_file_logging.assert_called_once_with()
+		signal_handler.assert_any_call(main_mod.signal.SIGTERM, main_mod.handle_shutdown)
+		signal_handler.assert_any_call(main_mod.signal.SIGINT, main_mod.handle_shutdown)
+		self.assertEqual(
+			[thread.target for thread in started_threads],
+			[
+				run_initial_setup_background,
+				run_daily_baseline_loop,
+				run_scheduler,
+			],
+		)
+		self.assertTrue(all(thread.daemon for thread in started_threads))
+		self.assertTrue(all(thread.started for thread in started_threads))
+		run_server.assert_called_once_with()
+
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Summary
- start the heavy sheets-receiver initial setup in a background thread
- keep the 8 AM baseline loop and scheduler threads non-blocking
- add startup coverage so main() starts the webhook server without waiting for initial setup

## Testing
- python -m compileall hrms/services/sheets_receiver/main.py hrms/tests/test_sheets_receiver_main.py
- ruff check hrms/services/sheets_receiver/main.py hrms/tests/test_sheets_receiver_main.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_sheets_receiver_main.py hrms/tests/test_sheets_receiver_processor.py -q