### PR TITLE
feat: add overtime post-approval workflow

### DIFF
--- a/hrms/api/hr_reports.py
+++ b/hrms/api/hr_reports.py
@@ -526,18 +526,19 @@ def get_overtime_report(
 	results = frappe.db.sql(
 		"""
         SELECT
-            a.employee,
+            ot.employee,
             e.employee_name,
             e.department,
             e.designation,
             e.branch,
-            SUM(GREATEST(COALESCE(a.working_hours, 0) - 8, 0)) as total_ot_hours,
-            COUNT(CASE WHEN a.working_hours > 8 THEN 1 END) as ot_days
-        FROM `tabAttendance` a
-        INNER JOIN `tabEmployee` e ON a.employee = e.name
-        WHERE a.attendance_date BETWEEN %(from_date)s AND %(to_date)s
+            SUM(COALESCE(ot.approved_payable_duration, ot.overtime_hours, 0)) as total_ot_hours,
+            COUNT(*) as ot_days
+        FROM `tabBEI Overtime Request` ot
+        INNER JOIN `tabEmployee` e ON ot.employee = e.name
+        WHERE ot.attendance_date BETWEEN %(from_date)s AND %(to_date)s
+          AND ot.overtime_status IN ('Approved', 'Payroll Locked')
           AND (%(department)s IS NULL OR e.department = %(department)s)
-        GROUP BY a.employee, e.employee_name, e.department, e.designation, e.branch
+        GROUP BY ot.employee, e.employee_name, e.department, e.designation, e.branch
         HAVING total_ot_hours > 0
         ORDER BY total_ot_hours DESC
     """,
@@ -551,11 +552,11 @@ def get_overtime_report(
 			ot_slip_hours = frappe.db.sql(
 				"""
                 SELECT
-                    SUM(COALESCE(total_hours, 0)) as approved_ot_hours
+                    SUM(COALESCE(total_overtime_duration, 0)) as approved_ot_hours
                 FROM `tabOvertime Slip`
                 WHERE employee = %s
-                AND from_date >= %s
-                AND to_date <= %s
+                AND start_date >= %s
+                AND end_date <= %s
                 AND docstatus = 1
             """,
 				(row["employee"], from_date, to_date),

--- a/hrms/api/overtime.py
+++ b/hrms/api/overtime.py
@@ -1,423 +1,732 @@
-"""
-Overtime Approval API
+from __future__ import annotations
 
-DOLE compliance: shifts >8 hours require supervisor approval before payroll
-inclusion. Unapproved OT hours are excluded from OT pay calculation.
-
-Flow:
-  1. Daily scheduled task scans Attendance for working_hours > 8
-  2. Creates BEI Overtime Request records (Pending Approval)
-  3. Supervisor calls approve_overtime() or reject_overtime()
-  4. payroll/salary slip calculation checks overtime_status = 'Approved'
-"""
+from datetime import datetime, time, timedelta
 
 import frappe
 from frappe import _
-from frappe.utils import add_days, flt, getdate, now_datetime, nowdate
+from frappe.utils import add_days, cint, flt, get_datetime, get_time, getdate, now_datetime, nowdate
 
+from hrms.api.store import resolve_employee_store_context
 from hrms.utils.api_helpers import _paginate
 
-OT_THRESHOLD_HOURS = 8.0  # Hours beyond which overtime kicks in
+OT_THRESHOLD_HOURS = 8.0
+DEFAULT_FLEX_MINUTES = 30
+FLEX_REASON = "Flex Exception"
+FLEX_EARLY = "Early Start Validation"
+FLEX_LATE = "Late Flex Exception"
+OT_PENDING = "Pending Review"
+OT_LEGACY_PENDING = "Pending Approval"
+OT_NEEDS_INFO = "Needs Clarification"
+OT_CLARIFIED = "Clarification Submitted"
+OT_APPROVED = "Approved"
+OT_REJECTED = "Rejected"
+OT_ESCALATED = "Escalated"
+OT_LOCKED = "Payroll Locked"
+FLEX_PENDING = "Pending Review"
+FLEX_NEEDS_INFO = "Needs Clarification"
+FLEX_CLARIFIED = "Clarification Submitted"
+FLEX_APPROVED = "Approved"
+FLEX_REJECTED = "Rejected"
+PAYROLL_NOT_READY = "Not Ready"
+PAYROLL_PENDING = "Pending Bridge"
+PAYROLL_BRIDGED = "Bridged"
+PAYROLL_LOCKED = "Payroll Locked"
+HR_OVERRIDE_ROLES = {"HR Manager", "HR User", "System Manager", "Administrator"}
+HEAD_OFFICE_KEYS = {"BRITTANY", "CAPITAL HOUSE", "BGC", "HEAD OFFICE", "HQ"}
+COMMISSARY_KEYS = {"COMMISSARY", "R&D", "R AND D"}
 
-# Roles allowed to approve/reject overtime
-OT_APPROVER_ROLES = {"HR Manager", "Store Supervisor", "Area Supervisor", "System Manager"}
+
+def _txt(value: str | None) -> str:
+	return str(value or "").strip()
 
 
-def _check_ot_approver_role():
-	user_roles = set(frappe.get_roles(frappe.session.user))
-	if not user_roles.intersection(OT_APPROVER_ROLES):
-		frappe.throw(
-			_("Only supervisors and HR managers can approve overtime"),
-			frappe.PermissionError,
+def _upper(value: str | None) -> str:
+	return _txt(value).upper()
+
+
+def _normalize_ot_status(status: str | None) -> str:
+	return OT_PENDING if status == OT_LEGACY_PENDING else _txt(status)
+
+
+def _is_store_oic(designation: str | None) -> bool:
+	label = _upper(designation)
+	return "OIC" in label or ("ASSISTANT" in label and "SUPERVISOR" in label) or ("ASST" in label and "SUPERVISOR" in label)
+
+
+def _is_store_supervisor(designation: str | None) -> bool:
+	label = _upper(designation)
+	return "STORE SUPERVISOR" in label and "ASSISTANT" not in label and "ASST" not in label
+
+
+def _is_commissary(branch: str | None) -> bool:
+	label = _upper(branch)
+	return any(key in label for key in COMMISSARY_KEYS)
+
+
+def _is_head_office(branch: str | None) -> bool:
+	label = _upper(branch)
+	return any(key in label for key in HEAD_OFFICE_KEYS)
+
+
+def _is_head_office_shift(shift_name: str | None) -> bool:
+	label = _upper(shift_name)
+	return label.startswith("HO ") or "HEAD OFFICE" in label or "BGC" in label or "CAPITAL" in label
+
+
+def _combine(date_value, time_value) -> datetime:
+	base = getdate(date_value)
+	tm = get_time(time_value)
+	if isinstance(tm, timedelta):
+		return datetime.combine(base, time.min) + tm
+	return datetime.combine(base, tm)
+
+
+def _hours(start_dt: datetime, end_dt: datetime) -> float:
+	return max(0.0, (end_dt - start_dt).total_seconds() / 3600.0)
+
+
+def _minutes(start_dt: datetime, end_dt: datetime) -> float:
+	return max(0.0, (end_dt - start_dt).total_seconds() / 60.0)
+
+
+def _roles(user: str | None = None) -> set[str]:
+	return set(frappe.get_roles(user or frappe.session.user))
+
+
+def _is_hr_override(user: str | None = None) -> bool:
+	return bool(_roles(user).intersection(HR_OVERRIDE_ROLES))
+
+
+def _assert_hr_access() -> None:
+	if not _is_hr_override():
+		frappe.throw(_("Only HR or administrators can access this view."), frappe.PermissionError)
+
+
+def _assert_review_access(doc, status_field: str) -> bool:
+	user = frappe.session.user
+	if _is_hr_override(user):
+		return user not in {_txt(getattr(doc, "assigned_approver", None)), _txt(getattr(doc, "fallback_approver", None)), _txt(getattr(doc, "escalation_approver", None))}
+	allowed = {_txt(getattr(doc, "assigned_approver", None)), _txt(getattr(doc, "fallback_approver", None)), _txt(getattr(doc, "escalation_approver", None))}
+	if user not in allowed:
+		raise frappe.PermissionError(_("You are not the assigned reviewer for {0}.").format(doc.name))
+	return False
+
+
+def _assert_employee_access(employee_name: str) -> None:
+	employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user, "status": "Active"}, "name")
+	if employee != employee_name and not _is_hr_override():
+		frappe.throw(_("You do not have permission to respond for this employee."), frappe.PermissionError)
+
+
+def _employee(employee_name: str):
+	row = frappe.db.get_value(
+		"Employee",
+		employee_name,
+		["name", "employee_name", "user_id", "branch", "department", "designation", "reports_to", "company"],
+		as_dict=True,
+	)
+	if not row:
+		frappe.throw(_("Employee {0} not found").format(employee_name))
+	return frappe._dict(row)
+
+
+def _employee_user(employee_name: str | None) -> str | None:
+	return _txt(frappe.db.get_value("Employee", employee_name, "user_id")) if employee_name else None
+
+
+def _default_hr_manager() -> str | None:
+	for user in frappe.get_all("Has Role", filters={"role": "HR Manager"}, pluck="parent"):
+		if user and frappe.db.get_value("User", user, "enabled"):
+			return user
+	return None
+
+
+def _manager_user(employee_name: str | None) -> str | None:
+	return _employee_user(employee_name)
+
+
+def _manager_manager_user(employee_name: str | None) -> str | None:
+	if not employee_name:
+		return None
+	manager = frappe.db.get_value("Employee", employee_name, "reports_to")
+	return _employee_user(manager)
+
+
+def _store_chain(employee_doc) -> dict[str, str | None]:
+	ctx = resolve_employee_store_context(employee_doc)
+	candidates = {value for value in {_txt(ctx.get("branch")), _txt(ctx.get("warehouse")), _txt(ctx.get("warehouse_name"))} if value}
+	rows = frappe.get_all(
+		"Employee",
+		filters={"status": "Active", "branch": ["in", list(candidates)]},
+		fields=["name", "user_id", "designation"],
+		limit_page_length=100,
+	) if candidates else []
+	primary = None
+	fallback = None
+	requester_user = _txt(employee_doc.user_id)
+	if _is_store_supervisor(employee_doc.designation):
+		try:
+			from hrms.api.store import _get_area_supervisor_for_store
+
+			primary = _txt(_get_area_supervisor_for_store(ctx.get("warehouse")))
+		except Exception:
+			primary = None
+	else:
+		for row in rows:
+			if row.user_id and row.user_id != requester_user and _is_store_supervisor(row.designation):
+				primary = row.user_id
+				break
+	if not fallback:
+		for row in rows:
+			if row.user_id and row.user_id not in {requester_user, primary} and _is_store_oic(row.designation):
+				fallback = row.user_id
+				break
+	try:
+		from hrms.api.store import _get_area_supervisor_for_store
+
+		escalation = _txt(_get_area_supervisor_for_store(ctx.get("warehouse")))
+	except Exception:
+		escalation = None
+	primary = primary or escalation or _default_hr_manager()
+	fallback = fallback or escalation or _default_hr_manager()
+	escalation = escalation or _default_hr_manager()
+	return {"team_type": "store", "assigned_approver": primary, "fallback_approver": fallback, "escalation_approver": escalation}
+
+
+def _approver_chain(employee_doc) -> dict[str, str | None]:
+	if resolve_employee_store_context(employee_doc).get("warehouse"):
+		return _store_chain(employee_doc)
+	team_type = "commissary" if _is_commissary(employee_doc.branch) and not _is_head_office(employee_doc.branch) else "office"
+	primary = _manager_user(employee_doc.reports_to)
+	fallback = _manager_manager_user(employee_doc.reports_to)
+	escalation = _default_hr_manager()
+	return {
+		"team_type": team_type,
+		"assigned_approver": primary or escalation,
+		"fallback_approver": fallback or escalation,
+		"escalation_approver": escalation,
+	}
+
+
+def _shift_context(employee_doc, attendance_date, shift_name: str | None = None):
+	shift_row = None
+	if shift_name:
+		shift_row = frappe.db.get_value(
+			"Shift Type",
+			shift_name,
+			["name", "start_time", "end_time", "begin_check_in_before_shift_start_time", "late_entry_grace_period", "allow_overtime", "overtime_type"],
+			as_dict=True,
 		)
+	if not shift_row:
+		assignment = frappe.db.get_value(
+			"Shift Assignment",
+			{"employee": employee_doc.name, "docstatus": 1, "status": "Active", "start_date": ("<=", attendance_date), "end_date": [">=", attendance_date]},
+			["shift_type"],
+			as_dict=True,
+		)
+		if not assignment:
+			assignment = frappe.db.get_value(
+				"Shift Assignment",
+				{"employee": employee_doc.name, "docstatus": 1, "status": "Active", "start_date": ("<=", attendance_date), "end_date": ("is", "not set")},
+				["shift_type"],
+				as_dict=True,
+			)
+		if assignment and assignment.get("shift_type"):
+			shift_row = frappe.db.get_value(
+				"Shift Type",
+				assignment["shift_type"],
+				["name", "start_time", "end_time", "begin_check_in_before_shift_start_time", "late_entry_grace_period", "allow_overtime", "overtime_type"],
+				as_dict=True,
+			)
+	if not shift_row:
+		return frappe._dict({"shift_name": shift_name, "scheduled_start": None, "scheduled_end": None, "flex_eligible": False, "allowed_early_minutes": 0, "late_flex_minutes": 0, "standard_working_hours": OT_THRESHOLD_HOURS, "overtime_type": None})
+	start_dt = _combine(attendance_date, shift_row["start_time"])
+	end_dt = _combine(attendance_date, shift_row["end_time"])
+	if end_dt <= start_dt:
+		end_dt += timedelta(days=1)
+	flex_eligible = not resolve_employee_store_context(employee_doc).get("warehouse") and not (_is_commissary(employee_doc.branch) and not _is_head_office(employee_doc.branch)) and (_is_head_office_shift(shift_row["name"]) or _is_head_office(employee_doc.branch) or (flt(shift_row.get("begin_check_in_before_shift_start_time")) > 0 and flt(shift_row.get("late_entry_grace_period")) > 0))
+	return frappe._dict(
+		{
+			"shift_name": shift_row["name"],
+			"scheduled_start": start_dt,
+			"scheduled_end": end_dt,
+			"flex_eligible": flex_eligible,
+			"allowed_early_minutes": int(min(flt(shift_row.get("begin_check_in_before_shift_start_time") or 0), DEFAULT_FLEX_MINUTES)) if flex_eligible else 0,
+			"late_flex_minutes": int(min(flt(shift_row.get("late_entry_grace_period") or 0), DEFAULT_FLEX_MINUTES)) if flex_eligible else 0,
+			"standard_working_hours": round(_hours(start_dt, end_dt), 2) or OT_THRESHOLD_HOURS,
+			"overtime_type": shift_row.get("overtime_type"),
+		}
+	)
 
 
-# ================================
-# DETECTION
-# ================================
+def _flex_doc(employee_name: str, attendance_date, flex_type: str):
+	name = frappe.db.get_value(
+		"Attendance Request",
+		{"employee": employee_name, "from_date": attendance_date, "to_date": attendance_date, "reason": FLEX_REASON, "flex_exception_type": flex_type, "docstatus": ("!=", 2)},
+		"name",
+	)
+	return frappe.get_doc("Attendance Request", name) if name else None
+
+
+def _validated_minutes(doc) -> float:
+	if not doc or _txt(getattr(doc, "review_status", None)) != FLEX_APPROVED:
+		return 0.0
+	return flt(doc.validated_minutes or doc.requested_minutes or 0)
+
+
+def _evaluate(attendance_doc, employee_doc, shift_ctx):
+	if not attendance_doc.get("in_time") or not attendance_doc.get("out_time") or not shift_ctx.scheduled_start or not shift_ctx.scheduled_end:
+		total = flt(attendance_doc.get("working_hours") or 0)
+		return frappe._dict({"total_hours": round(total, 2), "candidate_hours": round(max(0, total - OT_THRESHOLD_HOURS), 2), "eligible": total > OT_THRESHOLD_HOURS, "late_exception_minutes": 0, "early_exception_minutes": 0})
+	actual_in = get_datetime(attendance_doc.in_time)
+	actual_out = get_datetime(attendance_doc.out_time)
+	late_doc = _flex_doc(employee_doc.name, attendance_doc.attendance_date, FLEX_LATE)
+	early_doc = _flex_doc(employee_doc.name, attendance_doc.attendance_date, FLEX_EARLY)
+	approved_late = _validated_minutes(late_doc)
+	approved_early = _validated_minutes(early_doc)
+	standard_allowed_in = shift_ctx.scheduled_start - timedelta(minutes=shift_ctx.allowed_early_minutes)
+	late_minutes = _minutes(shift_ctx.scheduled_start, actual_in)
+	extra_early = _minutes(actual_in, standard_allowed_in) if actual_in < standard_allowed_in else 0
+	within_default_late = bool(shift_ctx.flex_eligible and shift_ctx.late_flex_minutes > 0 and 0 < late_minutes < shift_ctx.late_flex_minutes)
+	unresolved_late = bool(shift_ctx.flex_eligible and late_minutes >= shift_ctx.late_flex_minutes > 0 and approved_late <= 0)
+	counted_start = max(actual_in, shift_ctx.scheduled_start - timedelta(minutes=shift_ctx.allowed_early_minutes + approved_early))
+	expected_end = shift_ctx.scheduled_end + timedelta(minutes=(late_minutes if within_default_late else min(approved_late, late_minutes)))
+	effective_hours = _hours(counted_start, actual_out)
+	candidate = max(0.0, _hours(expected_end, actual_out))
+	return frappe._dict(
+		{
+			"total_hours": round(_hours(actual_in, actual_out), 2),
+			"candidate_hours": round(candidate, 2),
+			"eligible": candidate > 0 and effective_hours > OT_THRESHOLD_HOURS and not unresolved_late,
+			"late_exception_minutes": round(late_minutes, 2) if unresolved_late else 0,
+			"early_exception_minutes": round(extra_early, 2) if shift_ctx.flex_eligible else 0,
+		}
+	)
+
+
+def _upsert_flex(employee_doc, attendance_doc, shift_ctx, flex_type: str, requested_minutes: float, shift_record: str | None = None):
+	if requested_minutes <= 0:
+		return None
+	doc = _flex_doc(employee_doc.name, attendance_doc.attendance_date, flex_type)
+	chain = _approver_chain(employee_doc)
+	if not doc:
+		doc = frappe.new_doc("Attendance Request")
+		doc.employee = employee_doc.name
+		doc.company = employee_doc.company
+		doc.from_date = attendance_doc.attendance_date
+		doc.to_date = attendance_doc.attendance_date
+		doc.reason = FLEX_REASON
+		doc.flex_exception_type = flex_type
+		doc.review_status = FLEX_PENDING
+		doc.cutoff_datetime = f"{getdate(attendance_doc.attendance_date)} 23:59:00"
+		doc.explanation = "System-detected flex exception"
+	doc.shift = shift_ctx.shift_name or attendance_doc.get("shift")
+	doc.attendance = attendance_doc.name
+	doc.shift_record = shift_record or getattr(doc, "shift_record", None)
+	doc.requested_minutes = flt(requested_minutes)
+	doc.assigned_approver = chain["assigned_approver"]
+	doc.fallback_approver = chain["fallback_approver"]
+	doc.escalation_approver = chain["escalation_approver"]
+	doc.hr_notified = 1 if _default_hr_manager() else 0
+	doc.hr_notified_at = now_datetime() if doc.hr_notified else getattr(doc, "hr_notified_at", None)
+	if doc.is_new():
+		doc.insert(ignore_permissions=True)
+	else:
+		doc.save(ignore_permissions=True)
+	return doc
+
+
+def _ot_doc(attendance_name: str | None = None, shift_record_name: str | None = None):
+	filters = {"attendance": attendance_name} if attendance_name else {"shift_record": shift_record_name}
+	name = frappe.db.get_value("BEI Overtime Request", filters, "name") if any(filters.values()) else None
+	return frappe.get_doc("BEI Overtime Request", name) if name else None
+
+
+def _upsert_from_attendance_doc(attendance_doc, source_trigger: str = "attendance_close", shift_record_name: str | None = None):
+	employee_doc = _employee(attendance_doc.employee)
+	shift_ctx = _shift_context(employee_doc, attendance_doc.attendance_date, attendance_doc.get("shift"))
+	eval_result = _evaluate(attendance_doc, employee_doc, shift_ctx)
+	if eval_result.early_exception_minutes and shift_ctx.flex_eligible:
+		_upsert_flex(employee_doc, attendance_doc, shift_ctx, FLEX_EARLY, eval_result.early_exception_minutes, shift_record=shift_record_name)
+	if eval_result.late_exception_minutes and shift_ctx.flex_eligible:
+		_upsert_flex(employee_doc, attendance_doc, shift_ctx, FLEX_LATE, eval_result.late_exception_minutes, shift_record=shift_record_name)
+	doc = _ot_doc(attendance_name=attendance_doc.name, shift_record_name=shift_record_name)
+	if not eval_result.eligible and not doc:
+		return None
+	chain = _approver_chain(employee_doc)
+	if not doc:
+		doc = frappe.new_doc("BEI Overtime Request")
+	doc.employee = employee_doc.name
+	doc.attendance = attendance_doc.name
+	doc.attendance_date = attendance_doc.attendance_date
+	doc.shift = shift_ctx.shift_name or attendance_doc.get("shift")
+	doc.shift_record = shift_record_name
+	doc.total_hours = eval_result.total_hours
+	doc.regular_hours = OT_THRESHOLD_HOURS
+	doc.overtime_hours = eval_result.candidate_hours
+	doc.supervisor = employee_doc.reports_to
+	doc.request_source = "system_detected"
+	doc.source_trigger = source_trigger
+	doc.source_event_key = attendance_doc.name if source_trigger != "shift_record_close" else f"{source_trigger}:{shift_record_name or attendance_doc.name}"
+	doc.reason_category = "Post Shift OT"
+	doc.assigned_approver = chain["assigned_approver"]
+	doc.fallback_approver = chain["fallback_approver"]
+	doc.escalation_approver = chain["escalation_approver"]
+	doc.candidate_overtime_type = shift_ctx.overtime_type or attendance_doc.get("overtime_type")
+	doc.payroll_bridge_status = doc.payroll_bridge_status or PAYROLL_NOT_READY
+	if _normalize_ot_status(getattr(doc, "overtime_status", None)) in {"", OT_LEGACY_PENDING}:
+		doc.overtime_status = OT_PENDING
+	if doc.is_new():
+		doc.insert(ignore_permissions=True)
+	else:
+		doc.save(ignore_permissions=True)
+	return doc
+
+
+def upsert_overtime_case_from_attendance(attendance_name: str, source_trigger: str = "attendance_close"):
+	doc = _upsert_from_attendance_doc(frappe.get_doc("Attendance", attendance_name), source_trigger=source_trigger)
+	return doc.as_dict() if doc else None
+
+
+def upsert_overtime_case_from_shift_record(shift_record_name: str):
+	shift_doc = frappe.get_doc("BEI Shift Record", shift_record_name)
+	attendance_name = frappe.db.get_value("Attendance", {"employee": shift_doc.employee, "attendance_date": getdate(shift_doc.punch_in_time), "docstatus": 1}, "name")
+	if not attendance_name:
+		return None
+	return upsert_overtime_case_from_attendance(attendance_name, source_trigger="shift_record_close")
 
 
 def detect_overtime_for_date(attendance_date: str | None = None):
-	"""Scan Attendance records for a given date and create BEI Overtime Request
-	for any employee whose working_hours exceeds 8.
-
-	Called by daily scheduled task. Safe to re-run — skips if request already exists.
-
-	Args:
-	    attendance_date: Date string (YYYY-MM-DD). Defaults to yesterday.
-	"""
-	if not attendance_date:
-		attendance_date = str(add_days(getdate(nowdate()), -1))
-
-	# Find attendance records with OT
-	ot_records = frappe.db.sql(
-		"""
-        SELECT
-            a.name AS attendance_name,
-            a.employee,
-            a.attendance_date,
-            a.working_hours,
-            a.shift,
-            e.reports_to AS supervisor
-        FROM `tabAttendance` a
-        LEFT JOIN `tabEmployee` e ON e.name = a.employee
-        WHERE a.docstatus = 1
-          AND a.attendance_date = %s
-          AND a.working_hours > %s
-    """,
-		(attendance_date, OT_THRESHOLD_HOURS),
-		as_dict=True,
-	)
-
+	attendance_date = attendance_date or str(add_days(getdate(nowdate()), -1))
+	rows = frappe.get_all("Attendance", filters={"docstatus": 1, "attendance_date": attendance_date}, fields=["name"], limit_page_length=5000)
 	created = 0
-	skipped = 0
-
-	for rec in ot_records:
-		# Idempotency: skip if BEI Overtime Request already exists for this attendance
-		existing = frappe.db.exists("BEI Overtime Request", {"attendance": rec.attendance_name})
+	updated = 0
+	for row in rows:
+		existing = _ot_doc(attendance_name=row.name)
+		upsert_overtime_case_from_attendance(row.name, source_trigger="nightly_backfill")
 		if existing:
-			skipped += 1
-			continue
-
-		ot_hours = flt(rec.working_hours) - OT_THRESHOLD_HOURS
-
-		try:
-			doc = frappe.new_doc("BEI Overtime Request")
-			doc.employee = rec.employee
-			doc.attendance = rec.attendance_name
-			doc.attendance_date = rec.attendance_date
-			doc.shift = rec.shift
-			doc.total_hours = flt(rec.working_hours)
-			doc.regular_hours = OT_THRESHOLD_HOURS
-			doc.overtime_hours = round(ot_hours, 2)
-			doc.overtime_status = "Pending Approval"
-			doc.supervisor = rec.supervisor
-			doc.insert(ignore_permissions=True)
+			updated += 1
+		else:
 			created += 1
-		except Exception as e:
-			frappe.log_error(
-				f"Failed to create OT request for {rec.employee} on {rec.attendance_date}: {e}",
-				"Overtime Detection",
-			)
-
-	frappe.logger("overtime").info(
-		f"OT detection for {attendance_date}: {created} created, {skipped} skipped"
-	)
-	return {"date": attendance_date, "created": created, "skipped": skipped}
-
-
-# ================================
-# APPROVAL / REJECTION
-# ================================
+	return {"date": attendance_date, "created": created, "updated": updated}
 
 
 @frappe.whitelist()
-def approve_overtime(
-	overtime_request_name: str | None = None,
-	notes: str | None = None,
-	name: str | None = None,
-	approval_notes: str | None = None,
-):
-	"""Supervisor approves an overtime request.
-	Status: Pending Approval → Approved
+def get_operational_queue(status: str | None = None, include_resolved: int = 0):
+	user = frappe.session.user
+	ot_rows = frappe.db.sql(
+		"""
+		SELECT ot.name, ot.employee, emp.employee_name, emp.branch, emp.department, ot.attendance_date, ot.shift,
+		       ot.overtime_hours, ot.total_hours, ot.overtime_status, ot.clarification_question, ot.clarification_response, ot.review_note
+		FROM `tabBEI Overtime Request` ot
+		LEFT JOIN `tabEmployee` emp ON emp.name = ot.employee
+		WHERE ot.assigned_approver = %(user)s OR ot.fallback_approver = %(user)s OR ot.escalation_approver = %(user)s
+		ORDER BY ot.attendance_date DESC, ot.creation DESC
+		""",
+		{"user": user},
+		as_dict=True,
+	)
+	flex_rows = frappe.db.sql(
+		"""
+		SELECT ar.name, ar.employee, emp.employee_name, emp.branch, emp.department, ar.from_date AS attendance_date, ar.shift,
+		       ar.review_status, ar.flex_exception_type, ar.requested_minutes, ar.validated_minutes,
+		       ar.clarification_prompt, ar.clarification_response, ar.manager_decision_note
+		FROM `tabAttendance Request` ar
+		LEFT JOIN `tabEmployee` emp ON emp.name = ar.employee
+		WHERE ar.reason = %(reason)s
+		  AND (ar.assigned_approver = %(user)s OR ar.fallback_approver = %(user)s OR ar.escalation_approver = %(user)s)
+		ORDER BY ar.from_date DESC, ar.creation DESC
+		""",
+		{"reason": FLEX_REASON, "user": user},
+		as_dict=True,
+	)
+	items = []
+	for row in ot_rows:
+		ot_status = _normalize_ot_status(row.overtime_status)
+		if status and ot_status != status:
+			continue
+		if not int(include_resolved or 0) and ot_status not in {OT_PENDING, OT_NEEDS_INFO, OT_CLARIFIED, OT_ESCALATED}:
+			continue
+		items.append({"id": row.name, "item_type": "overtime", "status": ot_status, "employee": row.employee, "employee_name": row.employee_name, "branch": row.branch, "department": row.department, "attendance_date": row.attendance_date, "shift": row.shift, "overtime_hours": row.overtime_hours, "total_hours": row.total_hours, "clarification_question": row.clarification_question, "clarification_response": row.clarification_response, "review_note": row.review_note})
+	for row in flex_rows:
+		if status and row.review_status != status:
+			continue
+		if not int(include_resolved or 0) and row.review_status not in {FLEX_PENDING, FLEX_NEEDS_INFO, FLEX_CLARIFIED}:
+			continue
+		items.append({"id": row.name, "item_type": "flex_exception", "status": row.review_status, "employee": row.employee, "employee_name": row.employee_name, "branch": row.branch, "department": row.department, "attendance_date": row.attendance_date, "shift": row.shift, "flex_exception_type": row.flex_exception_type, "requested_minutes": row.requested_minutes, "validated_minutes": row.validated_minutes, "clarification_question": row.clarification_prompt, "clarification_response": row.clarification_response, "review_note": row.manager_decision_note})
+	return {"items": items, "count": len(items)}
 
-	Args:
-	    overtime_request_name: BEI Overtime Request name
-	    notes: Optional approval notes
 
-	Returns:
-	    dict: {success, status, overtime_hours}
-	"""
-	_check_ot_approver_role()
+@frappe.whitelist()
+def get_employee_ot_cases():
+	current_employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user, "status": "Active"}, "name")
+	if not current_employee:
+		return {"items": [], "count": 0}
+	ot_rows = frappe.get_all("BEI Overtime Request", filters={"employee": current_employee}, fields=["name", "attendance_date", "shift", "overtime_hours", "total_hours", "overtime_status", "clarification_question", "clarification_response", "review_note", "rejection_reason", "approval_notes"], order_by="attendance_date desc")
+	flex_rows = frappe.get_all("Attendance Request", filters={"employee": current_employee, "reason": FLEX_REASON}, fields=["name", "from_date", "shift", "review_status", "flex_exception_type", "requested_minutes", "validated_minutes", "clarification_prompt", "clarification_response", "manager_decision_note"], order_by="from_date desc")
+	items = [{"id": row.name, "item_type": "overtime", "status": _normalize_ot_status(row.overtime_status), "attendance_date": row.attendance_date, "shift": row.shift, "overtime_hours": row.overtime_hours, "total_hours": row.total_hours, "clarification_question": row.clarification_question, "clarification_response": row.clarification_response, "review_note": row.review_note or row.rejection_reason or row.approval_notes} for row in ot_rows]
+	items.extend({"id": row.name, "item_type": "flex_exception", "status": row.review_status, "attendance_date": row.from_date, "shift": row.shift, "flex_exception_type": row.flex_exception_type, "requested_minutes": row.requested_minutes, "validated_minutes": row.validated_minutes, "clarification_question": row.clarification_prompt, "clarification_response": row.clarification_response, "review_note": row.manager_decision_note} for row in flex_rows)
+	return {"items": items, "count": len(items)}
 
-	overtime_request_name = overtime_request_name or name
-	if not overtime_request_name:
-		frappe.throw(_("Overtime request name is required"))
 
-	notes = notes if notes is not None else approval_notes
-
-	doc = frappe.get_doc("BEI Overtime Request", overtime_request_name)
-	if doc.overtime_status != "Pending Approval":
-		frappe.throw(_("Only 'Pending Approval' overtime requests can be approved"))
-
-	doc.overtime_status = "Approved"
+def _save_ot_transition(doc, new_status: str, notes: str | None = None, approved_duration: float | None = None, approved_type: str | None = None):
+	is_override = _assert_review_access(doc, "overtime_status")
+	if is_override and not notes:
+		frappe.throw(_("HR override actions require notes."))
+	doc.overtime_status = new_status
 	doc.reviewed_by = frappe.session.user
 	doc.reviewed_at = now_datetime()
 	if notes:
-		doc.approval_notes = notes
+		doc.review_note = notes
+	if is_override:
+		doc.override_note = notes
+	if new_status == OT_APPROVED:
+		doc.approval_notes = notes or doc.approval_notes
+		doc.approved_payable_duration = flt(approved_duration if approved_duration is not None else doc.overtime_hours)
+		doc.approved_overtime_type = approved_type or doc.candidate_overtime_type or doc.approved_overtime_type
+		doc.payroll_bridge_status = PAYROLL_PENDING
+	if new_status == OT_REJECTED:
+		doc.rejection_reason = notes or doc.rejection_reason
+		doc.payroll_bridge_status = PAYROLL_NOT_READY
 	doc.save(ignore_permissions=True)
-
-	return {
-		"success": True,
-		"name": doc.name,
-		"status": doc.overtime_status,
-		"overtime_hours": doc.overtime_hours,
-		"employee": doc.employee,
-	}
+	return doc
 
 
 @frappe.whitelist()
-def reject_overtime(
-	overtime_request_name: str | None = None,
-	reason: str | None = None,
-	name: str | None = None,
-	rejection_reason: str | None = None,
-):
-	"""Supervisor rejects an overtime request.
-	Status: Pending Approval → Rejected
-	Effect: Employee paid for regular hours only (no OT pay in payroll).
+def approve_overtime(overtime_request_name: str | None = None, notes: str | None = None, name: str | None = None, approval_notes: str | None = None, approved_payable_duration: float | None = None, approved_overtime_type: str | None = None):
+	doc = _save_ot_transition(frappe.get_doc("BEI Overtime Request", overtime_request_name or name), OT_APPROVED, notes if notes is not None else approval_notes, approved_payable_duration, approved_overtime_type)
+	return {"success": True, "name": doc.name, "status": doc.overtime_status}
 
-	Args:
-	    overtime_request_name: BEI Overtime Request name
-	    reason: Required rejection reason
 
-	Returns:
-	    dict: {success, status}
-	"""
-	_check_ot_approver_role()
-
-	overtime_request_name = overtime_request_name or name
-	if not overtime_request_name:
-		frappe.throw(_("Overtime request name is required"))
-
+@frappe.whitelist()
+def reject_overtime(overtime_request_name: str | None = None, reason: str | None = None, name: str | None = None, rejection_reason: str | None = None):
 	reason = reason if reason is not None else rejection_reason
 	if not reason:
 		frappe.throw(_("Rejection reason is required"))
+	doc = _save_ot_transition(frappe.get_doc("BEI Overtime Request", overtime_request_name or name), OT_REJECTED, reason)
+	return {"success": True, "name": doc.name, "status": doc.overtime_status}
 
-	doc = frappe.get_doc("BEI Overtime Request", overtime_request_name)
-	if doc.overtime_status != "Pending Approval":
-		frappe.throw(_("Only 'Pending Approval' overtime requests can be rejected"))
 
-	doc.overtime_status = "Rejected"
+@frappe.whitelist()
+def request_overtime_clarification(name: str, question: str):
+	if not question:
+		frappe.throw(_("Clarification question is required"))
+	doc = frappe.get_doc("BEI Overtime Request", name)
+	_assert_review_access(doc, "overtime_status")
+	doc.overtime_status = OT_NEEDS_INFO
+	doc.clarification_question = question
 	doc.reviewed_by = frappe.session.user
 	doc.reviewed_at = now_datetime()
-	doc.rejection_reason = reason
 	doc.save(ignore_permissions=True)
-
-	return {
-		"success": True,
-		"name": doc.name,
-		"status": doc.overtime_status,
-		"employee": doc.employee,
-	}
+	return {"success": True, "name": doc.name, "status": doc.overtime_status}
 
 
 @frappe.whitelist()
-def get_pending_overtime(
-	store: str | None = None,
-	employee: str | None = None,
-	from_date: str | None = None,
-	to_date: str | None = None,
-):
-	"""Get overtime requests pending supervisor approval.
-
-	Args:
-	    store: Optional store/branch filter
-	    employee: Optional employee filter
-	    from_date: Optional date range start
-	    to_date: Optional date range end
-
-	Returns:
-	    list of dicts
-	"""
-	_check_ot_approver_role()
-
-	params = {
-		"employee": employee,
-		"from_date": from_date,
-		"to_date": to_date,
-		"store": store,
-	}
-
-	return frappe.db.sql(
-		"""
-        SELECT
-            ot.name,
-            ot.employee,
-            ot.attendance_date,
-            ot.shift,
-            ot.regular_hours,
-            ot.overtime_hours,
-            ot.total_hours,
-            ot.supervisor,
-            emp.employee_name,
-            emp.branch
-        FROM `tabBEI Overtime Request` ot
-        LEFT JOIN `tabEmployee` emp ON emp.name = ot.employee
-        WHERE ot.overtime_status = 'Pending Approval'
-          AND (%(employee)s IS NULL OR ot.employee = %(employee)s)
-          AND (%(from_date)s IS NULL OR ot.attendance_date >= %(from_date)s)
-          AND (%(to_date)s IS NULL OR ot.attendance_date <= %(to_date)s)
-          AND (%(store)s IS NULL OR emp.branch = %(store)s)
-        ORDER BY ot.attendance_date DESC
-    """,
-		params,
-		as_dict=True,
-	)
+def submit_overtime_clarification(name: str, response: str):
+	if not response:
+		frappe.throw(_("Clarification response is required"))
+	doc = frappe.get_doc("BEI Overtime Request", name)
+	_assert_employee_access(doc.employee)
+	doc.clarification_response = response
+	doc.employee_explanation = response
+	doc.overtime_status = OT_CLARIFIED
+	doc.save(ignore_permissions=True)
+	return {"success": True, "name": doc.name, "status": doc.overtime_status}
 
 
 @frappe.whitelist()
-def get_overtime_requests(
-	status: str | None = None,
-	store: str | None = None,
-	employee: str | None = None,
-	from_date: str | None = None,
-	to_date: str | None = None,
-	page: int = 1,
-	page_size: int = 20,
-):
-	"""Portal contract for overtime requests list with pagination."""
-	_check_ot_approver_role()
+def escalate_overtime(name: str, notes: str | None = None):
+	doc = frappe.get_doc("BEI Overtime Request", name)
+	_assert_review_access(doc, "overtime_status")
+	target = _txt(doc.fallback_approver or doc.escalation_approver)
+	if not target or target == _txt(frappe.session.user):
+		target = _txt(doc.escalation_approver)
+	if not target:
+		frappe.throw(_("No escalation approver is configured."))
+	doc.overtime_status = OT_ESCALATED
+	doc.assigned_approver = target
+	doc.review_note = notes or doc.review_note
+	doc.reviewed_by = frappe.session.user
+	doc.reviewed_at = now_datetime()
+	doc.save(ignore_permissions=True)
+	return {"success": True, "name": doc.name, "status": doc.overtime_status, "assigned_approver": target}
 
-	params = {
-		"status": status,
-		"employee": employee,
-		"from_date": from_date,
-		"to_date": to_date,
-		"store": store,
-	}
 
+@frappe.whitelist()
+def approve_flex_exception(name: str, notes: str | None = None, validated_minutes: float | None = None):
+	doc = frappe.get_doc("Attendance Request", name)
+	_assert_review_access(doc, "review_status")
+	doc.review_status = FLEX_APPROVED
+	doc.reviewed_by = frappe.session.user
+	doc.reviewed_at = now_datetime()
+	doc.manager_decision_note = notes or doc.manager_decision_note
+	doc.validated_minutes = flt(validated_minutes if validated_minutes is not None else doc.requested_minutes or 0)
+	doc.save(ignore_permissions=True)
+	if doc.attendance:
+		ot_doc = _upsert_from_attendance_doc(frappe.get_doc("Attendance", doc.attendance), source_trigger="attendance_close", shift_record_name=doc.shift_record)
+		if ot_doc:
+			doc.linked_ot_case = ot_doc.name
+			doc.save(ignore_permissions=True)
+	return {"success": True, "name": doc.name, "status": doc.review_status}
+
+
+@frappe.whitelist()
+def reject_flex_exception(name: str, reason: str):
+	if not reason:
+		frappe.throw(_("Rejection reason is required"))
+	doc = frappe.get_doc("Attendance Request", name)
+	_assert_review_access(doc, "review_status")
+	doc.review_status = FLEX_REJECTED
+	doc.reviewed_by = frappe.session.user
+	doc.reviewed_at = now_datetime()
+	doc.manager_decision_note = reason
+	doc.save(ignore_permissions=True)
+	return {"success": True, "name": doc.name, "status": doc.review_status}
+
+
+@frappe.whitelist()
+def request_flex_clarification(name: str, question: str):
+	if not question:
+		frappe.throw(_("Clarification question is required"))
+	doc = frappe.get_doc("Attendance Request", name)
+	_assert_review_access(doc, "review_status")
+	doc.review_status = FLEX_NEEDS_INFO
+	doc.clarification_prompt = question
+	doc.reviewed_by = frappe.session.user
+	doc.reviewed_at = now_datetime()
+	doc.save(ignore_permissions=True)
+	return {"success": True, "name": doc.name, "status": doc.review_status}
+
+
+@frappe.whitelist()
+def submit_flex_clarification(name: str, response: str):
+	if not response:
+		frappe.throw(_("Clarification response is required"))
+	doc = frappe.get_doc("Attendance Request", name)
+	_assert_employee_access(doc.employee)
+	doc.clarification_response = response
+	doc.review_status = FLEX_CLARIFIED
+	doc.save(ignore_permissions=True)
+	return {"success": True, "name": doc.name, "status": doc.review_status}
+
+
+@frappe.whitelist()
+def get_overtime_requests(status: str | None = None, store: str | None = None, employee: str | None = None, from_date: str | None = None, to_date: str | None = None, page: int = 1, page_size: int = 20):
+	_assert_hr_access()
 	rows = frappe.db.sql(
 		"""
-        SELECT
-            ot.name,
-            ot.employee,
-            ot.attendance_date,
-            ot.shift,
-            ot.regular_hours,
-            ot.overtime_hours,
-            ot.total_hours,
-            ot.overtime_status,
-            ot.supervisor,
-            ot.reviewed_by,
-            ot.reviewed_at,
-            ot.approval_notes,
-            ot.rejection_reason,
-            emp.employee_name,
-            emp.branch
-        FROM `tabBEI Overtime Request` ot
-        LEFT JOIN `tabEmployee` emp ON emp.name = ot.employee
-        WHERE (%(status)s IS NULL OR ot.overtime_status = %(status)s)
-          AND (%(employee)s IS NULL OR ot.employee = %(employee)s)
-          AND (%(from_date)s IS NULL OR ot.attendance_date >= %(from_date)s)
-          AND (%(to_date)s IS NULL OR ot.attendance_date <= %(to_date)s)
-          AND (%(store)s IS NULL OR emp.branch = %(store)s)
-        ORDER BY ot.attendance_date DESC, ot.creation DESC
-    """,
-		params,
+		SELECT ot.name, ot.employee, emp.employee_name, emp.branch, emp.department, ot.attendance_date, ot.shift, ot.regular_hours,
+		       ot.overtime_hours, ot.total_hours, ot.overtime_status, ot.assigned_approver, ot.fallback_approver, ot.escalation_approver,
+		       ot.reviewed_by, ot.reviewed_at, ot.review_note, ot.approval_notes, ot.rejection_reason, ot.approved_payable_duration,
+		       ot.approved_overtime_type, ot.payroll_bridge_status, ot.payroll_bridge_reference
+		FROM `tabBEI Overtime Request` ot
+		LEFT JOIN `tabEmployee` emp ON emp.name = ot.employee
+		WHERE (%(status)s IS NULL OR ot.overtime_status = %(status)s)
+		  AND (%(employee)s IS NULL OR ot.employee = %(employee)s)
+		  AND (%(from_date)s IS NULL OR ot.attendance_date >= %(from_date)s)
+		  AND (%(to_date)s IS NULL OR ot.attendance_date <= %(to_date)s)
+		  AND (%(store)s IS NULL OR emp.branch = %(store)s)
+		ORDER BY ot.attendance_date DESC, ot.creation DESC
+		""",
+		{"status": status, "employee": employee, "from_date": from_date, "to_date": to_date, "store": store},
 		as_dict=True,
 	)
-
-	return _paginate(rows, page=int(page or 1), page_size=int(page_size or 20))
+	return _paginate([{**dict(row), "overtime_status": _normalize_ot_status(row.overtime_status)} for row in rows], page=int(page or 1), page_size=int(page_size or 20))
 
 
 @frappe.whitelist()
-def get_overtime_summary(
-	store: str | None = None,
-	from_date: str | None = None,
-	to_date: str | None = None,
-):
-	"""Portal contract for overtime summary cards/tables."""
-	_check_ot_approver_role()
-
-	params = {
-		"from_date": from_date,
-		"to_date": to_date,
-		"store": store,
-	}
-
+def get_overtime_summary(store: str | None = None, from_date: str | None = None, to_date: str | None = None):
+	_assert_hr_access()
 	summary = frappe.db.sql(
 		"""
-        SELECT
-            COALESCE(emp.department, 'Unassigned') AS department,
-            COALESCE(emp.branch, 'Unassigned') AS store,
-            COUNT(*) AS total_requests,
-            COALESCE(SUM(ot.overtime_hours), 0) AS total_hours,
-            COALESCE(SUM(CASE WHEN ot.overtime_status = 'Approved' THEN ot.overtime_hours ELSE 0 END), 0) AS approved_hours,
-            COALESCE(SUM(CASE WHEN ot.overtime_status = 'Pending Approval' THEN ot.overtime_hours ELSE 0 END), 0) AS pending_hours,
-            COALESCE(SUM(CASE WHEN ot.overtime_status = 'Rejected' THEN ot.overtime_hours ELSE 0 END), 0) AS rejected_hours,
-            COALESCE(SUM(CASE WHEN ot.overtime_status = 'Approved' THEN 1 ELSE 0 END), 0) AS approved_count,
-            COALESCE(SUM(CASE WHEN ot.overtime_status = 'Pending Approval' THEN 1 ELSE 0 END), 0) AS pending_count,
-            COALESCE(SUM(CASE WHEN ot.overtime_status = 'Rejected' THEN 1 ELSE 0 END), 0) AS rejected_count
-        FROM `tabBEI Overtime Request` ot
-        LEFT JOIN `tabEmployee` emp ON emp.name = ot.employee
-        WHERE (%(from_date)s IS NULL OR ot.attendance_date >= %(from_date)s)
-          AND (%(to_date)s IS NULL OR ot.attendance_date <= %(to_date)s)
-          AND (%(store)s IS NULL OR emp.branch = %(store)s)
-        GROUP BY COALESCE(emp.department, 'Unassigned'), COALESCE(emp.branch, 'Unassigned')
-        ORDER BY store ASC, department ASC
-    """,
-		params,
+		SELECT COALESCE(emp.department, 'Unassigned') AS department, COALESCE(emp.branch, 'Unassigned') AS store,
+		       COUNT(*) AS total_requests, COALESCE(SUM(ot.overtime_hours), 0) AS total_hours,
+		       COALESCE(SUM(CASE WHEN ot.overtime_status = 'Approved' THEN COALESCE(ot.approved_payable_duration, ot.overtime_hours) ELSE 0 END), 0) AS approved_hours,
+		       COALESCE(SUM(CASE WHEN ot.overtime_status IN ('Pending Review', 'Needs Clarification', 'Clarification Submitted', 'Escalated', 'Pending Approval') THEN ot.overtime_hours ELSE 0 END), 0) AS pending_hours,
+		       COALESCE(SUM(CASE WHEN ot.overtime_status = 'Rejected' THEN ot.overtime_hours ELSE 0 END), 0) AS rejected_hours
+		FROM `tabBEI Overtime Request` ot
+		LEFT JOIN `tabEmployee` emp ON emp.name = ot.employee
+		WHERE (%(from_date)s IS NULL OR ot.attendance_date >= %(from_date)s)
+		  AND (%(to_date)s IS NULL OR ot.attendance_date <= %(to_date)s)
+		  AND (%(store)s IS NULL OR emp.branch = %(store)s)
+		GROUP BY COALESCE(emp.department, 'Unassigned'), COALESCE(emp.branch, 'Unassigned')
+		ORDER BY store ASC, department ASC
+		""",
+		{"from_date": from_date, "to_date": to_date, "store": store},
 		as_dict=True,
 	)
-
-	totals = {
-		"total_requests": 0,
-		"total_hours": 0.0,
-		"approved_hours": 0.0,
-		"pending_hours": 0.0,
-		"rejected_hours": 0.0,
-	}
+	totals = {"total_requests": 0, "total_hours": 0.0, "approved_hours": 0.0, "pending_hours": 0.0, "rejected_hours": 0.0}
 	for row in summary:
-		totals["total_requests"] += int(row.get("total_requests") or 0)
-		totals["total_hours"] += flt(row.get("total_hours"))
-		totals["approved_hours"] += flt(row.get("approved_hours"))
-		totals["pending_hours"] += flt(row.get("pending_hours"))
-		totals["rejected_hours"] += flt(row.get("rejected_hours"))
-
+		totals["total_requests"] += int(row.total_requests or 0)
+		totals["total_hours"] += flt(row.total_hours)
+		totals["approved_hours"] += flt(row.approved_hours)
+		totals["pending_hours"] += flt(row.pending_hours)
+		totals["rejected_hours"] += flt(row.rejected_hours)
 	return {"summary": summary, "totals": totals}
 
 
 @frappe.whitelist()
 def get_approved_overtime_hours(employee: str, from_date: str, to_date: str):
-	"""Get total approved overtime hours for an employee in a date range.
-
-	Used by payroll processing to calculate OT pay — only approved hours included.
-
-	Args:
-	    employee: Employee ID
-	    from_date: Period start
-	    to_date: Period end
-
-	Returns:
-	    dict: {approved_hours, pending_hours, rejected_hours}
-	"""
 	rows = frappe.db.sql(
 		"""
-        SELECT overtime_status, COALESCE(SUM(overtime_hours), 0) as hours
-        FROM `tabBEI Overtime Request`
-        WHERE employee = %s
-          AND attendance_date BETWEEN %s AND %s
-        GROUP BY overtime_status
-    """,
-		(employee, from_date, to_date),
+		SELECT overtime_status, COALESCE(SUM(COALESCE(approved_payable_duration, overtime_hours)), 0) AS hours
+		FROM `tabBEI Overtime Request`
+		WHERE employee = %(employee)s AND attendance_date BETWEEN %(from_date)s AND %(to_date)s
+		GROUP BY overtime_status
+		""",
+		{"employee": employee, "from_date": from_date, "to_date": to_date},
 		as_dict=True,
 	)
-
 	result = {"approved_hours": 0.0, "pending_hours": 0.0, "rejected_hours": 0.0}
-	status_map = {
-		"Approved": "approved_hours",
-		"Pending Approval": "pending_hours",
-		"Rejected": "rejected_hours",
-	}
 	for row in rows:
-		key = status_map.get(row.overtime_status)
-		if key:
-			result[key] = flt(row.hours)
-
+		status = _normalize_ot_status(row.overtime_status)
+		if status in {OT_APPROVED, OT_LOCKED}:
+			result["approved_hours"] += flt(row.hours)
+		elif status == OT_REJECTED:
+			result["rejected_hours"] += flt(row.hours)
+		else:
+			result["pending_hours"] += flt(row.hours)
 	return result
 
 
-# ================================
-# SCHEDULED TASK
-# ================================
+def get_approved_ot_bridge_rows(employee: str, start_date, end_date):
+	rows = frappe.db.sql(
+		"""
+		SELECT ot.name, ot.attendance AS reference_document, ot.attendance_date, COALESCE(ot.approved_overtime_type, ot.candidate_overtime_type) AS overtime_type,
+		       COALESCE(ot.approved_payable_duration, ot.overtime_hours) AS overtime_duration,
+		       COALESCE(a.standard_working_hours, %(standard_hours)s) AS standard_working_hours
+		FROM `tabBEI Overtime Request` ot
+		LEFT JOIN `tabAttendance` a ON a.name = ot.attendance
+		WHERE ot.employee = %(employee)s
+		  AND ot.attendance_date BETWEEN %(start_date)s AND %(end_date)s
+		  AND ot.overtime_status IN ('Approved', 'Payroll Locked')
+		  AND COALESCE(ot.approved_payable_duration, ot.overtime_hours) > 0
+		ORDER BY ot.attendance_date ASC, ot.creation ASC
+		""",
+		{"employee": employee, "start_date": start_date, "end_date": end_date, "standard_hours": OT_THRESHOLD_HOURS},
+		as_dict=True,
+	)
+	return [frappe._dict(row) for row in rows if row.get("overtime_type")]
+
+
+def mark_overtime_requests_bridged(ot_request_names: list[str], overtime_slip_name: str, locked: bool = False):
+	names = list(ot_request_names or [])
+	if not names and overtime_slip_name:
+		names = frappe.get_all(
+			"BEI Overtime Request",
+			filters={"payroll_bridge_reference": overtime_slip_name},
+			pluck="name",
+		)
+	for name in names:
+		doc = frappe.get_doc("BEI Overtime Request", name)
+		doc.payroll_bridge_status = PAYROLL_LOCKED if locked else PAYROLL_BRIDGED
+		doc.payroll_bridge_reference = overtime_slip_name
+		if locked and doc.overtime_status == OT_APPROVED:
+			doc.overtime_status = OT_LOCKED
+		doc.save(ignore_permissions=True)
 
 
 def scheduled_overtime_detection():
-	"""Daily scheduled task: detect OT for yesterday's attendance.
-
-	Called by hooks.py cron (daily).
-	"""
 	yesterday = str(add_days(getdate(nowdate()), -1))
 	result = detect_overtime_for_date(attendance_date=yesterday)
 	frappe.logger("overtime").info(f"Scheduled OT detection complete: {result}")

--- a/hrms/api/overtime.py
+++ b/hrms/api/overtime.py
@@ -50,7 +50,11 @@ def _normalize_ot_status(status: str | None) -> str:
 
 def _is_store_oic(designation: str | None) -> bool:
 	label = _upper(designation)
-	return "OIC" in label or ("ASSISTANT" in label and "SUPERVISOR" in label) or ("ASST" in label and "SUPERVISOR" in label)
+	return (
+		"OIC" in label
+		or ("ASSISTANT" in label and "SUPERVISOR" in label)
+		or ("ASST" in label and "SUPERVISOR" in label)
+	)
 
 
 def _is_store_supervisor(designation: str | None) -> bool:
@@ -105,8 +109,16 @@ def _assert_hr_access() -> None:
 def _assert_review_access(doc, status_field: str) -> bool:
 	user = frappe.session.user
 	if _is_hr_override(user):
-		return user not in {_txt(getattr(doc, "assigned_approver", None)), _txt(getattr(doc, "fallback_approver", None)), _txt(getattr(doc, "escalation_approver", None))}
-	allowed = {_txt(getattr(doc, "assigned_approver", None)), _txt(getattr(doc, "fallback_approver", None)), _txt(getattr(doc, "escalation_approver", None))}
+		return user not in {
+			_txt(getattr(doc, "assigned_approver", None)),
+			_txt(getattr(doc, "fallback_approver", None)),
+			_txt(getattr(doc, "escalation_approver", None)),
+		}
+	allowed = {
+		_txt(getattr(doc, "assigned_approver", None)),
+		_txt(getattr(doc, "fallback_approver", None)),
+		_txt(getattr(doc, "escalation_approver", None)),
+	}
 	if user not in allowed:
 		raise frappe.PermissionError(_("You are not the assigned reviewer for {0}.").format(doc.name))
 	return False
@@ -154,13 +166,21 @@ def _manager_manager_user(employee_name: str | None) -> str | None:
 
 def _store_chain(employee_doc) -> dict[str, str | None]:
 	ctx = resolve_employee_store_context(employee_doc)
-	candidates = {value for value in {_txt(ctx.get("branch")), _txt(ctx.get("warehouse")), _txt(ctx.get("warehouse_name"))} if value}
-	rows = frappe.get_all(
-		"Employee",
-		filters={"status": "Active", "branch": ["in", list(candidates)]},
-		fields=["name", "user_id", "designation"],
-		limit_page_length=100,
-	) if candidates else []
+	candidates = {
+		value
+		for value in {_txt(ctx.get("branch")), _txt(ctx.get("warehouse")), _txt(ctx.get("warehouse_name"))}
+		if value
+	}
+	rows = (
+		frappe.get_all(
+			"Employee",
+			filters={"status": "Active", "branch": ["in", list(candidates)]},
+			fields=["name", "user_id", "designation"],
+			limit_page_length=100,
+		)
+		if candidates
+		else []
+	)
 	primary = None
 	fallback = None
 	requester_user = _txt(employee_doc.user_id)
@@ -178,7 +198,11 @@ def _store_chain(employee_doc) -> dict[str, str | None]:
 				break
 	if not fallback:
 		for row in rows:
-			if row.user_id and row.user_id not in {requester_user, primary} and _is_store_oic(row.designation):
+			if (
+				row.user_id
+				and row.user_id not in {requester_user, primary}
+				and _is_store_oic(row.designation)
+			):
 				fallback = row.user_id
 				break
 	try:
@@ -190,13 +214,22 @@ def _store_chain(employee_doc) -> dict[str, str | None]:
 	primary = primary or escalation or _default_hr_manager()
 	fallback = fallback or escalation or _default_hr_manager()
 	escalation = escalation or _default_hr_manager()
-	return {"team_type": "store", "assigned_approver": primary, "fallback_approver": fallback, "escalation_approver": escalation}
+	return {
+		"team_type": "store",
+		"assigned_approver": primary,
+		"fallback_approver": fallback,
+		"escalation_approver": escalation,
+	}
 
 
 def _approver_chain(employee_doc) -> dict[str, str | None]:
 	if resolve_employee_store_context(employee_doc).get("warehouse"):
 		return _store_chain(employee_doc)
-	team_type = "commissary" if _is_commissary(employee_doc.branch) and not _is_head_office(employee_doc.branch) else "office"
+	team_type = (
+		"commissary"
+		if _is_commissary(employee_doc.branch) and not _is_head_office(employee_doc.branch)
+		else "office"
+	)
 	primary = _manager_user(employee_doc.reports_to)
 	fallback = _manager_manager_user(employee_doc.reports_to)
 	escalation = _default_hr_manager()
@@ -214,20 +247,40 @@ def _shift_context(employee_doc, attendance_date, shift_name: str | None = None)
 		shift_row = frappe.db.get_value(
 			"Shift Type",
 			shift_name,
-			["name", "start_time", "end_time", "begin_check_in_before_shift_start_time", "late_entry_grace_period", "allow_overtime", "overtime_type"],
+			[
+				"name",
+				"start_time",
+				"end_time",
+				"begin_check_in_before_shift_start_time",
+				"late_entry_grace_period",
+				"allow_overtime",
+				"overtime_type",
+			],
 			as_dict=True,
 		)
 	if not shift_row:
 		assignment = frappe.db.get_value(
 			"Shift Assignment",
-			{"employee": employee_doc.name, "docstatus": 1, "status": "Active", "start_date": ("<=", attendance_date), "end_date": [">=", attendance_date]},
+			{
+				"employee": employee_doc.name,
+				"docstatus": 1,
+				"status": "Active",
+				"start_date": ("<=", attendance_date),
+				"end_date": [">=", attendance_date],
+			},
 			["shift_type"],
 			as_dict=True,
 		)
 		if not assignment:
 			assignment = frappe.db.get_value(
 				"Shift Assignment",
-				{"employee": employee_doc.name, "docstatus": 1, "status": "Active", "start_date": ("<=", attendance_date), "end_date": ("is", "not set")},
+				{
+					"employee": employee_doc.name,
+					"docstatus": 1,
+					"status": "Active",
+					"start_date": ("<=", attendance_date),
+					"end_date": ("is", "not set"),
+				},
 				["shift_type"],
 				as_dict=True,
 			)
@@ -235,24 +288,62 @@ def _shift_context(employee_doc, attendance_date, shift_name: str | None = None)
 			shift_row = frappe.db.get_value(
 				"Shift Type",
 				assignment["shift_type"],
-				["name", "start_time", "end_time", "begin_check_in_before_shift_start_time", "late_entry_grace_period", "allow_overtime", "overtime_type"],
+				[
+					"name",
+					"start_time",
+					"end_time",
+					"begin_check_in_before_shift_start_time",
+					"late_entry_grace_period",
+					"allow_overtime",
+					"overtime_type",
+				],
 				as_dict=True,
 			)
 	if not shift_row:
-		return frappe._dict({"shift_name": shift_name, "scheduled_start": None, "scheduled_end": None, "flex_eligible": False, "allowed_early_minutes": 0, "late_flex_minutes": 0, "standard_working_hours": OT_THRESHOLD_HOURS, "overtime_type": None})
+		return frappe._dict(
+			{
+				"shift_name": shift_name,
+				"scheduled_start": None,
+				"scheduled_end": None,
+				"flex_eligible": False,
+				"allowed_early_minutes": 0,
+				"late_flex_minutes": 0,
+				"standard_working_hours": OT_THRESHOLD_HOURS,
+				"overtime_type": None,
+			}
+		)
 	start_dt = _combine(attendance_date, shift_row["start_time"])
 	end_dt = _combine(attendance_date, shift_row["end_time"])
 	if end_dt <= start_dt:
 		end_dt += timedelta(days=1)
-	flex_eligible = not resolve_employee_store_context(employee_doc).get("warehouse") and not (_is_commissary(employee_doc.branch) and not _is_head_office(employee_doc.branch)) and (_is_head_office_shift(shift_row["name"]) or _is_head_office(employee_doc.branch) or (flt(shift_row.get("begin_check_in_before_shift_start_time")) > 0 and flt(shift_row.get("late_entry_grace_period")) > 0))
+	flex_eligible = (
+		not resolve_employee_store_context(employee_doc).get("warehouse")
+		and not (_is_commissary(employee_doc.branch) and not _is_head_office(employee_doc.branch))
+		and (
+			_is_head_office_shift(shift_row["name"])
+			or _is_head_office(employee_doc.branch)
+			or (
+				flt(shift_row.get("begin_check_in_before_shift_start_time")) > 0
+				and flt(shift_row.get("late_entry_grace_period")) > 0
+			)
+		)
+	)
 	return frappe._dict(
 		{
 			"shift_name": shift_row["name"],
 			"scheduled_start": start_dt,
 			"scheduled_end": end_dt,
 			"flex_eligible": flex_eligible,
-			"allowed_early_minutes": int(min(flt(shift_row.get("begin_check_in_before_shift_start_time") or 0), DEFAULT_FLEX_MINUTES)) if flex_eligible else 0,
-			"late_flex_minutes": int(min(flt(shift_row.get("late_entry_grace_period") or 0), DEFAULT_FLEX_MINUTES)) if flex_eligible else 0,
+			"allowed_early_minutes": int(
+				min(flt(shift_row.get("begin_check_in_before_shift_start_time") or 0), DEFAULT_FLEX_MINUTES)
+			)
+			if flex_eligible
+			else 0,
+			"late_flex_minutes": int(
+				min(flt(shift_row.get("late_entry_grace_period") or 0), DEFAULT_FLEX_MINUTES)
+			)
+			if flex_eligible
+			else 0,
 			"standard_working_hours": round(_hours(start_dt, end_dt), 2) or OT_THRESHOLD_HOURS,
 			"overtime_type": shift_row.get("overtime_type"),
 		}
@@ -262,7 +353,14 @@ def _shift_context(employee_doc, attendance_date, shift_name: str | None = None)
 def _flex_doc(employee_name: str, attendance_date, flex_type: str):
 	name = frappe.db.get_value(
 		"Attendance Request",
-		{"employee": employee_name, "from_date": attendance_date, "to_date": attendance_date, "reason": FLEX_REASON, "flex_exception_type": flex_type, "docstatus": ("!=", 2)},
+		{
+			"employee": employee_name,
+			"from_date": attendance_date,
+			"to_date": attendance_date,
+			"reason": FLEX_REASON,
+			"flex_exception_type": flex_type,
+			"docstatus": ("!=", 2),
+		},
 		"name",
 	)
 	return frappe.get_doc("Attendance Request", name) if name else None
@@ -275,9 +373,22 @@ def _validated_minutes(doc) -> float:
 
 
 def _evaluate(attendance_doc, employee_doc, shift_ctx):
-	if not attendance_doc.get("in_time") or not attendance_doc.get("out_time") or not shift_ctx.scheduled_start or not shift_ctx.scheduled_end:
+	if (
+		not attendance_doc.get("in_time")
+		or not attendance_doc.get("out_time")
+		or not shift_ctx.scheduled_start
+		or not shift_ctx.scheduled_end
+	):
 		total = flt(attendance_doc.get("working_hours") or 0)
-		return frappe._dict({"total_hours": round(total, 2), "candidate_hours": round(max(0, total - OT_THRESHOLD_HOURS), 2), "eligible": total > OT_THRESHOLD_HOURS, "late_exception_minutes": 0, "early_exception_minutes": 0})
+		return frappe._dict(
+			{
+				"total_hours": round(total, 2),
+				"candidate_hours": round(max(0, total - OT_THRESHOLD_HOURS), 2),
+				"eligible": total > OT_THRESHOLD_HOURS,
+				"late_exception_minutes": 0,
+				"early_exception_minutes": 0,
+			}
+		)
 	actual_in = get_datetime(attendance_doc.in_time)
 	actual_out = get_datetime(attendance_doc.out_time)
 	late_doc = _flex_doc(employee_doc.name, attendance_doc.attendance_date, FLEX_LATE)
@@ -287,10 +398,21 @@ def _evaluate(attendance_doc, employee_doc, shift_ctx):
 	standard_allowed_in = shift_ctx.scheduled_start - timedelta(minutes=shift_ctx.allowed_early_minutes)
 	late_minutes = _minutes(shift_ctx.scheduled_start, actual_in)
 	extra_early = _minutes(actual_in, standard_allowed_in) if actual_in < standard_allowed_in else 0
-	within_default_late = bool(shift_ctx.flex_eligible and shift_ctx.late_flex_minutes > 0 and 0 < late_minutes < shift_ctx.late_flex_minutes)
-	unresolved_late = bool(shift_ctx.flex_eligible and late_minutes >= shift_ctx.late_flex_minutes > 0 and approved_late <= 0)
-	counted_start = max(actual_in, shift_ctx.scheduled_start - timedelta(minutes=shift_ctx.allowed_early_minutes + approved_early))
-	expected_end = shift_ctx.scheduled_end + timedelta(minutes=(late_minutes if within_default_late else min(approved_late, late_minutes)))
+	within_default_late = bool(
+		shift_ctx.flex_eligible
+		and shift_ctx.late_flex_minutes > 0
+		and 0 < late_minutes < shift_ctx.late_flex_minutes
+	)
+	unresolved_late = bool(
+		shift_ctx.flex_eligible and late_minutes >= shift_ctx.late_flex_minutes > 0 and approved_late <= 0
+	)
+	counted_start = max(
+		actual_in,
+		shift_ctx.scheduled_start - timedelta(minutes=shift_ctx.allowed_early_minutes + approved_early),
+	)
+	expected_end = shift_ctx.scheduled_end + timedelta(
+		minutes=(late_minutes if within_default_late else min(approved_late, late_minutes))
+	)
 	effective_hours = _hours(counted_start, actual_out)
 	candidate = max(0.0, _hours(expected_end, actual_out))
 	return frappe._dict(
@@ -304,7 +426,14 @@ def _evaluate(attendance_doc, employee_doc, shift_ctx):
 	)
 
 
-def _upsert_flex(employee_doc, attendance_doc, shift_ctx, flex_type: str, requested_minutes: float, shift_record: str | None = None):
+def _upsert_flex(
+	employee_doc,
+	attendance_doc,
+	shift_ctx,
+	flex_type: str,
+	requested_minutes: float,
+	shift_record: str | None = None,
+):
 	if requested_minutes <= 0:
 		return None
 	doc = _flex_doc(employee_doc.name, attendance_doc.attendance_date, flex_type)
@@ -342,14 +471,30 @@ def _ot_doc(attendance_name: str | None = None, shift_record_name: str | None = 
 	return frappe.get_doc("BEI Overtime Request", name) if name else None
 
 
-def _upsert_from_attendance_doc(attendance_doc, source_trigger: str = "attendance_close", shift_record_name: str | None = None):
+def _upsert_from_attendance_doc(
+	attendance_doc, source_trigger: str = "attendance_close", shift_record_name: str | None = None
+):
 	employee_doc = _employee(attendance_doc.employee)
 	shift_ctx = _shift_context(employee_doc, attendance_doc.attendance_date, attendance_doc.get("shift"))
 	eval_result = _evaluate(attendance_doc, employee_doc, shift_ctx)
 	if eval_result.early_exception_minutes and shift_ctx.flex_eligible:
-		_upsert_flex(employee_doc, attendance_doc, shift_ctx, FLEX_EARLY, eval_result.early_exception_minutes, shift_record=shift_record_name)
+		_upsert_flex(
+			employee_doc,
+			attendance_doc,
+			shift_ctx,
+			FLEX_EARLY,
+			eval_result.early_exception_minutes,
+			shift_record=shift_record_name,
+		)
 	if eval_result.late_exception_minutes and shift_ctx.flex_eligible:
-		_upsert_flex(employee_doc, attendance_doc, shift_ctx, FLEX_LATE, eval_result.late_exception_minutes, shift_record=shift_record_name)
+		_upsert_flex(
+			employee_doc,
+			attendance_doc,
+			shift_ctx,
+			FLEX_LATE,
+			eval_result.late_exception_minutes,
+			shift_record=shift_record_name,
+		)
 	doc = _ot_doc(attendance_name=attendance_doc.name, shift_record_name=shift_record_name)
 	if not eval_result.eligible and not doc:
 		return None
@@ -367,7 +512,11 @@ def _upsert_from_attendance_doc(attendance_doc, source_trigger: str = "attendanc
 	doc.supervisor = employee_doc.reports_to
 	doc.request_source = "system_detected"
 	doc.source_trigger = source_trigger
-	doc.source_event_key = attendance_doc.name if source_trigger != "shift_record_close" else f"{source_trigger}:{shift_record_name or attendance_doc.name}"
+	doc.source_event_key = (
+		attendance_doc.name
+		if source_trigger != "shift_record_close"
+		else f"{source_trigger}:{shift_record_name or attendance_doc.name}"
+	)
 	doc.reason_category = "Post Shift OT"
 	doc.assigned_approver = chain["assigned_approver"]
 	doc.fallback_approver = chain["fallback_approver"]
@@ -384,13 +533,19 @@ def _upsert_from_attendance_doc(attendance_doc, source_trigger: str = "attendanc
 
 
 def upsert_overtime_case_from_attendance(attendance_name: str, source_trigger: str = "attendance_close"):
-	doc = _upsert_from_attendance_doc(frappe.get_doc("Attendance", attendance_name), source_trigger=source_trigger)
+	doc = _upsert_from_attendance_doc(
+		frappe.get_doc("Attendance", attendance_name), source_trigger=source_trigger
+	)
 	return doc.as_dict() if doc else None
 
 
 def upsert_overtime_case_from_shift_record(shift_record_name: str):
 	shift_doc = frappe.get_doc("BEI Shift Record", shift_record_name)
-	attendance_name = frappe.db.get_value("Attendance", {"employee": shift_doc.employee, "attendance_date": getdate(shift_doc.punch_in_time), "docstatus": 1}, "name")
+	attendance_name = frappe.db.get_value(
+		"Attendance",
+		{"employee": shift_doc.employee, "attendance_date": getdate(shift_doc.punch_in_time), "docstatus": 1},
+		"name",
+	)
 	if not attendance_name:
 		return None
 	return upsert_overtime_case_from_attendance(attendance_name, source_trigger="shift_record_close")
@@ -398,7 +553,12 @@ def upsert_overtime_case_from_shift_record(shift_record_name: str):
 
 def detect_overtime_for_date(attendance_date: str | None = None):
 	attendance_date = attendance_date or str(add_days(getdate(nowdate()), -1))
-	rows = frappe.get_all("Attendance", filters={"docstatus": 1, "attendance_date": attendance_date}, fields=["name"], limit_page_length=5000)
+	rows = frappe.get_all(
+		"Attendance",
+		filters={"docstatus": 1, "attendance_date": attendance_date},
+		fields=["name"],
+		limit_page_length=5000,
+	)
 	created = 0
 	updated = 0
 	for row in rows:
@@ -445,31 +605,145 @@ def get_operational_queue(status: str | None = None, include_resolved: int = 0):
 		ot_status = _normalize_ot_status(row.overtime_status)
 		if status and ot_status != status:
 			continue
-		if not int(include_resolved or 0) and ot_status not in {OT_PENDING, OT_NEEDS_INFO, OT_CLARIFIED, OT_ESCALATED}:
+		if not int(include_resolved or 0) and ot_status not in {
+			OT_PENDING,
+			OT_NEEDS_INFO,
+			OT_CLARIFIED,
+			OT_ESCALATED,
+		}:
 			continue
-		items.append({"id": row.name, "item_type": "overtime", "status": ot_status, "employee": row.employee, "employee_name": row.employee_name, "branch": row.branch, "department": row.department, "attendance_date": row.attendance_date, "shift": row.shift, "overtime_hours": row.overtime_hours, "total_hours": row.total_hours, "clarification_question": row.clarification_question, "clarification_response": row.clarification_response, "review_note": row.review_note})
+		items.append(
+			{
+				"id": row.name,
+				"item_type": "overtime",
+				"status": ot_status,
+				"employee": row.employee,
+				"employee_name": row.employee_name,
+				"branch": row.branch,
+				"department": row.department,
+				"attendance_date": row.attendance_date,
+				"shift": row.shift,
+				"overtime_hours": row.overtime_hours,
+				"total_hours": row.total_hours,
+				"clarification_question": row.clarification_question,
+				"clarification_response": row.clarification_response,
+				"review_note": row.review_note,
+			}
+		)
 	for row in flex_rows:
 		if status and row.review_status != status:
 			continue
-		if not int(include_resolved or 0) and row.review_status not in {FLEX_PENDING, FLEX_NEEDS_INFO, FLEX_CLARIFIED}:
+		if not int(include_resolved or 0) and row.review_status not in {
+			FLEX_PENDING,
+			FLEX_NEEDS_INFO,
+			FLEX_CLARIFIED,
+		}:
 			continue
-		items.append({"id": row.name, "item_type": "flex_exception", "status": row.review_status, "employee": row.employee, "employee_name": row.employee_name, "branch": row.branch, "department": row.department, "attendance_date": row.attendance_date, "shift": row.shift, "flex_exception_type": row.flex_exception_type, "requested_minutes": row.requested_minutes, "validated_minutes": row.validated_minutes, "clarification_question": row.clarification_prompt, "clarification_response": row.clarification_response, "review_note": row.manager_decision_note})
+		items.append(
+			{
+				"id": row.name,
+				"item_type": "flex_exception",
+				"status": row.review_status,
+				"employee": row.employee,
+				"employee_name": row.employee_name,
+				"branch": row.branch,
+				"department": row.department,
+				"attendance_date": row.attendance_date,
+				"shift": row.shift,
+				"flex_exception_type": row.flex_exception_type,
+				"requested_minutes": row.requested_minutes,
+				"validated_minutes": row.validated_minutes,
+				"clarification_question": row.clarification_prompt,
+				"clarification_response": row.clarification_response,
+				"review_note": row.manager_decision_note,
+			}
+		)
 	return {"items": items, "count": len(items)}
 
 
 @frappe.whitelist()
 def get_employee_ot_cases():
-	current_employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user, "status": "Active"}, "name")
+	current_employee = frappe.db.get_value(
+		"Employee", {"user_id": frappe.session.user, "status": "Active"}, "name"
+	)
 	if not current_employee:
 		return {"items": [], "count": 0}
-	ot_rows = frappe.get_all("BEI Overtime Request", filters={"employee": current_employee}, fields=["name", "attendance_date", "shift", "overtime_hours", "total_hours", "overtime_status", "clarification_question", "clarification_response", "review_note", "rejection_reason", "approval_notes"], order_by="attendance_date desc")
-	flex_rows = frappe.get_all("Attendance Request", filters={"employee": current_employee, "reason": FLEX_REASON}, fields=["name", "from_date", "shift", "review_status", "flex_exception_type", "requested_minutes", "validated_minutes", "clarification_prompt", "clarification_response", "manager_decision_note"], order_by="from_date desc")
-	items = [{"id": row.name, "item_type": "overtime", "status": _normalize_ot_status(row.overtime_status), "attendance_date": row.attendance_date, "shift": row.shift, "overtime_hours": row.overtime_hours, "total_hours": row.total_hours, "clarification_question": row.clarification_question, "clarification_response": row.clarification_response, "review_note": row.review_note or row.rejection_reason or row.approval_notes} for row in ot_rows]
-	items.extend({"id": row.name, "item_type": "flex_exception", "status": row.review_status, "attendance_date": row.from_date, "shift": row.shift, "flex_exception_type": row.flex_exception_type, "requested_minutes": row.requested_minutes, "validated_minutes": row.validated_minutes, "clarification_question": row.clarification_prompt, "clarification_response": row.clarification_response, "review_note": row.manager_decision_note} for row in flex_rows)
+	ot_rows = frappe.get_all(
+		"BEI Overtime Request",
+		filters={"employee": current_employee},
+		fields=[
+			"name",
+			"attendance_date",
+			"shift",
+			"overtime_hours",
+			"total_hours",
+			"overtime_status",
+			"clarification_question",
+			"clarification_response",
+			"review_note",
+			"rejection_reason",
+			"approval_notes",
+		],
+		order_by="attendance_date desc",
+	)
+	flex_rows = frappe.get_all(
+		"Attendance Request",
+		filters={"employee": current_employee, "reason": FLEX_REASON},
+		fields=[
+			"name",
+			"from_date",
+			"shift",
+			"review_status",
+			"flex_exception_type",
+			"requested_minutes",
+			"validated_minutes",
+			"clarification_prompt",
+			"clarification_response",
+			"manager_decision_note",
+		],
+		order_by="from_date desc",
+	)
+	items = [
+		{
+			"id": row.name,
+			"item_type": "overtime",
+			"status": _normalize_ot_status(row.overtime_status),
+			"attendance_date": row.attendance_date,
+			"shift": row.shift,
+			"overtime_hours": row.overtime_hours,
+			"total_hours": row.total_hours,
+			"clarification_question": row.clarification_question,
+			"clarification_response": row.clarification_response,
+			"review_note": row.review_note or row.rejection_reason or row.approval_notes,
+		}
+		for row in ot_rows
+	]
+	items.extend(
+		{
+			"id": row.name,
+			"item_type": "flex_exception",
+			"status": row.review_status,
+			"attendance_date": row.from_date,
+			"shift": row.shift,
+			"flex_exception_type": row.flex_exception_type,
+			"requested_minutes": row.requested_minutes,
+			"validated_minutes": row.validated_minutes,
+			"clarification_question": row.clarification_prompt,
+			"clarification_response": row.clarification_response,
+			"review_note": row.manager_decision_note,
+		}
+		for row in flex_rows
+	)
 	return {"items": items, "count": len(items)}
 
 
-def _save_ot_transition(doc, new_status: str, notes: str | None = None, approved_duration: float | None = None, approved_type: str | None = None):
+def _save_ot_transition(
+	doc,
+	new_status: str,
+	notes: str | None = None,
+	approved_duration: float | None = None,
+	approved_type: str | None = None,
+):
 	is_override = _assert_review_access(doc, "overtime_status")
 	if is_override and not notes:
 		frappe.throw(_("HR override actions require notes."))
@@ -482,8 +756,12 @@ def _save_ot_transition(doc, new_status: str, notes: str | None = None, approved
 		doc.override_note = notes
 	if new_status == OT_APPROVED:
 		doc.approval_notes = notes or doc.approval_notes
-		doc.approved_payable_duration = flt(approved_duration if approved_duration is not None else doc.overtime_hours)
-		doc.approved_overtime_type = approved_type or doc.candidate_overtime_type or doc.approved_overtime_type
+		doc.approved_payable_duration = flt(
+			approved_duration if approved_duration is not None else doc.overtime_hours
+		)
+		doc.approved_overtime_type = (
+			approved_type or doc.candidate_overtime_type or doc.approved_overtime_type
+		)
 		doc.payroll_bridge_status = PAYROLL_PENDING
 	if new_status == OT_REJECTED:
 		doc.rejection_reason = notes or doc.rejection_reason
@@ -493,17 +771,37 @@ def _save_ot_transition(doc, new_status: str, notes: str | None = None, approved
 
 
 @frappe.whitelist()
-def approve_overtime(overtime_request_name: str | None = None, notes: str | None = None, name: str | None = None, approval_notes: str | None = None, approved_payable_duration: float | None = None, approved_overtime_type: str | None = None):
-	doc = _save_ot_transition(frappe.get_doc("BEI Overtime Request", overtime_request_name or name), OT_APPROVED, notes if notes is not None else approval_notes, approved_payable_duration, approved_overtime_type)
+def approve_overtime(
+	overtime_request_name: str | None = None,
+	notes: str | None = None,
+	name: str | None = None,
+	approval_notes: str | None = None,
+	approved_payable_duration: float | None = None,
+	approved_overtime_type: str | None = None,
+):
+	doc = _save_ot_transition(
+		frappe.get_doc("BEI Overtime Request", overtime_request_name or name),
+		OT_APPROVED,
+		notes if notes is not None else approval_notes,
+		approved_payable_duration,
+		approved_overtime_type,
+	)
 	return {"success": True, "name": doc.name, "status": doc.overtime_status}
 
 
 @frappe.whitelist()
-def reject_overtime(overtime_request_name: str | None = None, reason: str | None = None, name: str | None = None, rejection_reason: str | None = None):
+def reject_overtime(
+	overtime_request_name: str | None = None,
+	reason: str | None = None,
+	name: str | None = None,
+	rejection_reason: str | None = None,
+):
 	reason = reason if reason is not None else rejection_reason
 	if not reason:
 		frappe.throw(_("Rejection reason is required"))
-	doc = _save_ot_transition(frappe.get_doc("BEI Overtime Request", overtime_request_name or name), OT_REJECTED, reason)
+	doc = _save_ot_transition(
+		frappe.get_doc("BEI Overtime Request", overtime_request_name or name), OT_REJECTED, reason
+	)
 	return {"success": True, "name": doc.name, "status": doc.overtime_status}
 
 
@@ -560,10 +858,16 @@ def approve_flex_exception(name: str, notes: str | None = None, validated_minute
 	doc.reviewed_by = frappe.session.user
 	doc.reviewed_at = now_datetime()
 	doc.manager_decision_note = notes or doc.manager_decision_note
-	doc.validated_minutes = flt(validated_minutes if validated_minutes is not None else doc.requested_minutes or 0)
+	doc.validated_minutes = flt(
+		validated_minutes if validated_minutes is not None else doc.requested_minutes or 0
+	)
 	doc.save(ignore_permissions=True)
 	if doc.attendance:
-		ot_doc = _upsert_from_attendance_doc(frappe.get_doc("Attendance", doc.attendance), source_trigger="attendance_close", shift_record_name=doc.shift_record)
+		ot_doc = _upsert_from_attendance_doc(
+			frappe.get_doc("Attendance", doc.attendance),
+			source_trigger="attendance_close",
+			shift_record_name=doc.shift_record,
+		)
 		if ot_doc:
 			doc.linked_ot_case = ot_doc.name
 			doc.save(ignore_permissions=True)
@@ -611,7 +915,15 @@ def submit_flex_clarification(name: str, response: str):
 
 
 @frappe.whitelist()
-def get_overtime_requests(status: str | None = None, store: str | None = None, employee: str | None = None, from_date: str | None = None, to_date: str | None = None, page: int = 1, page_size: int = 20):
+def get_overtime_requests(
+	status: str | None = None,
+	store: str | None = None,
+	employee: str | None = None,
+	from_date: str | None = None,
+	to_date: str | None = None,
+	page: int = 1,
+	page_size: int = 20,
+):
 	_assert_hr_access()
 	rows = frappe.db.sql(
 		"""
@@ -631,7 +943,11 @@ def get_overtime_requests(status: str | None = None, store: str | None = None, e
 		{"status": status, "employee": employee, "from_date": from_date, "to_date": to_date, "store": store},
 		as_dict=True,
 	)
-	return _paginate([{**dict(row), "overtime_status": _normalize_ot_status(row.overtime_status)} for row in rows], page=int(page or 1), page_size=int(page_size or 20))
+	return _paginate(
+		[{**dict(row), "overtime_status": _normalize_ot_status(row.overtime_status)} for row in rows],
+		page=int(page or 1),
+		page_size=int(page_size or 20),
+	)
 
 
 @frappe.whitelist()
@@ -655,7 +971,13 @@ def get_overtime_summary(store: str | None = None, from_date: str | None = None,
 		{"from_date": from_date, "to_date": to_date, "store": store},
 		as_dict=True,
 	)
-	totals = {"total_requests": 0, "total_hours": 0.0, "approved_hours": 0.0, "pending_hours": 0.0, "rejected_hours": 0.0}
+	totals = {
+		"total_requests": 0,
+		"total_hours": 0.0,
+		"approved_hours": 0.0,
+		"pending_hours": 0.0,
+		"rejected_hours": 0.0,
+	}
 	for row in summary:
 		totals["total_requests"] += int(row.total_requests or 0)
 		totals["total_hours"] += flt(row.total_hours)
@@ -703,13 +1025,20 @@ def get_approved_ot_bridge_rows(employee: str, start_date, end_date):
 		  AND COALESCE(ot.approved_payable_duration, ot.overtime_hours) > 0
 		ORDER BY ot.attendance_date ASC, ot.creation ASC
 		""",
-		{"employee": employee, "start_date": start_date, "end_date": end_date, "standard_hours": OT_THRESHOLD_HOURS},
+		{
+			"employee": employee,
+			"start_date": start_date,
+			"end_date": end_date,
+			"standard_hours": OT_THRESHOLD_HOURS,
+		},
 		as_dict=True,
 	)
 	return [frappe._dict(row) for row in rows if row.get("overtime_type")]
 
 
-def mark_overtime_requests_bridged(ot_request_names: list[str], overtime_slip_name: str, locked: bool = False):
+def mark_overtime_requests_bridged(
+	ot_request_names: list[str], overtime_slip_name: str, locked: bool = False
+):
 	names = list(ot_request_names or [])
 	if not names and overtime_slip_name:
 		names = frappe.get_all(

--- a/hrms/hr/doctype/attendance_request/attendance_request.json
+++ b/hrms/hr/doctype/attendance_request/attendance_request.json
@@ -23,7 +23,26 @@
   "reason",
   "column_break_4",
   "explanation",
-  "amended_from"
+  "amended_from",
+  "review_status",
+  "flex_exception_type",
+  "attendance",
+  "shift_record",
+  "shift_assignment",
+  "cutoff_datetime",
+  "requested_minutes",
+  "validated_minutes",
+  "manager_decision_note",
+  "clarification_prompt",
+  "clarification_response",
+  "reviewed_by",
+  "reviewed_at",
+  "assigned_approver",
+  "fallback_approver",
+  "escalation_approver",
+  "hr_notified",
+  "hr_notified_at",
+  "linked_ot_case"
  ],
  "fields": [
   {
@@ -99,7 +118,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Reason",
-   "options": "Work From Home\nOn Duty",
+   "options": "Work From Home\nOn Duty\nFlex Exception",
    "reqd": 1
   },
   {
@@ -132,6 +151,115 @@
    "fieldname": "include_holidays",
    "fieldtype": "Check",
    "label": "Include Holidays"
+  },
+  {
+   "default": "Pending Review",
+   "fieldname": "review_status",
+   "fieldtype": "Select",
+   "label": "Review Status",
+   "options": "Pending Review\nNeeds Clarification\nClarification Submitted\nApproved\nRejected\nExpired"
+  },
+  {
+   "fieldname": "flex_exception_type",
+   "fieldtype": "Select",
+   "label": "Flex Exception Type",
+   "options": "Late Flex Exception\nEarly Start Validation"
+  },
+  {
+   "fieldname": "attendance",
+   "fieldtype": "Link",
+   "label": "Attendance",
+   "options": "Attendance"
+  },
+  {
+   "fieldname": "shift_record",
+   "fieldtype": "Link",
+   "label": "Shift Record",
+   "options": "BEI Shift Record"
+  },
+  {
+   "fieldname": "shift_assignment",
+   "fieldtype": "Link",
+   "label": "Shift Assignment",
+   "options": "Shift Assignment"
+  },
+  {
+   "fieldname": "cutoff_datetime",
+   "fieldtype": "Datetime",
+   "label": "Cutoff Datetime"
+  },
+  {
+   "fieldname": "requested_minutes",
+   "fieldtype": "Float",
+   "label": "Requested Minutes",
+   "precision": "2"
+  },
+  {
+   "fieldname": "validated_minutes",
+   "fieldtype": "Float",
+   "label": "Validated Minutes",
+   "precision": "2"
+  },
+  {
+   "fieldname": "manager_decision_note",
+   "fieldtype": "Small Text",
+   "label": "Manager Decision Note"
+  },
+  {
+   "fieldname": "clarification_prompt",
+   "fieldtype": "Small Text",
+   "label": "Clarification Prompt"
+  },
+  {
+   "fieldname": "clarification_response",
+   "fieldtype": "Small Text",
+   "label": "Clarification Response"
+  },
+  {
+   "fieldname": "reviewed_by",
+   "fieldtype": "Link",
+   "label": "Reviewed By",
+   "options": "User"
+  },
+  {
+   "fieldname": "reviewed_at",
+   "fieldtype": "Datetime",
+   "label": "Reviewed At"
+  },
+  {
+   "fieldname": "assigned_approver",
+   "fieldtype": "Link",
+   "label": "Assigned Approver",
+   "options": "User"
+  },
+  {
+   "fieldname": "fallback_approver",
+   "fieldtype": "Link",
+   "label": "Fallback Approver",
+   "options": "User"
+  },
+  {
+   "fieldname": "escalation_approver",
+   "fieldtype": "Link",
+   "label": "Escalation Approver",
+   "options": "User"
+  },
+  {
+   "default": "0",
+   "fieldname": "hr_notified",
+   "fieldtype": "Check",
+   "label": "HR Notified"
+  },
+  {
+   "fieldname": "hr_notified_at",
+   "fieldtype": "Datetime",
+   "label": "HR Notified At"
+  },
+  {
+   "fieldname": "linked_ot_case",
+   "fieldtype": "Link",
+   "label": "Linked OT Case",
+   "options": "BEI Overtime Request"
   }
  ],
  "is_submittable": 1,

--- a/hrms/hr/doctype/attendance_request/attendance_request.py
+++ b/hrms/hr/doctype/attendance_request/attendance_request.py
@@ -22,8 +22,21 @@ class AttendanceRequest(Document):
 		validate_active_employee(self.employee)
 		validate_dates(self, self.from_date, self.to_date, False)
 		self.validate_half_day()
+		if self.reason == "Flex Exception":
+			self.validate_flex_exception()
+			return
 		self.validate_request_overlap()
 		self.validate_no_attendance_to_create()
+
+	def validate_flex_exception(self):
+		if getdate(self.from_date) != getdate(self.to_date):
+			frappe.throw(_("Flex exceptions must stay on a single attendance date"))
+		if not self.flex_exception_type:
+			frappe.throw(_("Flex exception type is required"))
+		if not self.review_status:
+			self.review_status = "Pending Review"
+		if not self.cutoff_datetime:
+			self.cutoff_datetime = f"{self.from_date} 23:59:00"
 
 	def validate_half_day(self):
 		if self.half_day:
@@ -72,9 +85,13 @@ class AttendanceRequest(Document):
 		frappe.throw(msg, title=_("Overlapping Attendance Request"), exc=OverlappingAttendanceRequestError)
 
 	def on_submit(self):
+		if self.reason == "Flex Exception":
+			return
 		self.create_attendance_records()
 
 	def on_cancel(self):
+		if self.reason == "Flex Exception":
+			return
 		attendance_list = frappe.get_all(
 			"Attendance", {"employee": self.employee, "attendance_request": self.name, "docstatus": 1}
 		)

--- a/hrms/hr/doctype/bei_overtime_request/bei_overtime_request.json
+++ b/hrms/hr/doctype/bei_overtime_request/bei_overtime_request.json
@@ -21,8 +21,26 @@
 		"reviewed_by",
 		"reviewed_at",
 		"column_break_review",
+		"review_note",
 		"approval_notes",
-		"rejection_reason"
+		"rejection_reason",
+		"employee_explanation",
+		"clarification_question",
+		"clarification_response",
+		"override_note",
+		"shift_record",
+		"request_source",
+		"source_trigger",
+		"source_event_key",
+		"reason_category",
+		"assigned_approver",
+		"fallback_approver",
+		"escalation_approver",
+		"candidate_overtime_type",
+		"approved_payable_duration",
+		"approved_overtime_type",
+		"payroll_bridge_status",
+		"payroll_bridge_reference"
 	],
 	"fields": [
 		{
@@ -60,13 +78,13 @@
 			"fieldtype": "Column Break"
 		},
 		{
-			"default": "Pending Approval",
+			"default": "Pending Review",
 			"fieldname": "overtime_status",
 			"fieldtype": "Select",
 			"in_list_view": 1,
 			"in_standard_filter": 1,
 			"label": "Status",
-			"options": "Pending Approval\nApproved\nRejected"
+			"options": "Pending Review\nNeeds Clarification\nClarification Submitted\nApproved\nRejected\nEscalated\nPayroll Locked\nPending Approval"
 		},
 		{
 			"fieldname": "supervisor",
@@ -129,6 +147,11 @@
 			"fieldtype": "Column Break"
 		},
 		{
+			"fieldname": "review_note",
+			"fieldtype": "Small Text",
+			"label": "Review Note"
+		},
+		{
 			"fieldname": "approval_notes",
 			"fieldtype": "Small Text",
 			"label": "Approval Notes"
@@ -138,6 +161,103 @@
 			"fieldname": "rejection_reason",
 			"fieldtype": "Small Text",
 			"label": "Rejection Reason"
+		},
+		{
+			"fieldname": "employee_explanation",
+			"fieldtype": "Small Text",
+			"label": "Employee Explanation"
+		},
+		{
+			"fieldname": "clarification_question",
+			"fieldtype": "Small Text",
+			"label": "Clarification Question"
+		},
+		{
+			"fieldname": "clarification_response",
+			"fieldtype": "Small Text",
+			"label": "Clarification Response"
+		},
+		{
+			"fieldname": "override_note",
+			"fieldtype": "Small Text",
+			"label": "Override Note"
+		},
+		{
+			"fieldname": "shift_record",
+			"fieldtype": "Link",
+			"label": "Shift Record",
+			"options": "BEI Shift Record"
+		},
+		{
+			"fieldname": "request_source",
+			"fieldtype": "Select",
+			"label": "Request Source",
+			"options": "system_detected\nemployee_submitted\nmanager_validated"
+		},
+		{
+			"fieldname": "source_trigger",
+			"fieldtype": "Select",
+			"label": "Source Trigger",
+			"options": "attendance_close\nshift_record_close\nnightly_backfill"
+		},
+		{
+			"fieldname": "source_event_key",
+			"fieldtype": "Data",
+			"label": "Source Event Key"
+		},
+		{
+			"fieldname": "reason_category",
+			"fieldtype": "Select",
+			"label": "Reason Category",
+			"options": "Post Shift OT\nLate Flex Exception\nEarly Start Validation\nManual Review"
+		},
+		{
+			"fieldname": "assigned_approver",
+			"fieldtype": "Link",
+			"label": "Assigned Approver",
+			"options": "User"
+		},
+		{
+			"fieldname": "fallback_approver",
+			"fieldtype": "Link",
+			"label": "Fallback Approver",
+			"options": "User"
+		},
+		{
+			"fieldname": "escalation_approver",
+			"fieldtype": "Link",
+			"label": "Escalation Approver",
+			"options": "User"
+		},
+		{
+			"fieldname": "candidate_overtime_type",
+			"fieldtype": "Link",
+			"label": "Candidate Overtime Type",
+			"options": "Overtime Type"
+		},
+		{
+			"fieldname": "approved_payable_duration",
+			"fieldtype": "Float",
+			"label": "Approved Payable Duration",
+			"precision": "2"
+		},
+		{
+			"fieldname": "approved_overtime_type",
+			"fieldtype": "Link",
+			"label": "Approved Overtime Type",
+			"options": "Overtime Type"
+		},
+		{
+			"fieldname": "payroll_bridge_status",
+			"fieldtype": "Select",
+			"label": "Payroll Bridge Status",
+			"options": "Not Ready\nPending Bridge\nBridged\nPayroll Locked"
+		},
+		{
+			"fieldname": "payroll_bridge_reference",
+			"fieldtype": "Link",
+			"label": "Payroll Bridge Reference",
+			"options": "Overtime Slip"
 		}
 	],
 	"index_web_pages_for_search": 0,

--- a/hrms/hr/doctype/bei_shift_record/bei_shift_record.py
+++ b/hrms/hr/doctype/bei_shift_record/bei_shift_record.py
@@ -100,6 +100,32 @@ class BEIShiftRecord(Document):
 	def create_attendance_from_shift(self):
 		"""Bridge: create/update Attendance record from completed shift record."""
 		att_date = getdate(self.punch_in_time)
+		shift_assignment = frappe.db.get_value(
+			"Shift Assignment",
+			{
+				"employee": self.employee,
+				"docstatus": 1,
+				"status": "Active",
+				"start_date": ("<=", att_date),
+				"end_date": [">=", att_date],
+			},
+			["shift_type"],
+			as_dict=True,
+		)
+		if not shift_assignment:
+			shift_assignment = frappe.db.get_value(
+				"Shift Assignment",
+				{
+					"employee": self.employee,
+					"docstatus": 1,
+					"status": "Active",
+					"start_date": ("<=", att_date),
+					"end_date": ("is", "not set"),
+				},
+				["shift_type"],
+				as_dict=True,
+			)
+		shift_type = shift_assignment.get("shift_type") if shift_assignment else None
 
 		# Cap auto-punched-out shifts at 8h to prevent phantom overtime
 		if getattr(self, "auto_punched_out", 0):
@@ -121,8 +147,34 @@ class BEIShiftRecord(Document):
 			update_fields = {
 				"working_hours": working_hours,
 				"status": att_status,
+				"shift": shift_type,
+				"in_time": self.punch_in_time,
+				"out_time": self.punch_out_time,
 			}
 			frappe.db.set_value("Attendance", existing, update_fields)
+			try:
+				from hrms.hr.doctype.employee_checkin.employee_checkin import get_overtime_data
+
+				if shift_type and att_status == "Present":
+					overtime_data = get_overtime_data(shift_type, working_hours)
+					if overtime_data:
+						frappe.db.set_value(
+							"Attendance",
+							existing,
+							{
+								"overtime_type": frappe.db.get_value("Shift Type", shift_type, "overtime_type"),
+								"standard_working_hours": overtime_data.get("standard_working_hours"),
+								"actual_overtime_duration": overtime_data.get("actual_overtime_duration"),
+							},
+						)
+			except Exception:
+				pass
+			try:
+				from hrms.api.overtime import upsert_overtime_case_from_attendance
+
+				upsert_overtime_case_from_attendance(existing, source_trigger="shift_record_close")
+			except Exception:
+				frappe.log_error(frappe.get_traceback(), f"Failed OT upsert for Attendance {existing}")
 			return
 
 		# Create new Attendance via raw SQL (avoids ORM validation cascade)
@@ -154,7 +206,8 @@ class BEIShiftRecord(Document):
 			# Name collision with non-standard naming — fallback to update
 			frappe.db.sql("""
 				UPDATE `tabAttendance`
-				SET working_hours = %(hours)s, status = %(status)s, modified = NOW()
+				SET working_hours = %(hours)s, status = %(status)s, shift = %(shift)s,
+				    in_time = %(in_time)s, out_time = %(out_time)s, modified = NOW()
 				WHERE employee = %(employee)s AND attendance_date = %(date)s
 				LIMIT 1
 			""", {
@@ -162,7 +215,43 @@ class BEIShiftRecord(Document):
 				"date": att_date,
 				"status": att_status,
 				"hours": working_hours,
+				"shift": shift_type,
+				"in_time": self.punch_in_time,
+				"out_time": self.punch_out_time,
 			})
+
+		attendance_name = frappe.db.get_value(
+			"Attendance",
+			{"employee": self.employee, "attendance_date": att_date, "docstatus": 1},
+			"name",
+		)
+		if attendance_name:
+			try:
+				from hrms.hr.doctype.employee_checkin.employee_checkin import get_overtime_data
+
+				if shift_type and att_status == "Present":
+					overtime_data = get_overtime_data(shift_type, working_hours)
+					if overtime_data:
+						frappe.db.set_value(
+							"Attendance",
+							attendance_name,
+							{
+								"shift": shift_type,
+								"in_time": self.punch_in_time,
+								"out_time": self.punch_out_time,
+								"overtime_type": frappe.db.get_value("Shift Type", shift_type, "overtime_type"),
+								"standard_working_hours": overtime_data.get("standard_working_hours"),
+								"actual_overtime_duration": overtime_data.get("actual_overtime_duration"),
+							},
+						)
+			except Exception:
+				pass
+			try:
+				from hrms.api.overtime import upsert_overtime_case_from_attendance
+
+				upsert_overtime_case_from_attendance(attendance_name, source_trigger="shift_record_close")
+			except Exception:
+				frappe.log_error(frappe.get_traceback(), f"Failed OT upsert for Attendance {attendance_name}")
 
 		if needs_review:
 			frappe.logger().warning(

--- a/hrms/hr/doctype/bei_shift_record/bei_shift_record.py
+++ b/hrms/hr/doctype/bei_shift_record/bei_shift_record.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
-from frappe.utils import get_datetime, time_diff_in_hours, getdate
+from frappe.utils import get_datetime, getdate, time_diff_in_hours
 
 
 class BEIShiftRecord(Document):
@@ -77,12 +77,15 @@ class BEIShiftRecord(Document):
 
 		from hrms.utils.geo import calculate_haversine_distance
 
-		distance_km = calculate_haversine_distance(
-			last.punch_out_latitude,
-			last.punch_out_longitude,
-			self.punch_in_latitude,
-			self.punch_in_longitude,
-		) / 1000
+		distance_km = (
+			calculate_haversine_distance(
+				last.punch_out_latitude,
+				last.punch_out_longitude,
+				self.punch_in_latitude,
+				self.punch_in_longitude,
+			)
+			/ 1000
+		)
 
 		time_hours = time_diff_in_hours(
 			get_datetime(self.punch_in_time),
@@ -138,10 +141,7 @@ class BEIShiftRecord(Document):
 			needs_review = False
 
 		# Guard: don't duplicate — update if exists
-		existing = frappe.db.exists("Attendance", {
-			"employee": self.employee,
-			"attendance_date": att_date
-		})
+		existing = frappe.db.exists("Attendance", {"employee": self.employee, "attendance_date": att_date})
 
 		if existing:
 			update_fields = {
@@ -162,7 +162,9 @@ class BEIShiftRecord(Document):
 							"Attendance",
 							existing,
 							{
-								"overtime_type": frappe.db.get_value("Shift Type", shift_type, "overtime_type"),
+								"overtime_type": frappe.db.get_value(
+									"Shift Type", shift_type, "overtime_type"
+								),
 								"standard_working_hours": overtime_data.get("standard_working_hours"),
 								"actual_overtime_duration": overtime_data.get("actual_overtime_duration"),
 							},
@@ -182,7 +184,8 @@ class BEIShiftRecord(Document):
 		company = frappe.db.get_value("Employee", self.employee, "company")
 
 		try:
-			frappe.db.sql("""
+			frappe.db.sql(
+				"""
 				INSERT INTO `tabAttendance` (
 					name, employee, employee_name, attendance_date,
 					status, working_hours, docstatus,
@@ -192,33 +195,38 @@ class BEIShiftRecord(Document):
 					%(status)s, %(hours)s, 1,
 					%(company)s, NOW(), NOW(), %(user)s, %(user)s
 				)
-			""", {
-				"name": att_name,
-				"employee": self.employee,
-				"employee_name": self.employee_name,
-				"date": att_date,
-				"status": att_status,
-				"hours": working_hours,
-				"company": company,
-				"user": frappe.session.user,
-			})
+			""",
+				{
+					"name": att_name,
+					"employee": self.employee,
+					"employee_name": self.employee_name,
+					"date": att_date,
+					"status": att_status,
+					"hours": working_hours,
+					"company": company,
+					"user": frappe.session.user,
+				},
+			)
 		except Exception:
 			# Name collision with non-standard naming — fallback to update
-			frappe.db.sql("""
+			frappe.db.sql(
+				"""
 				UPDATE `tabAttendance`
 				SET working_hours = %(hours)s, status = %(status)s, shift = %(shift)s,
 				    in_time = %(in_time)s, out_time = %(out_time)s, modified = NOW()
 				WHERE employee = %(employee)s AND attendance_date = %(date)s
 				LIMIT 1
-			""", {
-				"employee": self.employee,
-				"date": att_date,
-				"status": att_status,
-				"hours": working_hours,
-				"shift": shift_type,
-				"in_time": self.punch_in_time,
-				"out_time": self.punch_out_time,
-			})
+			""",
+				{
+					"employee": self.employee,
+					"date": att_date,
+					"status": att_status,
+					"hours": working_hours,
+					"shift": shift_type,
+					"in_time": self.punch_in_time,
+					"out_time": self.punch_out_time,
+				},
+			)
 
 		attendance_name = frappe.db.get_value(
 			"Attendance",
@@ -239,7 +247,9 @@ class BEIShiftRecord(Document):
 								"shift": shift_type,
 								"in_time": self.punch_in_time,
 								"out_time": self.punch_out_time,
-								"overtime_type": frappe.db.get_value("Shift Type", shift_type, "overtime_type"),
+								"overtime_type": frappe.db.get_value(
+									"Shift Type", shift_type, "overtime_type"
+								),
 								"standard_working_hours": overtime_data.get("standard_working_hours"),
 								"actual_overtime_duration": overtime_data.get("actual_overtime_duration"),
 							},

--- a/hrms/hr/doctype/employee_checkin/employee_checkin.py
+++ b/hrms/hr/doctype/employee_checkin/employee_checkin.py
@@ -316,6 +316,13 @@ def create_or_update_attendance(
 		attendance.save()
 		attendance.submit()
 
+	try:
+		from hrms.api.overtime import upsert_overtime_case_from_attendance
+
+		upsert_overtime_case_from_attendance(attendance.name, source_trigger="attendance_close")
+	except Exception:
+		frappe.log_error(frappe.get_traceback(), f"Failed OT upsert for Attendance {attendance.name}")
+
 	return attendance
 
 

--- a/hrms/hr/doctype/overtime_slip/overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.py
@@ -150,7 +150,9 @@ class OvertimeSlip(Document):
 
 		records = []
 		if self.start_date and self.end_date:
-			records = get_approved_ot_bridge_rows(self.employee, getdate(self.start_date), getdate(self.end_date))
+			records = get_approved_ot_bridge_rows(
+				self.employee, getdate(self.start_date), getdate(self.end_date)
+			)
 			if not len(records):
 				frappe.throw(
 					_("No attendance records found for employee {0} between {1} and {2}").format(
@@ -465,7 +467,9 @@ def submit_overtime_slips_for_employees(overtime_slips, payroll_entry):
 			doc = frappe.get_doc("Overtime Slip", overtime_slip)
 			doc.submitted_via_payroll_entry = 1
 			doc.submit()
-			mark_overtime_requests_bridged(getattr(doc, "_bridge_ot_request_names", []), doc.name, locked=True)
+			mark_overtime_requests_bridged(
+				getattr(doc, "_bridge_ot_request_names", []), doc.name, locked=True
+			)
 			count += 1
 		except Exception as e:
 			frappe.clear_last_message()

--- a/hrms/hr/doctype/overtime_slip/overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.py
@@ -387,7 +387,12 @@ class OvertimeSlip(Document):
 
 
 @frappe.whitelist()
-def filter_employees_for_overtime_slip_creation(start_date, end_date, employees, limit=None):
+def filter_employees_for_overtime_slip_creation(
+	start_date: str,
+	end_date: str,
+	employees: list[str] | str,
+	limit: int | None = None,
+) -> list[str]:
 	from hrms.api.overtime import get_approved_ot_bridge_rows
 
 	if not employees:
@@ -421,6 +426,9 @@ def filter_employees_for_overtime_slip_creation(start_date, end_date, employees,
 	eligible_employees = list(
 		set(employees_with_overtime_attendance) - set(employees_with_existing_overtime_slips)
 	)
+
+	if limit:
+		return eligible_employees[:limit]
 
 	return eligible_employees
 

--- a/hrms/hr/doctype/overtime_slip/overtime_slip.py
+++ b/hrms/hr/doctype/overtime_slip/overtime_slip.py
@@ -96,6 +96,8 @@ class OvertimeSlip(Document):
 
 	@frappe.whitelist()
 	def get_emp_and_overtime_details(self):
+		from hrms.api.overtime import mark_overtime_requests_bridged
+
 		records = self.get_attendance_records()
 		if len(records):
 			self.create_overtime_details_row_for_attendance(records)
@@ -106,19 +108,23 @@ class OvertimeSlip(Document):
 					total_overtime_duration += detail.overtime_duration
 			self.total_overtime_duration = total_overtime_duration
 		self.save()
+		mark_overtime_requests_bridged(getattr(self, "_bridge_ot_request_names", []), self.name)
 
 	def create_overtime_details_row_for_attendance(self, records):
 		self.overtime_details = []
+		self._bridge_ot_request_names = []
 		overtime_type_cache = {}
 
 		for record in records:
+			if record.name:
+				self._bridge_ot_request_names.append(record.name)
 			if record.overtime_type not in overtime_type_cache:
 				overtime_type_cache[record.overtime_type] = frappe.db.get_value(
 					"Overtime Type", record.overtime_type, "maximum_overtime_hours_allowed"
 				)
 
 			maximum_overtime_hours_allowed = overtime_type_cache[record.overtime_type]
-			overtime_duration = record.actual_overtime_duration or 0.0
+			overtime_duration = record.overtime_duration or 0.0
 
 			if maximum_overtime_hours_allowed > 0:
 				overtime_duration = (
@@ -131,7 +137,7 @@ class OvertimeSlip(Document):
 				self.append(
 					"overtime_details",
 					{
-						"reference_document": record.name,
+						"reference_document": record.reference_document,
 						"date": record.attendance_date,
 						"overtime_type": record.overtime_type,
 						"overtime_duration": overtime_duration,
@@ -140,25 +146,11 @@ class OvertimeSlip(Document):
 				)
 
 	def get_attendance_records(self):
+		from hrms.api.overtime import get_approved_ot_bridge_rows
+
 		records = []
 		if self.start_date and self.end_date:
-			records = frappe.get_all(
-				"Attendance",
-				fields=[
-					"name",
-					"attendance_date",
-					"overtime_type",
-					"actual_overtime_duration",
-					"standard_working_hours",
-				],
-				filters={
-					"employee": self.employee,
-					"docstatus": 1,
-					"attendance_date": ("between", [getdate(self.start_date), getdate(self.end_date)]),
-					"status": "Present",
-					"overtime_type": ["!=", ""],
-				},
-			)
+			records = get_approved_ot_bridge_rows(self.employee, getdate(self.start_date), getdate(self.end_date))
 			if not len(records):
 				frappe.throw(
 					_("No attendance records found for employee {0} between {1} and {2}").format(
@@ -394,6 +386,8 @@ class OvertimeSlip(Document):
 
 @frappe.whitelist()
 def filter_employees_for_overtime_slip_creation(start_date, end_date, employees, limit=None):
+	from hrms.api.overtime import get_approved_ot_bridge_rows
+
 	if not employees:
 		return []
 
@@ -401,23 +395,9 @@ def filter_employees_for_overtime_slip_creation(start_date, end_date, employees,
 		employees = json.loads(employees)
 
 	OvertimeSlip = frappe.qb.DocType("Overtime Slip")
-	Attendance = frappe.qb.DocType("Attendance")
-
-	# First, get employees with valid attendance records
-	employees_with_overtime_attendance = (
-		frappe.qb.from_(Attendance)
-		.select(Attendance.employee)
-		.distinct()
-		.where(
-			(Attendance.employee.isin(employees))
-			& (Attendance.attendance_date >= start_date)
-			& (Attendance.attendance_date <= end_date)
-			& (Attendance.docstatus == 1)  # Only submitted attendance
-			& (Attendance.status == "Present")  # Only present attendance
-			& (Attendance.overtime_type != "")
-			& (Attendance.overtime_type.isnotnull())
-		)
-	).run(pluck=True)
+	employees_with_overtime_attendance = [
+		employee for employee in employees if get_approved_ot_bridge_rows(employee, start_date, end_date)
+	]
 
 	if not employees_with_overtime_attendance:
 		return []
@@ -476,6 +456,8 @@ def create_overtime_slips_for_employees(employees, args):
 
 
 def submit_overtime_slips_for_employees(overtime_slips, payroll_entry):
+	from hrms.api.overtime import mark_overtime_requests_bridged
+
 	count = 0
 	errors = []
 	for overtime_slip in overtime_slips:
@@ -483,6 +465,7 @@ def submit_overtime_slips_for_employees(overtime_slips, payroll_entry):
 			doc = frappe.get_doc("Overtime Slip", overtime_slip)
 			doc.submitted_via_payroll_entry = 1
 			doc.submit()
+			mark_overtime_requests_bridged(getattr(doc, "_bridge_ot_request_names", []), doc.name, locked=True)
 			count += 1
 		except Exception as e:
 			frappe.clear_last_message()

--- a/hrms/payroll/ph_payroll_formulas.py
+++ b/hrms/payroll/ph_payroll_formulas.py
@@ -208,7 +208,7 @@ def get_holiday_premium_days(employee, start_date, end_date, holiday_type="Regul
 
 
 def get_approved_ot_hours(employee, start_date, end_date, ot_type="regular"):
-    """Query approved Overtime Slip records.
+    """Query approved standard Overtime Slip records.
 
     Args:
         employee: Employee ID (string)
@@ -225,46 +225,26 @@ def get_approved_ot_hours(employee, start_date, end_date, ot_type="regular"):
     start = getdate(start_date)
     end = getdate(end_date)
 
-    # Map OT types to potential field/doctype values
-    # Note: Adjust field names based on actual BEI Overtime Slip DocType
     ot_type_filter = ""
     if ot_type == "regular":
-        ot_type_filter = "AND (os.overtime_type = 'Regular' OR os.overtime_type IS NULL)"
+        ot_type_filter = "AND od.overtime_type NOT LIKE '%Rest Day%' AND od.overtime_type NOT LIKE '%Holiday%'"
     elif ot_type == "rest_day":
-        ot_type_filter = "AND os.overtime_type = 'Rest Day'"
+        ot_type_filter = "AND od.overtime_type LIKE '%Rest Day%'"
     elif ot_type == "holiday":
-        ot_type_filter = "AND os.overtime_type = 'Holiday'"
+        ot_type_filter = "AND od.overtime_type LIKE '%Holiday%'"
 
-    # Query approved Overtime Slip records
-    # Adjust table/field names if BEI uses custom DocType
     result = frappe.db.sql(f"""
-        SELECT SUM(os.hours) as total_hours
-        FROM `tabBEI Overtime Slip` os
+        SELECT SUM(od.overtime_duration) as total_hours
+        FROM `tabOvertime Slip` os
+        INNER JOIN `tabOvertime Details` od ON od.parent = os.name
         WHERE os.employee = %(employee)s
-          AND os.date BETWEEN %(start_date)s AND %(end_date)s
           AND os.docstatus = 1
+          AND od.date BETWEEN %(start_date)s AND %(end_date)s
           {ot_type_filter}
-    """, {
+    """, {{
         "employee": employee,
         "start_date": start,
         "end_date": end
-    }, as_dict=True)
-
-    # Fallback: If no custom BEI OT DocType, try querying from Attendance custom fields
-    if not result or result[0].total_hours is None:
-        # Check if Attendance has ot_hours custom field
-        if frappe.db.has_column("Attendance", "ot_hours"):
-            result = frappe.db.sql("""
-                SELECT SUM(a.ot_hours) as total_hours
-                FROM `tabAttendance` a
-                WHERE a.employee = %(employee)s
-                  AND a.attendance_date BETWEEN %(start_date)s AND %(end_date)s
-                  AND a.docstatus = 1
-                  AND a.ot_hours > 0
-            """, {
-                "employee": employee,
-                "start_date": start,
-                "end_date": end
-            }, as_dict=True)
+    }}, as_dict=True)
 
     return flt(result[0].total_hours) if result and result[0].total_hours else 0.0

