### PR TITLE
fix: honor contract warehouse on stock transfers

### DIFF
--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -935,7 +935,7 @@ def create_stock_transfer(
 	se.posting_time = frappe.utils.nowtime()
 	se.from_warehouse = source_warehouse
 	if not is_intercompany:
-		se.to_warehouse = target_warehouse
+		se.to_warehouse = actual_target_warehouse
 	se.remarks = remarks or (f"{movement_type} for {strip_company_suffix(actual_target_warehouse)}")
 	stamp_stock_entry_contract(
 		se,
@@ -991,7 +991,7 @@ def create_stock_transfer(
 			"material_request_item": mr_item_ref,
 		}
 		if not is_intercompany:
-			row["t_warehouse"] = target_warehouse
+			row["t_warehouse"] = actual_target_warehouse
 		se.append("items", row)
 
 	if not se.items:

--- a/hrms/tests/test_s37_warehouse_role_gated_writes.py
+++ b/hrms/tests/test_s37_warehouse_role_gated_writes.py
@@ -299,6 +299,9 @@ spec.loader.exec_module(warehouse)
 class TestS37WarehouseRoleGatedWrites(unittest.TestCase):
 	def setUp(self):
 		_DOCS_CREATED.clear()
+		_MR_DOC.custom_destination_warehouse = "TEST-STORE-BGC - BEI"
+		_MR_DOC.custom_target_company = "Bebang Enterprise Inc."
+		_MR_DOC.custom_finance_treatment = "intercompany"
 
 	def test_create_purchase_receipt_uses_receiving_roles_and_ignore_permissions(self):
 		calls = []
@@ -362,6 +365,30 @@ class TestS37WarehouseRoleGatedWrites(unittest.TestCase):
 		self.assertTrue(created.submit_called)
 		self.assertTrue(created.flags.ignore_permissions)
 		self.assertTrue(created.flags.ignore_user_permissions)
+
+	def test_create_stock_transfer_uses_contract_destination_for_same_company(self):
+		_MR_DOC.custom_destination_warehouse = "Shaw BLVD - BKI"
+		_MR_DOC.custom_target_company = "Bebang Kitchen Inc."
+		_MR_DOC.custom_finance_treatment = "same_company"
+
+		result = warehouse.create_stock_transfer(
+			source_warehouse="SM Taytay - BKI",
+			target_warehouse="TEST-COMMISSARY - BKI",
+			items=[
+				{
+					"item_code": "FG002-A",
+					"qty": 1,
+					"uom": "Nos",
+				}
+			],
+			mr_name=_MR_DOC.name,
+			remarks="S037 same-company RM handoff",
+		)
+
+		self.assertTrue(result["success"])
+		created = _DOCS_CREATED[0]
+		self.assertEqual(created.to_warehouse, "Shaw BLVD - BKI")
+		self.assertEqual(created.items[0].t_warehouse, "Shaw BLVD - BKI")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- use the resolved contract destination warehouse when creating stock transfers\n- prevent same-company BKI requisitions from writing invalid target warehouses into Stock Entry lines\n- add regression coverage for Sprint 37 warehouse-centered handoffs\n\n## Testing\n- python hrms/tests/test_s37_warehouse_role_gated_writes.py\n- python hrms/tests/test_s37_commissary_request_contract.py\n- python hrms/tests/test_s37_store_order_contract.py\n- python hrms/tests/test_s37_store_receiving_contract.py\n- python -m py_compile hrms/api/warehouse.py hrms/tests/test_s37_warehouse_role_gated_writes.py