### PR TITLE
fix: add morning sync health reporting

### DIFF
--- a/docs/plans/2026-03-10-sprint-31-store-inventory-import-and-shadow-sync.md
+++ b/docs/plans/2026-03-10-sprint-31-store-inventory-import-and-shadow-sync.md
@@ -25,7 +25,7 @@ Tuesday, 2026-03-10 cutover prep + temporary bridge until each store fully cuts 
 Create a controlled store-inventory bridge that:
 
 1. Imports the extracted `3. INVENTORY` current balances into Frappe as store opening stock.
-2. Keeps store inventory mirrored from Google Sheets every morning at **8:00 AM PHT** until cutover is complete.
+2. Keeps store inventory mirrored from Google Sheets every morning at **7:00 AM PHT** until cutover is complete.
 3. Preserves the full workbook history for analytics without polluting Frappe's live stock ledger with synthetic historical transactions.
 4. Stops sheet-driven updates per store the moment that store starts using Frappe/my.bebang.ph as the stock source of truth.
 5. Tracks the linked reordering dependency: store order prefills must become sales-driven, and current FoodPanda workbook data only supports consolidated sales until an item-level FoodPanda pipeline exists.
@@ -51,7 +51,7 @@ Create a controlled store-inventory bridge that:
   - `hrms/tests/test_erp_sync.py` `test_sync_inventory_is_idempotent_by_sync_reference`
 - Sheets Receiver already provides a production scheduler, checksum tracking, retries, and webhook/watch management:
   - `hrms/services/sheets_receiver/`
-- Existing scheduler currently runs fallback sheet sync every `6` hours, not at `8:00 AM PHT`:
+- Existing scheduler currently runs fallback sheet sync every `6` hours, not at `7:00 AM PHT`:
   - `hrms/services/sheets_receiver/main.py`
 - Existing in-app stock count / daily stock update path already exists for post-cutover operation:
   - `hrms/api/inventory.py` `daily_stock_update`
@@ -115,7 +115,7 @@ Some older docs still describe `erp_sync.sync_inventory` as a log-only stub. The
 | FoodPanda order-header sales pipeline | workbook tabs `FP SUMMARY` -> `FP_CLEAN` -> `FP_REJECTS` -> `SALES_FACT_DAILY_FINAL`; `scripts/sync_foodpanda_to_supabase.py` | `[EXTEND]` | Keep this as the consolidated-sales and P&L revenue path |
 | Current snapshot -> Frappe payload transform | no dedicated transformer found | `[BUILD]` | Build a bridge script that outputs `item_code, warehouse, qty` rows |
 | Per-store cutover switch | no explicit cutover registry found | `[BUILD]` | Build an operator-visible cutover config to disable sheet sync store-by-store |
-| Morning 8AM inventory job | no store-workbook-specific 8AM job found | `[BUILD]` | Build a new scheduled runner on top of existing service patterns |
+| Morning 7AM inventory job | no store-workbook-specific 7AM job found | `[BUILD]` | Build a new scheduled runner on top of existing service patterns |
 | Sales-driven store demand snapshot | no store-item demand snapshot feeding `get_orderable_items` found | `[BUILD]` | Build a compact Frappe-side demand snapshot fed by Supabase sales + stock |
 | FoodPanda item-level workbook pipeline | no `FP_ITEMS_*` / `SALES_FACT_ITEM_DAILY` flow found | `[BUILD]` | Add a dedicated FoodPanda item pipeline so the channel can participate in future item-level reorder forecasts |
 | New frontend admin UI for sync control | none required for first delivery | `[SKIP]` | Keep control in config/runbook first; add UI only if operator friction appears |
@@ -124,7 +124,7 @@ Some older docs still describe `erp_sync.sync_inventory` as a log-only stub. The
 
 - Importing the extracted store `3. INVENTORY` current balances into Frappe store warehouses
 - Building the transformation and exception pipeline needed before calling `sync_inventory`
-- Adding an **8:00 AM PHT** automated shadow sync for store workbooks
+- Adding a **7:00 AM PHT** automated shadow sync for store workbooks
 - Per-store sync enable/disable and cutover state
 - Verification against `Bin.actual_qty` and store ordering availability
 - Preserving workbook history for analytics

--- a/docs/plans/2026-03-11-ian-warehouse-inventory-baseline-sync.md
+++ b/docs/plans/2026-03-11-ian-warehouse-inventory-baseline-sync.md
@@ -4,7 +4,7 @@ Date: 2026-03-11
 
 ## Purpose
 
-Prepare Frappe inventory so Ian can start warehouse operations from Frappe with a daily 8:00 AM PHT baseline sync from the active warehouse workbook.
+Prepare Frappe inventory so Ian can start warehouse operations from Frappe with a daily 7:00 AM PHT baseline sync from the active warehouse workbook.
 
 ## Active Source
 
@@ -29,7 +29,7 @@ Each transformed row is keyed by `inventory_key = <warehouse_code>::<item_code>`
 
 ## Runtime Behavior
 
-- Daily baseline scheduler includes `inventory` at `8:00 AM PHT`
+- Daily baseline scheduler includes `inventory` at `7:00 AM PHT`
 - Manual force sync endpoint:
   - `POST /api/sync/inventory?force=true`
 - Receiver sends `inventory` in per-warehouse chunks using `warehouse_source_code`

--- a/docs/runbooks/store-inventory-cutover-toggle.md
+++ b/docs/runbooks/store-inventory-cutover-toggle.md
@@ -14,7 +14,7 @@ Do not edit the fixture unless you are changing the default seed for future envi
 ## State Meanings
 
 - `shadow_sync`
-  The store still uses the Google Sheet as the operational stock source. Daily `8:00 AM PHT` sync remains active.
+  The store still uses the Google Sheet as the operational stock source. Daily `7:00 AM PHT` sync remains active.
 
 - `cutover_ready`
   The store is preparing to cut over. The bridge skips it.

--- a/docs/runbooks/store-inventory-shadow-sync-runbook.md
+++ b/docs/runbooks/store-inventory-shadow-sync-runbook.md
@@ -2,13 +2,38 @@
 
 ## Purpose
 
-Mirror each enabled store's Google Sheet `3. INVENTORY` tab into Frappe every day at `8:00 AM PHT` (`00:00 UTC`) until that store cuts over to Frappe/my.bebang as the stock source of truth.
+Mirror each enabled store's Google Sheet `3. INVENTORY` tab into Frappe every day at `7:00 AM PHT` (`23:00 UTC` previous day) until that store cuts over to Frappe/my.bebang as the stock source of truth.
 
 ## Scheduler
 
 - Hook: `hrms.api.erp_sync.enqueue_scheduled_store_inventory_shadow_sync`
-- Schedule: `0 0 * * *`
+- Schedule: `0 23 * * *`
 - Runtime job: `hrms.api.erp_sync.run_scheduled_store_inventory_shadow_sync`
+- Morning health report schedule: `15 0 * * *`
+- Morning health report writer: `hrms.api.erp_sync.scheduled_generate_morning_sync_health_report`
+
+## Morning Health Report
+
+Use the morning report to confirm, before `9:00 AM PHT`, whether all critical sync lanes are ready:
+
+- store inventory shadow sync
+- Ian warehouse inventory baseline
+- AP / procurement baselines
+
+API entry point:
+
+- `hrms.api.erp_sync.get_morning_sync_health_report`
+
+Artifact paths:
+
+- `sites/<site>/private/files/morning_sync_health_reports/YYYY-MM-DD_morning_sync_health_report.json`
+- `sites/<site>/private/files/morning_sync_health_reports/YYYY-MM-DD_morning_sync_health_report.md`
+
+Status meaning:
+
+- `green`: every area completed before `9:00 AM PHT` with no failed-row exceptions
+- `yellow`: every area completed before `9:00 AM PHT`, but at least one area completed with exceptions
+- `red`: at least one area missed the deadline or the receiver summary could not be fetched
 
 ## Registry And State
 