--- a/hrms/payroll/ph_payroll_formulas.py
+++ b/hrms/payroll/ph_payroll_formulas.py
@@ -9,6 +9,7 @@ Usage in Salary Component formula field:
 
 import frappe
 from frappe import _
+from frappe.query_builder.functions import Sum
 from frappe.utils import date_diff, flt, get_datetime, getdate
 
 
@@ -206,7 +207,7 @@ def get_holiday_premium_days(employee, start_date, end_date, holiday_type="Regul
 	return flt(worked_holidays, 1)
 
 
-def get_approved_ot_hours(employee, start_date, end_date, ot_type="regular"):
+def get_approved_ot_hours(employee: str, start_date: str, end_date: str, ot_type: str = "regular") -> float:
 	"""Query approved standard Overtime Slip records.
 
 	Args:
@@ -224,28 +225,30 @@ def get_approved_ot_hours(employee, start_date, end_date, ot_type="regular"):
 	start = getdate(start_date)
 	end = getdate(end_date)
 
-	ot_type_filter = ""
+	OvertimeSlip = frappe.qb.DocType("Overtime Slip")
+	OvertimeDetails = frappe.qb.DocType("Overtime Details")
+	query = (
+		frappe.qb.from_(OvertimeSlip)
+		.inner_join(OvertimeDetails)
+		.on(OvertimeDetails.parent == OvertimeSlip.name)
+		.select(Sum(OvertimeDetails.overtime_duration).as_("total_hours"))
+		.where(
+			(OvertimeSlip.employee == employee)
+			& (OvertimeSlip.docstatus == 1)
+			& (OvertimeDetails.date.between(start, end))
+		)
+	)
+
 	if ot_type == "regular":
-		ot_type_filter = (
-			"AND od.overtime_type NOT LIKE '%Rest Day%' AND od.overtime_type NOT LIKE '%Holiday%'"
+		query = query.where(
+			(~OvertimeDetails.overtime_type.like("%Rest Day%"))
+			& (~OvertimeDetails.overtime_type.like("%Holiday%"))
 		)
 	elif ot_type == "rest_day":
-		ot_type_filter = "AND od.overtime_type LIKE '%Rest Day%'"
+		query = query.where(OvertimeDetails.overtime_type.like("%Rest Day%"))
 	elif ot_type == "holiday":
-		ot_type_filter = "AND od.overtime_type LIKE '%Holiday%'"
+		query = query.where(OvertimeDetails.overtime_type.like("%Holiday%"))
 
-	result = frappe.db.sql(
-		f"""
-        SELECT SUM(od.overtime_duration) as total_hours
-        FROM `tabOvertime Slip` os
-        INNER JOIN `tabOvertime Details` od ON od.parent = os.name
-        WHERE os.employee = %(employee)s
-          AND os.docstatus = 1
-          AND od.date BETWEEN %(start_date)s AND %(end_date)s
-          {ot_type_filter}
-    """,
-		{{"employee": employee, "start_date": start, "end_date": end}},
-		as_dict=True,
-	)
+	result = query.run(as_dict=True)
 
 	return flt(result[0].total_hours) if result and result[0].total_hours else 0.0

--- a/hrms/payroll/ph_payroll_formulas.py
+++ b/hrms/payroll/ph_payroll_formulas.py
@@ -9,75 +9,71 @@ Usage in Salary Component formula field:
 
 import frappe
 from frappe import _
-from frappe.utils import getdate, date_diff, flt, get_datetime
+from frappe.utils import date_diff, flt, get_datetime, getdate
 
 
 def get_ytd_basic_salary(employee, payroll_period):
-    """Sum basic pay from all submitted Salary Slips in current payroll period.
+	"""Sum basic pay from all submitted Salary Slips in current payroll period.
 
-    Used by 13th Month Pay calculation:
-        13th_month = get_ytd_basic_salary(employee, payroll_period) / 12
+	Used by 13th Month Pay calculation:
+	    13th_month = get_ytd_basic_salary(employee, payroll_period) / 12
 
-    Args:
-        employee: Employee ID (string)
-        payroll_period: Payroll Period name (string, e.g., "2025")
+	Args:
+	    employee: Employee ID (string)
+	    payroll_period: Payroll Period name (string, e.g., "2025")
 
-    Returns:
-        float: Total basic salary year-to-date
-    """
-    if not employee or not payroll_period:
-        return 0.0
+	Returns:
+	    float: Total basic salary year-to-date
+	"""
+	if not employee or not payroll_period:
+		return 0.0
 
-    # Get payroll period dates
-    period = frappe.db.get_value(
-        "Payroll Period",
-        payroll_period,
-        ["start_date", "end_date"],
-        as_dict=True
-    )
+	# Get payroll period dates
+	period = frappe.db.get_value("Payroll Period", payroll_period, ["start_date", "end_date"], as_dict=True)
 
-    if not period:
-        return 0.0
+	if not period:
+		return 0.0
 
-    # Sum gross_pay from all submitted salary slips in period
-    result = frappe.db.sql("""
+	# Sum gross_pay from all submitted salary slips in period
+	result = frappe.db.sql(
+		"""
         SELECT SUM(ss.gross_pay) as total_basic
         FROM `tabSalary Slip` ss
         WHERE ss.employee = %(employee)s
           AND ss.docstatus = 1
           AND ss.start_date >= %(period_start)s
           AND ss.end_date <= %(period_end)s
-    """, {
-        "employee": employee,
-        "period_start": period.start_date,
-        "period_end": period.end_date
-    }, as_dict=True)
+    """,
+		{"employee": employee, "period_start": period.start_date, "period_end": period.end_date},
+		as_dict=True,
+	)
 
-    return flt(result[0].total_basic) if result and result[0].total_basic else 0.0
+	return flt(result[0].total_basic) if result and result[0].total_basic else 0.0
 
 
 def get_night_diff_hours(employee, start_date, end_date):
-    """Count hours worked between 10pm-6am from Employee Checkin records.
+	"""Count hours worked between 10pm-6am from Employee Checkin records.
 
-    Used by Night Differential formula:
-        night_diff_pay = hourly_rate * 0.1 * get_night_diff_hours(employee, start_date, end_date)
+	Used by Night Differential formula:
+	    night_diff_pay = hourly_rate * 0.1 * get_night_diff_hours(employee, start_date, end_date)
 
-    Args:
-        employee: Employee ID (string)
-        start_date: Period start date (string or date)
-        end_date: Period end date (string or date)
+	Args:
+	    employee: Employee ID (string)
+	    start_date: Period start date (string or date)
+	    end_date: Period end date (string or date)
 
-    Returns:
-        float: Total night differential hours
-    """
-    if not employee or not start_date or not end_date:
-        return 0.0
+	Returns:
+	    float: Total night differential hours
+	"""
+	if not employee or not start_date or not end_date:
+		return 0.0
 
-    start = getdate(start_date)
-    end = getdate(end_date)
+	start = getdate(start_date)
+	end = getdate(end_date)
 
-    # Query Employee Checkin records for the period
-    checkins = frappe.db.sql("""
+	# Query Employee Checkin records for the period
+	checkins = frappe.db.sql(
+		"""
         SELECT
             ec.time as checkin_time,
             ec.log_type
@@ -86,154 +82,160 @@ def get_night_diff_hours(employee, start_date, end_date):
           AND DATE(ec.time) BETWEEN %(start_date)s AND %(end_date)s
           AND ec.log_type IN ('IN', 'OUT')
         ORDER BY ec.time
-    """, {
-        "employee": employee,
-        "start_date": start,
-        "end_date": end
-    }, as_dict=True)
+    """,
+		{"employee": employee, "start_date": start, "end_date": end},
+		as_dict=True,
+	)
 
-    if not checkins:
-        return 0.0
+	if not checkins:
+		return 0.0
 
-    night_hours = 0.0
-    current_in = None
+	night_hours = 0.0
+	current_in = None
 
-    # Process checkin/checkout pairs
-    for checkin in checkins:
-        if checkin.log_type == "IN":
-            current_in = get_datetime(checkin.checkin_time)
-        elif checkin.log_type == "OUT" and current_in:
-            checkout_time = get_datetime(checkin.checkin_time)
-            night_hours += _calculate_night_hours(current_in, checkout_time)
-            current_in = None
+	# Process checkin/checkout pairs
+	for checkin in checkins:
+		if checkin.log_type == "IN":
+			current_in = get_datetime(checkin.checkin_time)
+		elif checkin.log_type == "OUT" and current_in:
+			checkout_time = get_datetime(checkin.checkin_time)
+			night_hours += _calculate_night_hours(current_in, checkout_time)
+			current_in = None
 
-    return flt(night_hours, 2)
+	return flt(night_hours, 2)
 
 
 def _calculate_night_hours(checkin_time, checkout_time):
-    """Calculate hours between 10pm-6am within a single checkin/checkout pair.
+	"""Calculate hours between 10pm-6am within a single checkin/checkout pair.
 
-    Args:
-        checkin_time: Check-in datetime
-        checkout_time: Check-out datetime
+	Args:
+	    checkin_time: Check-in datetime
+	    checkout_time: Check-out datetime
 
-    Returns:
-        float: Night differential hours
-    """
-    from datetime import datetime, time, timedelta
+	Returns:
+	    float: Night differential hours
+	"""
+	from datetime import datetime, time, timedelta
 
-    # Night shift is 10pm (22:00) to 6am (06:00)
-    night_start = time(22, 0)  # 10pm
-    night_end = time(6, 0)     # 6am
+	# Night shift is 10pm (22:00) to 6am (06:00)
+	night_start = time(22, 0)  # 10pm
+	night_end = time(6, 0)  # 6am
 
-    total_night_hours = 0.0
-    current = checkin_time
+	total_night_hours = 0.0
+	current = checkin_time
 
-    while current < checkout_time:
-        current_time = current.time()
+	while current < checkout_time:
+		current_time = current.time()
 
-        # Check if current hour is within night shift
-        if night_start <= current_time or current_time < night_end:
-            # Calculate hours in this segment (max 1 hour)
-            next_hour = min(current + timedelta(hours=1), checkout_time)
-            hours = (next_hour - current).total_seconds() / 3600
-            total_night_hours += hours
-            current = next_hour
-        else:
-            # Move to next hour
-            current += timedelta(hours=1)
+		# Check if current hour is within night shift
+		if night_start <= current_time or current_time < night_end:
+			# Calculate hours in this segment (max 1 hour)
+			next_hour = min(current + timedelta(hours=1), checkout_time)
+			hours = (next_hour - current).total_seconds() / 3600
+			total_night_hours += hours
+			current = next_hour
+		else:
+			# Move to next hour
+			current += timedelta(hours=1)
 
-    return total_night_hours
+	return total_night_hours
 
 
 def get_holiday_premium_days(employee, start_date, end_date, holiday_type="Regular Holiday"):
-    """Count days employee worked on holidays (from Attendance + Holiday List).
+	"""Count days employee worked on holidays (from Attendance + Holiday List).
 
-    Args:
-        employee: Employee ID (string)
-        start_date: Period start date (string or date)
-        end_date: Period end date (string or date)
-        holiday_type: "Regular Holiday" (200% premium) or "Special Holiday" (130% premium)
+	Args:
+	    employee: Employee ID (string)
+	    start_date: Period start date (string or date)
+	    end_date: Period end date (string or date)
+	    holiday_type: "Regular Holiday" (200% premium) or "Special Holiday" (130% premium)
 
-    Returns:
-        float: Number of holiday days worked
-    """
-    if not employee or not start_date or not end_date:
-        return 0.0
+	Returns:
+	    float: Number of holiday days worked
+	"""
+	if not employee or not start_date or not end_date:
+		return 0.0
 
-    start = getdate(start_date)
-    end = getdate(end_date)
+	start = getdate(start_date)
+	end = getdate(end_date)
 
-    # Get employee's holiday list
-    holiday_list = frappe.db.get_value("Employee", employee, "holiday_list")
-    if not holiday_list:
-        return 0.0
+	# Get employee's holiday list
+	holiday_list = frappe.db.get_value("Employee", employee, "holiday_list")
+	if not holiday_list:
+		return 0.0
 
-    # Get holidays in the period
-    holidays = frappe.db.sql("""
+	# Get holidays in the period
+	holidays = frappe.db.sql(
+		"""
         SELECT h.holiday_date
         FROM `tabHoliday` h
         WHERE h.parent = %(holiday_list)s
           AND h.holiday_date BETWEEN %(start_date)s AND %(end_date)s
           AND h.weekly_off = 0
           AND (%(holiday_type)s = '' OR h.description LIKE %(holiday_type_pattern)s)
-    """, {
-        "holiday_list": holiday_list,
-        "start_date": start,
-        "end_date": end,
-        "holiday_type": holiday_type,
-        "holiday_type_pattern": f"%{holiday_type}%"
-    }, as_dict=True)
+    """,
+		{
+			"holiday_list": holiday_list,
+			"start_date": start,
+			"end_date": end,
+			"holiday_type": holiday_type,
+			"holiday_type_pattern": f"%{holiday_type}%",
+		},
+		as_dict=True,
+	)
 
-    if not holidays:
-        return 0.0
+	if not holidays:
+		return 0.0
 
-    # Check attendance on those holidays
-    worked_holidays = 0
-    for holiday in holidays:
-        attendance = frappe.db.get_value(
-            "Attendance",
-            {
-                "employee": employee,
-                "attendance_date": holiday.holiday_date,
-                "status": "Present",
-                "docstatus": 1
-            },
-            "name"
-        )
-        if attendance:
-            worked_holidays += 1
+	# Check attendance on those holidays
+	worked_holidays = 0
+	for holiday in holidays:
+		attendance = frappe.db.get_value(
+			"Attendance",
+			{
+				"employee": employee,
+				"attendance_date": holiday.holiday_date,
+				"status": "Present",
+				"docstatus": 1,
+			},
+			"name",
+		)
+		if attendance:
+			worked_holidays += 1
 
-    return flt(worked_holidays, 1)
+	return flt(worked_holidays, 1)
 
 
 def get_approved_ot_hours(employee, start_date, end_date, ot_type="regular"):
-    """Query approved standard Overtime Slip records.
+	"""Query approved standard Overtime Slip records.
 
-    Args:
-        employee: Employee ID (string)
-        start_date: Period start date (string or date)
-        end_date: Period end date (string or date)
-        ot_type: "regular" (1.25x), "rest_day" (1.30x), "holiday" (2.6x)
+	Args:
+	    employee: Employee ID (string)
+	    start_date: Period start date (string or date)
+	    end_date: Period end date (string or date)
+	    ot_type: "regular" (1.25x), "rest_day" (1.30x), "holiday" (2.6x)
 
-    Returns:
-        float: Total approved overtime hours
-    """
-    if not employee or not start_date or not end_date:
-        return 0.0
+	Returns:
+	    float: Total approved overtime hours
+	"""
+	if not employee or not start_date or not end_date:
+		return 0.0
 
-    start = getdate(start_date)
-    end = getdate(end_date)
+	start = getdate(start_date)
+	end = getdate(end_date)
 
-    ot_type_filter = ""
-    if ot_type == "regular":
-        ot_type_filter = "AND od.overtime_type NOT LIKE '%Rest Day%' AND od.overtime_type NOT LIKE '%Holiday%'"
-    elif ot_type == "rest_day":
-        ot_type_filter = "AND od.overtime_type LIKE '%Rest Day%'"
-    elif ot_type == "holiday":
-        ot_type_filter = "AND od.overtime_type LIKE '%Holiday%'"
+	ot_type_filter = ""
+	if ot_type == "regular":
+		ot_type_filter = (
+			"AND od.overtime_type NOT LIKE '%Rest Day%' AND od.overtime_type NOT LIKE '%Holiday%'"
+		)
+	elif ot_type == "rest_day":
+		ot_type_filter = "AND od.overtime_type LIKE '%Rest Day%'"
+	elif ot_type == "holiday":
+		ot_type_filter = "AND od.overtime_type LIKE '%Holiday%'"
 
-    result = frappe.db.sql(f"""
+	result = frappe.db.sql(
+		f"""
         SELECT SUM(od.overtime_duration) as total_hours
         FROM `tabOvertime Slip` os
         INNER JOIN `tabOvertime Details` od ON od.parent = os.name
@@ -241,10 +243,9 @@ def get_approved_ot_hours(employee, start_date, end_date, ot_type="regular"):
           AND os.docstatus = 1
           AND od.date BETWEEN %(start_date)s AND %(end_date)s
           {ot_type_filter}
-    """, {{
-        "employee": employee,
-        "start_date": start,
-        "end_date": end
-    }}, as_dict=True)
+    """,
+		{{"employee": employee, "start_date": start, "end_date": end}},
+		as_dict=True,
+	)
 
-    return flt(result[0].total_hours) if result and result[0].total_hours else 0.0
+	return flt(result[0].total_hours) if result and result[0].total_hours else 0.0


### PR DESCRIPTION
## Summary
- add backend overtime request routing and post-approval actions for stores, head office, and commissary
- add flex exception support plus same-day attendance and shift triggers
- bridge payroll and overtime reporting to approved overtime requests instead of raw attendance OT

## Documentation
- Sprint plan: docs/plans/2026-03-11-sprint-35-overtime-post-approval-operational-workflow.md
- Reference commit: https://github.com/Bebang-Enterprise-Inc/hrms/commit/f39383734d2245325c27867921d8f07b90548072

## Verification
- python -B -m py_compile hrms\api\overtime.py hrms\hr\doctype\attendance_request\attendance_request.py hrms\hr\doctype\overtime_slip\overtime_slip.py hrms\hr\doctype\bei_shift_record\bei_shift_record.py hrms\payroll\ph_payroll_formulas.py hrms\api\hr_reports.py hrms\hr\doctype\employee_checkin\employee_checkin.py
- python JSON parse check for overtime/flex DocType JSON files
