### PR TITLE
fix: normalize salary slip aggregate fields

### DIFF
--- a/hrms/payroll/doctype/salary_slip/salary_slip.py
+++ b/hrms/payroll/doctype/salary_slip/salary_slip.py
@@ -2128,7 +2128,7 @@ class SalarySlip(TransactionBase):
 					"company": self.company,
 					"docstatus": 1,
 				},
-				fields=[{"SUM": "amount", "as": "total_amount"}],
+				fields=["sum(amount) as total_amount"],
 			)[0].total_amount
 			or 0.0
 		)
@@ -2278,7 +2278,7 @@ class SalarySlip(TransactionBase):
 
 		salary_slip_sum = frappe.get_list(
 			"Salary Slip",
-			fields=[{"SUM": "net_pay", "as": "net_sum"}, {"SUM": "gross_pay", "as": "gross_sum"}],
+			fields=["sum(net_pay) as net_sum", "sum(gross_pay) as gross_sum"],
 			filters={
 				"employee": self.employee,
 				"start_date": [">=", period_start_date],
@@ -2301,7 +2301,7 @@ class SalarySlip(TransactionBase):
 		first_day_of_the_month = get_first_day(self.start_date)
 		salary_slip_sum = frappe.get_list(
 			"Salary Slip",
-			fields=[{"SUM": "net_pay", "as": "sum"}],
+			fields=["sum(net_pay) as sum"],
 			filters={
 				"employee": self.employee,
 				"start_date": [">=", first_day_of_the_month],


### PR DESCRIPTION
## Summary
- replace dict-style aggregate field specs in salary slip queries with supported string expressions
- unblock salary slip preview/payroll certification for S035 overtime cases
- avoid DatabaseQuery sanitizer crashes when employee other income and YTD totals are computed

## Verification
- python -m py_compile hrms/payroll/doctype/salary_slip/salary_slip.py