--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -2877,9 +2877,7 @@ def _summarize_receiver_area(
 	all_ready = all(bool(lane.get("ready_before_deadline")) for lane in lanes)
 	all_clean = all(bool(lane.get("clean_success")) for lane in lanes)
 	completion_values = sorted(
-		completed_at
-		for lane in lanes
-		if (completed_at := lane.get("completed_at_pht"))
+		completed_at for lane in lanes if (completed_at := lane.get("completed_at_pht"))
 	)
 	if all_ready and all_clean:
 		status = "green"
@@ -3072,7 +3070,9 @@ def _persist_morning_sync_health_report(report: dict[str, Any]) -> dict[str, str
 	return {"json_path": str(json_path), "markdown_path": str(md_path)}
 
 
-def _collect_morning_sync_health_report(report_date: str | None = None, *, persist: bool = False) -> dict[str, Any]:
+def _collect_morning_sync_health_report(
+	report_date: str | None = None, *, persist: bool = False
+) -> dict[str, Any]:
 	"""Collect the consolidated morning report across store shadow sync and receiver baselines."""
 	report_date_value = _normalize_report_date(report_date)
 	report_date_text = report_date_value.isoformat()
@@ -3126,7 +3126,9 @@ def _collect_morning_sync_health_report(report_date: str | None = None, *, persi
 def get_morning_sync_health_report(report_date: str | None = None, persist: bool = False):
 	"""Return the consolidated morning report for store inventory, Ian inventory, and AP/procurement."""
 	_assert_sync_authorized()
-	persist_flag = persist if isinstance(persist, bool) else str(persist).strip().lower() in {"1", "true", "yes", "on"}
+	persist_flag = (
+		persist if isinstance(persist, bool) else str(persist).strip().lower() in {"1", "true", "yes", "on"}
+	)
 	return _collect_morning_sync_health_report(report_date=report_date, persist=persist_flag)
 
 

--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -12,6 +12,7 @@ import re
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import frappe
 from frappe import _
@@ -41,6 +42,11 @@ INVENTORY_BASELINE_SHEET_NAME = "Inventory"
 INVENTORY_BASELINE_BATCH_PREFIX = "INVBASE"
 STORE_INVENTORY_SHADOW_STALE_AFTER_MINUTES = 20
 STORE_INVENTORY_SHADOW_RECOVERY_COOLDOWN_MINUTES = 20
+PHT_TIMEZONE = ZoneInfo("Asia/Manila")
+MORNING_SYNC_TARGET_PHT_TIME = datetime.time(hour=7, minute=0)
+MORNING_SYNC_READY_DEADLINE_PHT_TIME = datetime.time(hour=9, minute=0)
+MORNING_SYNC_REPORT_DIRNAME = "morning_sync_health_reports"
+RECEIVER_MORNING_HEALTH_URL = "http://sheets-receiver:8765/api/morning-health"
 PO_REFERENCE_RE = re.compile(r"^\s*(?:PO|PURCHASE\s*ORDER)\s*[-#:/]?\s*[A-Z0-9-]+\s*$", re.IGNORECASE)
 
 
@@ -2800,3 +2806,330 @@ def trigger_sync(sheet_key: str | None = None, force: bool = False):
 		return response.json()
 	except Exception as e:
 		return {"status": "error", "message": str(e)}
+
+
+def _normalize_report_date(report_date: str | None) -> datetime.date:
+	"""Normalize a requested report date in site-local terms."""
+	return getdate(report_date or nowdate())
+
+
+def _parse_iso_datetime(value: str | None) -> datetime.datetime | None:
+	"""Parse an ISO timestamp with sane fallback for legacy values."""
+	if not value:
+		return None
+	try:
+		parsed = datetime.datetime.fromisoformat(str(value))
+	except ValueError:
+		return None
+	if parsed.tzinfo is None:
+		return parsed.replace(tzinfo=datetime.UTC)
+	return parsed.astimezone(datetime.UTC)
+
+
+def _to_pht_iso(value: datetime.datetime | None) -> str | None:
+	"""Render a UTC or naive datetime as an ISO timestamp in PHT."""
+	if value is None:
+		return None
+	if value.tzinfo is None:
+		value = value.replace(tzinfo=datetime.UTC)
+	return value.astimezone(PHT_TIMEZONE).isoformat()
+
+
+def _morning_sync_report_dir() -> Path:
+	"""Return the site-private output directory for morning sync health reports."""
+	return Path(frappe.get_site_path("private", "files", MORNING_SYNC_REPORT_DIRNAME))
+
+
+def _morning_sync_report_paths(report_date: str) -> tuple[Path, Path]:
+	"""Return the JSON and Markdown artifact paths for a report date."""
+	report_dir = _morning_sync_report_dir()
+	report_dir.mkdir(parents=True, exist_ok=True)
+	return (
+		report_dir / f"{report_date}_morning_sync_health_report.json",
+		report_dir / f"{report_date}_morning_sync_health_report.md",
+	)
+
+
+def _summarize_receiver_area(
+	receiver_report: dict[str, Any],
+	*,
+	key: str,
+	label: str,
+	sheet_keys: list[str],
+) -> dict[str, Any]:
+	"""Summarize one logical receiver area from lane-level health rows."""
+	lanes = [
+		lane
+		for lane in receiver_report.get("lanes", [])
+		if lane.get("sheet_key") in sheet_keys and lane.get("status") not in {"disabled", "missing"}
+	]
+	if not lanes:
+		return {
+			"key": key,
+			"label": label,
+			"status": "red",
+			"ready_before_deadline": False,
+			"clean_success": False,
+			"completed_at_pht": None,
+			"lanes": [],
+		}
+
+	all_ready = all(bool(lane.get("ready_before_deadline")) for lane in lanes)
+	all_clean = all(bool(lane.get("clean_success")) for lane in lanes)
+	completion_values = sorted(
+		completed_at
+		for lane in lanes
+		if (completed_at := lane.get("completed_at_pht"))
+	)
+	if all_ready and all_clean:
+		status = "green"
+	elif all_ready:
+		status = "yellow"
+	else:
+		status = "red"
+
+	return {
+		"key": key,
+		"label": label,
+		"status": status,
+		"ready_before_deadline": all_ready,
+		"clean_success": all_clean,
+		"completed_at_pht": completion_values[-1] if completion_values else None,
+		"lanes": lanes,
+	}
+
+
+def _build_store_inventory_morning_health(report_date_value: datetime.date) -> dict[str, Any]:
+	"""Build readiness and cleanliness status for the store shadow-sync bridge."""
+	registry_rows = store_inventory_shadow_sync_builder.load_store_registry(
+		store_inventory_shadow_sync_builder.get_runtime_registry_path()
+	)
+	runtime_state = store_inventory_shadow_sync_builder.load_runtime_state(
+		store_inventory_shadow_sync_builder.get_runtime_state_path()
+	)
+	importable_states = getattr(store_inventory_shadow_sync_builder, "IMPORTABLE_STATES", {"shadow_sync"})
+	target_rows = [
+		row
+		for row in registry_rows
+		if getattr(row, "sheet_sync_enabled", False) and getattr(row, "state", "") in importable_states
+	]
+	report_date_text = report_date_value.isoformat()
+	deadline_utc = datetime.datetime.combine(
+		report_date_value,
+		MORNING_SYNC_READY_DEADLINE_PHT_TIME,
+		tzinfo=PHT_TIMEZONE,
+	).astimezone(datetime.UTC)
+
+	completed_store_codes: list[str] = []
+	pending_store_codes: list[str] = []
+	late_store_codes: list[str] = []
+	error_rows: list[dict[str, str]] = []
+	completion_times: list[datetime.datetime] = []
+
+	for row in target_rows:
+		last_success_at = _parse_iso_datetime(getattr(row, "last_success_at", ""))
+		last_inventory_date = getattr(row, "last_inventory_date", "")
+		if last_success_at and last_inventory_date == report_date_text:
+			completed_store_codes.append(row.store_code)
+			completion_times.append(last_success_at)
+			if last_success_at > deadline_utc:
+				late_store_codes.append(row.store_code)
+		else:
+			pending_store_codes.append(row.store_code)
+
+		last_error = getattr(row, "last_error", "")
+		if last_error:
+			error_rows.append({"store_code": row.store_code, "error": last_error})
+
+	latest_completion = max(completion_times) if completion_times else None
+	ready_before_deadline = bool(target_rows) and not pending_store_codes and not late_store_codes
+	clean_success = ready_before_deadline and not error_rows
+	if clean_success:
+		status = "green"
+	elif ready_before_deadline:
+		status = "yellow"
+	else:
+		status = "red"
+
+	last_run = runtime_state.get("last_run", {}) if isinstance(runtime_state, dict) else {}
+	return {
+		"key": "store_inventory_shadow_sync",
+		"label": "Store Inventory Shadow Sync",
+		"status": status,
+		"ready_before_deadline": ready_before_deadline,
+		"clean_success": clean_success,
+		"report_date": report_date_text,
+		"enabled_stores": len(target_rows),
+		"completed_stores": len(completed_store_codes),
+		"pending_store_codes": pending_store_codes,
+		"late_store_codes": late_store_codes,
+		"error_stores": error_rows,
+		"latest_completion_at_pht": _to_pht_iso(latest_completion),
+		"last_run": {
+			"status": last_run.get("status"),
+			"run_date": last_run.get("run_date"),
+			"generated_at": last_run.get("generated_at"),
+			"updated_at": last_run.get("updated_at"),
+			"failed_stores": last_run.get("failed_stores"),
+			"current_stage": last_run.get("current_stage"),
+		},
+	}
+
+
+def _fetch_receiver_morning_health(report_date: str) -> dict[str, Any]:
+	"""Fetch the receiver-side health summary without failing the whole report on transport errors."""
+	import requests
+
+	try:
+		response = requests.get(
+			RECEIVER_MORNING_HEALTH_URL,
+			params={"report_date": report_date},
+			timeout=15,
+		)
+		response.raise_for_status()
+		return response.json()
+	except Exception as exc:
+		return {
+			"service": "sheets-receiver",
+			"report_date": report_date,
+			"generated_at_utc": datetime.datetime.now(datetime.UTC).isoformat(),
+			"generated_at_pht": datetime.datetime.now(PHT_TIMEZONE).isoformat(),
+			"baseline_target_pht_time": MORNING_SYNC_TARGET_PHT_TIME.strftime("%H:%M"),
+			"ready_deadline_pht_time": MORNING_SYNC_READY_DEADLINE_PHT_TIME.strftime("%H:%M"),
+			"status": "red",
+			"ready_before_deadline": False,
+			"error": str(exc),
+			"lanes": [],
+		}
+
+
+def _build_morning_sync_health_markdown(report: dict[str, Any]) -> str:
+	"""Render a compact Markdown summary for the morning sync health artifact."""
+	lines = [
+		"# Morning Sync Health Report",
+		"",
+		f"- report_date: `{report['report_date']}`",
+		f"- overall_status: `{report['status']}`",
+		f"- sync_target_pht_time: `{report['sync_target_pht_time']}`",
+		f"- ready_deadline_pht_time: `{report['ready_deadline_pht_time']}`",
+		f"- generated_at_pht: `{report['generated_at_pht']}`",
+		"",
+	]
+	for area in report["areas"]:
+		lines.extend(
+			[
+				f"## {area['label']}",
+				"",
+				f"- status: `{area['status']}`",
+				f"- ready_before_deadline: `{area['ready_before_deadline']}`",
+			]
+		)
+		if area["key"] == "store_inventory_shadow_sync":
+			lines.extend(
+				[
+					f"- completed_stores: `{area['completed_stores']}/{area['enabled_stores']}`",
+					f"- latest_completion_at_pht: `{area['latest_completion_at_pht'] or ''}`",
+				]
+			)
+			if area["pending_store_codes"]:
+				lines.append(f"- pending_store_codes: `{', '.join(area['pending_store_codes'])}`")
+			if area["late_store_codes"]:
+				lines.append(f"- late_store_codes: `{', '.join(area['late_store_codes'])}`")
+			if area["error_stores"]:
+				lines.append(f"- error_store_count: `{len(area['error_stores'])}`")
+		else:
+			lines.extend(
+				[
+					f"- completed_at_pht: `{area.get('completed_at_pht') or ''}`",
+					f"- lane_count: `{len(area.get('lanes', []))}`",
+				]
+			)
+		lines.append("")
+
+	if report.get("receiver", {}).get("error"):
+		lines.extend(["## Receiver Error", "", f"- `{report['receiver']['error']}`", ""])
+
+	lines.extend(["## Receiver Lane Detail", ""])
+	for lane in report.get("receiver", {}).get("lanes", []):
+		lines.append(
+			"- `{name}` [{sheet_key}] status=`{status}` ready_before_deadline=`{ready}` completed_at_pht=`{completed}`".format(
+				name=lane.get("name", lane.get("sheet_key", "lane")),
+				sheet_key=lane.get("sheet_key", "lane"),
+				status=lane.get("status", "unknown"),
+				ready=lane.get("ready_before_deadline"),
+				completed=lane.get("completed_at_pht") or "",
+			)
+		)
+
+	return "\n".join(lines).rstrip() + "\n"
+
+
+def _persist_morning_sync_health_report(report: dict[str, Any]) -> dict[str, str]:
+	"""Write the JSON and Markdown artifacts for a morning sync health report."""
+	json_path, md_path = _morning_sync_report_paths(report["report_date"])
+	json_path.write_text(json.dumps(report, indent=2, ensure_ascii=False), encoding="utf-8")
+	md_path.write_text(_build_morning_sync_health_markdown(report), encoding="utf-8")
+	return {"json_path": str(json_path), "markdown_path": str(md_path)}
+
+
+def _collect_morning_sync_health_report(report_date: str | None = None, *, persist: bool = False) -> dict[str, Any]:
+	"""Collect the consolidated morning report across store shadow sync and receiver baselines."""
+	report_date_value = _normalize_report_date(report_date)
+	report_date_text = report_date_value.isoformat()
+	receiver_report = _fetch_receiver_morning_health(report_date_text)
+	store_area = _build_store_inventory_morning_health(report_date_value)
+	ian_area = _summarize_receiver_area(
+		receiver_report,
+		key="ian_warehouse_inventory",
+		label="Ian Warehouse Inventory",
+		sheet_keys=["inventory"],
+	)
+	ap_procurement_area = _summarize_receiver_area(
+		receiver_report,
+		key="ap_procurement_baselines",
+		label="AP / Procurement Baselines",
+		sheet_keys=[
+			"ap_opening_balance",
+			"procurement_suppliers",
+			"procurement_requisitions",
+			"procurement_purchase_orders",
+			"procurement_goods_receipts",
+		],
+	)
+	areas = [store_area, ian_area, ap_procurement_area]
+	all_ready = all(bool(area.get("ready_before_deadline")) for area in areas)
+	all_clean = all(bool(area.get("clean_success")) for area in areas)
+	if all_ready and all_clean:
+		status = "green"
+	elif all_ready:
+		status = "yellow"
+	else:
+		status = "red"
+
+	report = {
+		"report_date": report_date_text,
+		"generated_at_utc": datetime.datetime.now(datetime.UTC).isoformat(),
+		"generated_at_pht": datetime.datetime.now(PHT_TIMEZONE).isoformat(),
+		"sync_target_pht_time": MORNING_SYNC_TARGET_PHT_TIME.strftime("%H:%M"),
+		"ready_deadline_pht_time": MORNING_SYNC_READY_DEADLINE_PHT_TIME.strftime("%H:%M"),
+		"status": status,
+		"ready_before_deadline": all_ready,
+		"areas": areas,
+		"receiver": receiver_report,
+	}
+	if persist:
+		report["artifacts"] = _persist_morning_sync_health_report(report)
+	return report
+
+
+@frappe.whitelist()
+def get_morning_sync_health_report(report_date: str | None = None, persist: bool = False):
+	"""Return the consolidated morning report for store inventory, Ian inventory, and AP/procurement."""
+	_assert_sync_authorized()
+	persist_flag = persist if isinstance(persist, bool) else str(persist).strip().lower() in {"1", "true", "yes", "on"}
+	return _collect_morning_sync_health_report(report_date=report_date, persist=persist_flag)
+
+
+def scheduled_generate_morning_sync_health_report(report_date: str | None = None) -> dict[str, Any]:
+	"""Generate and persist the daily morning sync health report for operations."""
+	return _collect_morning_sync_health_report(report_date=report_date, persist=True)

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -376,10 +376,14 @@ scheduler_events = {
 		],
 		# Monthly billing generation: 6 AM on 1st of each month
 		"0 6 1 * *": ["hrms.api.billing.scheduled_monthly_billing"],
-		# Store demand + inventory shadow sync: 8:00 AM PHT daily (00:00 UTC)
-		"0 0 * * *": [
+		# Store demand + inventory shadow sync: 7:00 AM PHT daily (23:00 UTC previous day)
+		"0 23 * * *": [
 			"hrms.api.erp_sync.enqueue_scheduled_store_inventory_shadow_sync",
 			"hrms.api.erp_sync.enqueue_scheduled_store_demand_snapshot_sync",
+		],
+		# Morning sync health report: 8:15 AM PHT daily (00:15 UTC) after sync buffer
+		"15 0 * * *": [
+			"hrms.api.erp_sync.scheduled_generate_morning_sync_health_report",
 		],
 		# Store inventory shadow sync watchdog: resume stale in-progress runs after deploy interruptions
 		"*/10 * * * *": [

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -370,17 +370,14 @@ scheduler_events = {
 		"0 0,6,12,18 * * *": [
 			"hrms.utils.adms_monitor.refresh_biometric_status",
 		],
-		# Biometric daily digest: 7 AM PHT = 23:00 UTC (previous day)
+		# Biometric daily digest + store syncs: 7 AM PHT = 23:00 UTC (previous day)
 		"0 23 * * *": [
 			"hrms.utils.biometric_alerts.send_daily_digest",
-		],
-		# Monthly billing generation: 6 AM on 1st of each month
-		"0 6 1 * *": ["hrms.api.billing.scheduled_monthly_billing"],
-		# Store demand + inventory shadow sync: 7:00 AM PHT daily (23:00 UTC previous day)
-		"0 23 * * *": [
 			"hrms.api.erp_sync.enqueue_scheduled_store_inventory_shadow_sync",
 			"hrms.api.erp_sync.enqueue_scheduled_store_demand_snapshot_sync",
 		],
+		# Monthly billing generation: 6 AM on 1st of each month
+		"0 6 1 * *": ["hrms.api.billing.scheduled_monthly_billing"],
 		# Morning sync health report: 8:15 AM PHT daily (00:15 UTC) after sync buffer
 		"15 0 * * *": [
 			"hrms.api.erp_sync.scheduled_generate_morning_sync_health_report",

--- a/hrms/services/sheets_receiver/main.py
+++ b/hrms/services/sheets_receiver/main.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 PHT_TIMEZONE = ZoneInfo("Asia/Manila")
 DAILY_BASELINE_TRIGGER = "daily_baseline"
 INTERVAL_BASELINE_TRIGGER = "interval_baseline"
-DAILY_BASELINE_PHT_TIME = dt_time(hour=8, minute=0)
+DAILY_BASELINE_PHT_TIME = dt_time(hour=7, minute=0)
 BASELINE_LOOP_SLEEP_SECONDS = 30
 DAILY_BASELINE_SHEET_KEYS = (
 	"inventory",
@@ -130,7 +130,7 @@ def _normalize_now_utc(now_utc: datetime | None = None) -> datetime:
 
 
 def get_daily_baseline_sheet_keys() -> tuple[str, ...]:
-	"""Return the sheet keys that must be force-synced at 8:00 AM PHT."""
+	"""Return the sheet keys that must be force-synced at 7:00 AM PHT."""
 	return DAILY_BASELINE_SHEET_KEYS
 
 
@@ -236,7 +236,7 @@ def _run_baseline_sync_guarded(
 
 def run_daily_baseline_sync_if_due(now_utc: datetime | None = None):
 	"""
-	Force-sync Inventory, AP, and Procurement baseline sheets once per PHT day after 8:00 AM.
+	Force-sync Inventory, AP, and Procurement baseline sheets once per PHT day after 7:00 AM.
 
 	This does not rely on the host/container timezone. It checks whether each target
 	sheet already has a successful `daily_baseline` sync logged for the current PHT
@@ -270,7 +270,7 @@ def run_daily_baseline_loop(
 	"""Run the 8AM PHT baseline gate in a dedicated loop so long jobs cannot starve it."""
 	stop_event = stop_event or threading.Event()
 	logger.info(
-		"Daily AP/procurement baseline loop started: every %s seconds, target 8 AM PHT",
+		"Daily AP/procurement baseline loop started: every %s seconds, target 7 AM PHT",
 		sleep_seconds,
 	)
 
@@ -472,7 +472,7 @@ def run_scheduler():
 	logger.info("Scheduler started with jobs:")
 	logger.info("  - Sheet watch renewal: every 1 hour")
 	logger.info("  - Sheet backup sync: every 6 hours")
-	logger.info("  - Daily AP/procurement baseline sync: dedicated loop, target 8 AM PHT")
+	logger.info("  - Daily AP/procurement baseline sync: dedicated loop, target 7 AM PHT")
 	if config.baseline_test_interval_minutes > 0:
 		logger.info(
 			"  - Interval AP/procurement baseline sync: every %s minutes (test mode)",

--- a/hrms/services/sheets_receiver/models.py
+++ b/hrms/services/sheets_receiver/models.py
@@ -322,6 +322,28 @@ class Database:
 			)
 			return cursor.lastrowid
 
+	def _row_to_sync_log(self, row: sqlite3.Row | None) -> SyncLog | None:
+		"""Hydrate a SyncLog dataclass from a sqlite row."""
+		if not row:
+			return None
+
+		return SyncLog(
+			id=row["id"],
+			spreadsheet_id=row["spreadsheet_id"],
+			spreadsheet_name=row["spreadsheet_name"],
+			sheet_name=row["sheet_name"],
+			trigger=row["trigger"],
+			status=row["status"],
+			rows_processed=row["rows_processed"],
+			rows_created=row["rows_created"],
+			rows_updated=row["rows_updated"],
+			rows_failed=row["rows_failed"],
+			error_message=row["error_message"],
+			duration_seconds=row["duration_seconds"],
+			data_checksum=row["data_checksum"],
+			created_at=datetime.fromisoformat(row["created_at"]),
+		)
+
 	def get_recent_syncs(self, limit: int = 50) -> list[SyncLog]:
 		"""Get recent sync logs."""
 		with self._connection() as conn:
@@ -334,25 +356,7 @@ class Database:
 				(limit,),
 			).fetchall()
 
-			return [
-				SyncLog(
-					id=row["id"],
-					spreadsheet_id=row["spreadsheet_id"],
-					spreadsheet_name=row["spreadsheet_name"],
-					sheet_name=row["sheet_name"],
-					trigger=row["trigger"],
-					status=row["status"],
-					rows_processed=row["rows_processed"],
-					rows_created=row["rows_created"],
-					rows_updated=row["rows_updated"],
-					rows_failed=row["rows_failed"],
-					error_message=row["error_message"],
-					duration_seconds=row["duration_seconds"],
-					data_checksum=row["data_checksum"],
-					created_at=datetime.fromisoformat(row["created_at"]),
-				)
-				for row in rows
-			]
+			return [sync_log for row in rows if (sync_log := self._row_to_sync_log(row))]
 
 	def get_latest_sync(
 		self,
@@ -377,25 +381,36 @@ class Database:
 
 		with self._connection() as conn:
 			row = conn.execute(" ".join(query), params).fetchone()
-			if not row:
-				return None
+			return self._row_to_sync_log(row)
 
-			return SyncLog(
-				id=row["id"],
-				spreadsheet_id=row["spreadsheet_id"],
-				spreadsheet_name=row["spreadsheet_name"],
-				sheet_name=row["sheet_name"],
-				trigger=row["trigger"],
-				status=row["status"],
-				rows_processed=row["rows_processed"],
-				rows_created=row["rows_created"],
-				rows_updated=row["rows_updated"],
-				rows_failed=row["rows_failed"],
-				error_message=row["error_message"],
-				duration_seconds=row["duration_seconds"],
-				data_checksum=row["data_checksum"],
-				created_at=datetime.fromisoformat(row["created_at"]),
-			)
+	def get_latest_sync_since(
+		self,
+		spreadsheet_id: str,
+		sheet_name: str,
+		since: datetime,
+		*,
+		status: str | None = None,
+		trigger: str | None = None,
+	) -> SyncLog | None:
+		"""Return the most recent sync log for a sheet on or after a UTC timestamp."""
+		if since.tzinfo is not None:
+			since = since.astimezone(UTC).replace(tzinfo=None)
+
+		query = [
+			"SELECT * FROM sync_logs WHERE spreadsheet_id = ? AND sheet_name = ? AND created_at >= ?",
+		]
+		params: list[Any] = [spreadsheet_id, sheet_name, since.isoformat()]
+		if status:
+			query.append("AND status = ?")
+			params.append(status)
+		if trigger:
+			query.append("AND trigger = ?")
+			params.append(trigger)
+		query.append("ORDER BY created_at DESC LIMIT 1")
+
+		with self._connection() as conn:
+			row = conn.execute(" ".join(query), params).fetchone()
+			return self._row_to_sync_log(row)
 
 	def has_successful_sync_since(
 		self,

--- a/hrms/services/sheets_receiver/webhook.py
+++ b/hrms/services/sheets_receiver/webhook.py
@@ -10,9 +10,9 @@ from datetime import time as dt_time
 from typing import Any, Optional
 from zoneinfo import ZoneInfo
 
-from fastapi import FastAPI, Request, Header, BackgroundTasks, HTTPException
-from fastapi.responses import JSONResponse
 import uvicorn
+from fastapi import BackgroundTasks, FastAPI, Header, HTTPException, Request
+from fastapi.responses import JSONResponse
 
 from .config import get_config
 from .processor import get_processor
@@ -23,963 +23,894 @@ PHT_TIMEZONE = ZoneInfo("Asia/Manila")
 BASELINE_TARGET_PHT_TIME = dt_time(hour=7, minute=0)
 MORNING_READY_DEADLINE_PHT_TIME = dt_time(hour=9, minute=0)
 MORNING_HEALTH_SHEET_KEYS = (
-    "inventory",
-    "ap_opening_balance",
-    "procurement_suppliers",
-    "procurement_requisitions",
-    "procurement_purchase_orders",
-    "procurement_goods_receipts",
+	"inventory",
+	"ap_opening_balance",
+	"procurement_suppliers",
+	"procurement_requisitions",
+	"procurement_purchase_orders",
+	"procurement_goods_receipts",
 )
 
 
 def _normalize_report_date(report_date: str | None) -> date:
-    """Normalize the requested report date in PHT."""
-    if report_date:
-        return date.fromisoformat(report_date)
-    return datetime.now(PHT_TIMEZONE).date()
+	"""Normalize the requested report date in PHT."""
+	if report_date:
+		return date.fromisoformat(report_date)
+	return datetime.now(PHT_TIMEZONE).date()
 
 
 def _serialize_sync_log(sync_log: Any | None) -> dict[str, Any] | None:
-    """Serialize a sync log dataclass for API responses."""
-    if not sync_log:
-        return None
+	"""Serialize a sync log dataclass for API responses."""
+	if not sync_log:
+		return None
 
-    created_at_utc = sync_log.created_at.replace(tzinfo=UTC)
-    return {
-        "id": sync_log.id,
-        "trigger": sync_log.trigger,
-        "status": sync_log.status,
-        "rows_processed": sync_log.rows_processed,
-        "rows_created": sync_log.rows_created,
-        "rows_updated": sync_log.rows_updated,
-        "rows_failed": sync_log.rows_failed,
-        "error_message": sync_log.error_message,
-        "duration_seconds": sync_log.duration_seconds,
-        "created_at_utc": created_at_utc.isoformat(),
-        "created_at_pht": created_at_utc.astimezone(PHT_TIMEZONE).isoformat(),
-    }
+	created_at_utc = sync_log.created_at.replace(tzinfo=UTC)
+	return {
+		"id": sync_log.id,
+		"trigger": sync_log.trigger,
+		"status": sync_log.status,
+		"rows_processed": sync_log.rows_processed,
+		"rows_created": sync_log.rows_created,
+		"rows_updated": sync_log.rows_updated,
+		"rows_failed": sync_log.rows_failed,
+		"error_message": sync_log.error_message,
+		"duration_seconds": sync_log.duration_seconds,
+		"created_at_utc": created_at_utc.isoformat(),
+		"created_at_pht": created_at_utc.astimezone(PHT_TIMEZONE).isoformat(),
+	}
 
 
 def _build_lane_health(sheet_key: str, report_date_value: date) -> dict[str, Any]:
-    """Summarize one receiver lane for the morning health report."""
-    from .config import get_sheet_config
-    from .models import get_db
+	"""Summarize one receiver lane for the morning health report."""
+	from .config import get_sheet_config
+	from .models import get_db
 
-    sheet_config = get_sheet_config(sheet_key)
-    if not sheet_config:
-        return {
-            "sheet_key": sheet_key,
-            "status": "missing",
-            "ready_before_deadline": False,
-            "clean_success": False,
-        }
+	sheet_config = get_sheet_config(sheet_key)
+	if not sheet_config:
+		return {
+			"sheet_key": sheet_key,
+			"status": "missing",
+			"ready_before_deadline": False,
+			"clean_success": False,
+		}
 
-    if not getattr(sheet_config, "enabled", True):
-        return {
-            "sheet_key": sheet_key,
-            "name": sheet_config.name,
-            "status": "disabled",
-            "ready_before_deadline": False,
-            "clean_success": False,
-        }
+	if not getattr(sheet_config, "enabled", True):
+		return {
+			"sheet_key": sheet_key,
+			"name": sheet_config.name,
+			"status": "disabled",
+			"ready_before_deadline": False,
+			"clean_success": False,
+		}
 
-    pht_day_start = datetime.combine(report_date_value, dt_time.min, tzinfo=PHT_TIMEZONE)
-    pht_deadline = datetime.combine(report_date_value, MORNING_READY_DEADLINE_PHT_TIME, tzinfo=PHT_TIMEZONE)
-    day_start_utc = pht_day_start.astimezone(UTC)
-    deadline_utc = pht_deadline.astimezone(UTC)
+	pht_day_start = datetime.combine(report_date_value, dt_time.min, tzinfo=PHT_TIMEZONE)
+	pht_deadline = datetime.combine(report_date_value, MORNING_READY_DEADLINE_PHT_TIME, tzinfo=PHT_TIMEZONE)
+	day_start_utc = pht_day_start.astimezone(UTC)
+	deadline_utc = pht_deadline.astimezone(UTC)
 
-    db = get_db()
-    latest_today = db.get_latest_sync_since(
-        sheet_config.spreadsheet_id,
-        sheet_config.sheet_name,
-        day_start_utc,
-        trigger="daily_baseline",
-    )
-    latest_success_today = db.get_latest_sync_since(
-        sheet_config.spreadsheet_id,
-        sheet_config.sheet_name,
-        day_start_utc,
-        trigger="daily_baseline",
-        status="success",
-    )
+	db = get_db()
+	latest_today = db.get_latest_sync_since(
+		sheet_config.spreadsheet_id,
+		sheet_config.sheet_name,
+		day_start_utc,
+		trigger="daily_baseline",
+	)
+	latest_success_today = db.get_latest_sync_since(
+		sheet_config.spreadsheet_id,
+		sheet_config.sheet_name,
+		day_start_utc,
+		trigger="daily_baseline",
+		status="success",
+	)
 
-    ready_before_deadline = bool(
-        latest_success_today and latest_success_today.created_at.replace(tzinfo=UTC) <= deadline_utc
-    )
-    clean_success = bool(latest_success_today and latest_success_today.rows_failed == 0)
+	ready_before_deadline = bool(
+		latest_success_today and latest_success_today.created_at.replace(tzinfo=UTC) <= deadline_utc
+	)
+	clean_success = bool(latest_success_today and latest_success_today.rows_failed == 0)
 
-    if latest_today is None:
-        status = "pending"
-    elif latest_today.status == "success":
-        status = "completed_with_exceptions" if latest_today.rows_failed else "completed"
-    elif latest_success_today is not None:
-        status = f"{latest_today.status}_after_success"
-    else:
-        status = latest_today.status or "unknown"
+	if latest_today is None:
+		status = "pending"
+	elif latest_today.status == "success":
+		status = "completed_with_exceptions" if latest_today.rows_failed else "completed"
+	elif latest_success_today is not None:
+		status = f"{latest_today.status}_after_success"
+	else:
+		status = latest_today.status or "unknown"
 
-    return {
-        "sheet_key": sheet_key,
-        "name": sheet_config.name,
-        "sheet_name": sheet_config.sheet_name,
-        "owner_email": sheet_config.owner_email,
-        "status": status,
-        "ready_before_deadline": ready_before_deadline,
-        "clean_success": clean_success,
-        "latest_today": _serialize_sync_log(latest_today),
-        "latest_success_today": _serialize_sync_log(latest_success_today),
-        "completed_at_pht": (
-            latest_success_today.created_at.replace(tzinfo=UTC).astimezone(PHT_TIMEZONE).isoformat()
-            if latest_success_today
-            else None
-        ),
-    }
+	return {
+		"sheet_key": sheet_key,
+		"name": sheet_config.name,
+		"sheet_name": sheet_config.sheet_name,
+		"owner_email": sheet_config.owner_email,
+		"status": status,
+		"ready_before_deadline": ready_before_deadline,
+		"clean_success": clean_success,
+		"latest_today": _serialize_sync_log(latest_today),
+		"latest_success_today": _serialize_sync_log(latest_success_today),
+		"completed_at_pht": (
+			latest_success_today.created_at.replace(tzinfo=UTC).astimezone(PHT_TIMEZONE).isoformat()
+			if latest_success_today
+			else None
+		),
+	}
 
 
 def build_morning_health_report(report_date: str | None = None) -> dict[str, Any]:
-    """Build the receiver-side morning health report for Ian inventory + AP/procurement."""
-    report_date_value = _normalize_report_date(report_date)
-    lane_rows = [_build_lane_health(sheet_key, report_date_value) for sheet_key in MORNING_HEALTH_SHEET_KEYS]
-    active_lanes = [lane for lane in lane_rows if lane.get("status") not in {"disabled", "missing"}]
-    all_ready = bool(active_lanes) and all(lane.get("ready_before_deadline") for lane in active_lanes)
-    all_clean = all(lane.get("clean_success") for lane in active_lanes) if active_lanes else False
+	"""Build the receiver-side morning health report for Ian inventory + AP/procurement."""
+	report_date_value = _normalize_report_date(report_date)
+	lane_rows = [_build_lane_health(sheet_key, report_date_value) for sheet_key in MORNING_HEALTH_SHEET_KEYS]
+	active_lanes = [lane for lane in lane_rows if lane.get("status") not in {"disabled", "missing"}]
+	all_ready = bool(active_lanes) and all(lane.get("ready_before_deadline") for lane in active_lanes)
+	all_clean = all(lane.get("clean_success") for lane in active_lanes) if active_lanes else False
 
-    if all_ready and all_clean:
-        status = "green"
-    elif all_ready:
-        status = "yellow"
-    else:
-        status = "red"
+	if all_ready and all_clean:
+		status = "green"
+	elif all_ready:
+		status = "yellow"
+	else:
+		status = "red"
 
-    return {
-        "service": "sheets-receiver",
-        "report_date": report_date_value.isoformat(),
-        "generated_at_utc": datetime.now(UTC).isoformat(),
-        "generated_at_pht": datetime.now(PHT_TIMEZONE).isoformat(),
-        "baseline_target_pht_time": BASELINE_TARGET_PHT_TIME.strftime("%H:%M"),
-        "ready_deadline_pht_time": MORNING_READY_DEADLINE_PHT_TIME.strftime("%H:%M"),
-        "status": status,
-        "ready_before_deadline": all_ready,
-        "lanes": lane_rows,
-    }
+	return {
+		"service": "sheets-receiver",
+		"report_date": report_date_value.isoformat(),
+		"generated_at_utc": datetime.now(UTC).isoformat(),
+		"generated_at_pht": datetime.now(PHT_TIMEZONE).isoformat(),
+		"baseline_target_pht_time": BASELINE_TARGET_PHT_TIME.strftime("%H:%M"),
+		"ready_deadline_pht_time": MORNING_READY_DEADLINE_PHT_TIME.strftime("%H:%M"),
+		"status": status,
+		"ready_before_deadline": all_ready,
+		"lanes": lane_rows,
+	}
 
-app = FastAPI(
-    title="Sheets Receiver",
-    description="Google Sheets sync service for BEI ERP",
-    version="1.0.0"
-)
+
+app = FastAPI(title="Sheets Receiver", description="Google Sheets sync service for BEI ERP", version="1.0.0")
 
 
 @app.get("/health")
 async def health_check():
-    """Health check endpoint."""
-    return {"status": "healthy", "service": "sheets-receiver"}
+	"""Health check endpoint."""
+	return {"status": "healthy", "service": "sheets-receiver"}
 
 
 @app.post("/webhook/sheets")
 async def handle_webhook(
-    request: Request,
-    background_tasks: BackgroundTasks,
-    x_goog_channel_id: Optional[str] = Header(None, alias="X-Goog-Channel-ID"),
-    x_goog_resource_id: Optional[str] = Header(None, alias="X-Goog-Resource-ID"),
-    x_goog_resource_state: Optional[str] = Header(None, alias="X-Goog-Resource-State"),
-    x_goog_changed: Optional[str] = Header(None, alias="X-Goog-Changed"),
-    x_goog_message_number: Optional[str] = Header(None, alias="X-Goog-Message-Number"),
+	request: Request,
+	background_tasks: BackgroundTasks,
+	x_goog_channel_id: str | None = Header(None, alias="X-Goog-Channel-ID"),
+	x_goog_resource_id: str | None = Header(None, alias="X-Goog-Resource-ID"),
+	x_goog_resource_state: str | None = Header(None, alias="X-Goog-Resource-State"),
+	x_goog_changed: str | None = Header(None, alias="X-Goog-Changed"),
+	x_goog_message_number: str | None = Header(None, alias="X-Goog-Message-Number"),
 ):
-    """
-    Handle Google Drive push notification.
+	"""
+	Handle Google Drive push notification.
 
-    Google sends these headers:
-    - X-Goog-Channel-ID: The channel ID we specified
-    - X-Goog-Resource-ID: Unique ID for the watched resource
-    - X-Goog-Resource-State: 'sync', 'change', 'remove', etc.
-    - X-Goog-Changed: What changed (e.g., 'content', 'properties')
-    - X-Goog-Message-Number: Sequential message number
+	Google sends these headers:
+	- X-Goog-Channel-ID: The channel ID we specified
+	- X-Goog-Resource-ID: Unique ID for the watched resource
+	- X-Goog-Resource-State: 'sync', 'change', 'remove', etc.
+	- X-Goog-Changed: What changed (e.g., 'content', 'properties')
+	- X-Goog-Message-Number: Sequential message number
 
-    We need to respond quickly (within 10 seconds) or Google will retry.
-    So we process in background.
-    """
-    logger.info(
-        f"Webhook received: state={x_goog_resource_state}, "
-        f"channel={x_goog_channel_id}, resource={x_goog_resource_id}"
-    )
+	We need to respond quickly (within 10 seconds) or Google will retry.
+	So we process in background.
+	"""
+	logger.info(
+		f"Webhook received: state={x_goog_resource_state}, "
+		f"channel={x_goog_channel_id}, resource={x_goog_resource_id}"
+	)
 
-    # Acknowledge quickly - Google requires fast response
-    if x_goog_resource_state == 'sync':
-        # Initial sync notification - just acknowledge
-        return {"status": "acknowledged"}
+	# Acknowledge quickly - Google requires fast response
+	if x_goog_resource_state == "sync":
+		# Initial sync notification - just acknowledge
+		return {"status": "acknowledged"}
 
-    # Get file ID from resource ID (it's the spreadsheet ID)
-    # Note: We need to look up which spreadsheet this resource_id belongs to
-    # Since we store the mapping in our database
-    from .models import get_db
-    db = get_db()
+	# Get file ID from resource ID (it's the spreadsheet ID)
+	# Note: We need to look up which spreadsheet this resource_id belongs to
+	# Since we store the mapping in our database
+	from .models import get_db
 
-    # Find the spreadsheet by channel or resource
-    # Try to find by looking up our watch channels
-    watch = None
-    if x_goog_channel_id:
-        with db._connection() as conn:
-            row = conn.execute(
-                "SELECT spreadsheet_id FROM watch_channels WHERE channel_id = ?",
-                (x_goog_channel_id,)
-            ).fetchone()
-            if row:
-                spreadsheet_id = row['spreadsheet_id']
-            else:
-                logger.warning(f"Unknown channel: {x_goog_channel_id}")
-                return {"status": "unknown_channel"}
-    else:
-        logger.warning("No channel ID in webhook")
-        return {"status": "missing_channel_id"}
+	db = get_db()
 
-    # Process in background
-    background_tasks.add_task(
-        process_change_background,
-        spreadsheet_id=spreadsheet_id,
-        resource_state=x_goog_resource_state,
-        channel_id=x_goog_channel_id
-    )
+	# Find the spreadsheet by channel or resource.
+	# We currently look up the watched spreadsheet by the registered channel ID.
+	if x_goog_channel_id:
+		with db._connection() as conn:
+			row = conn.execute(
+				"SELECT spreadsheet_id FROM watch_channels WHERE channel_id = ?", (x_goog_channel_id,)
+			).fetchone()
+			if row:
+				spreadsheet_id = row["spreadsheet_id"]
+			else:
+				logger.warning(f"Unknown channel: {x_goog_channel_id}")
+				return {"status": "unknown_channel"}
+	else:
+		logger.warning("No channel ID in webhook")
+		return {"status": "missing_channel_id"}
 
-    return {"status": "processing"}
+	# Process in background
+	background_tasks.add_task(
+		process_change_background,
+		spreadsheet_id=spreadsheet_id,
+		resource_state=x_goog_resource_state,
+		channel_id=x_goog_channel_id,
+	)
+
+	return {"status": "processing"}
 
 
-async def process_change_background(
-    spreadsheet_id: str,
-    resource_state: str,
-    channel_id: str
-):
-    """Background task to process the change."""
-    try:
-        processor = get_processor()
-        processor.process_webhook(
-            spreadsheet_id=spreadsheet_id,
-            resource_state=resource_state,
-            channel_id=channel_id
-        )
-    except Exception as e:
-        logger.error(f"Error processing webhook: {e}")
+async def process_change_background(spreadsheet_id: str, resource_state: str, channel_id: str):
+	"""Background task to process the change."""
+	try:
+		processor = get_processor()
+		processor.process_webhook(
+			spreadsheet_id=spreadsheet_id, resource_state=resource_state, channel_id=channel_id
+		)
+	except Exception as e:
+		logger.error(f"Error processing webhook: {e}")
 
 
 @app.post("/api/sync/{sheet_key}")
-async def trigger_sync(
-    sheet_key: str,
-    background_tasks: BackgroundTasks,
-    force: bool = False
-):
-    """
-    Manually trigger sync for a specific sheet.
+async def trigger_sync(sheet_key: str, background_tasks: BackgroundTasks, force: bool = False):
+	"""
+	Manually trigger sync for a specific sheet.
 
-    Args:
-        sheet_key: Key from WATCHED_SHEETS config (e.g., 'ar_aging')
-        force: If True, sync even if no changes detected
-    """
-    from .config import get_watched_sheets
+	Args:
+	    sheet_key: Key from WATCHED_SHEETS config (e.g., 'ar_aging')
+	    force: If True, sync even if no changes detected
+	"""
+	from .config import get_watched_sheets
 
-    sheets = get_watched_sheets()
-    if sheet_key not in sheets:
-        raise HTTPException(status_code=404, detail=f"Unknown sheet: {sheet_key}")
+	sheets = get_watched_sheets()
+	if sheet_key not in sheets:
+		raise HTTPException(status_code=404, detail=f"Unknown sheet: {sheet_key}")
 
-    sheet_config = sheets[sheet_key]
+	sheet_config = sheets[sheet_key]
 
-    background_tasks.add_task(
-        sync_sheet_background,
-        sheet_config=sheet_config,
-        force=force
-    )
+	background_tasks.add_task(sync_sheet_background, sheet_config=sheet_config, force=force)
 
-    return {"status": "sync_queued", "sheet": sheet_config.name}
+	return {"status": "sync_queued", "sheet": sheet_config.name}
 
 
 async def sync_sheet_background(sheet_config, force: bool):
-    """Background task to sync a sheet."""
-    try:
-        processor = get_processor()
-        processor.sync_sheet(sheet_config, trigger='manual', force=force)
-    except Exception as e:
-        logger.error(f"Error syncing {sheet_config.name}: {e}")
+	"""Background task to sync a sheet."""
+	try:
+		processor = get_processor()
+		processor.sync_sheet(sheet_config, trigger="manual", force=force)
+	except Exception as e:
+		logger.error(f"Error syncing {sheet_config.name}: {e}")
 
 
 @app.post("/api/sync-all")
 async def trigger_sync_all(background_tasks: BackgroundTasks, force: bool = False):
-    """Trigger sync for all configured sheets."""
-    background_tasks.add_task(sync_all_background, force=force)
-    return {"status": "sync_all_queued"}
+	"""Trigger sync for all configured sheets."""
+	background_tasks.add_task(sync_all_background, force=force)
+	return {"status": "sync_all_queued"}
 
 
 async def sync_all_background(force: bool):
-    """Background task to sync all sheets."""
-    try:
-        processor = get_processor()
-        processor.sync_all_sheets(trigger='manual', force=force)
-    except Exception as e:
-        logger.error(f"Error in sync_all: {e}")
+	"""Background task to sync all sheets."""
+	try:
+		processor = get_processor()
+		processor.sync_all_sheets(trigger="manual", force=force)
+	except Exception as e:
+		logger.error(f"Error in sync_all: {e}")
 
 
 @app.get("/api/status")
 async def get_status():
-    """Get service status and recent sync history."""
-    from .models import get_db
-    from .config import get_watched_sheets
+	"""Get service status and recent sync history."""
+	from .config import get_watched_sheets
+	from .models import get_db
 
-    db = get_db()
-    recent_syncs = db.get_recent_syncs(limit=20)
+	db = get_db()
+	recent_syncs = db.get_recent_syncs(limit=20)
 
-    # Get watch status
-    watches = []
-    for key, sheet in get_watched_sheets().items():
-        watch = db.get_watch(sheet.spreadsheet_id)
-        watches.append({
-            'name': sheet.name,
-            'spreadsheet_id': sheet.spreadsheet_id,
-            'has_watch': watch is not None,
-            'watch_expires': watch.expiration.isoformat() if watch else None,
-            'hours_until_expiry': watch.hours_until_expiry if watch else None
-        })
+	# Get watch status
+	watches = []
+	for _, sheet in get_watched_sheets().items():
+		watch = db.get_watch(sheet.spreadsheet_id)
+		watches.append(
+			{
+				"name": sheet.name,
+				"spreadsheet_id": sheet.spreadsheet_id,
+				"has_watch": watch is not None,
+				"watch_expires": watch.expiration.isoformat() if watch else None,
+				"hours_until_expiry": watch.hours_until_expiry if watch else None,
+			}
+		)
 
-    # Get change tracking summary
-    processor = get_processor()
-    change_summary = processor.get_change_summary(days=7)
-    unacked_alerts = processor.get_unacknowledged_alerts()
+	# Get change tracking summary
+	processor = get_processor()
+	change_summary = processor.get_change_summary(days=7)
+	unacked_alerts = processor.get_unacknowledged_alerts()
 
-    return {
-        'service': 'sheets-receiver',
-        'version': '1.0.0',
-        'watches': watches,
-        'change_tracking': {
-            'summary_7_days': change_summary,
-            'unacknowledged_alerts': len(unacked_alerts),
-            'alerts': [
-                {
-                    'id': a['id'],
-                    'type': a['alert_type'],
-                    'message': a['alert_message'][:100] + '...' if len(a['alert_message']) > 100 else a['alert_message']
-                }
-                for a in unacked_alerts[:5]  # Show first 5
-            ]
-        },
-        'recent_syncs': [
-            {
-                'spreadsheet_name': s.spreadsheet_name,
-                'status': s.status,
-                'trigger': s.trigger,
-                'rows_processed': s.rows_processed,
-                'created_at': s.created_at.isoformat()
-            }
-            for s in recent_syncs
-        ]
-    }
+	return {
+		"service": "sheets-receiver",
+		"version": "1.0.0",
+		"watches": watches,
+		"change_tracking": {
+			"summary_7_days": change_summary,
+			"unacknowledged_alerts": len(unacked_alerts),
+			"alerts": [
+				{
+					"id": a["id"],
+					"type": a["alert_type"],
+					"message": a["alert_message"][:100] + "..."
+					if len(a["alert_message"]) > 100
+					else a["alert_message"],
+				}
+				for a in unacked_alerts[:5]  # Show first 5
+			],
+		},
+		"recent_syncs": [
+			{
+				"spreadsheet_name": s.spreadsheet_name,
+				"status": s.status,
+				"trigger": s.trigger,
+				"rows_processed": s.rows_processed,
+				"created_at": s.created_at.isoformat(),
+			}
+			for s in recent_syncs
+		],
+	}
 
 
 @app.get("/api/morning-health")
 async def get_morning_health(report_date: str | None = None):
-    """Get same-day baseline readiness for Ian inventory and AP/procurement."""
-    try:
-        return build_morning_health_report(report_date=report_date)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+	"""Get same-day baseline readiness for Ian inventory and AP/procurement."""
+	try:
+		return build_morning_health_report(report_date=report_date)
+	except ValueError as exc:
+		raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.post("/api/watches/setup")
 async def setup_watches():
-    """Set up watches for all configured sheets."""
-    from .sheets_client import get_sheets_client
+	"""Set up watches for all configured sheets."""
+	from .sheets_client import get_sheets_client
 
-    client = get_sheets_client()
-    watches = client.setup_all_watches()
+	client = get_sheets_client()
+	watches = client.setup_all_watches()
 
-    return {
-        'status': 'success',
-        'watches_created': len(watches),
-        'watches': [
-            {
-                'name': w.spreadsheet_name,
-                'channel_id': w.channel_id,
-                'expires': w.expiration.isoformat()
-            }
-            for w in watches
-        ]
-    }
+	return {
+		"status": "success",
+		"watches_created": len(watches),
+		"watches": [
+			{"name": w.spreadsheet_name, "channel_id": w.channel_id, "expires": w.expiration.isoformat()}
+			for w in watches
+		],
+	}
 
 
 @app.post("/api/watches/renew")
 async def renew_watches():
-    """Renew expiring watches."""
-    from .sheets_client import get_sheets_client
+	"""Renew expiring watches."""
+	from .sheets_client import get_sheets_client
 
-    client = get_sheets_client()
-    renewed = client.renew_expiring_watches()
+	client = get_sheets_client()
+	renewed = client.renew_expiring_watches()
 
-    return {
-        'status': 'success',
-        'watches_renewed': len(renewed)
-    }
+	return {"status": "success", "watches_renewed": len(renewed)}
 
 
 # ========================================
 # CHANGE TRACKING ENDPOINTS
 # ========================================
 
+
 @app.get("/api/changes")
-async def get_changes(
-    spreadsheet_id: Optional[str] = None,
-    change_type: Optional[str] = None,
-    limit: int = 100
-):
-    """
-    Get recent row-level changes.
+async def get_changes(spreadsheet_id: str | None = None, change_type: str | None = None, limit: int = 100):
+	"""
+	Get recent row-level changes.
 
-    Query params:
-        spreadsheet_id: Filter by spreadsheet (optional)
-        change_type: Filter by type - added, modified, deleted (optional)
-        limit: Max records (default 100)
+	Query params:
+	    spreadsheet_id: Filter by spreadsheet (optional)
+	    change_type: Filter by type - added, modified, deleted (optional)
+	    limit: Max records (default 100)
 
-    Returns:
-        List of changes with before/after values
-    """
-    processor = get_processor()
-    changes = processor.get_recent_changes(
-        spreadsheet_id=spreadsheet_id,
-        limit=limit,
-        change_type=change_type
-    )
+	Returns:
+	    List of changes with before/after values
+	"""
+	processor = get_processor()
+	changes = processor.get_recent_changes(
+		spreadsheet_id=spreadsheet_id, limit=limit, change_type=change_type
+	)
 
-    return {
-        'total': len(changes),
-        'changes': changes
-    }
+	return {"total": len(changes), "changes": changes}
 
 
 @app.get("/api/changes/summary")
-async def get_change_summary(
-    spreadsheet_id: Optional[str] = None,
-    days: int = 7
-):
-    """
-    Get summary of changes over time.
+async def get_change_summary(spreadsheet_id: str | None = None, days: int = 7):
+	"""
+	Get summary of changes over time.
 
-    Query params:
-        spreadsheet_id: Filter by spreadsheet (optional)
-        days: How many days to look back (default 7)
+	Query params:
+	    spreadsheet_id: Filter by spreadsheet (optional)
+	    days: How many days to look back (default 7)
 
-    Returns:
-        Summary with counts by type
-    """
-    processor = get_processor()
-    return processor.get_change_summary(
-        spreadsheet_id=spreadsheet_id,
-        days=days
-    )
+	Returns:
+	    Summary with counts by type
+	"""
+	processor = get_processor()
+	return processor.get_change_summary(spreadsheet_id=spreadsheet_id, days=days)
 
 
 @app.get("/api/changes/modified")
 async def get_modified_rows(limit: int = 50):
-    """
-    Get recently modified rows (edits to existing data).
+	"""
+	Get recently modified rows (edits to existing data).
 
-    This is the key endpoint for detecting when team members
-    edit existing records instead of adding new ones.
-    """
-    processor = get_processor()
-    changes = processor.get_recent_changes(
-        change_type='modified',
-        limit=limit
-    )
+	This is the key endpoint for detecting when team members
+	edit existing records instead of adding new ones.
+	"""
+	processor = get_processor()
+	changes = processor.get_recent_changes(change_type="modified", limit=limit)
 
-    return {
-        'total': len(changes),
-        'message': 'These rows had existing data modified (not new entries)',
-        'changes': changes
-    }
+	return {
+		"total": len(changes),
+		"message": "These rows had existing data modified (not new entries)",
+		"changes": changes,
+	}
 
 
 @app.get("/api/alerts")
 async def get_alerts():
-    """
-    Get unacknowledged alerts.
+	"""
+	Get unacknowledged alerts.
 
-    Alerts are generated for suspicious patterns:
-    - Mass edits (many rows modified at once)
-    - Deletions
-    - Financial field changes
-    - More modifications than additions
-    """
-    processor = get_processor()
-    alerts = processor.get_unacknowledged_alerts()
+	Alerts are generated for suspicious patterns:
+	- Mass edits (many rows modified at once)
+	- Deletions
+	- Financial field changes
+	- More modifications than additions
+	"""
+	processor = get_processor()
+	alerts = processor.get_unacknowledged_alerts()
 
-    return {
-        'total': len(alerts),
-        'alerts': alerts
-    }
+	return {"total": len(alerts), "alerts": alerts}
 
 
 @app.post("/api/alerts/{alert_id}/acknowledge")
 async def acknowledge_alert(alert_id: int):
-    """Mark an alert as acknowledged."""
-    processor = get_processor()
-    success = processor.acknowledge_alert(alert_id)
+	"""Mark an alert as acknowledged."""
+	processor = get_processor()
+	success = processor.acknowledge_alert(alert_id)
 
-    if success:
-        return {'status': 'acknowledged', 'alert_id': alert_id}
-    else:
-        raise HTTPException(status_code=404, detail=f"Alert {alert_id} not found")
+	if success:
+		return {"status": "acknowledged", "alert_id": alert_id}
+	else:
+		raise HTTPException(status_code=404, detail=f"Alert {alert_id} not found")
 
 
 # ========================================
 # FOLDER WATCHING ENDPOINTS (POS Files)
 # ========================================
 
+
 @app.post("/webhook/folder")
 async def handle_folder_webhook(
-    request: Request,
-    background_tasks: BackgroundTasks,
-    x_goog_channel_id: Optional[str] = Header(None, alias="X-Goog-Channel-ID"),
-    x_goog_resource_id: Optional[str] = Header(None, alias="X-Goog-Resource-ID"),
-    x_goog_resource_state: Optional[str] = Header(None, alias="X-Goog-Resource-State"),
-    x_goog_changed: Optional[str] = Header(None, alias="X-Goog-Changed"),
+	request: Request,
+	background_tasks: BackgroundTasks,
+	x_goog_channel_id: str | None = Header(None, alias="X-Goog-Channel-ID"),
+	x_goog_resource_id: str | None = Header(None, alias="X-Goog-Resource-ID"),
+	x_goog_resource_state: str | None = Header(None, alias="X-Goog-Resource-State"),
+	x_goog_changed: str | None = Header(None, alias="X-Goog-Changed"),
 ):
-    """
-    Handle Google Drive folder push notification.
+	"""
+	Handle Google Drive folder push notification.
 
-    When files are added/modified in a watched folder, Google sends a notification.
-    We respond quickly and process in background.
-    """
-    logger.info(
-        f"Folder webhook received: state={x_goog_resource_state}, "
-        f"channel={x_goog_channel_id}, changed={x_goog_changed}"
-    )
+	When files are added/modified in a watched folder, Google sends a notification.
+	We respond quickly and process in background.
+	"""
+	logger.info(
+		f"Folder webhook received: state={x_goog_resource_state}, "
+		f"channel={x_goog_channel_id}, changed={x_goog_changed}"
+	)
 
-    if x_goog_resource_state == 'sync':
-        return {"status": "sync_acknowledged"}
+	if x_goog_resource_state == "sync":
+		return {"status": "sync_acknowledged"}
 
-    if not x_goog_channel_id:
-        logger.warning("No channel ID in folder webhook")
-        return {"status": "missing_channel_id"}
+	if not x_goog_channel_id:
+		logger.warning("No channel ID in folder webhook")
+		return {"status": "missing_channel_id"}
 
-    # Look up folder watch
-    from .models import get_db
-    db = get_db()
-    watch = db.get_folder_watch_by_channel(x_goog_channel_id)
+	# Look up folder watch
+	from .models import get_db
 
-    if not watch:
-        logger.warning(f"Unknown folder channel: {x_goog_channel_id}")
-        return {"status": "unknown_channel"}
+	db = get_db()
+	watch = db.get_folder_watch_by_channel(x_goog_channel_id)
 
-    # Process in background
-    background_tasks.add_task(
-        process_folder_change_background,
-        folder_id=watch['folder_id'],
-        folder_name=watch['folder_name'],
-        store_code=watch.get('store_code'),
-        resource_state=x_goog_resource_state
-    )
+	if not watch:
+		logger.warning(f"Unknown folder channel: {x_goog_channel_id}")
+		return {"status": "unknown_channel"}
 
-    return {"status": "processing", "folder": watch['folder_name']}
+	# Process in background
+	background_tasks.add_task(
+		process_folder_change_background,
+		folder_id=watch["folder_id"],
+		folder_name=watch["folder_name"],
+		store_code=watch.get("store_code"),
+		resource_state=x_goog_resource_state,
+	)
+
+	return {"status": "processing", "folder": watch["folder_name"]}
 
 
 async def process_folder_change_background(
-    folder_id: str,
-    folder_name: str,
-    store_code: str,
-    resource_state: str
+	folder_id: str, folder_name: str, store_code: str, resource_state: str
 ):
-    """Background task to check for new files in folder."""
-    try:
-        from .folder_watcher import get_folder_watcher
-        from .models import get_db
+	"""Background task to check for new files in folder."""
+	try:
+		from .folder_watcher import get_folder_watcher
+		from .models import get_db
 
-        watcher = get_folder_watcher()
-        db = get_db()
+		watcher = get_folder_watcher()
+		db = get_db()
 
-        # Get files modified in last hour (Google doesn't tell us which file changed)
-        from datetime import datetime, timedelta
-        since = datetime.utcnow() - timedelta(hours=1)
+		# Get files modified in last hour (Google doesn't tell us which file changed)
+		from datetime import datetime, timedelta
 
-        new_files = watcher.list_new_files(folder_id, since=since)
+		since = datetime.utcnow() - timedelta(hours=1)
 
-        queued_count = 0
-        for file_info in new_files:
-            if not db.is_file_processed(file_info['id']):
-                file_info['folder_id'] = folder_id
-                db.queue_file(file_info, store_code=store_code)
-                queued_count += 1
-                logger.info(f"Queued new file: {file_info['name']} from {folder_name}")
+		new_files = watcher.list_new_files(folder_id, since=since)
 
-        logger.info(f"Folder change processed: {folder_name}, {queued_count} files queued")
+		queued_count = 0
+		for file_info in new_files:
+			if not db.is_file_processed(file_info["id"]):
+				file_info["folder_id"] = folder_id
+				db.queue_file(file_info, store_code=store_code)
+				queued_count += 1
+				logger.info(f"Queued new file: {file_info['name']} from {folder_name}")
 
-    except Exception as e:
-        logger.error(f"Error processing folder change for {folder_name}: {e}")
+		logger.info(f"Folder change processed: {folder_name}, {queued_count} files queued")
+
+	except Exception as e:
+		logger.error(f"Error processing folder change for {folder_name}: {e}")
 
 
 @app.post("/api/folders/seed")
 async def seed_existing_files():
-    """
-    Mark all existing files in watched folders as 'already processed'.
+	"""
+	Mark all existing files in watched folders as 'already processed'.
 
-    CRITICAL: Run this BEFORE setting up watches to prevent reprocessing
-    files that were already extracted (e.g., January 2026 data).
+	CRITICAL: Run this BEFORE setting up watches to prevent reprocessing
+	files that were already extracted (e.g., January 2026 data).
 
-    Files are marked with report_type='seeded' and record_count=0 to
-    distinguish them from actually processed files.
-    """
-    from .folder_watcher import get_folder_watcher
-    from .models import get_db
-    from .config import get_watched_folders
-    from datetime import datetime
+	Files are marked with report_type='seeded' and record_count=0 to
+	distinguish them from actually processed files.
+	"""
+	from datetime import datetime
 
-    watcher = get_folder_watcher()
-    db = get_db()
-    folders = get_watched_folders()
+	from .config import get_watched_folders
+	from .folder_watcher import get_folder_watcher
+	from .models import get_db
 
-    total_seeded = 0
-    folder_counts = {}
+	watcher = get_folder_watcher()
+	db = get_db()
+	folders = get_watched_folders()
 
-    for store_code, folder_config in folders.items():
-        try:
-            # Get ALL files in folder (no time filter)
-            files = watcher.list_new_files(folder_config.folder_id, since=None)
+	total_seeded = 0
+	folder_counts = {}
 
-            seeded = 0
-            for file_info in files:
-                if not db.is_file_processed(file_info['id']):
-                    # Mark as processed WITHOUT extracting data
-                    db.mark_file_processed(
-                        file_id=file_info['id'],
-                        file_name=file_info['name'],
-                        folder_id=folder_config.folder_id,
-                        store_code=store_code,
-                        md5_checksum=file_info.get('md5Checksum', ''),
-                        record_count=0,  # 0 = seeded, not extracted
-                        report_type='seeded',
-                        extracted_data={
-                            'seeded_at': datetime.utcnow().isoformat(),
-                            'reason': 'pre-existing file, already processed in Jan 2026 extraction'
-                        }
-                    )
-                    seeded += 1
+	for store_code, folder_config in folders.items():
+		try:
+			# Get ALL files in folder (no time filter)
+			files = watcher.list_new_files(folder_config.folder_id, since=None)
 
-            folder_counts[folder_config.name] = seeded
-            total_seeded += seeded
-            logger.info(f"Seeded {seeded} existing files in {folder_config.name}")
+			seeded = 0
+			for file_info in files:
+				if not db.is_file_processed(file_info["id"]):
+					# Mark as processed WITHOUT extracting data
+					db.mark_file_processed(
+						file_id=file_info["id"],
+						file_name=file_info["name"],
+						folder_id=folder_config.folder_id,
+						store_code=store_code,
+						md5_checksum=file_info.get("md5Checksum", ""),
+						record_count=0,  # 0 = seeded, not extracted
+						report_type="seeded",
+						extracted_data={
+							"seeded_at": datetime.utcnow().isoformat(),
+							"reason": "pre-existing file, already processed in Jan 2026 extraction",
+						},
+					)
+					seeded += 1
 
-        except Exception as e:
-            logger.error(f"Error seeding {folder_config.name}: {e}")
-            folder_counts[folder_config.name] = f"ERROR: {str(e)}"
+			folder_counts[folder_config.name] = seeded
+			total_seeded += seeded
+			logger.info(f"Seeded {seeded} existing files in {folder_config.name}")
 
-    return {
-        'status': 'success',
-        'message': 'Existing files marked as processed - will NOT be re-extracted',
-        'total_seeded': total_seeded,
-        'by_folder': folder_counts
-    }
+		except Exception as e:
+			logger.error(f"Error seeding {folder_config.name}: {e}")
+			folder_counts[folder_config.name] = f"ERROR: {e!s}"
+
+	return {
+		"status": "success",
+		"message": "Existing files marked as processed - will NOT be re-extracted",
+		"total_seeded": total_seeded,
+		"by_folder": folder_counts,
+	}
 
 
 @app.post("/api/folders/setup")
 async def setup_folder_watches(seed_existing: bool = True):
-    """
-    Set up watches for all POS store folders.
+	"""
+	Set up watches for all POS store folders.
 
-    Args:
-        seed_existing: If True (default), mark all existing files as processed
-                      BEFORE creating watches. This prevents reprocessing
-                      files from January 2026 that were already extracted.
+	Args:
+	    seed_existing: If True (default), mark all existing files as processed
+	                  BEFORE creating watches. This prevents reprocessing
+	                  files from January 2026 that were already extracted.
 
-    Process:
-        1. Seed existing files (if enabled) - marks ~6000 files as 'seeded'
-        2. Create folder watches for all 43 stores
-        3. Only NEW uploads after this point will be processed
-    """
-    from .folder_watcher import get_folder_watcher
+	Process:
+	    1. Seed existing files (if enabled) - marks ~6000 files as 'seeded'
+	    2. Create folder watches for all 43 stores
+	    3. Only NEW uploads after this point will be processed
+	"""
+	from .folder_watcher import get_folder_watcher
 
-    result = {
-        'status': 'success',
-        'seeding': None,
-        'watches_created': 0,
-        'watches': []
-    }
+	result = {"status": "success", "seeding": None, "watches_created": 0, "watches": []}
 
-    # Step 1: Seed existing files first (CRITICAL - prevents reprocessing)
-    if seed_existing:
-        logger.info("Seeding existing files before creating watches...")
-        seed_result = await seed_existing_files()
-        result['seeding'] = {
-            'total_seeded': seed_result['total_seeded'],
-            'message': 'Existing files marked as processed - only NEW uploads will be extracted'
-        }
+	# Step 1: Seed existing files first (CRITICAL - prevents reprocessing)
+	if seed_existing:
+		logger.info("Seeding existing files before creating watches...")
+		seed_result = await seed_existing_files()
+		result["seeding"] = {
+			"total_seeded": seed_result["total_seeded"],
+			"message": "Existing files marked as processed - only NEW uploads will be extracted",
+		}
 
-    # Step 2: Create folder watches
-    watcher = get_folder_watcher()
-    watches = watcher.setup_all_folder_watches()
+	# Step 2: Create folder watches
+	watcher = get_folder_watcher()
+	watches = watcher.setup_all_folder_watches()
 
-    result['watches_created'] = len(watches)
-    result['watches'] = [
-        {
-            'folder_name': w.get('folder_name'),
-            'store_code': w.get('store_code'),
-            'channel_id': w.get('channel_id'),
-            'expires': w.get('expiration').isoformat() if hasattr(w.get('expiration'), 'isoformat') else w.get('expiration')
-        }
-        for w in watches
-    ]
+	result["watches_created"] = len(watches)
+	result["watches"] = [
+		{
+			"folder_name": w.get("folder_name"),
+			"store_code": w.get("store_code"),
+			"channel_id": w.get("channel_id"),
+			"expires": w.get("expiration").isoformat()
+			if hasattr(w.get("expiration"), "isoformat")
+			else w.get("expiration"),
+		}
+		for w in watches
+	]
 
-    return result
+	return result
 
 
 @app.post("/api/folders/renew")
 async def renew_folder_watches():
-    """Renew expiring folder watches."""
-    from .folder_watcher import get_folder_watcher
+	"""Renew expiring folder watches."""
+	from .folder_watcher import get_folder_watcher
 
-    watcher = get_folder_watcher()
-    renewed = watcher.renew_expiring_folder_watches()
+	watcher = get_folder_watcher()
+	renewed = watcher.renew_expiring_folder_watches()
 
-    return {
-        'status': 'success',
-        'watches_renewed': len(renewed)
-    }
+	return {"status": "success", "watches_renewed": len(renewed)}
 
 
 @app.get("/api/folders/status")
 async def get_folder_status():
-    """Get status of all folder watches."""
-    from .models import get_db
+	"""Get status of all folder watches."""
+	from .models import get_db
 
-    db = get_db()
-    watches = db.get_all_folder_watches()
-    queue_summary = db.get_file_queue_summary()
+	db = get_db()
+	watches = db.get_all_folder_watches()
+	queue_summary = db.get_file_queue_summary()
 
-    from datetime import datetime
-    now = datetime.utcnow()
+	from datetime import datetime
 
-    return {
-        'service': 'folder-watcher',
-        'total_folders': len(watches),
-        'watches': [
-            {
-                'folder_name': w['folder_name'],
-                'store_code': w['store_code'],
-                'hours_until_expiry': (w['expiration'] - now).total_seconds() / 3600
-            }
-            for w in watches
-        ],
-        'file_queue': queue_summary
-    }
+	now = datetime.utcnow()
+
+	return {
+		"service": "folder-watcher",
+		"total_folders": len(watches),
+		"watches": [
+			{
+				"folder_name": w["folder_name"],
+				"store_code": w["store_code"],
+				"hours_until_expiry": (w["expiration"] - now).total_seconds() / 3600,
+			}
+			for w in watches
+		],
+		"file_queue": queue_summary,
+	}
 
 
 @app.get("/api/files/queue")
-async def get_file_queue(status: Optional[str] = None, limit: int = 50):
-    """Get files in processing queue."""
-    from .models import get_db
+async def get_file_queue(status: str | None = None, limit: int = 50):
+	"""Get files in processing queue."""
+	from .models import get_db
 
-    db = get_db()
+	db = get_db()
 
-    if status == 'pending':
-        files = db.get_pending_files(limit=limit)
-    else:
-        # Get all files from queue
-        with db._connection() as conn:
-            if status:
-                rows = conn.execute(
-                    "SELECT * FROM file_queue WHERE status = ? ORDER BY detected_at DESC LIMIT ?",
-                    (status, limit)
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    "SELECT * FROM file_queue ORDER BY detected_at DESC LIMIT ?",
-                    (limit,)
-                ).fetchall()
-            files = [dict(row) for row in rows]
+	if status == "pending":
+		files = db.get_pending_files(limit=limit)
+	else:
+		# Get all files from queue
+		with db._connection() as conn:
+			if status:
+				rows = conn.execute(
+					"SELECT * FROM file_queue WHERE status = ? ORDER BY detected_at DESC LIMIT ?",
+					(status, limit),
+				).fetchall()
+			else:
+				rows = conn.execute(
+					"SELECT * FROM file_queue ORDER BY detected_at DESC LIMIT ?", (limit,)
+				).fetchall()
+			files = [dict(row) for row in rows]
 
-    return {
-        'total': len(files),
-        'files': files
-    }
+	return {"total": len(files), "files": files}
 
 
 @app.get("/api/files/processed")
-async def get_processed_files(store_code: Optional[str] = None, limit: int = 100):
-    """Get list of processed files."""
-    from .models import get_db
+async def get_processed_files(store_code: str | None = None, limit: int = 100):
+	"""Get list of processed files."""
+	from .models import get_db
 
-    db = get_db()
-    files = db.get_processed_files(store_code=store_code, limit=limit)
+	db = get_db()
+	files = db.get_processed_files(store_code=store_code, limit=limit)
 
-    return {
-        'total': len(files),
-        'files': files
-    }
+	return {"total": len(files), "files": files}
 
 
 @app.post("/api/files/{file_id}/reprocess")
 async def reprocess_file(file_id: str, background_tasks: BackgroundTasks):
-    """Reprocess a failed file."""
-    from .models import get_db
+	"""Reprocess a failed file."""
+	from .models import get_db
 
-    db = get_db()
+	db = get_db()
 
-    # Update status back to pending
-    db.update_file_status(file_id, 'pending')
+	# Update status back to pending
+	db.update_file_status(file_id, "pending")
 
-    return {'status': 'requeued', 'file_id': file_id}
+	return {"status": "requeued", "file_id": file_id}
 
 
 @app.post("/api/folders/scan")
 async def scan_folder(folder_id: str, background_tasks: BackgroundTasks):
-    """
-    Manually scan a folder for new files.
+	"""
+	Manually scan a folder for new files.
 
-    Useful for initial setup or if webhooks missed something.
-    """
-    from .folder_watcher import get_folder_watcher
-    from .models import get_db
-    from .config import get_folder_by_id
+	Useful for initial setup or if webhooks missed something.
+	"""
+	from .config import get_folder_by_id
+	from .folder_watcher import get_folder_watcher
+	from .models import get_db
 
-    watcher = get_folder_watcher()
-    db = get_db()
+	watcher = get_folder_watcher()
+	db = get_db()
 
-    folder_config = get_folder_by_id(folder_id)
-    store_code = folder_config.store_code if folder_config else None
+	folder_config = get_folder_by_id(folder_id)
+	store_code = folder_config.store_code if folder_config else None
 
-    # Get all files in folder
-    files = watcher.list_new_files(folder_id, since=None)
+	# Get all files in folder
+	files = watcher.list_new_files(folder_id, since=None)
 
-    queued = 0
-    skipped = 0
-    for file_info in files:
-        if db.is_file_processed(file_info['id']):
-            skipped += 1
-        else:
-            file_info['folder_id'] = folder_id
-            db.queue_file(file_info, store_code=store_code)
-            queued += 1
+	queued = 0
+	skipped = 0
+	for file_info in files:
+		if db.is_file_processed(file_info["id"]):
+			skipped += 1
+		else:
+			file_info["folder_id"] = folder_id
+			db.queue_file(file_info, store_code=store_code)
+			queued += 1
 
-    return {
-        'status': 'scanned',
-        'folder_id': folder_id,
-        'files_queued': queued,
-        'files_skipped': skipped
-    }
+	return {"status": "scanned", "folder_id": folder_id, "files_queued": queued, "files_skipped": skipped}
 
 
 @app.post("/api/folders/scan-all")
 async def scan_all_folders(background_tasks: BackgroundTasks):
-    """
-    Scan ALL store folders (including date subfolders) for new files.
+	"""
+	Scan ALL store folders (including date subfolders) for new files.
 
-    This recursively scans each store folder and its date subfolders
-    (e.g., Store/2026-01-31/files) to find all unprocessed files.
+	This recursively scans each store folder and its date subfolders
+	(e.g., Store/2026-01-31/files) to find all unprocessed files.
 
-    Use this to catch up on missed files or after initial setup.
-    """
-    from .folder_watcher import get_folder_watcher
+	Use this to catch up on missed files or after initial setup.
+	"""
+	from .folder_watcher import get_folder_watcher
 
-    watcher = get_folder_watcher()
-    result = watcher.scan_all_stores()
+	watcher = get_folder_watcher()
+	result = watcher.scan_all_stores()
 
-    return {
-        'status': 'scanned',
-        'total_found': result['total_found'],
-        'total_queued': result['total_queued'],
-        'stores_with_files': result['stores_with_files'],
-        'stores': result['stores']
-    }
+	return {
+		"status": "scanned",
+		"total_found": result["total_found"],
+		"total_queued": result["total_queued"],
+		"stores_with_files": result["stores_with_files"],
+		"stores": result["stores"],
+	}
 
 
 @app.post("/api/files/process")
 async def process_pending_files(
-    background_tasks: BackgroundTasks,
-    limit: int = 50,
-    parallel: bool = True,
-    workers: int = 10
+	background_tasks: BackgroundTasks, limit: int = 50, parallel: bool = True, workers: int = 10
 ):
-    """
-    Process pending files from the queue with parallel processing.
+	"""
+	Process pending files from the queue with parallel processing.
 
-    Downloads files from Google Drive, extracts POS data, and updates
-    the database. Uses parallel workers to overcome Google Drive API latency.
+	Downloads files from Google Drive, extracts POS data, and updates
+	the database. Uses parallel workers to overcome Google Drive API latency.
 
-    Args:
-        limit: Maximum files to process (default 50)
-        parallel: Use parallel processing (default True)
-        workers: Number of parallel workers (default 10)
+	Args:
+	    limit: Maximum files to process (default 50)
+	    parallel: Use parallel processing (default True)
+	    workers: Number of parallel workers (default 10)
 
-    Performance:
-        Sequential: ~1.3s/file (Google Drive latency bottleneck)
-        Parallel (10 workers): ~0.13s/file effective throughput
-    """
-    from .file_processor import FileProcessor
+	Performance:
+	    Sequential: ~1.3s/file (Google Drive latency bottleneck)
+	    Parallel (10 workers): ~0.13s/file effective throughput
+	"""
+	from .file_processor import FileProcessor
 
-    processor = FileProcessor(max_workers=workers)
-    result = processor.process_pending_files(limit=limit, parallel=parallel)
+	processor = FileProcessor(max_workers=workers)
+	result = processor.process_pending_files(limit=limit, parallel=parallel)
 
-    return result
+	return result
 
 
 @app.post("/api/files/process-all")
 async def process_all_pending_files(
-    background_tasks: BackgroundTasks,
-    batch_size: int = 50,
-    workers: int = 10
+	background_tasks: BackgroundTasks, batch_size: int = 50, workers: int = 10
 ):
-    """
-    Process ALL pending files in the queue with parallel processing.
+	"""
+	Process ALL pending files in the queue with parallel processing.
 
-    Uses parallel workers for high throughput processing of large queues.
+	Uses parallel workers for high throughput processing of large queues.
 
-    Args:
-        batch_size: Files per batch (default 50)
-        workers: Parallel workers per batch (default 10)
+	Args:
+	    batch_size: Files per batch (default 50)
+	    workers: Parallel workers per batch (default 10)
 
-    Performance estimate:
-        - 6,300 files with 10 workers at 1.3s/file
-        - Effective: ~13 files/sec = ~8 minutes total
-        - vs Sequential: ~2.3 hours
-    """
-    from .file_processor import FileProcessor
-    from .models import get_db
-    import time
+	Performance estimate:
+	    - 6,300 files with 10 workers at 1.3s/file
+	    - Effective: ~13 files/sec = ~8 minutes total
+	    - vs Sequential: ~2.3 hours
+	"""
+	import time
 
-    db = get_db()
-    queue_summary = db.get_file_queue_summary()
-    pending_count = queue_summary.get('pending', 0)
+	from .file_processor import FileProcessor
+	from .models import get_db
 
-    if pending_count == 0:
-        return {
-            'status': 'no_pending_files',
-            'message': 'No files in queue to process'
-        }
+	db = get_db()
+	queue_summary = db.get_file_queue_summary()
+	pending_count = queue_summary.get("pending", 0)
 
-    start_time = time.time()
+	if pending_count == 0:
+		return {"status": "no_pending_files", "message": "No files in queue to process"}
 
-    # Process synchronously for now to get accurate timing
-    processor = FileProcessor(max_workers=workers)
-    result = processor.process_all_pending(batch_size=batch_size)
+	start_time = time.time()
 
-    elapsed = time.time() - start_time
-    files_per_sec = result['processed'] / elapsed if elapsed > 0 else 0
+	# Process synchronously for now to get accurate timing
+	processor = FileProcessor(max_workers=workers)
+	result = processor.process_all_pending(batch_size=batch_size)
 
-    return {
-        'status': 'completed',
-        'processed': result['processed'],
-        'failed': result['failed'],
-        'total_records': result['total_records'],
-        'batches': result['batches'],
-        'elapsed_seconds': round(elapsed, 1),
-        'files_per_second': round(files_per_sec, 2),
-        'parallel_workers': workers
-    }
+	elapsed = time.time() - start_time
+	files_per_sec = result["processed"] / elapsed if elapsed > 0 else 0
+
+	return {
+		"status": "completed",
+		"processed": result["processed"],
+		"failed": result["failed"],
+		"total_records": result["total_records"],
+		"batches": result["batches"],
+		"elapsed_seconds": round(elapsed, 1),
+		"files_per_second": round(files_per_sec, 2),
+		"parallel_workers": workers,
+	}
 
 
 def run_server():
-    """Run the webhook server."""
-    config = get_config()
+	"""Run the webhook server."""
+	config = get_config()
 
-    uvicorn.run(
-        app,
-        host=config.webhook_host,
-        port=config.webhook_port,
-        log_level=config.log_level.lower()
-    )
+	uvicorn.run(app, host=config.webhook_host, port=config.webhook_port, log_level=config.log_level.lower())
 
 
 if __name__ == "__main__":
-    run_server()
+	run_server()

--- a/hrms/services/sheets_receiver/webhook.py
+++ b/hrms/services/sheets_receiver/webhook.py
@@ -5,7 +5,10 @@ Handles incoming push notifications from Google Drive.
 """
 
 import logging
-from typing import Optional
+from datetime import UTC, date, datetime
+from datetime import time as dt_time
+from typing import Any, Optional
+from zoneinfo import ZoneInfo
 
 from fastapi import FastAPI, Request, Header, BackgroundTasks, HTTPException
 from fastapi.responses import JSONResponse
@@ -15,6 +18,149 @@ from .config import get_config
 from .processor import get_processor
 
 logger = logging.getLogger(__name__)
+
+PHT_TIMEZONE = ZoneInfo("Asia/Manila")
+BASELINE_TARGET_PHT_TIME = dt_time(hour=7, minute=0)
+MORNING_READY_DEADLINE_PHT_TIME = dt_time(hour=9, minute=0)
+MORNING_HEALTH_SHEET_KEYS = (
+    "inventory",
+    "ap_opening_balance",
+    "procurement_suppliers",
+    "procurement_requisitions",
+    "procurement_purchase_orders",
+    "procurement_goods_receipts",
+)
+
+
+def _normalize_report_date(report_date: str | None) -> date:
+    """Normalize the requested report date in PHT."""
+    if report_date:
+        return date.fromisoformat(report_date)
+    return datetime.now(PHT_TIMEZONE).date()
+
+
+def _serialize_sync_log(sync_log: Any | None) -> dict[str, Any] | None:
+    """Serialize a sync log dataclass for API responses."""
+    if not sync_log:
+        return None
+
+    created_at_utc = sync_log.created_at.replace(tzinfo=UTC)
+    return {
+        "id": sync_log.id,
+        "trigger": sync_log.trigger,
+        "status": sync_log.status,
+        "rows_processed": sync_log.rows_processed,
+        "rows_created": sync_log.rows_created,
+        "rows_updated": sync_log.rows_updated,
+        "rows_failed": sync_log.rows_failed,
+        "error_message": sync_log.error_message,
+        "duration_seconds": sync_log.duration_seconds,
+        "created_at_utc": created_at_utc.isoformat(),
+        "created_at_pht": created_at_utc.astimezone(PHT_TIMEZONE).isoformat(),
+    }
+
+
+def _build_lane_health(sheet_key: str, report_date_value: date) -> dict[str, Any]:
+    """Summarize one receiver lane for the morning health report."""
+    from .config import get_sheet_config
+    from .models import get_db
+
+    sheet_config = get_sheet_config(sheet_key)
+    if not sheet_config:
+        return {
+            "sheet_key": sheet_key,
+            "status": "missing",
+            "ready_before_deadline": False,
+            "clean_success": False,
+        }
+
+    if not getattr(sheet_config, "enabled", True):
+        return {
+            "sheet_key": sheet_key,
+            "name": sheet_config.name,
+            "status": "disabled",
+            "ready_before_deadline": False,
+            "clean_success": False,
+        }
+
+    pht_day_start = datetime.combine(report_date_value, dt_time.min, tzinfo=PHT_TIMEZONE)
+    pht_deadline = datetime.combine(report_date_value, MORNING_READY_DEADLINE_PHT_TIME, tzinfo=PHT_TIMEZONE)
+    day_start_utc = pht_day_start.astimezone(UTC)
+    deadline_utc = pht_deadline.astimezone(UTC)
+
+    db = get_db()
+    latest_today = db.get_latest_sync_since(
+        sheet_config.spreadsheet_id,
+        sheet_config.sheet_name,
+        day_start_utc,
+        trigger="daily_baseline",
+    )
+    latest_success_today = db.get_latest_sync_since(
+        sheet_config.spreadsheet_id,
+        sheet_config.sheet_name,
+        day_start_utc,
+        trigger="daily_baseline",
+        status="success",
+    )
+
+    ready_before_deadline = bool(
+        latest_success_today and latest_success_today.created_at.replace(tzinfo=UTC) <= deadline_utc
+    )
+    clean_success = bool(latest_success_today and latest_success_today.rows_failed == 0)
+
+    if latest_today is None:
+        status = "pending"
+    elif latest_today.status == "success":
+        status = "completed_with_exceptions" if latest_today.rows_failed else "completed"
+    elif latest_success_today is not None:
+        status = f"{latest_today.status}_after_success"
+    else:
+        status = latest_today.status or "unknown"
+
+    return {
+        "sheet_key": sheet_key,
+        "name": sheet_config.name,
+        "sheet_name": sheet_config.sheet_name,
+        "owner_email": sheet_config.owner_email,
+        "status": status,
+        "ready_before_deadline": ready_before_deadline,
+        "clean_success": clean_success,
+        "latest_today": _serialize_sync_log(latest_today),
+        "latest_success_today": _serialize_sync_log(latest_success_today),
+        "completed_at_pht": (
+            latest_success_today.created_at.replace(tzinfo=UTC).astimezone(PHT_TIMEZONE).isoformat()
+            if latest_success_today
+            else None
+        ),
+    }
+
+
+def build_morning_health_report(report_date: str | None = None) -> dict[str, Any]:
+    """Build the receiver-side morning health report for Ian inventory + AP/procurement."""
+    report_date_value = _normalize_report_date(report_date)
+    lane_rows = [_build_lane_health(sheet_key, report_date_value) for sheet_key in MORNING_HEALTH_SHEET_KEYS]
+    active_lanes = [lane for lane in lane_rows if lane.get("status") not in {"disabled", "missing"}]
+    all_ready = bool(active_lanes) and all(lane.get("ready_before_deadline") for lane in active_lanes)
+    all_clean = all(lane.get("clean_success") for lane in active_lanes) if active_lanes else False
+
+    if all_ready and all_clean:
+        status = "green"
+    elif all_ready:
+        status = "yellow"
+    else:
+        status = "red"
+
+    return {
+        "service": "sheets-receiver",
+        "report_date": report_date_value.isoformat(),
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+        "generated_at_pht": datetime.now(PHT_TIMEZONE).isoformat(),
+        "baseline_target_pht_time": BASELINE_TARGET_PHT_TIME.strftime("%H:%M"),
+        "ready_deadline_pht_time": MORNING_READY_DEADLINE_PHT_TIME.strftime("%H:%M"),
+        "status": status,
+        "ready_before_deadline": all_ready,
+        "lanes": lane_rows,
+    }
 
 app = FastAPI(
     title="Sheets Receiver",
@@ -222,6 +368,15 @@ async def get_status():
             for s in recent_syncs
         ]
     }
+
+
+@app.get("/api/morning-health")
+async def get_morning_health(report_date: str | None = None):
+    """Get same-day baseline readiness for Ian inventory and AP/procurement."""
+    try:
+        return build_morning_health_report(report_date=report_date)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.post("/api/watches/setup")

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -12,16 +12,17 @@ if str(ROOT) not in sys.path:
 
 
 def _install_fake_hrms():
-	if "hrms" in sys.modules:
-		return
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
 
-	hrms_pkg = types.ModuleType("hrms")
-	hrms_pkg.__path__ = []
-	sys.modules["hrms"] = hrms_pkg
-
-	utils_pkg = types.ModuleType("hrms.utils")
-	utils_pkg.__path__ = []
-	sys.modules["hrms.utils"] = utils_pkg
+	if "hrms.utils" not in sys.modules:
+		utils_pkg = types.ModuleType("hrms.utils")
+		utils_pkg.__path__ = []
+		sys.modules["hrms.utils"] = utils_pkg
+	else:
+		utils_pkg = sys.modules["hrms.utils"]
 
 	store_snapshot_mod = types.ModuleType("hrms.utils.store_order_demand_snapshot")
 	store_snapshot_mod.DEFAULT_DESTINATION_DIR = ROOT / "tmp"
@@ -293,6 +294,231 @@ class TestErpSyncRuntime(unittest.TestCase):
 		erp_sync.frappe.enqueue.assert_not_called()
 		save_registry_mock.assert_called_once()
 		save_state_mock.assert_called_once()
+
+	def test_get_morning_sync_health_report_is_yellow_when_receiver_has_exceptions(self):
+		registry_rows = [
+			types.SimpleNamespace(
+				store_code="AFT",
+				sheet_sync_enabled=True,
+				state="shadow_sync",
+				last_inventory_date="2026-01-01",
+				last_success_at="2026-01-01T07:22:00+08:00",
+				last_error="",
+			),
+			types.SimpleNamespace(
+				store_code="AMM",
+				sheet_sync_enabled=True,
+				state="shadow_sync",
+				last_inventory_date="2026-01-01",
+				last_success_at="2026-01-01T07:25:00+08:00",
+				last_error="",
+			),
+		]
+		runtime_state = {
+			"last_run": {
+				"status": "completed",
+				"run_date": "2026-01-01",
+				"generated_at": "2026-01-01T07:00:00+08:00",
+				"updated_at": "2026-01-01T07:25:00+08:00",
+				"failed_stores": 0,
+				"current_stage": "completed",
+			}
+		}
+		receiver_payload = {
+			"status": "yellow",
+			"ready_before_deadline": True,
+			"lanes": [
+				{
+					"sheet_key": "inventory",
+					"name": "Inventory",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T07:40:00+08:00",
+				},
+				{
+					"sheet_key": "ap_opening_balance",
+					"name": "AP Opening Balance",
+					"status": "completed_with_exceptions",
+					"ready_before_deadline": True,
+					"clean_success": False,
+					"completed_at_pht": "2026-01-01T08:05:00+08:00",
+				},
+				{
+					"sheet_key": "procurement_suppliers",
+					"name": "Procurement Suppliers",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T07:50:00+08:00",
+				},
+				{
+					"sheet_key": "procurement_requisitions",
+					"name": "Procurement Requisitions",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T07:55:00+08:00",
+				},
+				{
+					"sheet_key": "procurement_purchase_orders",
+					"name": "Procurement Purchase Orders",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T08:00:00+08:00",
+				},
+				{
+					"sheet_key": "procurement_goods_receipts",
+					"name": "Procurement Goods Receipts",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T08:02:00+08:00",
+				},
+			],
+		}
+
+		class _Response:
+			def raise_for_status(self):
+				return None
+
+			def json(self):
+				return receiver_payload
+
+		with (
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"load_store_registry",
+				return_value=registry_rows,
+			),
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"load_runtime_state",
+				return_value=runtime_state,
+			),
+			patch("requests.get", return_value=_Response()),
+		):
+			report = erp_sync.get_morning_sync_health_report(report_date="2026-01-01")
+
+		self.assertEqual(report["status"], "yellow")
+		self.assertTrue(report["ready_before_deadline"])
+		areas = {area["key"]: area for area in report["areas"]}
+		self.assertEqual(areas["store_inventory_shadow_sync"]["status"], "green")
+		self.assertEqual(areas["ian_warehouse_inventory"]["status"], "green")
+		self.assertEqual(areas["ap_procurement_baselines"]["status"], "yellow")
+
+	def test_get_morning_sync_health_report_is_red_when_store_sync_is_incomplete(self):
+		registry_rows = [
+			types.SimpleNamespace(
+				store_code="AFT",
+				sheet_sync_enabled=True,
+				state="shadow_sync",
+				last_inventory_date="2026-01-01",
+				last_success_at="2026-01-01T07:22:00+08:00",
+				last_error="",
+			),
+			types.SimpleNamespace(
+				store_code="AMM",
+				sheet_sync_enabled=True,
+				state="shadow_sync",
+				last_inventory_date="",
+				last_success_at="",
+				last_error="download failed",
+			),
+		]
+		runtime_state = {
+			"last_run": {
+				"status": "in_progress",
+				"run_date": "2026-01-01",
+				"generated_at": "2026-01-01T07:00:00+08:00",
+				"updated_at": "2026-01-01T07:40:00+08:00",
+				"failed_stores": 1,
+				"current_stage": "download",
+			}
+		}
+		receiver_payload = {
+			"status": "green",
+			"ready_before_deadline": True,
+			"lanes": [
+				{
+					"sheet_key": "inventory",
+					"name": "Inventory",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T07:30:00+08:00",
+				},
+				{
+					"sheet_key": "ap_opening_balance",
+					"name": "AP Opening Balance",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T07:40:00+08:00",
+				},
+				{
+					"sheet_key": "procurement_suppliers",
+					"name": "Procurement Suppliers",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T07:45:00+08:00",
+				},
+				{
+					"sheet_key": "procurement_requisitions",
+					"name": "Procurement Requisitions",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T07:50:00+08:00",
+				},
+				{
+					"sheet_key": "procurement_purchase_orders",
+					"name": "Procurement Purchase Orders",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T07:55:00+08:00",
+				},
+				{
+					"sheet_key": "procurement_goods_receipts",
+					"name": "Procurement Goods Receipts",
+					"status": "completed",
+					"ready_before_deadline": True,
+					"clean_success": True,
+					"completed_at_pht": "2026-01-01T08:00:00+08:00",
+				},
+			],
+		}
+
+		class _Response:
+			def raise_for_status(self):
+				return None
+
+			def json(self):
+				return receiver_payload
+
+		with (
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"load_store_registry",
+				return_value=registry_rows,
+			),
+			patch.object(
+				erp_sync.store_inventory_shadow_sync_builder,
+				"load_runtime_state",
+				return_value=runtime_state,
+			),
+			patch("requests.get", return_value=_Response()),
+		):
+			report = erp_sync.get_morning_sync_health_report(report_date="2026-01-01")
+
+		self.assertEqual(report["status"], "red")
+		self.assertFalse(report["ready_before_deadline"])
+		store_area = next(area for area in report["areas"] if area["key"] == "store_inventory_shadow_sync")
+		self.assertEqual(store_area["status"], "red")
+		self.assertEqual(store_area["pending_store_codes"], ["AMM"])
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_sheets_receiver_main.py
+++ b/hrms/tests/test_sheets_receiver_main.py
@@ -188,8 +188,8 @@ class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
 		)
 		main_mod._maybe_generate_ap_exception_report = MagicMock()
 
-	def test_daily_baseline_sync_skips_before_8am_pht(self):
-		now_utc = datetime(2026, 3, 9, 23, 59, tzinfo=UTC)
+	def test_daily_baseline_sync_skips_before_7am_pht(self):
+		now_utc = datetime(2026, 3, 9, 22, 59, tzinfo=UTC)
 
 		results = main_mod.run_daily_baseline_sync_if_due(now_utc=now_utc)
 
@@ -197,8 +197,8 @@ class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
 		self.processor.sync_sheet.assert_not_called()
 		self.db.has_successful_sync_since.assert_not_called()
 
-	def test_daily_baseline_sync_runs_force_sync_for_target_sheets_after_8am_pht(self):
-		now_utc = datetime(2026, 3, 10, 0, 5, tzinfo=UTC)
+	def test_daily_baseline_sync_runs_force_sync_for_target_sheets_after_7am_pht(self):
+		now_utc = datetime(2026, 3, 9, 23, 5, tzinfo=UTC)
 
 		results = main_mod.run_daily_baseline_sync_if_due(now_utc=now_utc)
 
@@ -209,7 +209,7 @@ class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
 			self.assertTrue(call.kwargs["force"])
 
 	def test_daily_baseline_sync_skips_sheets_already_synced_today(self):
-		now_utc = datetime(2026, 3, 10, 0, 5, tzinfo=UTC)
+		now_utc = datetime(2026, 3, 9, 23, 5, tzinfo=UTC)
 		self.db.has_successful_sync_since.side_effect = lambda spreadsheet_id, sheet_name, trigger, since: (
 			sheet_name == "SUPPLIERS SOA"
 		)
@@ -231,7 +231,7 @@ class TestSheetsReceiverDailyBaselineSync(unittest.TestCase):
 		)
 
 	def test_daily_baseline_sync_generates_ap_exception_report_when_enabled(self):
-		now_utc = datetime(2026, 3, 10, 0, 5, tzinfo=UTC)
+		now_utc = datetime(2026, 3, 9, 23, 5, tzinfo=UTC)
 		main_mod.get_config.return_value = types.SimpleNamespace(
 			baseline_test_interval_minutes=0,
 			generate_ap_exception_reports=True,

--- a/hrms/tests/test_sheets_receiver_webhook.py
+++ b/hrms/tests/test_sheets_receiver_webhook.py
@@ -1,0 +1,211 @@
+import importlib.util
+import sys
+import types
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_sheets_receiver_dependencies():
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
+
+	if "hrms.services" not in sys.modules:
+		services_pkg = types.ModuleType("hrms.services")
+		services_pkg.__path__ = []
+		sys.modules["hrms.services"] = services_pkg
+
+	if "hrms.services.sheets_receiver" not in sys.modules:
+		sheets_pkg = types.ModuleType("hrms.services.sheets_receiver")
+		sheets_pkg.__path__ = []
+		sys.modules["hrms.services.sheets_receiver"] = sheets_pkg
+
+	config_mod = types.ModuleType("hrms.services.sheets_receiver.config")
+	config_mod.get_config = lambda: types.SimpleNamespace()
+	config_mod.get_watched_sheets = lambda: {}
+	config_mod.get_sheet_config = lambda _sheet_key: None
+	sys.modules["hrms.services.sheets_receiver.config"] = config_mod
+
+	models_mod = types.ModuleType("hrms.services.sheets_receiver.models")
+	models_mod.get_db = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.models"] = models_mod
+
+	processor_mod = types.ModuleType("hrms.services.sheets_receiver.processor")
+	processor_mod.get_processor = lambda: types.SimpleNamespace()
+	sys.modules["hrms.services.sheets_receiver.processor"] = processor_mod
+
+
+_install_fake_sheets_receiver_dependencies()
+config_mod = sys.modules["hrms.services.sheets_receiver.config"]
+models_mod = sys.modules["hrms.services.sheets_receiver.models"]
+webhook_spec = importlib.util.spec_from_file_location(
+	"hrms.services.sheets_receiver.webhook_under_test",
+	ROOT / "hrms" / "services" / "sheets_receiver" / "webhook.py",
+)
+webhook_mod = importlib.util.module_from_spec(webhook_spec)
+webhook_spec.loader.exec_module(webhook_mod)
+
+
+class _FakeSyncLog:
+	def __init__(self, *, status: str, created_at: datetime, rows_failed: int = 0):
+		self.id = 1
+		self.trigger = "daily_baseline"
+		self.status = status
+		self.rows_processed = 10
+		self.rows_created = 1
+		self.rows_updated = 9
+		self.rows_failed = rows_failed
+		self.error_message = None
+		self.duration_seconds = 1.2
+		self.created_at = created_at.replace(tzinfo=None)
+
+
+class _FakeDb:
+	def __init__(self, mapping):
+		self.mapping = mapping
+
+	def get_latest_sync_since(self, spreadsheet_id, sheet_name, since, *, status=None, trigger=None):
+		return self.mapping.get((sheet_name, status))
+
+
+class TestSheetsReceiverMorningHealthReport(unittest.TestCase):
+	def setUp(self):
+		self.sheet_configs = {
+			"inventory": types.SimpleNamespace(
+				name="Inventory",
+				spreadsheet_id="book-inventory",
+				sheet_name="SUMMARY 2026",
+				owner_email="ian@bebang.ph",
+				enabled=True,
+			),
+			"ap_opening_balance": types.SimpleNamespace(
+				name="AP Opening Balance",
+				spreadsheet_id="book-ap",
+				sheet_name="SUPPLIERS SOA",
+				owner_email="alyssa@bebang.ph",
+				enabled=True,
+			),
+			"procurement_suppliers": types.SimpleNamespace(
+				name="Procurement Suppliers",
+				spreadsheet_id="book-proc",
+				sheet_name="Suppliers",
+				owner_email="aldrin@bebang.ph",
+				enabled=True,
+			),
+			"procurement_requisitions": types.SimpleNamespace(
+				name="Procurement Requisitions",
+				spreadsheet_id="book-proc",
+				sheet_name="Purchase Requisitions",
+				owner_email="aldrin@bebang.ph",
+				enabled=True,
+			),
+			"procurement_purchase_orders": types.SimpleNamespace(
+				name="Procurement Purchase Orders",
+				spreadsheet_id="book-proc",
+				sheet_name="Purchase Orders",
+				owner_email="aldrin@bebang.ph",
+				enabled=True,
+			),
+			"procurement_goods_receipts": types.SimpleNamespace(
+				name="Procurement Goods Receipts",
+				spreadsheet_id="book-proc",
+				sheet_name="Goods Receipts",
+				owner_email="aldrin@bebang.ph",
+				enabled=True,
+			),
+		}
+		config_mod.get_sheet_config = lambda sheet_key: self.sheet_configs.get(sheet_key)
+
+	def test_report_is_yellow_when_all_lanes_ready_but_ap_has_failed_rows(self):
+		fake_db = _FakeDb(
+			{
+				("SUMMARY 2026", None): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 12, 23, 35, tzinfo=UTC),
+				),
+				("SUMMARY 2026", "success"): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 12, 23, 35, tzinfo=UTC),
+				),
+				("SUPPLIERS SOA", None): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 5, tzinfo=UTC),
+					rows_failed=2,
+				),
+				("SUPPLIERS SOA", "success"): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 5, tzinfo=UTC),
+					rows_failed=2,
+				),
+				("Suppliers", None): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 2, tzinfo=UTC),
+				),
+				("Suppliers", "success"): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 2, tzinfo=UTC),
+				),
+				("Purchase Requisitions", None): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 4, tzinfo=UTC),
+				),
+				("Purchase Requisitions", "success"): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 4, tzinfo=UTC),
+				),
+				("Purchase Orders", None): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 7, tzinfo=UTC),
+				),
+				("Purchase Orders", "success"): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 7, tzinfo=UTC),
+				),
+				("Goods Receipts", None): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 8, tzinfo=UTC),
+				),
+				("Goods Receipts", "success"): _FakeSyncLog(
+					status="success",
+					created_at=datetime(2026, 3, 13, 0, 8, tzinfo=UTC),
+				),
+			}
+		)
+		models_mod.get_db = lambda: fake_db
+
+		report = webhook_mod.build_morning_health_report("2026-03-13")
+
+		self.assertEqual(report["status"], "yellow")
+		self.assertTrue(report["ready_before_deadline"])
+		ap_lane = next(lane for lane in report["lanes"] if lane["sheet_key"] == "ap_opening_balance")
+		self.assertEqual(ap_lane["status"], "completed_with_exceptions")
+		self.assertTrue(ap_lane["ready_before_deadline"])
+
+	def test_report_is_red_when_inventory_lane_has_no_success_today(self):
+		fake_db = _FakeDb(
+			{
+				("SUMMARY 2026", None): _FakeSyncLog(
+					status="failed",
+					created_at=datetime(2026, 3, 12, 23, 10, tzinfo=UTC),
+				),
+			}
+		)
+		models_mod.get_db = lambda: fake_db
+
+		report = webhook_mod.build_morning_health_report("2026-03-13")
+
+		self.assertEqual(report["status"], "red")
+		self.assertFalse(report["ready_before_deadline"])
+		inventory_lane = next(lane for lane in report["lanes"] if lane["sheet_key"] == "inventory")
+		self.assertEqual(inventory_lane["status"], "failed")
+		self.assertFalse(inventory_lane["ready_before_deadline"])
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
## Summary
- move store inventory shadow sync and receiver daily baselines to 7:00 AM PHT for a 2-hour ops buffer
- add receiver and Frappe morning health report paths covering store inventory, Ian inventory, and AP/procurement
- add tests for the 7 AM gate and consolidated morning health status

## Verification
- python -m py_compile hrms/services/sheets_receiver/models.py hrms/services/sheets_receiver/webhook.py hrms/services/sheets_receiver/main.py hrms/api/erp_sync.py hrms/tests/test_sheets_receiver_main.py hrms/tests/test_sheets_receiver_webhook.py hrms/tests/test_erp_sync_runtime.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest hrms/tests/test_sheets_receiver_main.py hrms/tests/test_sheets_receiver_webhook.py hrms/tests/test_erp_sync_runtime.py -q