### PR TITLE
Fix S035 overtime escalation routing

### DIFF
--- a/hrms/api/overtime.py
+++ b/hrms/api/overtime.py
@@ -836,9 +836,9 @@ def submit_overtime_clarification(name: str, response: str):
 def escalate_overtime(name: str, notes: str | None = None):
 	doc = frappe.get_doc("BEI Overtime Request", name)
 	_assert_review_access(doc, "overtime_status")
-	target = _txt(doc.fallback_approver or doc.escalation_approver)
+	target = _txt(doc.escalation_approver)
 	if not target or target == _txt(frappe.session.user):
-		target = _txt(doc.escalation_approver)
+		target = _txt(doc.fallback_approver)
 	if not target:
 		frappe.throw(_("No escalation approver is configured."))
 	doc.overtime_status = OT_ESCALATED

--- a/hrms/tests/test_overtime_api_contract.py
+++ b/hrms/tests/test_overtime_api_contract.py
@@ -2,9 +2,9 @@ import importlib.util
 import sys
 import types
 import unittest
+from datetime import datetime, time
 from pathlib import Path
 from unittest.mock import patch
-from datetime import datetime, time
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
@@ -49,16 +49,16 @@ def _install_fake_frappe():
 			return [
 				AttrDict(
 					{
-					"department": "Operations",
-					"store": "ARANETA",
-					"total_requests": 3,
-					"total_hours": 8.0,
-					"approved_hours": 5.0,
-					"pending_hours": 2.0,
-					"rejected_hours": 1.0,
-					"approved_count": 2,
-					"pending_count": 1,
-					"rejected_count": 0,
+						"department": "Operations",
+						"store": "ARANETA",
+						"total_requests": 3,
+						"total_hours": 8.0,
+						"approved_hours": 5.0,
+						"pending_hours": 2.0,
+						"rejected_hours": 1.0,
+						"approved_count": 2,
+						"pending_count": 1,
+						"rejected_count": 0,
 					}
 				)
 			]
@@ -66,21 +66,21 @@ def _install_fake_frappe():
 		return [
 			AttrDict(
 				{
-				"name": "OT-0001",
-				"employee": "EMP-0001",
-				"employee_name": "Test Employee",
-				"branch": "ARANETA",
-				"attendance_date": "2026-02-27",
-				"shift": "Morning",
-				"regular_hours": 8.0,
-				"overtime_hours": 1.5,
-				"total_hours": 9.5,
-				"overtime_status": "Pending Approval",
-				"supervisor": "EMP-MGR-001",
-				"reviewed_by": None,
-				"reviewed_at": None,
-				"approval_notes": None,
-				"rejection_reason": None,
+					"name": "OT-0001",
+					"employee": "EMP-0001",
+					"employee_name": "Test Employee",
+					"branch": "ARANETA",
+					"attendance_date": "2026-02-27",
+					"shift": "Morning",
+					"regular_hours": 8.0,
+					"overtime_hours": 1.5,
+					"total_hours": 9.5,
+					"overtime_status": "Pending Approval",
+					"supervisor": "EMP-MGR-001",
+					"reviewed_by": None,
+					"reviewed_at": None,
+					"approval_notes": None,
+					"rejection_reason": None,
 				}
 			)
 		]
@@ -106,7 +106,9 @@ def _install_fake_frappe():
 	utils.nowdate = lambda: "2026-02-27"
 	utils.now_datetime = lambda: datetime(2026, 2, 27, 8, 0, 0)
 	utils.getdate = lambda value=None: value
-	utils.get_datetime = lambda value=None: value if isinstance(value, datetime) else datetime(2026, 2, 27, 8, 0, 0)
+	utils.get_datetime = lambda value=None: (
+		value if isinstance(value, datetime) else datetime(2026, 2, 27, 8, 0, 0)
+	)
 	utils.get_time = lambda value=None: value if isinstance(value, time) else time(8, 0, 0)
 	utils.add_days = lambda date_obj, days: date_obj
 

--- a/hrms/tests/test_overtime_api_contract.py
+++ b/hrms/tests/test_overtime_api_contract.py
@@ -4,15 +4,24 @@ import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
+from datetime import datetime, time
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
 	sys.path.insert(0, str(ROOT))
 
 
+class AttrDict(dict):
+	def __getattr__(self, name):
+		try:
+			return self[name]
+		except KeyError as exc:
+			raise AttributeError(name) from exc
+
+
 def _install_fake_frappe():
-	if "frappe" in sys.modules:
-		return
+	sys.modules.pop("frappe", None)
+	sys.modules.pop("frappe.utils", None)
 
 	frappe = types.ModuleType("frappe")
 	utils = types.ModuleType("frappe.utils")
