### PR TITLE
fix: align commissary company with BKI warehouse

### DIFF
--- a/hrms/api/commissary.py
+++ b/hrms/api/commissary.py
@@ -27,6 +27,7 @@ from hrms.utils.bei_config import get_company
 from hrms.utils.supply_chain_contracts import (
 	CANONICAL_COMMISSARY_OPERATION_WAREHOUSE,
 	get_preferred_commissary_warehouses,
+	resolve_warehouse_company,
 )
 
 # ============================================================
@@ -68,6 +69,11 @@ def get_commissary_warehouse():
 		or _existing_candidate(include_legacy=True)
 		or CANONICAL_COMMISSARY_OPERATION_WAREHOUSE
 	)
+
+
+def get_commissary_company() -> str:
+	"""Resolve the legal entity that owns the active commissary warehouse."""
+	return resolve_warehouse_company(get_commissary_warehouse()) or get_company()
 
 
 def _raise_direct_fulfillment_retired() -> None:
@@ -556,7 +562,7 @@ def create_dispatch_transfer(
 	# Create Stock Entry
 	se = frappe.new_doc("Stock Entry")
 	se.stock_entry_type = "Material Transfer"
-	se.company = get_company()
+	se.company = get_commissary_company()
 	se.posting_date = today()
 	se.posting_time = frappe.utils.nowtime()
 	se.from_warehouse = commissary_warehouse
@@ -696,7 +702,7 @@ def fulfill_store_order(mr_name: str, items: str | list[dict[str, Any]]):
 	# Create Stock Entry
 	se = frappe.new_doc("Stock Entry")
 	se.stock_entry_type = "Material Transfer"
-	se.company = get_company()
+	se.company = get_commissary_company()
 	se.posting_date = today()
 	se.posting_time = frappe.utils.nowtime()
 	se.from_warehouse = commissary_warehouse
@@ -1949,7 +1955,7 @@ def create_hub_transfer(
 	# Create Stock Entry
 	se = frappe.new_doc("Stock Entry")
 	se.stock_entry_type = "Material Transfer"
-	se.company = get_company()
+	se.company = get_commissary_company()
 	se.posting_date = today()
 	se.posting_time = frappe.utils.nowtime()
 	se.from_warehouse = commissary_warehouse

--- a/hrms/api/commissary_dashboard.py
+++ b/hrms/api/commissary_dashboard.py
@@ -13,8 +13,7 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, flt, today
 
-from hrms.api.commissary import get_commissary_warehouse
-from hrms.utils.bei_config import get_company
+from hrms.api.commissary import get_commissary_company, get_commissary_warehouse
 
 # ============================================================
 # DASHBOARD / SUMMARY
@@ -292,7 +291,7 @@ def submit_production_output(
 	commissary_warehouse = get_commissary_warehouse()
 
 	se = frappe.new_doc("Stock Entry")
-	se.company = get_company()
+	se.company = get_commissary_company()
 	se.posting_date = today()
 	se.posting_time = frappe.utils.nowtime()
 	se.to_warehouse = commissary_warehouse

--- a/hrms/api/commissary_requisition.py
+++ b/hrms/api/commissary_requisition.py
@@ -7,8 +7,7 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, flt, today
 
-from hrms.api.commissary import get_commissary_warehouse
-from hrms.utils.bei_config import get_company
+from hrms.api.commissary import get_commissary_company, get_commissary_warehouse
 from hrms.utils.supply_chain_contracts import (
 	REQUEST_SOURCE_COMMISSARY_RAW_MATERIAL,
 	get_request_source_label,
@@ -531,7 +530,7 @@ def create_work_order(item_code, qty, planned_start_date=None, remarks=None):
 	wo.qty = flt(qty)
 	wo.fg_warehouse = commissary_warehouse
 	wo.wip_warehouse = commissary_warehouse  # Same warehouse for simplicity
-	wo.company = get_company()
+	wo.company = get_commissary_company()
 	wo.planned_start_date = planned_start_date or today()
 	wo.expected_delivery_date = planned_start_date or today()
 

--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -935,7 +935,7 @@ def create_stock_transfer(
 	se.posting_time = frappe.utils.nowtime()
 	se.from_warehouse = source_warehouse
 	if not is_intercompany:
-		se.to_warehouse = target_warehouse
+		se.to_warehouse = actual_target_warehouse
 	se.remarks = remarks or (f"{movement_type} for {strip_company_suffix(actual_target_warehouse)}")
 	stamp_stock_entry_contract(
 		se,
@@ -991,7 +991,7 @@ def create_stock_transfer(
 			"material_request_item": mr_item_ref,
 		}
 		if not is_intercompany:
-			row["t_warehouse"] = target_warehouse
+			row["t_warehouse"] = actual_target_warehouse
 		se.append("items", row)
 
 	if not se.items:

--- a/hrms/tests/test_commissary_dashboard_summary.py
+++ b/hrms/tests/test_commissary_dashboard_summary.py
@@ -30,12 +30,14 @@ def _install_fake_modules():
 	fake_frappe.whitelist = _whitelist
 	fake_frappe.throw = lambda msg: (_ for _ in ()).throw(Exception(msg))
 	fake_frappe._ = lambda msg: msg
-	sys.modules["frappe"] = fake_frappe
 
 	fake_utils = types.ModuleType("frappe.utils")
 	fake_utils.flt = float
 	fake_utils.today = lambda: "2026-03-12"
 	fake_utils.add_days = lambda value, days: value
+	fake_utils.nowtime = lambda: "12:00:00"
+	fake_frappe.utils = fake_utils
+	sys.modules["frappe"] = fake_frappe
 	sys.modules["frappe.utils"] = fake_utils
 
 	sys.modules.setdefault("hrms", types.ModuleType("hrms"))
@@ -44,6 +46,7 @@ def _install_fake_modules():
 
 	fake_commissary = types.ModuleType("hrms.api.commissary")
 	fake_commissary.get_commissary_warehouse = lambda: "Shaw BLVD - BKI"
+	fake_commissary.get_commissary_company = lambda: "Bebang Kitchen Inc."
 	sys.modules["hrms.api.commissary"] = fake_commissary
 
 	fake_bei_config = types.ModuleType("hrms.utils.bei_config")
@@ -115,6 +118,73 @@ class TestCommissaryDashboardSummary(unittest.TestCase):
 		self.assertEqual(data["stock_summary"]["total_items"], 2)
 		self.assertEqual(data["stock_summary"]["total_qty"], 6.5)
 		self.assertEqual(data["stock_summary"]["total_value"], 900.75)
+
+	def test_submit_production_output_uses_commissary_company_for_bki_warehouse(self):
+		created = {}
+
+		class _FakeStockEntry:
+			def __init__(self):
+				self.company = None
+				self.stock_entry_type = None
+				self.posting_date = None
+				self.posting_time = None
+				self.to_warehouse = None
+				self.remarks = None
+				self.items = []
+				self.insert_called = False
+				self.submit_called = False
+				self.name = "MAT-STE-UNIT-0001"
+
+			def append(self, table, row):
+				defaults = {"batch_no": None, "s_warehouse": None, "t_warehouse": None}
+				defaults.update(row)
+				self.items.append(types.SimpleNamespace(**defaults))
+
+			def insert(self):
+				self.insert_called = True
+				return self
+
+			def submit(self):
+				self.submit_called = True
+				return self
+
+		def fake_new_doc(doctype):
+			self.assertEqual(doctype, "Stock Entry")
+			doc = _FakeStockEntry()
+			created["doc"] = doc
+			return doc
+
+		with (
+			patch.object(commissary_dashboard, "get_commissary_warehouse", return_value="Shaw BLVD - BKI"),
+			patch.object(commissary_dashboard, "get_commissary_company", return_value="Bebang Kitchen Inc."),
+			patch.object(commissary_dashboard.frappe, "new_doc", side_effect=fake_new_doc, create=True),
+			patch.object(
+				commissary_dashboard.frappe.db,
+				"get_value",
+				side_effect=[None],
+				create=True,
+			),
+			patch.object(
+				commissary_dashboard.frappe,
+				"get_doc",
+				return_value=types.SimpleNamespace(
+					item_name="BANANA CINNAMON", description="Finished good", stock_uom="KG"
+				),
+				create=True,
+			),
+		):
+			result = commissary_dashboard.submit_production_output(
+				items='[{"item_code":"FG002-A","qty":1,"uom":"KG"}]',
+				remarks="unit-test",
+			)
+
+		doc = created["doc"]
+		self.assertEqual(doc.company, "Bebang Kitchen Inc.")
+		self.assertEqual(doc.to_warehouse, "Shaw BLVD - BKI")
+		self.assertEqual(doc.stock_entry_type, "Material Receipt")
+		self.assertTrue(doc.insert_called)
+		self.assertTrue(doc.submit_called)
+		self.assertEqual(result["data"]["name"], "MAT-STE-UNIT-0001")
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_s37_commissary_warehouse_resolution.py
+++ b/hrms/tests/test_s37_commissary_warehouse_resolution.py
@@ -20,6 +20,14 @@ class _FakeDB:
 	def sql(self, query, warehouse_name):
 		return [(1 if warehouse_name in self.stocked else 0,)]
 
+	def get_value(self, doctype, name, fieldname=None):
+		if doctype == "Warehouse" and fieldname == "company":
+			if name == "Shaw BLVD - BKI":
+				return "Bebang Kitchen Inc."
+			if name == "TEST-COMMISSARY - BEI":
+				return "Bebang Enterprise Inc."
+		return None
+
 
 class _FakeFrappe(types.ModuleType):
 	@property
@@ -159,6 +167,24 @@ class TestS37CommissaryWarehouseResolution(unittest.TestCase):
 			)
 		)
 		self.assertEqual(module.get_commissary_warehouse(), "TEST-COMMISSARY - BEI")
+
+	def test_resolves_commissary_company_from_active_bki_warehouse(self):
+		module = _load_module(
+			_FakeDB(
+				existing={"Shaw BLVD - BKI", "TEST-COMMISSARY - BEI"},
+				stocked={"Shaw BLVD - BKI"},
+			)
+		)
+		self.assertEqual(module.get_commissary_company(), "Bebang Kitchen Inc.")
+
+	def test_resolves_commissary_company_from_legacy_warehouse_when_bki_missing(self):
+		module = _load_module(
+			_FakeDB(
+				existing={"TEST-COMMISSARY - BEI"},
+				stocked={"TEST-COMMISSARY - BEI"},
+			)
+		)
+		self.assertEqual(module.get_commissary_company(), "Bebang Enterprise Inc.")
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_s37_warehouse_role_gated_writes.py
+++ b/hrms/tests/test_s37_warehouse_role_gated_writes.py
@@ -299,6 +299,9 @@ spec.loader.exec_module(warehouse)
 class TestS37WarehouseRoleGatedWrites(unittest.TestCase):
 	def setUp(self):
 		_DOCS_CREATED.clear()
+		_MR_DOC.custom_destination_warehouse = "TEST-STORE-BGC - BEI"
+		_MR_DOC.custom_target_company = "Bebang Enterprise Inc."
+		_MR_DOC.custom_finance_treatment = "intercompany"
 
 	def test_create_purchase_receipt_uses_receiving_roles_and_ignore_permissions(self):
 		calls = []
@@ -362,6 +365,30 @@ class TestS37WarehouseRoleGatedWrites(unittest.TestCase):
 		self.assertTrue(created.submit_called)
 		self.assertTrue(created.flags.ignore_permissions)
 		self.assertTrue(created.flags.ignore_user_permissions)
+
+	def test_create_stock_transfer_uses_contract_destination_for_same_company(self):
+		_MR_DOC.custom_destination_warehouse = "Shaw BLVD - BKI"
+		_MR_DOC.custom_target_company = "Bebang Kitchen Inc."
+		_MR_DOC.custom_finance_treatment = "same_company"
+
+		result = warehouse.create_stock_transfer(
+			source_warehouse="SM Taytay - BKI",
+			target_warehouse="TEST-COMMISSARY - BKI",
+			items=[
+				{
+					"item_code": "FG002-A",
+					"qty": 1,
+					"uom": "Nos",
+				}
+			],
+			mr_name=_MR_DOC.name,
+			remarks="S037 same-company RM handoff",
+		)
+
+		self.assertTrue(result["success"])
+		created = _DOCS_CREATED[0]
+		self.assertEqual(created.to_warehouse, "Shaw BLVD - BKI")
+		self.assertEqual(created.items[0].t_warehouse, "Shaw BLVD - BKI")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- resolve commissary company from the active commissary warehouse instead of the global default company\n- apply the same company resolution to production output and commissary work orders\n- add regression coverage for commissary warehouse/company resolution and production output\n\n## Testing\n- python hrms/tests/test_s37_commissary_warehouse_resolution.py\n- python hrms/tests/test_commissary_dashboard_summary.py\n- python hrms/tests/test_s37_commissary_quality_contract.py\n- python -m py_compile hrms/api/commissary.py hrms/api/commissary_dashboard.py hrms/api/commissary_requisition.py hrms/tests/test_commissary_dashboard_summary.py hrms/tests/test_s37_commissary_warehouse_resolution.py