@@ -38,7 +47,8 @@ def _install_fake_frappe():
 		query = str(query)
 		if "GROUP BY COALESCE(emp.department" in query:
 			return [
-				{
+				AttrDict(
+					{
 					"department": "Operations",
 					"store": "ARANETA",
 					"total_requests": 3,
@@ -49,11 +59,13 @@ def _install_fake_frappe():
 					"approved_count": 2,
 					"pending_count": 1,
 					"rejected_count": 0,
-				}
+					}
+				)
 			]
 
 		return [
-			{
+			AttrDict(
+				{
 				"name": "OT-0001",
 				"employee": "EMP-0001",
 				"employee_name": "Test Employee",
@@ -69,7 +81,8 @@ def _install_fake_frappe():
 				"reviewed_at": None,
 				"approval_notes": None,
 				"rejection_reason": None,
-			}
+				}
+			)
 		]
 
 	frappe.whitelist = whitelist
@@ -79,14 +92,22 @@ def _install_fake_frappe():
 	frappe.get_roles = lambda user=None: ["HR Manager"]
 	frappe.local.session = types.SimpleNamespace(user="test.hr@bebang.ph")
 	frappe.get_doc = lambda *args, **kwargs: None
-	frappe.local.db = types.SimpleNamespace(sql=_sql, exists=lambda *args, **kwargs: False)
+	frappe.local.db = types.SimpleNamespace(
+		sql=_sql,
+		exists=lambda *args, **kwargs: False,
+		get_value=lambda *args, **kwargs: None,
+	)
 	frappe.__getattr__ = _module_getattr
+	frappe._dict = lambda value=None: AttrDict(value or {})
 	frappe.logger = lambda *args, **kwargs: types.SimpleNamespace(info=lambda *a, **k: None)
 
+	utils.cint = lambda value=0: int(value or 0)
 	utils.flt = lambda value, precision=None: float(value or 0)
 	utils.nowdate = lambda: "2026-02-27"
-	utils.now_datetime = lambda: "2026-02-27 08:00:00"
+	utils.now_datetime = lambda: datetime(2026, 2, 27, 8, 0, 0)
 	utils.getdate = lambda value=None: value
+	utils.get_datetime = lambda value=None: value if isinstance(value, datetime) else datetime(2026, 2, 27, 8, 0, 0)
+	utils.get_time = lambda value=None: value if isinstance(value, time) else time(8, 0, 0)
 	utils.add_days = lambda date_obj, days: date_obj
 
 	sys.modules["frappe"] = frappe
@@ -103,6 +124,10 @@ def _install_stub_dependencies():
 	}
 	sys.modules["hrms.utils.api_helpers"] = api_helpers
 
+	store = types.ModuleType("hrms.api.store")
+	store.resolve_employee_store_context = lambda *args, **kwargs: {}
+	sys.modules["hrms.api.store"] = store
+
 
 class FakeOTDoc:
 	def __init__(self, name):
@@ -110,10 +135,18 @@ class FakeOTDoc:
 		self.overtime_status = "Pending Approval"
 		self.overtime_hours = 1.5
 		self.employee = "EMP-0001"
+		self.assigned_approver = "test.supervisor@bebang.ph"
+		self.fallback_approver = "test.staff@bebang.ph"
+		self.escalation_approver = "test.area@bebang.ph"
 		self.approval_notes = None
 		self.rejection_reason = None
 		self.reviewed_by = None
 		self.reviewed_at = None
+		self.candidate_overtime_type = "Regular Day Overtime"
+		self.approved_overtime_type = None
+		self.review_note = None
+		self.override_note = None
+		self.payroll_bridge_status = None
 
 	def save(self, **kwargs):
 		return self
@@ -166,6 +199,19 @@ class OvertimeApiContractTests(unittest.TestCase):
 
 		self.assertEqual(result["status"], "Rejected")
 		self.assertEqual(doc.rejection_reason, "invalid")
+
+	def test_escalate_prefers_escalation_approver_over_fallback(self):
+		doc = FakeOTDoc("OT-0003")
+		with (
+			patch.object(overtime.frappe, "get_doc", return_value=doc),
+			patch.object(overtime, "_assert_review_access", return_value=False),
+		):
+			result = overtime.escalate_overtime(name="OT-0003", notes="Escalating to area supervisor")
+
+		self.assertEqual(result["status"], overtime.OT_ESCALATED)
+		self.assertEqual(result["assigned_approver"], "test.area@bebang.ph")
+		self.assertEqual(doc.assigned_approver, "test.area@bebang.ph")
+		self.assertEqual(doc.review_note, "Escalating to area supervisor")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- route overtime escalation to the escalation approver before falling back to backup reviewer
- add a contract test proving store escalation goes to the area supervisor

## Verification
- python -m py_compile hrms/api/overtime.py hrms/tests/test_overtime_api_contract.py
- ='1'; python -m pytest hrms/tests/test_overtime_api_contract.py -q