### PR TITLE
feat: add structured blip notification intelligence

### DIFF
--- a/hrms/api/discount_abuse.py
+++ b/hrms/api/discount_abuse.py
@@ -3656,10 +3656,24 @@ def _send_critical_discount_alert_notifications_internal(
 	email_sent = False
 
 	try:
-		from hrms.api.google_chat import send_message_to_space
+		from hrms.api.google_chat import send_notification_event
 		from hrms.utils.bei_config import SPACE_ACCOUNTING, get_chat_space
 
-		chat_sent = send_message_to_space(get_chat_space(SPACE_ACCOUNTING), message)
+		chat_sent = send_notification_event(
+			{
+				"family": "discount_critical_digest",
+				"source_system": "frappe",
+				"source_ref": f"discount_audit:{target_day.isoformat()}",
+				"severity": "critical",
+				"owner": "Accounting",
+				"requested_space": get_chat_space(SPACE_ACCOUNTING),
+				"facts": {
+					"business_date": target_day.isoformat(),
+					"rows": rows,
+					"review_url": PORTAL_QUEUE_URL,
+				},
+			}
+		)
 	except Exception as exc:
 		frappe.log_error(
 			title="Discount Alert Chat Notification Failed",

--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -3194,5 +3194,40 @@ def get_morning_sync_health_report(report_date: str | None = None, persist: bool
 
 
 def scheduled_generate_morning_sync_health_report(report_date: str | None = None) -> dict[str, Any]:
-	"""Generate and persist the daily morning sync health report for operations."""
-	return _collect_morning_sync_health_report(report_date=report_date, persist=True)
+	"""Generate, persist, and notify the daily morning sync health report for operations."""
+	report = _collect_morning_sync_health_report(report_date=report_date, persist=True)
+	try:
+		from hrms.api.google_chat import send_notification_event
+
+		severity = "medium"
+		if report.get("status") == "red":
+			severity = "critical"
+		elif report.get("status") == "yellow":
+			severity = "high"
+
+		notification_sent = send_notification_event(
+			{
+				"family": "morning_readiness_digest",
+				"source_system": "frappe",
+				"source_ref": f"morning_sync:{report.get('report_date')}",
+				"severity": severity,
+				"owner": "ERP Automation / Ops",
+				"facts": {
+					"report_date": report.get("report_date"),
+					"status": report.get("status"),
+					"areas": report.get("areas") or [],
+					"sync_target_pht_time": report.get("sync_target_pht_time"),
+					"ready_deadline_pht_time": report.get("ready_deadline_pht_time"),
+					"artifact_markdown_path": ((report.get("artifacts") or {}).get("markdown_path")),
+				},
+			}
+		)
+		report["notification_sent"] = bool(notification_sent)
+	except Exception as exc:
+		frappe.log_error(
+			title="Morning Sync Digest Notification Failed",
+			message=str(exc),
+		)
+		report["notification_sent"] = False
+		report["notification_error"] = str(exc)
+	return report

--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -240,7 +240,7 @@ def _row_has_meaningful_value(row: dict[str, Any], keys: list[str]) -> bool:
 			if value.strip():
 				return True
 			continue
-		if isinstance(value, (int, float)):
+		if isinstance(value, int | float):
 			if flt(value) != 0:
 				return True
 			continue

--- a/hrms/api/google_chat.py
+++ b/hrms/api/google_chat.py
@@ -14,15 +14,18 @@ import json
 import os
 import re
 import time
+import hashlib
+
 import frappe
 import requests
 
 from hrms.utils.chat_space_lockdown import route_outbound_chat_space
 from hrms.utils.google_oauth import (
-    force_refresh_access_token,
-    get_valid_access_token,
-    has_valid_token,
+	force_refresh_access_token,
+	get_valid_access_token,
+	has_valid_token,
 )
+from hrms.utils.notification_intelligence import build_notification_event, render_notification_text, validate_notification_event
 
 _SPACE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{8,}$")
 
@@ -163,32 +166,29 @@ def _derive_space_label(space_type: str, memberships: list[dict], fallback: str)
     return ", ".join(names[:3]) + f" +{len(names) - 3}"
 
 
-def send_message_to_space(space_name: str, message: str) -> bool:
-    """
-    Send a Google Chat message to a space using the bot service account.
-    Uses credentials/task-manager-service.json with chat.bot scope.
+def _truthy(value: object) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
-    This is an INTERNAL utility function — NOT a whitelist API endpoint.
-    Multiple modules import this to avoid duplicating service account auth logic.
 
-    Args:
-        space_name: Google Chat space identifier, e.g. "spaces/AAQA3NVVR6c"
-        message: Plain text message to send
-
-    Returns:
-        True if message was sent successfully, False otherwise (never throws).
-    """
+def _send_message_to_space_internal(
+    space_name: str,
+    message: str,
+    *,
+    family: str | None = None,
+    context: str = "hrms.api.google_chat.send_message_to_space",
+) -> dict[str, object]:
+    """Low-level Google Chat transport with optional family-aware routing."""
     logger = frappe.logger("google_chat")
     try:
         from google.oauth2 import service_account
         from googleapiclient.discovery import build
     except ImportError:
         logger.warning("google-auth package not installed — GChat notification skipped")
-        return False
+        return {"success": False, "sent": False, "reason": "google_auth_missing"}
 
     if not space_name:
-        logger.warning("send_message_to_space: space_name is empty, skipping")
-        return False
+        logger.warning("_send_message_to_space_internal: space_name is empty, skipping")
+        return {"success": False, "sent": False, "reason": "missing_space"}
 
     try:
         from hrms.utils.bei_config import get_service_account_path
@@ -197,36 +197,278 @@ def send_message_to_space(space_name: str, message: str) -> bool:
         target_space = route_outbound_chat_space(
             space_name,
             logger=logger,
-            context="hrms.api.google_chat.send_message_to_space",
+            context=context,
+            family=family,
         )
 
         if not os.path.exists(cred_path):
             logger.warning(
-                f"send_message_to_space: service account file missing at {cred_path}, skipping"
+                f"_send_message_to_space_internal: service account file missing at {cred_path}, skipping"
             )
-            return False
+            return {"success": False, "sent": False, "reason": "service_account_missing"}
 
         creds = service_account.Credentials.from_service_account_file(
             cred_path,
             scopes=["https://www.googleapis.com/auth/chat.bot"],
         )
         chat = build("chat", "v1", credentials=creds)
-        chat.spaces().messages().create(
+        result = chat.spaces().messages().create(
             parent=target_space,
             body={"text": message},
         ).execute()
 
-        logger.info(f"GChat message sent to {target_space}")
-        return True
+        logger.info("GChat message sent to %s family=%s", target_space, family or "legacy")
+        return {
+            "success": True,
+            "sent": True,
+            "target_space": target_space,
+            "message_id": result.get("name"),
+        }
 
     except Exception as e:
-        # CRITICAL: Never throw — callers must not be blocked by notification failures
         logger.error(f"send_message_to_space failed for {space_name}: {str(e)}")
         frappe.log_error(
             title="Google Chat Send Error",
-            message=f"space={space_name}, error={str(e)[:500]}",
+            message=f"space={space_name}, family={family or 'legacy'}, error={str(e)[:500]}",
         )
+        return {"success": False, "sent": False, "reason": "send_failed", "error": str(e)}
+
+
+def send_message_to_space(space_name: str, message: str) -> bool:
+    """
+    Legacy raw-string sender. Migrated families should use send_notification_event().
+    """
+    result = _send_message_to_space_internal(
+        space_name,
+        message,
+        context="hrms.api.google_chat.send_message_to_space",
+    )
+    return bool(result.get("success"))
+
+
+def _notification_cache() -> object | None:
+    cache_factory = getattr(frappe, "cache", None)
+    if not callable(cache_factory):
+        return None
+    try:
+        return cache_factory()
+    except Exception:
+        return None
+
+
+def _notification_dedup_cache_key(event: dict[str, object]) -> str:
+    family = str(event.get("family") or "unknown")
+    dedup_key = str(event.get("dedup_key") or "")
+    digest = hashlib.sha1(dedup_key.encode("utf-8")).hexdigest()[:20]
+    return f"s038:notification:{family}:{digest}"
+
+
+def _notification_dedup_window_seconds(event: dict[str, object]) -> int:
+    try:
+        from hrms.utils.notification_intelligence import get_notification_policy
+
+        policy = get_notification_policy(str(event.get("family") or ""))
+        return max(int(policy.get("dedup_window_minutes") or 0) * 60, 0)
+    except Exception:
+        return 0
+
+
+def _notification_dedup_hit(event: dict[str, object]) -> bool:
+    cache = _notification_cache()
+    ttl_seconds = _notification_dedup_window_seconds(event)
+    if cache is None or ttl_seconds <= 0:
         return False
+    try:
+        return bool(cache.get_value(_notification_dedup_cache_key(event)))
+    except Exception:
+        return False
+
+
+def _mark_notification_delivered(event: dict[str, object]) -> None:
+    cache = _notification_cache()
+    ttl_seconds = _notification_dedup_window_seconds(event)
+    if cache is None or ttl_seconds <= 0:
+        return
+    try:
+        cache.set_value(
+            _notification_dedup_cache_key(event),
+            {"sent_at": time.time(), "source_ref": event.get("source_ref")},
+            expires_in_sec=ttl_seconds,
+        )
+    except Exception:
+        return
+
+
+def _notification_config_get(key: str, default: object | None = None) -> object | None:
+    config = getattr(frappe, "conf", {})
+    getter = getattr(config, "get", None)
+    if callable(getter):
+        return getter(key, default)
+    return default
+
+
+def _maybe_polish_notification_text(
+    event: dict[str, object], deterministic_text: str
+) -> tuple[str, dict[str, str]]:
+    """Optional OpenAI phrasing layer with deterministic fallback."""
+    if not _truthy(_notification_config_get("notification_ai_polish_enabled", False)):
+        return deterministic_text, {"mode": "deterministic", "reason": "disabled"}
+
+    api_key = str(_notification_config_get("openai_api_key", "") or "").strip()
+    if not api_key:
+        return deterministic_text, {"mode": "deterministic", "reason": "missing_openai_key"}
+
+    model = str(_notification_config_get("notification_ai_model", "gpt-4o-mini") or "gpt-4o-mini")
+    prompt = (
+        "Rewrite this operations notification to sound like a concise AI assistant brief. "
+        "Preserve every fact, number, owner, action, evidence link, and section heading exactly. "
+        "Do not invent causes, fix steps, or new facts.\n\n"
+        f"{deterministic_text}"
+    )
+
+    try:
+        response = requests.post(
+            "https://api.openai.com/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": model,
+                "temperature": 0.2,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "You rewrite operational alerts without changing facts or sections.",
+                    },
+                    {"role": "user", "content": prompt},
+                ],
+            },
+            timeout=12,
+        )
+        response.raise_for_status()
+        data = response.json()
+        content = (
+            (data.get("choices") or [{}])[0]
+            .get("message", {})
+            .get("content", "")
+        )
+        text = str(content or "").strip()
+        if not text:
+            return deterministic_text, {"mode": "deterministic", "reason": "empty_ai_response"}
+        return text, {"mode": "ai_polished", "model": model}
+    except Exception as exc:
+        return deterministic_text, {"mode": "deterministic", "reason": f"ai_error:{str(exc)[:80]}"}
+
+
+def _coerce_notification_event_payload(
+    event: dict[str, object] | str | None = None,
+    **kwargs,
+) -> dict[str, object]:
+    if isinstance(event, dict):
+        payload = dict(event)
+    elif isinstance(event, str) and event.strip():
+        payload = json.loads(event)
+    else:
+        payload = {}
+    if kwargs:
+        payload.update({key: value for key, value in kwargs.items() if key not in {"dry_run"}})
+    facts = payload.get("facts")
+    if isinstance(facts, str) and facts.strip():
+        payload["facts"] = json.loads(facts)
+    elif facts is None:
+        payload["facts"] = {}
+    return payload
+
+
+def _deliver_notification_event(
+    event: dict[str, object] | str | None = None,
+    *,
+    dry_run: bool = False,
+    **kwargs,
+) -> dict[str, object]:
+    logger = frappe.logger("google_chat")
+    try:
+        payload = _coerce_notification_event_payload(event, **kwargs)
+        normalized = build_notification_event(payload)
+        validation_errors = validate_notification_event(normalized)
+        if validation_errors:
+            raise ValueError("Missing notification fields: " + ", ".join(validation_errors))
+
+        deterministic_text = render_notification_text(normalized)
+        final_text, ai_meta = _maybe_polish_notification_text(normalized, deterministic_text)
+        normalized["rendered_text"] = final_text
+
+        if dry_run:
+            return {
+                "success": True,
+                "sent": False,
+                "skipped": False,
+                "dry_run": True,
+                "family": normalized["family"],
+                "target_space": normalized["requested_space"],
+                "rendered_text": final_text,
+                "ai_meta": ai_meta,
+                "source_ref": normalized["source_ref"],
+                "dedup_key": normalized["dedup_key"],
+            }
+
+        if _notification_dedup_hit(normalized):
+            logger.info(
+                "Notification dedup hit family=%s source_ref=%s",
+                normalized["family"],
+                normalized["source_ref"],
+            )
+            return {
+                "success": True,
+                "sent": False,
+                "skipped": True,
+                "reason": "dedup_window_active",
+                "family": normalized["family"],
+                "target_space": normalized["requested_space"],
+                "dedup_key": normalized["dedup_key"],
+            }
+
+        send_result = _send_message_to_space_internal(
+            str(normalized["requested_space"]),
+            final_text,
+            family=str(normalized["family"]),
+            context="hrms.api.google_chat.send_notification_event",
+        )
+        if send_result.get("success"):
+            _mark_notification_delivered(normalized)
+        return {
+            "success": bool(send_result.get("success")),
+            "sent": bool(send_result.get("sent")),
+            "skipped": False,
+            "family": normalized["family"],
+            "target_space": send_result.get("target_space", normalized["requested_space"]),
+            "message_id": send_result.get("message_id"),
+            "rendered_text": final_text,
+            "ai_meta": ai_meta,
+            "source_ref": normalized["source_ref"],
+            "dedup_key": normalized["dedup_key"],
+        }
+    except Exception as exc:
+        logger.error("send_notification_event failed: %s", exc)
+        frappe.log_error(
+            title="Structured Notification Error",
+            message=f"error={str(exc)[:500]} event={str(event)[:1000]}",
+        )
+        return {"success": False, "sent": False, "skipped": False, "error": str(exc)}
+
+
+def send_notification_event(event: dict[str, object]) -> bool:
+    """Canonical structured sender for Sprint 38 migrated families."""
+    result = _deliver_notification_event(event)
+    return bool(result.get("success"))
+
+
+@frappe.whitelist()
+def ingest_notification_event(event: dict[str, object] | str | None = None, dry_run: bool = False, **kwargs):
+    """Whitelisted structured ingest endpoint for standalone services."""
+    dry_run_flag = dry_run if isinstance(dry_run, bool) else _truthy(dry_run)
+    return _deliver_notification_event(event, dry_run=dry_run_flag, **kwargs)
 
 
 @frappe.whitelist()
@@ -455,12 +697,31 @@ def on_approval_queue_insert(doc, method=None):
     Fires via doc_events: BEI Approval Queue → after_insert.
     """
     try:
-        from hrms.utils.bei_config import get_chat_space, SPACE_NOTIFICATIONS
-        space = get_chat_space(SPACE_NOTIFICATIONS)
-        subject = getattr(doc, "subject", None) or getattr(doc, "name", "Unknown")
-        queue_type = getattr(doc, "approval_type", None) or getattr(doc, "doctype", "Item")
-        message = f"*New Approval Needed*\n\n{queue_type}: *{subject}*\nPlease review and approve."
-        send_message_to_space(space, message)
+        reference_doctype = getattr(doc, "reference_doctype", None) or getattr(doc, "approval_type", None) or "Approval"
+        reference_name = getattr(doc, "reference_name", None) or getattr(doc, "subject", None) or getattr(doc, "name", "Unknown")
+        dashboard_url = (
+            "https://my.bebang.ph/dashboard/store-ops/order-approvals"
+            if reference_doctype == "BEI Store Order"
+            else ""
+        )
+        send_notification_event(
+            {
+                "family": "approval_queue_new",
+                "source_system": "frappe",
+                "source_ref": getattr(doc, "name", None) or reference_name,
+                "severity": "critical" if getattr(doc, "priority", None) == "Urgent" else "high",
+                "owner": getattr(doc, "assigned_approver", None) or "Assigned Approver",
+                "facts": {
+                    "queue_name": getattr(doc, "name", None),
+                    "reference_doctype": reference_doctype,
+                    "reference_name": reference_name,
+                    "store": getattr(doc, "store", None),
+                    "priority": getattr(doc, "priority", None),
+                    "assigned_approver": getattr(doc, "assigned_approver", None),
+                    "dashboard_url": dashboard_url,
+                },
+            }
+        )
     except Exception as e:
         frappe.log_error(
             title="Approval Queue Notification Error",
@@ -474,7 +735,7 @@ def on_store_order_update(doc, method=None):
     Fires via doc_events: BEI Store Order → on_update.
     Notifies on: Approved, Cancelled.
     """
-    _NOTIFY_STATUSES = {"Approved", "Cancelled"}
+    _NOTIFY_STATUSES = {"Cancelled"}
     status = getattr(doc, "status", None)
     if status not in _NOTIFY_STATUSES:
         return

--- a/hrms/api/google_chat.py
+++ b/hrms/api/google_chat.py
@@ -56,6 +56,7 @@ def _agent_log(hypothesis_id: str, location: str, message: str, data: dict | Non
 		"timestamp": int(time.time() * 1000),
 	}
 	try:
+		# nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal -- debug log path is internal and not user-controlled.
 		with open(log_path, "a", encoding="utf-8") as f:
 			f.write(json.dumps(payload, ensure_ascii=False) + "\n")
 	except Exception:

--- a/hrms/api/google_chat.py
+++ b/hrms/api/google_chat.py
@@ -10,14 +10,15 @@ using their OAuth tokens.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
 import time
-import hashlib
+
+import requests
 
 import frappe
-import requests
 
 from hrms.utils.chat_space_lockdown import route_outbound_chat_space
 from hrms.utils.google_oauth import (
@@ -25,746 +26,746 @@ from hrms.utils.google_oauth import (
 	get_valid_access_token,
 	has_valid_token,
 )
-from hrms.utils.notification_intelligence import build_notification_event, render_notification_text, validate_notification_event
+from hrms.utils.notification_intelligence import (
+	build_notification_event,
+	render_notification_text,
+	validate_notification_event,
+)
 
 _SPACE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{8,}$")
 
 
-
 def _agent_log(hypothesis_id: str, location: str, message: str, data: dict | None = None) -> None:
-    """
-    Debug-mode NDJSON logger. Writes to local Cursor debug log.
-    Do not log secrets or PII (emails, names, tokens).
-    """
-    try:
-        log_path = os.path.join(frappe.get_site_path("..", ".cursor"), "debug.log")
-    except Exception:
-        # Fallback for non-site contexts
-        log_path = os.path.join(os.getcwd(), ".cursor", "debug.log")
+	"""
+	Debug-mode NDJSON logger. Writes to local Cursor debug log.
+	Do not log secrets or PII (emails, names, tokens).
+	"""
+	try:
+		log_path = os.path.join(frappe.get_site_path("..", ".cursor"), "debug.log")
+	except Exception:
+		# Fallback for non-site contexts
+		log_path = os.path.join(os.getcwd(), ".cursor", "debug.log")
 
-    payload = {
-        "sessionId": "debug-session",
-        "runId": "run1",
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data or {},
-        "timestamp": int(time.time() * 1000),
-    }
-    try:
-        with open(log_path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(payload, ensure_ascii=False) + "\n")
-    except Exception:
-        # Never break main flow due to logging
-        pass
+	payload = {
+		"sessionId": "debug-session",
+		"runId": "run1",
+		"hypothesisId": hypothesis_id,
+		"location": location,
+		"message": message,
+		"data": data or {},
+		"timestamp": int(time.time() * 1000),
+	}
+	try:
+		with open(log_path, "a", encoding="utf-8") as f:
+			f.write(json.dumps(payload, ensure_ascii=False) + "\n")
+	except Exception:
+		# Never break main flow due to logging
+		pass
 
 
 def _space_id_suffix(space_name: str) -> str:
-    # "spaces/AAQA..." -> "AAQA..."
-    return (space_name or "").split("/")[-1][:16]
+	# "spaces/AAQA..." -> "AAQA..."
+	return (space_name or "").split("/")[-1][:16]
 
 
 def _needs_membership_label(space: dict) -> bool:
-    """
-    DMs and unnamed group chats often have empty displayName.
-    We treat "displayName missing" OR "looks like an ID" as needing enrichment.
-    """
-    dn = (space.get("displayName") or "").strip()
-    if not dn:
-        return True
-    if " " not in dn and _SPACE_ID_RE.match(dn):
-        return True
-    return False
+	"""
+	DMs and unnamed group chats often have empty displayName.
+	We treat "displayName missing" OR "looks like an ID" as needing enrichment.
+	"""
+	dn = (space.get("displayName") or "").strip()
+	if not dn:
+		return True
+	if " " not in dn and _SPACE_ID_RE.match(dn):
+		return True
+	return False
 
 
 def _fetch_space_memberships(access_token: str, space_name: str) -> list[dict]:
-    """
-    Returns memberships list. Do not log member names/emails (PII).
-    """
-    # Runtime evidence in prod:
-    # - `/memberships` returned HTML 404
-    # - `fields=` caused 400 INVALID_ARGUMENT
-    # - `readMask=` caused 400 INVALID_ARGUMENT
-    #
-    # Therefore we keep this as minimal as possible: pageSize only.
-    endpoints = [
-        ("members", f"https://chat.googleapis.com/v1/{space_name}/members"),
-        ("memberships", f"https://chat.googleapis.com/v1/{space_name}/memberships"),
-    ]
+	"""
+	Returns memberships list. Do not log member names/emails (PII).
+	"""
+	# Runtime evidence in prod:
+	# - `/memberships` returned HTML 404
+	# - `fields=` caused 400 INVALID_ARGUMENT
+	# - `readMask=` caused 400 INVALID_ARGUMENT
+	#
+	# Therefore we keep this as minimal as possible: pageSize only.
+	endpoints = [
+		("members", f"https://chat.googleapis.com/v1/{space_name}/members"),
+		("memberships", f"https://chat.googleapis.com/v1/{space_name}/memberships"),
+	]
 
-    last_err = None
-    for kind, url in endpoints:
-        params = {"pageSize": 100}
+	last_err = None
+	for kind, url in endpoints:
+		params = {"pageSize": 100}
 
-        resp = requests.get(
-            url,
-            headers={"Authorization": f"Bearer {access_token}"},
-            params=params,
-            timeout=30,
-        )
+		resp = requests.get(
+			url,
+			headers={"Authorization": f"Bearer {access_token}"},
+			params=params,
+			timeout=30,
+		)
 
-        _agent_log(
-            "H3",
-            "hrms/api/google_chat.py:_fetch_space_memberships",
-            "Tried membership endpoint",
-            {
-                "kind": kind,
-                "status": resp.status_code,
-                "spaceId": _space_id_suffix(space_name),
-                "contentType": (resp.headers.get("Content-Type") or "")[:60],
-            },
-        )
+		_agent_log(
+			"H3",
+			"hrms/api/google_chat.py:_fetch_space_memberships",
+			"Tried membership endpoint",
+			{
+				"kind": kind,
+				"status": resp.status_code,
+				"spaceId": _space_id_suffix(space_name),
+				"contentType": (resp.headers.get("Content-Type") or "")[:60],
+			},
+		)
 
-        # Known mismatch: some environments return HTML 404 for one of these endpoints.
-        if resp.status_code == 404:
-            last_err = f"{kind} 404"
-            continue
+		# Known mismatch: some environments return HTML 404 for one of these endpoints.
+		if resp.status_code == 404:
+			last_err = f"{kind} 404"
+			continue
 
-        if resp.status_code != 200:
-            # Avoid JSON parsing here; Google errors can be JSON but we've observed HTML responses too.
-            snippet = (resp.text or "")[:200]
-            raise requests.HTTPError(f"{kind}.list failed: {resp.status_code} {snippet}")
+		if resp.status_code != 200:
+			# Avoid JSON parsing here; Google errors can be JSON but we've observed HTML responses too.
+			snippet = (resp.text or "")[:200]
+			raise requests.HTTPError(f"{kind}.list failed: {resp.status_code} {snippet}")
 
-        try:
-            data = resp.json() if resp.text else {}
-        except Exception:
-            data = {}
+		try:
+			data = resp.json() if resp.text else {}
+		except Exception:
+			data = {}
 
-        items = data.get("memberships") or []
-        return items or []
+		items = data.get("memberships") or []
+		return items or []
 
-    raise requests.HTTPError(f"memberships.list failed: 404 ({last_err or 'unknown'})")
+	raise requests.HTTPError(f"memberships.list failed: 404 ({last_err or 'unknown'})")
 
 
 def _derive_space_label(space_type: str, memberships: list[dict], fallback: str) -> str:
-    """
-    Build a human-friendly label from membership displayNames.
-    We intentionally avoid logging/returning emails; displayName is what Chat shows.
-    """
-    # Collect member display names (may be missing, depending on API permissions/fields returned).
-    names = []
-    for m in memberships:
-        member = m.get("member") or {}
-        dn = (member.get("displayName") or "").strip()
-        if dn:
-            names.append(dn)
+	"""
+	Build a human-friendly label from membership displayNames.
+	We intentionally avoid logging/returning emails; displayName is what Chat shows.
+	"""
+	# Collect member display names (may be missing, depending on API permissions/fields returned).
+	names = []
+	for m in memberships:
+		member = m.get("member") or {}
+		dn = (member.get("displayName") or "").strip()
+		if dn:
+			names.append(dn)
 
-    names = list(dict.fromkeys(names))  # de-dupe, preserve order
-    if not names:
-        return fallback
+	names = list(dict.fromkeys(names))  # de-dupe, preserve order
+	if not names:
+		return fallback
 
-    # DIRECT_MESSAGE: prefer single other name, but we can't reliably identify "me" here;
-    # still better than opaque IDs.
-    if space_type == "DIRECT_MESSAGE":
-        if len(names) == 1:
-            return names[0]
-        return ", ".join(names[:2])
+	# DIRECT_MESSAGE: prefer single other name, but we can't reliably identify "me" here;
+	# still better than opaque IDs.
+	if space_type == "DIRECT_MESSAGE":
+		if len(names) == 1:
+			return names[0]
+		return ", ".join(names[:2])
 
-    # GROUP_CHAT (group DM / unnamed group): join up to 3 names + "+N"
-    if len(names) <= 3:
-        return ", ".join(names)
-    return ", ".join(names[:3]) + f" +{len(names) - 3}"
+	# GROUP_CHAT (group DM / unnamed group): join up to 3 names + "+N"
+	if len(names) <= 3:
+		return ", ".join(names)
+	return ", ".join(names[:3]) + f" +{len(names) - 3}"
 
 
 def _truthy(value: object) -> bool:
-    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+	return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _send_message_to_space_internal(
-    space_name: str,
-    message: str,
-    *,
-    family: str | None = None,
-    context: str = "hrms.api.google_chat.send_message_to_space",
+	space_name: str,
+	message: str,
+	*,
+	family: str | None = None,
+	context: str = "hrms.api.google_chat.send_message_to_space",
 ) -> dict[str, object]:
-    """Low-level Google Chat transport with optional family-aware routing."""
-    logger = frappe.logger("google_chat")
-    try:
-        from google.oauth2 import service_account
-        from googleapiclient.discovery import build
-    except ImportError:
-        logger.warning("google-auth package not installed — GChat notification skipped")
-        return {"success": False, "sent": False, "reason": "google_auth_missing"}
+	"""Low-level Google Chat transport with optional family-aware routing."""
+	logger = frappe.logger("google_chat")
+	try:
+		from google.oauth2 import service_account
+		from googleapiclient.discovery import build
+	except ImportError:
+		logger.warning("google-auth package not installed — GChat notification skipped")
+		return {"success": False, "sent": False, "reason": "google_auth_missing"}
 
-    if not space_name:
-        logger.warning("_send_message_to_space_internal: space_name is empty, skipping")
-        return {"success": False, "sent": False, "reason": "missing_space"}
+	if not space_name:
+		logger.warning("_send_message_to_space_internal: space_name is empty, skipping")
+		return {"success": False, "sent": False, "reason": "missing_space"}
 
-    try:
-        from hrms.utils.bei_config import get_service_account_path
+	try:
+		from hrms.utils.bei_config import get_service_account_path
 
-        cred_path = get_service_account_path()
-        target_space = route_outbound_chat_space(
-            space_name,
-            logger=logger,
-            context=context,
-            family=family,
-        )
+		cred_path = get_service_account_path()
+		target_space = route_outbound_chat_space(
+			space_name,
+			logger=logger,
+			context=context,
+			family=family,
+		)
 
-        if not os.path.exists(cred_path):
-            logger.warning(
-                f"_send_message_to_space_internal: service account file missing at {cred_path}, skipping"
-            )
-            return {"success": False, "sent": False, "reason": "service_account_missing"}
+		if not os.path.exists(cred_path):
+			logger.warning(
+				f"_send_message_to_space_internal: service account file missing at {cred_path}, skipping"
+			)
+			return {"success": False, "sent": False, "reason": "service_account_missing"}
 
-        creds = service_account.Credentials.from_service_account_file(
-            cred_path,
-            scopes=["https://www.googleapis.com/auth/chat.bot"],
-        )
-        chat = build("chat", "v1", credentials=creds)
-        result = chat.spaces().messages().create(
-            parent=target_space,
-            body={"text": message},
-        ).execute()
+		creds = service_account.Credentials.from_service_account_file(
+			cred_path,
+			scopes=["https://www.googleapis.com/auth/chat.bot"],
+		)
+		chat = build("chat", "v1", credentials=creds)
+		result = (
+			chat.spaces()
+			.messages()
+			.create(
+				parent=target_space,
+				body={"text": message},
+			)
+			.execute()
+		)
 
-        logger.info("GChat message sent to %s family=%s", target_space, family or "legacy")
-        return {
-            "success": True,
-            "sent": True,
-            "target_space": target_space,
-            "message_id": result.get("name"),
-        }
+		logger.info("GChat message sent to %s family=%s", target_space, family or "legacy")
+		return {
+			"success": True,
+			"sent": True,
+			"target_space": target_space,
+			"message_id": result.get("name"),
+		}
 
-    except Exception as e:
-        logger.error(f"send_message_to_space failed for {space_name}: {str(e)}")
-        frappe.log_error(
-            title="Google Chat Send Error",
-            message=f"space={space_name}, family={family or 'legacy'}, error={str(e)[:500]}",
-        )
-        return {"success": False, "sent": False, "reason": "send_failed", "error": str(e)}
+	except Exception as e:
+		logger.error(f"send_message_to_space failed for {space_name}: {e!s}")
+		frappe.log_error(
+			title="Google Chat Send Error",
+			message=f"space={space_name}, family={family or 'legacy'}, error={str(e)[:500]}",
+		)
+		return {"success": False, "sent": False, "reason": "send_failed", "error": str(e)}
 
 
 def send_message_to_space(space_name: str, message: str) -> bool:
-    """
-    Legacy raw-string sender. Migrated families should use send_notification_event().
-    """
-    result = _send_message_to_space_internal(
-        space_name,
-        message,
-        context="hrms.api.google_chat.send_message_to_space",
-    )
-    return bool(result.get("success"))
+	"""
+	Legacy raw-string sender. Migrated families should use send_notification_event().
+	"""
+	result = _send_message_to_space_internal(
+		space_name,
+		message,
+		context="hrms.api.google_chat.send_message_to_space",
+	)
+	return bool(result.get("success"))
 
 
 def _notification_cache() -> object | None:
-    cache_factory = getattr(frappe, "cache", None)
-    if not callable(cache_factory):
-        return None
-    try:
-        return cache_factory()
-    except Exception:
-        return None
+	cache_factory = getattr(frappe, "cache", None)
+	if not callable(cache_factory):
+		return None
+	try:
+		return cache_factory()
+	except Exception:
+		return None
 
 
 def _notification_dedup_cache_key(event: dict[str, object]) -> str:
-    family = str(event.get("family") or "unknown")
-    dedup_key = str(event.get("dedup_key") or "")
-    digest = hashlib.sha1(dedup_key.encode("utf-8")).hexdigest()[:20]
-    return f"s038:notification:{family}:{digest}"
+	family = str(event.get("family") or "unknown")
+	dedup_key = str(event.get("dedup_key") or "")
+	digest = hashlib.sha1(dedup_key.encode("utf-8")).hexdigest()[:20]
+	return f"s038:notification:{family}:{digest}"
 
 
 def _notification_dedup_window_seconds(event: dict[str, object]) -> int:
-    try:
-        from hrms.utils.notification_intelligence import get_notification_policy
+	try:
+		from hrms.utils.notification_intelligence import get_notification_policy
 
-        policy = get_notification_policy(str(event.get("family") or ""))
-        return max(int(policy.get("dedup_window_minutes") or 0) * 60, 0)
-    except Exception:
-        return 0
+		policy = get_notification_policy(str(event.get("family") or ""))
+		return max(int(policy.get("dedup_window_minutes") or 0) * 60, 0)
+	except Exception:
+		return 0
 
 
 def _notification_dedup_hit(event: dict[str, object]) -> bool:
-    cache = _notification_cache()
-    ttl_seconds = _notification_dedup_window_seconds(event)
-    if cache is None or ttl_seconds <= 0:
-        return False
-    try:
-        return bool(cache.get_value(_notification_dedup_cache_key(event)))
-    except Exception:
-        return False
+	cache = _notification_cache()
+	ttl_seconds = _notification_dedup_window_seconds(event)
+	if cache is None or ttl_seconds <= 0:
+		return False
+	try:
+		return bool(cache.get_value(_notification_dedup_cache_key(event)))
+	except Exception:
+		return False
 
 
 def _mark_notification_delivered(event: dict[str, object]) -> None:
-    cache = _notification_cache()
-    ttl_seconds = _notification_dedup_window_seconds(event)
-    if cache is None or ttl_seconds <= 0:
-        return
-    try:
-        cache.set_value(
-            _notification_dedup_cache_key(event),
-            {"sent_at": time.time(), "source_ref": event.get("source_ref")},
-            expires_in_sec=ttl_seconds,
-        )
-    except Exception:
-        return
+	cache = _notification_cache()
+	ttl_seconds = _notification_dedup_window_seconds(event)
+	if cache is None or ttl_seconds <= 0:
+		return
+	try:
+		cache.set_value(
+			_notification_dedup_cache_key(event),
+			{"sent_at": time.time(), "source_ref": event.get("source_ref")},
+			expires_in_sec=ttl_seconds,
+		)
+	except Exception:
+		return
 
 
 def _notification_config_get(key: str, default: object | None = None) -> object | None:
-    config = getattr(frappe, "conf", {})
-    getter = getattr(config, "get", None)
-    if callable(getter):
-        return getter(key, default)
-    return default
+	config = getattr(frappe, "conf", {})
+	getter = getattr(config, "get", None)
+	if callable(getter):
+		return getter(key, default)
+	return default
 
 
 def _maybe_polish_notification_text(
-    event: dict[str, object], deterministic_text: str
+	event: dict[str, object], deterministic_text: str
 ) -> tuple[str, dict[str, str]]:
-    """Optional OpenAI phrasing layer with deterministic fallback."""
-    if not _truthy(_notification_config_get("notification_ai_polish_enabled", False)):
-        return deterministic_text, {"mode": "deterministic", "reason": "disabled"}
+	"""Optional OpenAI phrasing layer with deterministic fallback."""
+	if not _truthy(_notification_config_get("notification_ai_polish_enabled", False)):
+		return deterministic_text, {"mode": "deterministic", "reason": "disabled"}
 
-    api_key = str(_notification_config_get("openai_api_key", "") or "").strip()
-    if not api_key:
-        return deterministic_text, {"mode": "deterministic", "reason": "missing_openai_key"}
+	api_key = str(_notification_config_get("openai_api_key", "") or "").strip()
+	if not api_key:
+		return deterministic_text, {"mode": "deterministic", "reason": "missing_openai_key"}
 
-    model = str(_notification_config_get("notification_ai_model", "gpt-4o-mini") or "gpt-4o-mini")
-    prompt = (
-        "Rewrite this operations notification to sound like a concise AI assistant brief. "
-        "Preserve every fact, number, owner, action, evidence link, and section heading exactly. "
-        "Do not invent causes, fix steps, or new facts.\n\n"
-        f"{deterministic_text}"
-    )
+	model = str(_notification_config_get("notification_ai_model", "gpt-4o-mini") or "gpt-4o-mini")
+	prompt = (
+		"Rewrite this operations notification to sound like a concise AI assistant brief. "
+		"Preserve every fact, number, owner, action, evidence link, and section heading exactly. "
+		"Do not invent causes, fix steps, or new facts.\n\n"
+		f"{deterministic_text}"
+	)
 
-    try:
-        response = requests.post(
-            "https://api.openai.com/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "model": model,
-                "temperature": 0.2,
-                "messages": [
-                    {
-                        "role": "system",
-                        "content": "You rewrite operational alerts without changing facts or sections.",
-                    },
-                    {"role": "user", "content": prompt},
-                ],
-            },
-            timeout=12,
-        )
-        response.raise_for_status()
-        data = response.json()
-        content = (
-            (data.get("choices") or [{}])[0]
-            .get("message", {})
-            .get("content", "")
-        )
-        text = str(content or "").strip()
-        if not text:
-            return deterministic_text, {"mode": "deterministic", "reason": "empty_ai_response"}
-        return text, {"mode": "ai_polished", "model": model}
-    except Exception as exc:
-        return deterministic_text, {"mode": "deterministic", "reason": f"ai_error:{str(exc)[:80]}"}
+	try:
+		response = requests.post(
+			"https://api.openai.com/v1/chat/completions",
+			headers={
+				"Authorization": f"Bearer {api_key}",
+				"Content-Type": "application/json",
+			},
+			json={
+				"model": model,
+				"temperature": 0.2,
+				"messages": [
+					{
+						"role": "system",
+						"content": "You rewrite operational alerts without changing facts or sections.",
+					},
+					{"role": "user", "content": prompt},
+				],
+			},
+			timeout=12,
+		)
+		response.raise_for_status()
+		data = response.json()
+		content = (data.get("choices") or [{}])[0].get("message", {}).get("content", "")
+		text = str(content or "").strip()
+		if not text:
+			return deterministic_text, {"mode": "deterministic", "reason": "empty_ai_response"}
+		return text, {"mode": "ai_polished", "model": model}
+	except Exception as exc:
+		return deterministic_text, {"mode": "deterministic", "reason": f"ai_error:{str(exc)[:80]}"}
 
 
 def _coerce_notification_event_payload(
-    event: dict[str, object] | str | None = None,
-    **kwargs,
+	event: dict[str, object] | str | None = None,
+	**kwargs,
 ) -> dict[str, object]:
-    if isinstance(event, dict):
-        payload = dict(event)
-    elif isinstance(event, str) and event.strip():
-        payload = json.loads(event)
-    else:
-        payload = {}
-    if kwargs:
-        payload.update({key: value for key, value in kwargs.items() if key not in {"dry_run"}})
-    facts = payload.get("facts")
-    if isinstance(facts, str) and facts.strip():
-        payload["facts"] = json.loads(facts)
-    elif facts is None:
-        payload["facts"] = {}
-    return payload
+	if isinstance(event, dict):
+		payload = dict(event)
+	elif isinstance(event, str) and event.strip():
+		payload = json.loads(event)
+	else:
+		payload = {}
+	if kwargs:
+		payload.update({key: value for key, value in kwargs.items() if key not in {"dry_run"}})
+	facts = payload.get("facts")
+	if isinstance(facts, str) and facts.strip():
+		payload["facts"] = json.loads(facts)
+	elif facts is None:
+		payload["facts"] = {}
+	return payload
 
 
 def _deliver_notification_event(
-    event: dict[str, object] | str | None = None,
-    *,
-    dry_run: bool = False,
-    **kwargs,
+	event: dict[str, object] | str | None = None,
+	*,
+	dry_run: bool = False,
+	**kwargs,
 ) -> dict[str, object]:
-    logger = frappe.logger("google_chat")
-    try:
-        payload = _coerce_notification_event_payload(event, **kwargs)
-        normalized = build_notification_event(payload)
-        validation_errors = validate_notification_event(normalized)
-        if validation_errors:
-            raise ValueError("Missing notification fields: " + ", ".join(validation_errors))
+	logger = frappe.logger("google_chat")
+	try:
+		payload = _coerce_notification_event_payload(event, **kwargs)
+		normalized = build_notification_event(payload)
+		validation_errors = validate_notification_event(normalized)
+		if validation_errors:
+			raise ValueError("Missing notification fields: " + ", ".join(validation_errors))
 
-        deterministic_text = render_notification_text(normalized)
-        final_text, ai_meta = _maybe_polish_notification_text(normalized, deterministic_text)
-        normalized["rendered_text"] = final_text
+		deterministic_text = render_notification_text(normalized)
+		final_text, ai_meta = _maybe_polish_notification_text(normalized, deterministic_text)
+		normalized["rendered_text"] = final_text
 
-        if dry_run:
-            return {
-                "success": True,
-                "sent": False,
-                "skipped": False,
-                "dry_run": True,
-                "family": normalized["family"],
-                "target_space": normalized["requested_space"],
-                "rendered_text": final_text,
-                "ai_meta": ai_meta,
-                "source_ref": normalized["source_ref"],
-                "dedup_key": normalized["dedup_key"],
-            }
+		if dry_run:
+			return {
+				"success": True,
+				"sent": False,
+				"skipped": False,
+				"dry_run": True,
+				"family": normalized["family"],
+				"target_space": normalized["requested_space"],
+				"rendered_text": final_text,
+				"ai_meta": ai_meta,
+				"source_ref": normalized["source_ref"],
+				"dedup_key": normalized["dedup_key"],
+			}
 
-        if _notification_dedup_hit(normalized):
-            logger.info(
-                "Notification dedup hit family=%s source_ref=%s",
-                normalized["family"],
-                normalized["source_ref"],
-            )
-            return {
-                "success": True,
-                "sent": False,
-                "skipped": True,
-                "reason": "dedup_window_active",
-                "family": normalized["family"],
-                "target_space": normalized["requested_space"],
-                "dedup_key": normalized["dedup_key"],
-            }
+		if _notification_dedup_hit(normalized):
+			logger.info(
+				"Notification dedup hit family=%s source_ref=%s",
+				normalized["family"],
+				normalized["source_ref"],
+			)
+			return {
+				"success": True,
+				"sent": False,
+				"skipped": True,
+				"reason": "dedup_window_active",
+				"family": normalized["family"],
+				"target_space": normalized["requested_space"],
+				"dedup_key": normalized["dedup_key"],
+			}
 
-        send_result = _send_message_to_space_internal(
-            str(normalized["requested_space"]),
-            final_text,
-            family=str(normalized["family"]),
-            context="hrms.api.google_chat.send_notification_event",
-        )
-        if send_result.get("success"):
-            _mark_notification_delivered(normalized)
-        return {
-            "success": bool(send_result.get("success")),
-            "sent": bool(send_result.get("sent")),
-            "skipped": False,
-            "family": normalized["family"],
-            "target_space": send_result.get("target_space", normalized["requested_space"]),
-            "message_id": send_result.get("message_id"),
-            "rendered_text": final_text,
-            "ai_meta": ai_meta,
-            "source_ref": normalized["source_ref"],
-            "dedup_key": normalized["dedup_key"],
-        }
-    except Exception as exc:
-        logger.error("send_notification_event failed: %s", exc)
-        frappe.log_error(
-            title="Structured Notification Error",
-            message=f"error={str(exc)[:500]} event={str(event)[:1000]}",
-        )
-        return {"success": False, "sent": False, "skipped": False, "error": str(exc)}
+		send_result = _send_message_to_space_internal(
+			str(normalized["requested_space"]),
+			final_text,
+			family=str(normalized["family"]),
+			context="hrms.api.google_chat.send_notification_event",
+		)
+		if send_result.get("success"):
+			_mark_notification_delivered(normalized)
+		return {
+			"success": bool(send_result.get("success")),
+			"sent": bool(send_result.get("sent")),
+			"skipped": False,
+			"family": normalized["family"],
+			"target_space": send_result.get("target_space", normalized["requested_space"]),
+			"message_id": send_result.get("message_id"),
+			"rendered_text": final_text,
+			"ai_meta": ai_meta,
+			"source_ref": normalized["source_ref"],
+			"dedup_key": normalized["dedup_key"],
+		}
+	except Exception as exc:
+		logger.error("send_notification_event failed: %s", exc)
+		frappe.log_error(
+			title="Structured Notification Error",
+			message=f"error={str(exc)[:500]} event={str(event)[:1000]}",
+		)
+		return {"success": False, "sent": False, "skipped": False, "error": str(exc)}
 
 
 def send_notification_event(event: dict[str, object]) -> bool:
-    """Canonical structured sender for Sprint 38 migrated families."""
-    result = _deliver_notification_event(event)
-    return bool(result.get("success"))
+	"""Canonical structured sender for Sprint 38 migrated families."""
+	result = _deliver_notification_event(event)
+	return bool(result.get("success"))
 
 
 @frappe.whitelist()
 def ingest_notification_event(event: dict[str, object] | str | None = None, dry_run: bool = False, **kwargs):
-    """Whitelisted structured ingest endpoint for standalone services."""
-    dry_run_flag = dry_run if isinstance(dry_run, bool) else _truthy(dry_run)
-    return _deliver_notification_event(event, dry_run=dry_run_flag, **kwargs)
+	"""Whitelisted structured ingest endpoint for standalone services."""
+	dry_run_flag = dry_run if isinstance(dry_run, bool) else _truthy(dry_run)
+	return _deliver_notification_event(event, dry_run=dry_run_flag, **kwargs)
 
 
 @frappe.whitelist()
 def get_user_chat_spaces():
-    """
-    Fetch Google Chat spaces the current user has access to.
-    
-    Returns:
-        dict: {
-            "success": True/False,
-            "spaces": [{"name": "spaces/xxx", "displayName": "Team Chat", "type": "SPACE"}],
-            "error": "error message if failed",
-            "needs_auth": True if user needs to re-authenticate
-        }
-    """
-    user = frappe.session.user
-    
-    if user == "Guest":
-        return {"success": False, "error": "Not authenticated", "needs_auth": True}
-    
-    # Check if user has connected their Google account
-    if not has_valid_token(user):
-        return {
-            "success": False,
-            "error": "Google account not connected",
-            "needs_auth": True
-        }
-    
-    try:
-        access_token = get_valid_access_token(user)
-    except frappe.AuthenticationError as e:
-        return {"success": False, "error": str(e), "needs_auth": True}
-    except Exception as e:
-        frappe.log_error(
-            title="Google Chat Token Error",
-            message=f"User: {user}, Error: {str(e)}"
-        )
-        return {"success": False, "error": "Failed to get access token"}
-    
-    try:
-        response = requests.get(
-            "https://chat.googleapis.com/v1/spaces",
-            headers={"Authorization": f"Bearer {access_token}"},
-            params={"pageSize": 100},
-            timeout=30
-        )
-        
-        if response.status_code == 401:
-            # Token might be expired/invalid due to clock skew or revocation.
-            # Try a forced refresh once before asking the user to reconnect.
-            try:
-                refreshed = force_refresh_access_token(user)
-                response = requests.get(
-                    "https://chat.googleapis.com/v1/spaces",
-                    headers={"Authorization": f"Bearer {refreshed}"},
-                    params={"pageSize": 100},
-                    timeout=30,
-                )
-            except frappe.AuthenticationError as e:
-                return {"success": False, "error": str(e), "needs_auth": True}
+	"""
+	Fetch Google Chat spaces the current user has access to.
 
-            if response.status_code == 401:
-                # Token was refreshed but still rejected - user may have revoked access
-                return {
-                    "success": False,
-                    "error": "Google access was revoked. Please reconnect your account.",
-                    "needs_auth": True,
-                }
-        
-        if response.status_code == 403:
-            # User hasn't granted chat.spaces.readonly scope
-            return {
-                "success": False,
-                "error": "Google Chat permission not granted. Please reconnect your account.",
-                "needs_auth": True
-            }
-        
-        if response.status_code != 200:
-            frappe.log_error(
-                title="Google Chat API Error",
-                message=f"User: {user}, Status: {response.status_code}, Body: {response.text[:500]}"
-            )
-            return {"success": False, "error": "Failed to fetch spaces from Google"}
-        
-        data = response.json()
+	Returns:
+	    dict: {
+	        "success": True/False,
+	        "spaces": [{"name": "spaces/xxx", "displayName": "Team Chat", "type": "SPACE"}],
+	        "error": "error message if failed",
+	        "needs_auth": True if user needs to re-authenticate
+	    }
+	"""
+	user = frappe.session.user
 
-        raw_spaces = data.get("spaces", []) or []
-        _agent_log(
-            "H1",
-            "hrms/api/google_chat.py:get_user_chat_spaces",
-            "Fetched spaces.list",
-            {
-                "count": len(raw_spaces),
-                "types": sorted(list({(s.get('spaceType') or 'UNKNOWN') for s in raw_spaces}))[:10],
-            },
-        )
+	if user == "Guest":
+		return {"success": False, "error": "Not authenticated", "needs_auth": True}
 
-        spaces_out = []
-        for s in raw_spaces:
-            space_name = s.get("name") or ""
-            space_type = s.get("spaceType", "SPACE")
-            display_name = (s.get("displayName") or "").strip()
-            fallback = display_name or _space_id_suffix(space_name) or "Unnamed"
+	# Check if user has connected their Google account
+	if not has_valid_token(user):
+		return {"success": False, "error": "Google account not connected", "needs_auth": True}
 
-            # Pragmatic product decision (runtime evidence):
-            # Listing membership for DMs / unnamed group chats is not reliable in this environment
-            # (404/400 errors), and Google often does not provide enough data to derive a label.
-            #
-            # To avoid showing users opaque IDs like "AAQA...", we filter:
-            # - ALL DIRECT_MESSAGE spaces
-            # - GROUP_CHAT spaces whose displayName looks like an ID or is missing
-            if space_type == "DIRECT_MESSAGE":
-                continue
-            if space_type == "GROUP_CHAT" and _needs_membership_label(s):
-                continue
+	try:
+		access_token = get_valid_access_token(user)
+	except frappe.AuthenticationError as e:
+		return {"success": False, "error": str(e), "needs_auth": True}
+	except Exception as e:
+		frappe.log_error(title="Google Chat Token Error", message=f"User: {user}, Error: {e!s}")
+		return {"success": False, "error": "Failed to get access token"}
 
-            # For regular SPACE entries (and named group chats), attempt enrichment only if needed.
-            if _needs_membership_label(s):
-                try:
-                    memberships = _fetch_space_memberships(access_token, space_name)
-                    display_name = _derive_space_label(space_type, memberships, fallback)
-                    _agent_log(
-                        "H1",
-                        "hrms/api/google_chat.py:get_user_chat_spaces",
-                        "Enriched space label via memberships",
-                        {
-                            "spaceType": space_type,
-                            "spaceId": _space_id_suffix(space_name),
-                            "membershipCount": len(memberships),
-                        },
-                    )
-                except requests.HTTPError as e:
-                    # If scope missing, force reconnect with upgraded scopes
-                    msg = str(e)
-                    _agent_log(
-                        "H2",
-                        "hrms/api/google_chat.py:get_user_chat_spaces",
-                        "Membership enrichment failed",
-                        {"spaceType": space_type, "spaceId": _space_id_suffix(space_name), "error": msg[:120]},
-                    )
-                    if " 403 " in msg or msg.startswith("memberships.list failed: 403"):
-                        # Return a clear reconnect signal so UI prompts consent again.
-                        return {
-                            "success": False,
-                            "error": "Google Chat membership permission not granted. Please reconnect your account.",
-                            "needs_auth": True,
-                        }
-                    # Surface evidence in server logs for non-403 failures (do not log member names/emails).
-                    frappe.log_error(
-                        title="Google Chat Memberships Error",
-                        message=(
-                            f"User: {user}, spaceType={space_type}, "
-                            f"spaceId={_space_id_suffix(space_name)}, err={msg[:200]}"
-                        ),
-                    )
-                    display_name = fallback
-                except Exception as e:
-                    _agent_log(
-                        "H2",
-                        "hrms/api/google_chat.py:get_user_chat_spaces",
-                        "Membership enrichment unexpected error",
-                        {"spaceType": space_type, "spaceId": _space_id_suffix(space_name)},
-                    )
-                    frappe.log_error(
-                        title="Google Chat Memberships Unexpected Error",
-                        message=(
-                            f"User: {user}, spaceType={space_type}, "
-                            f"spaceId={_space_id_suffix(space_name)}, err={str(e)[:200]}"
-                        ),
-                    )
-                    display_name = fallback
-            else:
-                display_name = display_name or fallback
+	try:
+		response = requests.get(
+			"https://chat.googleapis.com/v1/spaces",
+			headers={"Authorization": f"Bearer {access_token}"},
+			params={"pageSize": 100},
+			timeout=30,
+		)
 
-            spaces_out.append(
-                {
-                    "name": space_name,
-                    "displayName": display_name,
-                    "type": space_type,
-                }
-            )
+		if response.status_code == 401:
+			# Token might be expired/invalid due to clock skew or revocation.
+			# Try a forced refresh once before asking the user to reconnect.
+			try:
+				refreshed = force_refresh_access_token(user)
+				response = requests.get(
+					"https://chat.googleapis.com/v1/spaces",
+					headers={"Authorization": f"Bearer {refreshed}"},
+					params={"pageSize": 100},
+					timeout=30,
+				)
+			except frappe.AuthenticationError as e:
+				return {"success": False, "error": str(e), "needs_auth": True}
 
-        return {"success": True, "spaces": spaces_out}
-        
-    except requests.Timeout:
-        frappe.log_error(
-            title="Google Chat Timeout",
-            message=f"User: {user}"
-        )
-        return {"success": False, "error": "Request timed out. Please try again."}
-        
-    except requests.RequestException as e:
-        frappe.log_error(
-            title="Google Chat Request Error",
-            message=f"User: {user}, Error: {str(e)}"
-        )
-        return {"success": False, "error": "Network error while contacting Google"}
+			if response.status_code == 401:
+				# Token was refreshed but still rejected - user may have revoked access
+				return {
+					"success": False,
+					"error": "Google access was revoked. Please reconnect your account.",
+					"needs_auth": True,
+				}
+
+		if response.status_code == 403:
+			# User hasn't granted chat.spaces.readonly scope
+			return {
+				"success": False,
+				"error": "Google Chat permission not granted. Please reconnect your account.",
+				"needs_auth": True,
+			}
+
+		if response.status_code != 200:
+			frappe.log_error(
+				title="Google Chat API Error",
+				message=f"User: {user}, Status: {response.status_code}, Body: {response.text[:500]}",
+			)
+			return {"success": False, "error": "Failed to fetch spaces from Google"}
+
+		data = response.json()
+
+		raw_spaces = data.get("spaces", []) or []
+		_agent_log(
+			"H1",
+			"hrms/api/google_chat.py:get_user_chat_spaces",
+			"Fetched spaces.list",
+			{
+				"count": len(raw_spaces),
+				"types": sorted(list({(s.get("spaceType") or "UNKNOWN") for s in raw_spaces}))[:10],
+			},
+		)
+
+		spaces_out = []
+		for s in raw_spaces:
+			space_name = s.get("name") or ""
+			space_type = s.get("spaceType", "SPACE")
+			display_name = (s.get("displayName") or "").strip()
+			fallback = display_name or _space_id_suffix(space_name) or "Unnamed"
+
+			# Pragmatic product decision (runtime evidence):
+			# Listing membership for DMs / unnamed group chats is not reliable in this environment
+			# (404/400 errors), and Google often does not provide enough data to derive a label.
+			#
+			# To avoid showing users opaque IDs like "AAQA...", we filter:
+			# - ALL DIRECT_MESSAGE spaces
+			# - GROUP_CHAT spaces whose displayName looks like an ID or is missing
+			if space_type == "DIRECT_MESSAGE":
+				continue
+			if space_type == "GROUP_CHAT" and _needs_membership_label(s):
+				continue
+
+			# For regular SPACE entries (and named group chats), attempt enrichment only if needed.
+			if _needs_membership_label(s):
+				try:
+					memberships = _fetch_space_memberships(access_token, space_name)
+					display_name = _derive_space_label(space_type, memberships, fallback)
+					_agent_log(
+						"H1",
+						"hrms/api/google_chat.py:get_user_chat_spaces",
+						"Enriched space label via memberships",
+						{
+							"spaceType": space_type,
+							"spaceId": _space_id_suffix(space_name),
+							"membershipCount": len(memberships),
+						},
+					)
+				except requests.HTTPError as e:
+					# If scope missing, force reconnect with upgraded scopes
+					msg = str(e)
+					_agent_log(
+						"H2",
+						"hrms/api/google_chat.py:get_user_chat_spaces",
+						"Membership enrichment failed",
+						{
+							"spaceType": space_type,
+							"spaceId": _space_id_suffix(space_name),
+							"error": msg[:120],
+						},
+					)
+					if " 403 " in msg or msg.startswith("memberships.list failed: 403"):
+						# Return a clear reconnect signal so UI prompts consent again.
+						return {
+							"success": False,
+							"error": "Google Chat membership permission not granted. Please reconnect your account.",
+							"needs_auth": True,
+						}
+					# Surface evidence in server logs for non-403 failures (do not log member names/emails).
+					frappe.log_error(
+						title="Google Chat Memberships Error",
+						message=(
+							f"User: {user}, spaceType={space_type}, "
+							f"spaceId={_space_id_suffix(space_name)}, err={msg[:200]}"
+						),
+					)
+					display_name = fallback
+				except Exception as e:
+					_agent_log(
+						"H2",
+						"hrms/api/google_chat.py:get_user_chat_spaces",
+						"Membership enrichment unexpected error",
+						{"spaceType": space_type, "spaceId": _space_id_suffix(space_name)},
+					)
+					frappe.log_error(
+						title="Google Chat Memberships Unexpected Error",
+						message=(
+							f"User: {user}, spaceType={space_type}, "
+							f"spaceId={_space_id_suffix(space_name)}, err={str(e)[:200]}"
+						),
+					)
+					display_name = fallback
+			else:
+				display_name = display_name or fallback
+
+			spaces_out.append(
+				{
+					"name": space_name,
+					"displayName": display_name,
+					"type": space_type,
+				}
+			)
+
+		return {"success": True, "spaces": spaces_out}
+
+	except requests.Timeout:
+		frappe.log_error(title="Google Chat Timeout", message=f"User: {user}")
+		return {"success": False, "error": "Request timed out. Please try again."}
+
+	except requests.RequestException as e:
+		frappe.log_error(title="Google Chat Request Error", message=f"User: {user}, Error: {e!s}")
+		return {"success": False, "error": "Network error while contacting Google"}
 
 
 @frappe.whitelist()
 def check_chat_connection():
-    """
-    Check if current user has Google Chat connected.
+	"""
+	Check if current user has Google Chat connected.
 
-    Returns:
-        dict: {"connected": True/False, "user": "email"}
-    """
-    user = frappe.session.user
+	Returns:
+	    dict: {"connected": True/False, "user": "email"}
+	"""
+	user = frappe.session.user
 
-    if user == "Guest":
-        return {"connected": False, "user": None}
+	if user == "Guest":
+		return {"connected": False, "user": None}
 
-    return {
-        "connected": has_valid_token(user),
-        "user": user
-    }
+	return {"connected": has_valid_token(user), "user": user}
 
 
 # ---------------------------------------------------------------------------
 # Doc Event Handlers (wired via hooks.py doc_events)
 # ---------------------------------------------------------------------------
 
+
 def on_approval_queue_insert(doc, method=None):
-    """
-    Notify relevant space when a new BEI Approval Queue item is created.
-    Fires via doc_events: BEI Approval Queue → after_insert.
-    """
-    try:
-        reference_doctype = getattr(doc, "reference_doctype", None) or getattr(doc, "approval_type", None) or "Approval"
-        reference_name = getattr(doc, "reference_name", None) or getattr(doc, "subject", None) or getattr(doc, "name", "Unknown")
-        dashboard_url = (
-            "https://my.bebang.ph/dashboard/store-ops/order-approvals"
-            if reference_doctype == "BEI Store Order"
-            else ""
-        )
-        send_notification_event(
-            {
-                "family": "approval_queue_new",
-                "source_system": "frappe",
-                "source_ref": getattr(doc, "name", None) or reference_name,
-                "severity": "critical" if getattr(doc, "priority", None) == "Urgent" else "high",
-                "owner": getattr(doc, "assigned_approver", None) or "Assigned Approver",
-                "facts": {
-                    "queue_name": getattr(doc, "name", None),
-                    "reference_doctype": reference_doctype,
-                    "reference_name": reference_name,
-                    "store": getattr(doc, "store", None),
-                    "priority": getattr(doc, "priority", None),
-                    "assigned_approver": getattr(doc, "assigned_approver", None),
-                    "dashboard_url": dashboard_url,
-                },
-            }
-        )
-    except Exception as e:
-        frappe.log_error(
-            title="Approval Queue Notification Error",
-            message=f"doc={doc.name}, error={str(e)[:300]}",
-        )
+	"""
+	Notify relevant space when a new BEI Approval Queue item is created.
+	Fires via doc_events: BEI Approval Queue → after_insert.
+	"""
+	try:
+		reference_doctype = (
+			getattr(doc, "reference_doctype", None) or getattr(doc, "approval_type", None) or "Approval"
+		)
+		reference_name = (
+			getattr(doc, "reference_name", None)
+			or getattr(doc, "subject", None)
+			or getattr(doc, "name", "Unknown")
+		)
+		dashboard_url = (
+			"https://my.bebang.ph/dashboard/store-ops/order-approvals"
+			if reference_doctype == "BEI Store Order"
+			else ""
+		)
+		send_notification_event(
+			{
+				"family": "approval_queue_new",
+				"source_system": "frappe",
+				"source_ref": getattr(doc, "name", None) or reference_name,
+				"severity": "critical" if getattr(doc, "priority", None) == "Urgent" else "high",
+				"owner": getattr(doc, "assigned_approver", None) or "Assigned Approver",
+				"facts": {
+					"queue_name": getattr(doc, "name", None),
+					"reference_doctype": reference_doctype,
+					"reference_name": reference_name,
+					"store": getattr(doc, "store", None),
+					"priority": getattr(doc, "priority", None),
+					"assigned_approver": getattr(doc, "assigned_approver", None),
+					"dashboard_url": dashboard_url,
+				},
+			}
+		)
+	except Exception as e:
+		frappe.log_error(
+			title="Approval Queue Notification Error",
+			message=f"doc={doc.name}, error={str(e)[:300]}",
+		)
 
 
 def on_store_order_update(doc, method=None):
-    """
-    Notify store's Google Chat space when a BEI Store Order status changes.
-    Fires via doc_events: BEI Store Order → on_update.
-    Notifies on: Approved, Cancelled.
-    """
-    _NOTIFY_STATUSES = {"Cancelled"}
-    status = getattr(doc, "status", None)
-    if status not in _NOTIFY_STATUSES:
-        return
+	"""
+	Notify store's Google Chat space when a BEI Store Order status changes.
+	Fires via doc_events: BEI Store Order → on_update.
+	Notifies on: Approved, Cancelled.
+	"""
+	_NOTIFY_STATUSES = {"Cancelled"}
+	status = getattr(doc, "status", None)
+	if status not in _NOTIFY_STATUSES:
+		return
 
-    # Only notify on actual status transitions, not re-saves
-    if not doc.is_new() and not doc.has_value_changed("status"):
-        return
+	# Only notify on actual status transitions, not re-saves
+	if not doc.is_new() and not doc.has_value_changed("status"):
+		return
 
-    try:
-        # Prefer per-store space from linked Warehouse, fall back to global setting
-        space = None
-        store_warehouse = getattr(doc, "warehouse", None) or getattr(doc, "store_warehouse", None)
-        if store_warehouse:
-            space = frappe.db.get_value("Warehouse", store_warehouse, "custom_gchat_space")
+	try:
+		# Prefer per-store space from linked Warehouse, fall back to global setting
+		space = None
+		store_warehouse = getattr(doc, "warehouse", None) or getattr(doc, "store_warehouse", None)
+		if store_warehouse:
+			space = frappe.db.get_value("Warehouse", store_warehouse, "custom_gchat_space")
 
-        if not space:
-            from hrms.utils.bei_config import get_chat_space, SPACE_NOTIFICATIONS
-            space = get_chat_space(SPACE_NOTIFICATIONS)
+		if not space:
+			from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
 
-        if status == "Approved":
-            message = f"*Store Order Approved*\n\nOrder *{doc.name}* has been approved and is being prepared."
-        else:
-            reason = getattr(doc, "cancellation_reason", None) or ""
-            reason_text = f"\nReason: {reason}" if reason else ""
-            message = f"*Store Order Cancelled*\n\nOrder *{doc.name}* was cancelled.{reason_text}"
+			space = get_chat_space(SPACE_NOTIFICATIONS)
 
-        send_message_to_space(space, message)
-    except Exception as e:
-        frappe.log_error(
-            title="Store Order Notification Error",
-            message=f"doc={doc.name}, status={status}, error={str(e)[:300]}",
-        )
+		if status == "Approved":
+			message = f"*Store Order Approved*\n\nOrder *{doc.name}* has been approved and is being prepared."
+		else:
+			reason = getattr(doc, "cancellation_reason", None) or ""
+			reason_text = f"\nReason: {reason}" if reason else ""
+			message = f"*Store Order Cancelled*\n\nOrder *{doc.name}* was cancelled.{reason_text}"
+
+		send_message_to_space(space, message)
+	except Exception as e:
+		frappe.log_error(
+			title="Store Order Notification Error",
+			message=f"doc={doc.name}, status={status}, error={str(e)[:300]}",
+		)

--- a/hrms/api/projects.py
+++ b/hrms/api/projects.py
@@ -9,6 +9,7 @@ Handles maintenance request management for the Projects team dashboard at my.beb
 import json
 import math
 import re
+from typing import Any
 
 import frappe
 from frappe import _
@@ -43,18 +44,18 @@ def _normalize_store_identity(value):
 
 @frappe.whitelist()
 def get_maintenance_queue(
-	status=None,
-	priority=None,
-	category=None,
-	store=None,
-	assigned_to=None,
-	date_from=None,
-	date_to=None,
-	search=None,
-	sort_by="request_date",
-	sort_order="desc",
-	page=1,
-	page_size=20,
+	status: Any = None,
+	priority: Any = None,
+	category: Any = None,
+	store: Any = None,
+	assigned_to: Any = None,
+	date_from: Any = None,
+	date_to: Any = None,
+	search: Any = None,
+	sort_by: Any = "request_date",
+	sort_order: Any = "desc",
+	page: Any = 1,
+	page_size: Any = 20,
 ):
 	"""
 	Get maintenance requests for Projects dashboard with full filtering and pagination.
@@ -193,6 +194,7 @@ def get_maintenance_queue(
 	offset = (page - 1) * page_size
 
 	# Get requests with photo count
+	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-sql-format-injection -- where/search fragments are built from allowlisted clauses and values stay parameterized.
 	requests_sql = f"""
         SELECT
             mr.name,
@@ -249,7 +251,7 @@ def get_maintenance_queue(
 
 
 @frappe.whitelist()
-def get_maintenance_request_detail(request_id):
+def get_maintenance_request_detail(request_id: Any):
 	"""
 	Get full detail of a maintenance request including photos, completion, and history.
 
@@ -366,7 +368,12 @@ def get_maintenance_request_detail(request_id):
 
 @frappe.whitelist()
 def assign_maintenance_request(
-	request_id=None, assigned_to=None, vendor=None, scheduled_date=None, estimated_cost=None, notes=None
+	request_id: Any = None,
+	assigned_to: Any = None,
+	vendor: Any = None,
+	scheduled_date: Any = None,
+	estimated_cost: Any = None,
+	notes: Any = None,
 ):
 	"""
 	Assign a maintenance request to internal staff or external vendor.
@@ -453,7 +460,7 @@ def assign_maintenance_request(
 
 
 @frappe.whitelist()
-def update_maintenance_status(request_id=None, status=None, notes=None):
+def update_maintenance_status(request_id: Any = None, status: Any = None, notes: Any = None):
 	"""
 	Update maintenance request status.
 
@@ -555,15 +562,15 @@ def update_maintenance_status(request_id=None, status=None, notes=None):
 
 @frappe.whitelist()
 def record_maintenance_completion(
-	request_id=None,
-	completion_date=None,
-	technician_name=None,
-	work_description=None,
-	resolution_status=None,
-	actual_cost=None,
-	follow_up_needed=False,
-	follow_up_notes=None,
-	after_photos=None,
+	request_id: Any = None,
+	completion_date: Any = None,
+	technician_name: Any = None,
+	work_description: Any = None,
+	resolution_status: Any = None,
+	actual_cost: Any = None,
+	follow_up_needed: Any = False,
+	follow_up_notes: Any = None,
+	after_photos: Any = None,
 ):
 	"""
 	Record completion of maintenance work.
@@ -741,7 +748,7 @@ def record_maintenance_completion(
 
 
 @frappe.whitelist()
-def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
+def get_maintenance_dashboard_stats(date_from: Any = None, date_to: Any = None, store: Any = None):
 	"""
 	Get aggregated stats for Projects dashboard.
 
@@ -786,6 +793,7 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
 	where_clause = " AND " + " AND ".join(conditions) if conditions else ""
 
 	# Get status counts
+	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-sql-format-injection -- where_clause is assembled from fixed predicates and bound params only.
 	status_counts = frappe.db.sql(
 		f"""
         SELECT
@@ -823,6 +831,7 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
 	urgent_count = frappe.db.sql(urgent_sql, values, as_dict=True)[0].count
 
 	# Get counts by category
+	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-sql-format-injection -- where_clause is assembled from fixed predicates and bound params only.
 	category_sql = f"""
         SELECT
             issue_category,
@@ -836,6 +845,7 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
 	by_category = {row.issue_category: row.count for row in category_counts}
 
 	# Get counts by store
+	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-sql-format-injection -- where_clause is assembled from fixed predicates and bound params only.
 	store_sql = f"""
         SELECT
             store_code,
@@ -849,6 +859,7 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
 	by_store = {row.store_code: row.count for row in store_counts}
 
 	# Calculate average resolution time (for completed/verified requests)
+	# nosemgrep: frappe-semgrep-rules.rules.security.frappe-sql-format-injection -- where_clause is assembled from fixed predicates and bound params only.
 	resolution_sql = f"""
         SELECT
             AVG(DATEDIFF(mr.resolved_date, mr.request_date)) as avg_days
@@ -900,7 +911,9 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
 
 
 @frappe.whitelist()
-def export_maintenance_requests(status=None, date_from=None, date_to=None, store=None, format="xlsx"):
+def export_maintenance_requests(
+	status: Any = None, date_from: Any = None, date_to: Any = None, store: Any = None, format: Any = "xlsx"
+):
 	"""
 	Export maintenance requests to Excel file.
 
@@ -1054,7 +1067,7 @@ def get_stores_list():
 
 
 @frappe.whitelist()
-def assess_maintenance_request(request_id, concern_type, notes=None):
+def assess_maintenance_request(request_id: Any, concern_type: Any, notes: Any = None):
 	"""
 	Technician assesses the request and sets concern type.
 
@@ -1099,7 +1112,7 @@ def assess_maintenance_request(request_id, concern_type, notes=None):
 
 
 @frappe.whitelist()
-def set_maintenance_charge(request_id, charge_amount, charging_reason):
+def set_maintenance_charge(request_id: Any, charge_amount: Any, charging_reason: Any):
 	"""
 	Set a charge to store for a maintenance request.
 
@@ -1185,7 +1198,7 @@ def _notify_maintenance_charge_pending_ack(doc):
 
 
 @frappe.whitelist()
-def acknowledge_maintenance_charge(request_id):
+def acknowledge_maintenance_charge(request_id: Any):
 	"""
 	Store supervisor acknowledges charge to store.
 
@@ -1253,7 +1266,7 @@ def acknowledge_maintenance_charge(request_id):
 
 
 @frappe.whitelist()
-def get_pending_charges(store=None, page=1, page_size=20):
+def get_pending_charges(store: Any = None, page: Any = 1, page_size: Any = 20):
 	"""
 	Get maintenance requests with pending store charges.
 
@@ -1328,7 +1341,7 @@ def get_pending_charges(store=None, page=1, page_size=20):
 
 
 @frappe.whitelist()
-def add_maintenance_materials(request_id, materials):
+def add_maintenance_materials(request_id: Any, materials: Any):
 	"""
 	Add materials to a maintenance request.
 
@@ -1399,7 +1412,9 @@ def add_maintenance_materials(request_id, materials):
 
 
 @frappe.whitelist()
-def update_maintenance_costs(request_id, labor_hours=None, labor_cost=None, vendor_cost=None):
+def update_maintenance_costs(
+	request_id: Any, labor_hours: Any = None, labor_cost: Any = None, vendor_cost: Any = None
+):
 	"""
 	Update labor costs for a maintenance request.
 
@@ -1560,7 +1575,7 @@ def get_project_dashboard():
 
 
 @frappe.whitelist()
-def get_project_detail(project):
+def get_project_detail(project: Any):
 	"""
 	Get full project detail with related documents.
 
@@ -1677,7 +1692,7 @@ def get_project_detail(project):
 
 
 @frappe.whitelist()
-def advance_project_stage(project, new_stage, notes=None):
+def advance_project_stage(project: Any, new_stage: Any, notes: Any = None):
 	"""
 	Move project to a new stage.
 
@@ -1738,7 +1753,7 @@ def advance_project_stage(project, new_stage, notes=None):
 
 
 @frappe.whitelist()
-def update_project_progress(project, progress_percent, notes=None):
+def update_project_progress(project: Any, progress_percent: Any, notes: Any = None):
 	"""
 	Update project progress percentage.
 
@@ -1782,7 +1797,7 @@ def update_project_progress(project, progress_percent, notes=None):
 
 
 @frappe.whitelist()
-def submit_site_inspection(inspection_id):
+def submit_site_inspection(inspection_id: Any):
 	"""
 	Submit a site inspection for approval.
 
@@ -1816,7 +1831,7 @@ def submit_site_inspection(inspection_id):
 
 
 @frappe.whitelist()
-def approve_site_inspection(inspection_id, approval_notes=None):
+def approve_site_inspection(inspection_id: Any, approval_notes: Any = None):
 	"""
 	Approve a submitted site inspection.
 
@@ -1855,7 +1870,7 @@ def approve_site_inspection(inspection_id, approval_notes=None):
 
 
 @frappe.whitelist()
-def reject_site_inspection(inspection_id, rejection_reason):
+def reject_site_inspection(inspection_id: Any, rejection_reason: Any):
 	"""
 	Reject a submitted site inspection.
 
@@ -1897,7 +1912,7 @@ def reject_site_inspection(inspection_id, rejection_reason):
 
 
 @frappe.whitelist()
-def get_bid_comparison(project):
+def get_bid_comparison(project: Any):
 	"""
 	Get bid comparison for a project.
 
@@ -1957,7 +1972,7 @@ def get_bid_comparison(project):
 
 
 @frappe.whitelist()
-def evaluate_bid(bid_id, technical_score, financial_score, evaluation_notes=None):
+def evaluate_bid(bid_id: Any, technical_score: Any, financial_score: Any, evaluation_notes: Any = None):
 	"""
 	Evaluate a project bid.
 
@@ -2001,7 +2016,7 @@ def evaluate_bid(bid_id, technical_score, financial_score, evaluation_notes=None
 
 
 @frappe.whitelist()
-def award_bid(bid_id, final_amount=None, award_notes=None):
+def award_bid(bid_id: Any, final_amount: Any = None, award_notes: Any = None):
 	"""
 	Award a bid to a contractor.
 
@@ -2073,7 +2088,7 @@ def award_bid(bid_id, final_amount=None, award_notes=None):
 
 
 @frappe.whitelist()
-def complete_milestone(milestone_id, actual_date=None, notes=None):
+def complete_milestone(milestone_id: Any, actual_date: Any = None, notes: Any = None):
 	"""
 	Mark a milestone as completed.
 
@@ -2113,7 +2128,7 @@ def complete_milestone(milestone_id, actual_date=None, notes=None):
 
 
 @frappe.whitelist()
-def verify_milestone(milestone_id, verification_notes=None):
+def verify_milestone(milestone_id: Any, verification_notes: Any = None):
 	"""
 	Verify a completed milestone.
 
@@ -2153,7 +2168,7 @@ def verify_milestone(milestone_id, verification_notes=None):
 
 
 @frappe.whitelist()
-def create_milestone_billing(milestone_id):
+def create_milestone_billing(milestone_id: Any):
 	"""
 	Create a payment request for a verified milestone.
 
@@ -2224,7 +2239,14 @@ def _update_project_progress_from_milestones(project_name):
 
 
 @frappe.whitelist()
-def get_punchlist(project, status=None, category=None, severity=None, page=1, page_size=50):
+def get_punchlist(
+	project: Any,
+	status: Any = None,
+	category: Any = None,
+	severity: Any = None,
+	page: Any = 1,
+	page_size: Any = 50,
+):
 	"""
 	Get punchlist items for a project.
 
@@ -2300,15 +2322,15 @@ def get_punchlist(project, status=None, category=None, severity=None, page=1, pa
 
 @frappe.whitelist()
 def add_punchlist_item(
-	project,
-	category,
-	location,
-	description,
-	severity="Minor",
-	photo=None,
-	assigned_to=None,
-	contractor=None,
-	due_date=None,
+	project: Any,
+	category: Any,
+	location: Any,
+	description: Any,
+	severity: Any = "Minor",
+	photo: Any = None,
+	assigned_to: Any = None,
+	contractor: Any = None,
+	due_date: Any = None,
 ):
 	"""
 	Add a punchlist item to a project.
@@ -2365,7 +2387,7 @@ def add_punchlist_item(
 
 
 @frappe.whitelist()
-def resolve_punchlist_item(item_id, resolution_notes, after_photo=None):
+def resolve_punchlist_item(item_id: Any, resolution_notes: Any, after_photo: Any = None):
 	"""
 	Mark a punchlist item as resolved.
 
@@ -2409,7 +2431,7 @@ def resolve_punchlist_item(item_id, resolution_notes, after_photo=None):
 
 
 @frappe.whitelist()
-def close_punchlist_item(item_id):
+def close_punchlist_item(item_id: Any):
 	"""
 	Close a resolved punchlist item after verification.
 
@@ -2440,7 +2462,7 @@ def close_punchlist_item(item_id):
 
 
 @frappe.whitelist()
-def waive_punchlist_item(item_id, reason):
+def waive_punchlist_item(item_id: Any, reason: Any):
 	"""
 	Waive a punchlist item (accept as-is).
 
@@ -2480,7 +2502,7 @@ def waive_punchlist_item(item_id, reason):
 
 
 @frappe.whitelist()
-def get_permit_checklist(project):
+def get_permit_checklist(project: Any):
 	"""
 	Get permit status checklist for a project.
 
@@ -2548,7 +2570,12 @@ def get_permit_checklist(project):
 
 @frappe.whitelist()
 def update_permit_status(
-	permit_id, status, permit_number=None, approval_date=None, expiry_date=None, remarks=None
+	permit_id: Any,
+	status: Any,
+	permit_number: Any = None,
+	approval_date: Any = None,
+	expiry_date: Any = None,
+	remarks: Any = None,
 ):
 	"""
 	Update permit status and details.

--- a/hrms/api/projects.py
+++ b/hrms/api/projects.py
@@ -12,7 +12,7 @@ import re
 
 import frappe
 from frappe import _
-from frappe.utils import nowdate, now_datetime, getdate, date_diff, flt, sbool
+from frappe.utils import date_diff, flt, getdate, now_datetime, nowdate, sbool
 
 # RBAC AUDIT 2026-02-20: All endpoints reviewed. See G-031 in sprint-04-maintenance.md.
 # Maintenance endpoints: MAINTENANCE_STAFF_ROLES for write, authenticated-only for read
@@ -29,11 +29,11 @@ from frappe.utils import nowdate, now_datetime, getdate, date_diff, flt, sbool
 
 
 def _normalize_store_identity(value):
-    text = str(value or "").strip()
-    if not text:
-        return ""
-    text = re.sub(r"\s*-\s*(BEI|Bebang Enterprise Inc\.?)\s*$", "", text, flags=re.IGNORECASE)
-    return re.sub(r"[^A-Z0-9]", "", text.upper())
+	text = str(value or "").strip()
+	if not text:
+		return ""
+	text = re.sub(r"\s*-\s*(BEI|Bebang Enterprise Inc\.?)\s*$", "", text, flags=re.IGNORECASE)
+	return re.sub(r"[^A-Z0-9]", "", text.upper())
 
 
 # ==============================================================================
@@ -43,152 +43,157 @@ def _normalize_store_identity(value):
 
 @frappe.whitelist()
 def get_maintenance_queue(
-    status=None,
-    priority=None,
-    category=None,
-    store=None,
-    assigned_to=None,
-    date_from=None,
-    date_to=None,
-    search=None,
-    sort_by="request_date",
-    sort_order="desc",
-    page=1,
-    page_size=20
+	status=None,
+	priority=None,
+	category=None,
+	store=None,
+	assigned_to=None,
+	date_from=None,
+	date_to=None,
+	search=None,
+	sort_by="request_date",
+	sort_order="desc",
+	page=1,
+	page_size=20,
 ):
-    """
-    Get maintenance requests for Projects dashboard with full filtering and pagination.
+	"""
+	Get maintenance requests for Projects dashboard with full filtering and pagination.
 
-    Args:
-        status: Filter by status (Open, Assigned, In Progress, Completed, Verified, Cancelled)
-        priority: Filter by priority (Urgent, High, Normal)
-        category: Filter by issue_category (Electrical, Plumbing, etc.)
-        store: Filter by specific store (warehouse name)
-        assigned_to: Filter by assignee (User)
-        date_from: Filter by request_date >= date_from
-        date_to: Filter by request_date <= date_to
-        search: Search in description, store_code
-        sort_by: Field to sort by (default: request_date)
-        sort_order: Sort direction (asc/desc, default: desc)
-        page: Page number (default: 1)
-        page_size: Items per page (default: 20)
+	Args:
+	    status: Filter by status (Open, Assigned, In Progress, Completed, Verified, Cancelled)
+	    priority: Filter by priority (Urgent, High, Normal)
+	    category: Filter by issue_category (Electrical, Plumbing, etc.)
+	    store: Filter by specific store (warehouse name)
+	    assigned_to: Filter by assignee (User)
+	    date_from: Filter by request_date >= date_from
+	    date_to: Filter by request_date <= date_to
+	    search: Search in description, store_code
+	    sort_by: Field to sort by (default: request_date)
+	    sort_order: Sort direction (asc/desc, default: desc)
+	    page: Page number (default: 1)
+	    page_size: Items per page (default: 20)
 
-    Returns:
-        {
-            "requests": [...],
-            "total": int,
-            "page": int,
-            "page_size": int,
-            "pages": int
-        }
-    """
-    # Auth guard: reject unauthenticated requests
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {
+	        "requests": [...],
+	        "total": int,
+	        "page": int,
+	        "page_size": int,
+	        "pages": int
+	    }
+	"""
+	# Auth guard: reject unauthenticated requests
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    # Build filters
-    filters = []
+	# Build filters
+	filters = []
 
-    if status:
-        if isinstance(status, str):
-            if "," in status:
-                # Support comma-separated values
-                filters.append(["status", "in", [s.strip() for s in status.split(",")]])
-            else:
-                filters.append(["status", "=", status])
-        elif isinstance(status, list):
-            filters.append(["status", "in", status])
+	if status:
+		if isinstance(status, str):
+			if "," in status:
+				# Support comma-separated values
+				filters.append(["status", "in", [s.strip() for s in status.split(",")]])
+			else:
+				filters.append(["status", "=", status])
+		elif isinstance(status, list):
+			filters.append(["status", "in", status])
 
-    if priority:
-        if isinstance(priority, str):
-            if "," in priority:
-                filters.append(["priority", "in", [p.strip() for p in priority.split(",")]])
-            else:
-                filters.append(["priority", "=", priority])
-        elif isinstance(priority, list):
-            filters.append(["priority", "in", priority])
+	if priority:
+		if isinstance(priority, str):
+			if "," in priority:
+				filters.append(["priority", "in", [p.strip() for p in priority.split(",")]])
+			else:
+				filters.append(["priority", "=", priority])
+		elif isinstance(priority, list):
+			filters.append(["priority", "in", priority])
 
-    if category:
-        if isinstance(category, str):
-            if "," in category:
-                filters.append(["issue_category", "in", [c.strip() for c in category.split(",")]])
-            else:
-                filters.append(["issue_category", "=", category])
-        elif isinstance(category, list):
-            filters.append(["issue_category", "in", category])
+	if category:
+		if isinstance(category, str):
+			if "," in category:
+				filters.append(["issue_category", "in", [c.strip() for c in category.split(",")]])
+			else:
+				filters.append(["issue_category", "=", category])
+		elif isinstance(category, list):
+			filters.append(["issue_category", "in", category])
 
-    if store:
-        filters.append(["store", "=", store])
+	if store:
+		filters.append(["store", "=", store])
 
-    if assigned_to:
-        filters.append(["assigned_to", "=", assigned_to])
+	if assigned_to:
+		filters.append(["assigned_to", "=", assigned_to])
 
-    if date_from:
-        filters.append(["request_date", ">=", date_from])
+	if date_from:
+		filters.append(["request_date", ">=", date_from])
 
-    if date_to:
-        filters.append(["request_date", "<=", date_to])
+	if date_to:
+		filters.append(["request_date", "<=", date_to])
 
-    # Convert page params to int
-    page = int(page)
-    page_size = int(page_size)
+	# Convert page params to int
+	page = int(page)
+	page_size = int(page_size)
 
-    # Validate sort_by to prevent SQL injection
-    allowed_sort_fields = [
-        "request_date", "priority", "status", "issue_category",
-        "store_code", "creation", "modified"
-    ]
-    if sort_by not in allowed_sort_fields:
-        sort_by = "request_date"
+	# Validate sort_by to prevent SQL injection
+	allowed_sort_fields = [
+		"request_date",
+		"priority",
+		"status",
+		"issue_category",
+		"store_code",
+		"creation",
+		"modified",
+	]
+	if sort_by not in allowed_sort_fields:
+		sort_by = "request_date"
 
-    if sort_order.lower() not in ["asc", "desc"]:
-        sort_order = "desc"
+	if sort_order.lower() not in ["asc", "desc"]:
+		sort_order = "desc"
 
-    # Build search condition
-    search_condition = ""
-    if search:
-        search = f"%{search}%"
-        search_condition = f" AND (mr.description LIKE %(search)s OR mr.store_code LIKE %(search)s OR mr.name LIKE %(search)s)"
+	# Build search condition
+	search_condition = ""
+	if search:
+		search = f"%{search}%"
+		search_condition = " AND (mr.description LIKE %(search)s OR mr.store_code LIKE %(search)s OR mr.name LIKE %(search)s)"
 
-    # Build filter conditions
-    filter_conditions = []
-    filter_values = {"search": search} if search else {}
+	# Build filter conditions
+	filter_conditions = []
+	filter_values = {"search": search} if search else {}
 
-    for i, f in enumerate(filters):
-        field, op, value = f
-        if op == "=":
-            filter_conditions.append(f"mr.{field} = %(filter_{i})s")
-            filter_values[f"filter_{i}"] = value
-        elif op == "in":
-            placeholders = ", ".join([f"%(filter_{i}_{j})s" for j in range(len(value))])
-            filter_conditions.append(f"mr.{field} IN ({placeholders})")
-            for j, v in enumerate(value):
-                filter_values[f"filter_{i}_{j}"] = v
-        elif op == ">=":
-            filter_conditions.append(f"mr.{field} >= %(filter_{i})s")
-            filter_values[f"filter_{i}"] = value
-        elif op == "<=":
-            filter_conditions.append(f"mr.{field} <= %(filter_{i})s")
-            filter_values[f"filter_{i}"] = value
+	for i, f in enumerate(filters):
+		field, op, value = f
+		if op == "=":
+			filter_conditions.append(f"mr.{field} = %(filter_{i})s")
+			filter_values[f"filter_{i}"] = value
+		elif op == "in":
+			placeholders = ", ".join([f"%(filter_{i}_{j})s" for j in range(len(value))])
+			filter_conditions.append(f"mr.{field} IN ({placeholders})")
+			for j, v in enumerate(value):
+				filter_values[f"filter_{i}_{j}"] = v
+		elif op == ">=":
+			filter_conditions.append(f"mr.{field} >= %(filter_{i})s")
+			filter_values[f"filter_{i}"] = value
+		elif op == "<=":
+			filter_conditions.append(f"mr.{field} <= %(filter_{i})s")
+			filter_values[f"filter_{i}"] = value
 
-    where_clause = ""
-    if filter_conditions:
-        where_clause = " AND " + " AND ".join(filter_conditions)
+	where_clause = ""
+	if filter_conditions:
+		where_clause = " AND " + " AND ".join(filter_conditions)
 
-    # Get total count
-    count_sql = f"""
+	# Get total count
+	count_sql = f"""
         SELECT COUNT(*) as total
         FROM `tabBEI Maintenance Request` mr
         WHERE 1=1 {where_clause} {search_condition}
     """
-    total = frappe.db.sql(count_sql, filter_values, as_dict=True)[0].total
+	total = frappe.db.sql(count_sql, filter_values, as_dict=True)[0].total
 
-    # Calculate pagination
-    pages = math.ceil(total / page_size) if total > 0 else 1
-    offset = (page - 1) * page_size
+	# Calculate pagination
+	pages = math.ceil(total / page_size) if total > 0 else 1
+	offset = (page - 1) * page_size
 
-    # Get requests with photo count
-    requests_sql = f"""
+	# Get requests with photo count
+	requests_sql = f"""
         SELECT
             mr.name,
             mr.store,
@@ -222,22 +227,20 @@ def get_maintenance_queue(
         LIMIT {page_size} OFFSET {offset}
     """
 
-    requests = frappe.db.sql(requests_sql, filter_values, as_dict=True)
+	requests = frappe.db.sql(requests_sql, filter_values, as_dict=True)
 
-    # Get reporter names
-    for req in requests:
-        if req.reported_by:
-            req["reporter_name"] = frappe.db.get_value("User", req.reported_by, "full_name") or req.reported_by
-        if req.assigned_to:
-            req["assignee_name"] = frappe.db.get_value("User", req.assigned_to, "full_name") or req.assigned_to
+	# Get reporter names
+	for req in requests:
+		if req.reported_by:
+			req["reporter_name"] = (
+				frappe.db.get_value("User", req.reported_by, "full_name") or req.reported_by
+			)
+		if req.assigned_to:
+			req["assignee_name"] = (
+				frappe.db.get_value("User", req.assigned_to, "full_name") or req.assigned_to
+			)
 
-    return {
-        "requests": requests,
-        "total": total,
-        "page": page,
-        "page_size": page_size,
-        "pages": pages
-    }
+	return {"requests": requests, "total": total, "page": page, "page_size": page_size, "pages": pages}
 
 
 # ==============================================================================
@@ -247,113 +250,113 @@ def get_maintenance_queue(
 
 @frappe.whitelist()
 def get_maintenance_request_detail(request_id):
-    """
-    Get full detail of a maintenance request including photos, completion, and history.
+	"""
+	Get full detail of a maintenance request including photos, completion, and history.
 
-    Args:
-        request_id: The maintenance request name (e.g., MR-BGC-0058)
+	Args:
+	    request_id: The maintenance request name (e.g., MR-BGC-0058)
 
-    Returns:
-        {
-            "request": {...},
-            "photos": [...],
-            "completion": {...} or None,
-            "history": [...] (status changes)
-        }
-    """
-    # Auth guard: reject unauthenticated requests
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {
+	        "request": {...},
+	        "photos": [...],
+	        "completion": {...} or None,
+	        "history": [...] (status changes)
+	    }
+	"""
+	# Auth guard: reject unauthenticated requests
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    if not request_id:
-        frappe.throw(_("Request ID is required"))
+	if not request_id:
+		frappe.throw(_("Request ID is required"))
 
-    if not frappe.db.exists("BEI Maintenance Request", request_id):
-        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+	if not frappe.db.exists("BEI Maintenance Request", request_id):
+		frappe.throw(_("Maintenance request {0} not found").format(request_id))
 
-    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+	doc = frappe.get_doc("BEI Maintenance Request", request_id)
 
-    # Get request data
-    request_data = doc.as_dict()
+	# Get request data
+	request_data = doc.as_dict()
 
-    # Add computed fields
-    request_data["age_days"] = date_diff(nowdate(), doc.request_date) if doc.request_date else 0
+	# Add computed fields
+	request_data["age_days"] = date_diff(nowdate(), doc.request_date) if doc.request_date else 0
 
-    # Get reporter name
-    if doc.reported_by:
-        request_data["reporter_name"] = frappe.db.get_value("User", doc.reported_by, "full_name") or doc.reported_by
+	# Get reporter name
+	if doc.reported_by:
+		request_data["reporter_name"] = (
+			frappe.db.get_value("User", doc.reported_by, "full_name") or doc.reported_by
+		)
 
-    # Get assignee name
-    if doc.assigned_to:
-        request_data["assignee_name"] = frappe.db.get_value("User", doc.assigned_to, "full_name") or doc.assigned_to
+	# Get assignee name
+	if doc.assigned_to:
+		request_data["assignee_name"] = (
+			frappe.db.get_value("User", doc.assigned_to, "full_name") or doc.assigned_to
+		)
 
-    # Get store display name
-    if doc.store:
-        request_data["store_display"] = frappe.db.get_value("Warehouse", doc.store, "warehouse_name") or doc.store
+	# Get store display name
+	if doc.store:
+		request_data["store_display"] = (
+			frappe.db.get_value("Warehouse", doc.store, "warehouse_name") or doc.store
+		)
 
-    # Get photos
-    photos = []
-    for photo in doc.photos:
-        photos.append({
-            "name": photo.name,
-            "photo": photo.photo,
-            "caption": photo.caption or ""
-        })
+	# Get photos
+	photos = []
+	for photo in doc.photos:
+		photos.append({"name": photo.name, "photo": photo.photo, "caption": photo.caption or ""})
 
-    # Get completion record if exists
-    completion = None
-    if doc.completion:
-        comp_doc = frappe.get_doc("BEI Maintenance Completion", doc.completion)
-        completion = comp_doc.as_dict()
-        if comp_doc.verified_by:
-            completion["verifier_name"] = frappe.db.get_value("User", comp_doc.verified_by, "full_name")
+	# Get completion record if exists
+	completion = None
+	if doc.completion:
+		comp_doc = frappe.get_doc("BEI Maintenance Completion", doc.completion)
+		completion = comp_doc.as_dict()
+		if comp_doc.verified_by:
+			completion["verifier_name"] = frappe.db.get_value("User", comp_doc.verified_by, "full_name")
 
-    # Get history from Version log
-    history = []
-    try:
-        versions = frappe.get_all(
-            "Version",
-            filters={
-                "docname": request_id,
-                "ref_doctype": "BEI Maintenance Request"
-            },
-            fields=["creation", "owner", "data"],
-            order_by="creation asc"
-        )
+	# Get history from Version log
+	history = []
+	try:
+		versions = frappe.get_all(
+			"Version",
+			filters={"docname": request_id, "ref_doctype": "BEI Maintenance Request"},
+			fields=["creation", "owner", "data"],
+			order_by="creation asc",
+		)
 
-        for version in versions:
-            try:
-                data = json.loads(version.data)
-                changes = data.get("changed", [])
+		for version in versions:
+			try:
+				data = json.loads(version.data)
+				changes = data.get("changed", [])
 
-                for change in changes:
-                    field, old_val, new_val = change
-                    if field == "status":
-                        history.append({
-                            "timestamp": version.creation.isoformat() if version.creation else None,
-                            "action": f"Status changed from {old_val} to {new_val}",
-                            "user": version.owner,
-                            "user_name": frappe.db.get_value("User", version.owner, "full_name") or version.owner
-                        })
-            except (json.JSONDecodeError, KeyError):
-                continue
-    except Exception:
-        pass  # Version tracking may not be enabled
+				for change in changes:
+					field, old_val, new_val = change
+					if field == "status":
+						history.append(
+							{
+								"timestamp": version.creation.isoformat() if version.creation else None,
+								"action": f"Status changed from {old_val} to {new_val}",
+								"user": version.owner,
+								"user_name": frappe.db.get_value("User", version.owner, "full_name")
+								or version.owner,
+							}
+						)
+			except (json.JSONDecodeError, KeyError):
+				continue
+	except Exception:
+		pass  # Version tracking may not be enabled
 
-    # Add creation event
-    history.insert(0, {
-        "timestamp": doc.creation.isoformat() if doc.creation else None,
-        "action": "Request created",
-        "user": doc.reported_by or doc.owner,
-        "user_name": request_data.get("reporter_name") or doc.owner
-    })
+	# Add creation event
+	history.insert(
+		0,
+		{
+			"timestamp": doc.creation.isoformat() if doc.creation else None,
+			"action": "Request created",
+			"user": doc.reported_by or doc.owner,
+			"user_name": request_data.get("reporter_name") or doc.owner,
+		},
+	)
 
-    return {
-        "request": request_data,
-        "photos": photos,
-        "completion": completion,
-        "history": history
-    }
+	return {"request": request_data, "photos": photos, "completion": completion, "history": history}
 
 
 # ==============================================================================
@@ -363,93 +366,85 @@ def get_maintenance_request_detail(request_id):
 
 @frappe.whitelist()
 def assign_maintenance_request(
-    request_id=None,
-    assigned_to=None,
-    vendor=None,
-    scheduled_date=None,
-    estimated_cost=None,
-    notes=None
+	request_id=None, assigned_to=None, vendor=None, scheduled_date=None, estimated_cost=None, notes=None
 ):
-    """
-    Assign a maintenance request to internal staff or external vendor.
-    Updates status to 'Assigned'.
+	"""
+	Assign a maintenance request to internal staff or external vendor.
+	Updates status to 'Assigned'.
 
-    Args:
-        request_id: The maintenance request name
-        assigned_to: Internal User (optional)
-        vendor: External vendor name (optional)
-        scheduled_date: When work is scheduled (optional)
-        estimated_cost: Estimated cost (optional)
-        notes: Assignment notes (optional)
+	Args:
+	    request_id: The maintenance request name
+	    assigned_to: Internal User (optional)
+	    vendor: External vendor name (optional)
+	    scheduled_date: When work is scheduled (optional)
+	    estimated_cost: Estimated cost (optional)
+	    notes: Assignment notes (optional)
 
-    Returns:
-        {
-            "success": True,
-            "message": "...",
-            "request": {...}
-        }
-    """
-    # RBAC: Only Projects User/Manager can assign requests
-    user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "System Manager", "Administrator"]
-    if not any(role in user_roles for role in allowed_roles):
-        frappe.throw(_("You do not have permission to assign maintenance requests"), frappe.PermissionError)
+	Returns:
+	    {
+	        "success": True,
+	        "message": "...",
+	        "request": {...}
+	    }
+	"""
+	# RBAC: Only Projects User/Manager can assign requests
+	user_roles = frappe.get_roles(frappe.session.user)
+	allowed_roles = ["Projects User", "Projects Manager", "System Manager", "Administrator"]
+	if not any(role in user_roles for role in allowed_roles):
+		frappe.throw(_("You do not have permission to assign maintenance requests"), frappe.PermissionError)
 
-    if not request_id:
-        frappe.throw(_("Request ID is required"))
+	if not request_id:
+		frappe.throw(_("Request ID is required"))
 
-    if not assigned_to and not vendor:
-        frappe.throw(_("Either internal assignee or vendor must be specified"))
+	if not assigned_to and not vendor:
+		frappe.throw(_("Either internal assignee or vendor must be specified"))
 
-    if not frappe.db.exists("BEI Maintenance Request", request_id):
-        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+	if not frappe.db.exists("BEI Maintenance Request", request_id):
+		frappe.throw(_("Maintenance request {0} not found").format(request_id))
 
-    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+	doc = frappe.get_doc("BEI Maintenance Request", request_id)
 
-    # Check current status allows assignment
-    if doc.status not in ["Open", "Assigned"]:
-        frappe.throw(_("Cannot assign request with status {0}").format(doc.status))
+	# Check current status allows assignment
+	if doc.status not in ["Open", "Assigned"]:
+		frappe.throw(_("Cannot assign request with status {0}").format(doc.status))
 
-    # Update assignment fields
-    if assigned_to:
-        if not frappe.db.exists("User", assigned_to):
-            frappe.throw(_("User {0} not found").format(assigned_to))
-        doc.assigned_to = assigned_to
-        doc.vendor = None  # Clear vendor if assigning to internal
+	# Update assignment fields
+	if assigned_to:
+		if not frappe.db.exists("User", assigned_to):
+			frappe.throw(_("User {0} not found").format(assigned_to))
+		doc.assigned_to = assigned_to
+		doc.vendor = None  # Clear vendor if assigning to internal
 
-    if vendor:
-        doc.vendor = vendor
-        doc.assigned_to = None  # Clear internal if assigning to vendor
+	if vendor:
+		doc.vendor = vendor
+		doc.assigned_to = None  # Clear internal if assigning to vendor
 
-    if scheduled_date:
-        doc.scheduled_date = scheduled_date
+	if scheduled_date:
+		doc.scheduled_date = scheduled_date
 
-    if estimated_cost is not None:
-        doc.estimated_cost = flt(estimated_cost)
+	if estimated_cost is not None:
+		doc.estimated_cost = flt(estimated_cost)
 
-    # Update status
-    doc.status = "Assigned"
+	# Update status
+	doc.status = "Assigned"
 
-    # Add notes as comment if provided
-    if notes:
-        doc.add_comment("Comment", notes)
+	# Add notes as comment if provided
+	if notes:
+		doc.add_comment("Comment", notes)
 
-    doc.flags.ignore_permissions = True
-    doc.save()
+	doc.flags.ignore_permissions = True
+	doc.save()
 
-    # Get assignee name for response
-    assignee_name = None
-    if assigned_to:
-        assignee_name = frappe.db.get_value("User", assigned_to, "full_name")
+	# Get assignee name for response
+	assignee_name = None
+	if assigned_to:
+		assignee_name = frappe.db.get_value("User", assigned_to, "full_name")
 
-    return {
-        "success": True,
-        "message": _("Request {0} assigned to {1}").format(
-            request_id,
-            assignee_name or vendor
-        ),
-        "request": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Request {0} assigned to {1}").format(request_id, assignee_name or vendor),
+		"request": doc.as_dict(),
+	}
 
 
 # ==============================================================================
@@ -459,88 +454,98 @@ def assign_maintenance_request(
 
 @frappe.whitelist()
 def update_maintenance_status(request_id=None, status=None, notes=None):
-    """
-    Update maintenance request status.
+	"""
+	Update maintenance request status.
 
-    Valid transitions:
-    - Open -> Assigned, Cancelled
-    - Assigned -> In Progress, Open, Cancelled
-    - In Progress -> Completed, Assigned
-    - Completed -> Verified (via store verification only)
+	Valid transitions:
+	- Open -> Assigned, Cancelled
+	- Assigned -> In Progress, Open, Cancelled
+	- In Progress -> Completed, Assigned
+	- Completed -> Verified (via store verification only)
 
-    Args:
-        request_id: The maintenance request name
-        status: New status
-        notes: Optional status change notes
+	Args:
+	    request_id: The maintenance request name
+	    status: New status
+	    notes: Optional status change notes
 
-    Returns:
-        {
-            "success": True,
-            "message": "...",
-            "request": {...}
-        }
-    """
-    # BUG-001 fix: Enforce role-based access control
-    user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "System Manager", "Administrator"]
-    if not any(role in user_roles for role in allowed_roles):
-        frappe.throw(_("You do not have permission to update maintenance request status"), frappe.PermissionError)
+	Returns:
+	    {
+	        "success": True,
+	        "message": "...",
+	        "request": {...}
+	    }
+	"""
+	# BUG-001 fix: Enforce role-based access control
+	user_roles = frappe.get_roles(frappe.session.user)
+	allowed_roles = ["Projects User", "Projects Manager", "System Manager", "Administrator"]
+	if not any(role in user_roles for role in allowed_roles):
+		frappe.throw(
+			_("You do not have permission to update maintenance request status"), frappe.PermissionError
+		)
 
-    if not request_id:
-        frappe.throw(_("Request ID is required"))
+	if not request_id:
+		frappe.throw(_("Request ID is required"))
 
-    if not status:
-        frappe.throw(_("Status is required"))
+	if not status:
+		frappe.throw(_("Status is required"))
 
-    valid_statuses = ["Open", "Assigned", "In Progress", "Pending Acknowledgement", "Completed", "Verified", "Cancelled"]
-    if status not in valid_statuses:
-        frappe.throw(_("Invalid status: {0}").format(status))
+	valid_statuses = [
+		"Open",
+		"Assigned",
+		"In Progress",
+		"Pending Acknowledgement",
+		"Completed",
+		"Verified",
+		"Cancelled",
+	]
+	if status not in valid_statuses:
+		frappe.throw(_("Invalid status: {0}").format(status))
 
-    if not frappe.db.exists("BEI Maintenance Request", request_id):
-        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+	if not frappe.db.exists("BEI Maintenance Request", request_id):
+		frappe.throw(_("Maintenance request {0} not found").format(request_id))
 
-    doc = frappe.get_doc("BEI Maintenance Request", request_id)
-    old_status = doc.status
+	doc = frappe.get_doc("BEI Maintenance Request", request_id)
+	old_status = doc.status
 
-    # Define valid transitions
-    valid_transitions = {
-        "Open": ["Assigned", "Cancelled"],
-        "Assigned": ["In Progress", "Pending Acknowledgement", "Open", "Cancelled"],
-        "In Progress": ["Completed", "Pending Acknowledgement", "Assigned", "Cancelled"],
-        "Pending Acknowledgement": ["In Progress", "Assigned", "Cancelled"],
-        "Completed": ["Verified", "In Progress", "Open"],  # Verified via store, Open for reopen
-        "Verified": ["Open"],  # Can reopen verified requests
-        "Cancelled": ["Open"]  # Can reopen cancelled requests
-    }
+	# Define valid transitions
+	valid_transitions = {
+		"Open": ["Assigned", "Cancelled"],
+		"Assigned": ["In Progress", "Pending Acknowledgement", "Open", "Cancelled"],
+		"In Progress": ["Completed", "Pending Acknowledgement", "Assigned", "Cancelled"],
+		"Pending Acknowledgement": ["In Progress", "Assigned", "Cancelled"],
+		"Completed": ["Verified", "In Progress", "Open"],  # Verified via store, Open for reopen
+		"Verified": ["Open"],  # Can reopen verified requests
+		"Cancelled": ["Open"],  # Can reopen cancelled requests
+	}
 
-    if status not in valid_transitions.get(old_status, []) and status != old_status:
-        frappe.throw(_(
-            "Cannot change status from {0} to {1}. Valid transitions: {2}"
-        ).format(old_status, status, ", ".join(valid_transitions.get(old_status, []))))
+	if status not in valid_transitions.get(old_status, []) and status != old_status:
+		frappe.throw(
+			_("Cannot change status from {0} to {1}. Valid transitions: {2}").format(
+				old_status, status, ", ".join(valid_transitions.get(old_status, []))
+			)
+		)
 
-    doc.status = status
+	doc.status = status
 
-    # Set resolved date when completing (only if not already set)
-    if status == "Completed" and not doc.resolved_date:
-        doc.resolved_date = nowdate()
-    # Clear resolved date when reopening
-    if status in ["Open", "Assigned", "In Progress", "Pending Acknowledgement"]:
-        doc.resolved_date = None
+	# Set resolved date when completing (only if not already set)
+	if status == "Completed" and not doc.resolved_date:
+		doc.resolved_date = nowdate()
+	# Clear resolved date when reopening
+	if status in ["Open", "Assigned", "In Progress", "Pending Acknowledgement"]:
+		doc.resolved_date = None
 
-    # Add notes as comment if provided
-    if notes:
-        doc.add_comment("Comment", f"Status changed to {status}: {notes}")
+	# Add notes as comment if provided
+	if notes:
+		doc.add_comment("Comment", f"Status changed to {status}: {notes}")
 
-    doc.flags.ignore_permissions = True
-    doc.save()
+	doc.flags.ignore_permissions = True
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Request {0} status updated from {1} to {2}").format(
-            request_id, old_status, status
-        ),
-        "request": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Request {0} status updated from {1} to {2}").format(request_id, old_status, status),
+		"request": doc.as_dict(),
+	}
 
 
 # ==============================================================================
@@ -550,181 +555,184 @@ def update_maintenance_status(request_id=None, status=None, notes=None):
 
 @frappe.whitelist()
 def record_maintenance_completion(
-    request_id=None,
-    completion_date=None,
-    technician_name=None,
-    work_description=None,
-    resolution_status=None,
-    actual_cost=None,
-    follow_up_needed=False,
-    follow_up_notes=None,
-    after_photos=None
+	request_id=None,
+	completion_date=None,
+	technician_name=None,
+	work_description=None,
+	resolution_status=None,
+	actual_cost=None,
+	follow_up_needed=False,
+	follow_up_notes=None,
+	after_photos=None,
 ):
-    """
-    Record completion of maintenance work.
-    Creates BEI Maintenance Completion record and updates request status.
+	"""
+	Record completion of maintenance work.
+	Creates BEI Maintenance Completion record and updates request status.
 
-    Args:
-        request_id: The maintenance request name
-        completion_date: Date work was completed
-        technician_name: Name of technician who did the work
-        work_description: Description of work performed
-        resolution_status: Fully Resolved, Partially Resolved, Not Resolved
-        actual_cost: Actual cost incurred (optional)
-        follow_up_needed: Whether follow-up is needed
-        follow_up_notes: Notes about follow-up (required if follow_up_needed)
-        after_photos: Photo URL(s) as proof of completion
+	Args:
+	    request_id: The maintenance request name
+	    completion_date: Date work was completed
+	    technician_name: Name of technician who did the work
+	    work_description: Description of work performed
+	    resolution_status: Fully Resolved, Partially Resolved, Not Resolved
+	    actual_cost: Actual cost incurred (optional)
+	    follow_up_needed: Whether follow-up is needed
+	    follow_up_notes: Notes about follow-up (required if follow_up_needed)
+	    after_photos: Photo URL(s) as proof of completion
 
-    Returns:
-        {
-            "success": True,
-            "message": "...",
-            "completion": {...}
-        }
-    """
-    # RBAC: Only Projects User/Manager can record completions
-    user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "System Manager", "Administrator"]
-    if not any(role in user_roles for role in allowed_roles):
-        frappe.throw(_("You do not have permission to record maintenance completions"), frappe.PermissionError)
+	Returns:
+	    {
+	        "success": True,
+	        "message": "...",
+	        "completion": {...}
+	    }
+	"""
+	# RBAC: Only Projects User/Manager can record completions
+	user_roles = frappe.get_roles(frappe.session.user)
+	allowed_roles = ["Projects User", "Projects Manager", "System Manager", "Administrator"]
+	if not any(role in user_roles for role in allowed_roles):
+		frappe.throw(
+			_("You do not have permission to record maintenance completions"), frappe.PermissionError
+		)
 
-    if not request_id:
-        frappe.throw(_("Request ID is required"))
+	if not request_id:
+		frappe.throw(_("Request ID is required"))
 
-    if not frappe.db.exists("BEI Maintenance Request", request_id):
-        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+	if not frappe.db.exists("BEI Maintenance Request", request_id):
+		frappe.throw(_("Maintenance request {0} not found").format(request_id))
 
-    # Validate required fields
-    if not completion_date:
-        frappe.throw(_("Completion date is required"))
+	# Validate required fields
+	if not completion_date:
+		frappe.throw(_("Completion date is required"))
 
-    if getdate(completion_date) > getdate(nowdate()):
-        frappe.throw(_("Completion date cannot be in the future"))
+	if getdate(completion_date) > getdate(nowdate()):
+		frappe.throw(_("Completion date cannot be in the future"))
 
-    if not technician_name:
-        frappe.throw(_("Technician name is required"))
+	if not technician_name:
+		frappe.throw(_("Technician name is required"))
 
-    if not work_description:
-        frappe.throw(_("Work description is required"))
+	if not work_description:
+		frappe.throw(_("Work description is required"))
 
-    valid_resolution_statuses = ["Fully Resolved", "Partially Resolved", "Not Resolved"]
-    if resolution_status not in valid_resolution_statuses:
-        frappe.throw(_("Invalid resolution status. Must be one of: {0}").format(
-            ", ".join(valid_resolution_statuses)
-        ))
+	valid_resolution_statuses = ["Fully Resolved", "Partially Resolved", "Not Resolved"]
+	if resolution_status not in valid_resolution_statuses:
+		frappe.throw(
+			_("Invalid resolution status. Must be one of: {0}").format(", ".join(valid_resolution_statuses))
+		)
 
-    follow_up_needed = sbool(follow_up_needed)
-    if follow_up_needed and not (follow_up_notes and follow_up_notes.strip()):
-        frappe.throw(_("Follow-up notes are required when follow-up is needed"))
+	follow_up_needed = sbool(follow_up_needed)
+	if follow_up_needed and not (follow_up_notes and follow_up_notes.strip()):
+		frappe.throw(_("Follow-up notes are required when follow-up is needed"))
 
-    if not after_photos:
-        frappe.throw(_("At least one after photo is required as proof of completion"))
+	if not after_photos:
+		frappe.throw(_("At least one after photo is required as proof of completion"))
 
-    request_doc = frappe.get_doc("BEI Maintenance Request", request_id)
+	request_doc = frappe.get_doc("BEI Maintenance Request", request_id)
 
-    # Check if completion already exists
-    if request_doc.completion:
-        frappe.throw(_("Completion record already exists: {0}").format(request_doc.completion))
+	# Check if completion already exists
+	if request_doc.completion:
+		frappe.throw(_("Completion record already exists: {0}").format(request_doc.completion))
 
-    # Create completion record
-    completion = frappe.new_doc("BEI Maintenance Completion")
-    completion.maintenance_request = request_id
-    completion.store = request_doc.store
-    completion.completion_date = completion_date
-    completion.status = "Pending Verification"
-    completion.resolution_status = resolution_status
-    completion.technician_name = technician_name
-    completion.work_description = work_description
+	# Create completion record
+	completion = frappe.new_doc("BEI Maintenance Completion")
+	completion.maintenance_request = request_id
+	completion.store = request_doc.store
+	completion.completion_date = completion_date
+	completion.status = "Pending Verification"
+	completion.resolution_status = resolution_status
+	completion.technician_name = technician_name
+	completion.work_description = work_description
 
-    if actual_cost is not None:
-        completion.actual_cost = flt(actual_cost)
+	if actual_cost is not None:
+		completion.actual_cost = flt(actual_cost)
 
-    completion.follow_up_needed = 1 if follow_up_needed else 0
-    if follow_up_notes:
-        completion.follow_up_notes = follow_up_notes
+	completion.follow_up_needed = 1 if follow_up_needed else 0
+	if follow_up_notes:
+		completion.follow_up_notes = follow_up_notes
 
-    # Handle after photos (single or multiple)
-    # Photos may arrive as base64 data URLs from camera capture — save as File attachments
-    from hrms.api.store import save_base64_image
+	# Handle after photos (single or multiple)
+	# Photos may arrive as base64 data URLs from camera capture — save as File attachments
+	from hrms.api.store import save_base64_image
 
-    if isinstance(after_photos, str):
-        try:
-            after_photos = json.loads(after_photos)
-        except json.JSONDecodeError:
-            # It's a single URL/base64 string
-            pass
+	if isinstance(after_photos, str):
+		try:
+			after_photos = json.loads(after_photos)
+		except json.JSONDecodeError:
+			# It's a single URL/base64 string
+			pass
 
-    if isinstance(after_photos, list):
-        # Take first photo for the main field (TODO: add child table for multiple)
-        photo_data = after_photos[0] if after_photos else None
-    else:
-        photo_data = after_photos
+	if isinstance(after_photos, list):
+		# Take first photo for the main field (TODO: add child table for multiple)
+		photo_data = after_photos[0] if after_photos else None
+	else:
+		photo_data = after_photos
 
-    # photo_data may be a dict like {"photo": "data:image/png;base64,...", "caption": "..."}
-    # Extract the actual image data string before passing to save_base64_image
-    # Handle nested dicts: {"photo": {"photo": "data:..."}} or missing keys
-    if isinstance(photo_data, dict):
-        inner = photo_data.get('photo', '') or photo_data.get('url', '') or ''
-        if isinstance(inner, dict):
-            frappe.log_error(
-                f"Nested photo dict received -- frontend sending wrong format: {photo_data}",
-                "Photo Payload Warning"
-            )
-            inner = inner.get('photo', '') or inner.get('url', '') or ''
-        photo_data = inner
+	# photo_data may be a dict like {"photo": "data:image/png;base64,...", "caption": "..."}
+	# Extract the actual image data string before passing to save_base64_image
+	# Handle nested dicts: {"photo": {"photo": "data:..."}} or missing keys
+	if isinstance(photo_data, dict):
+		inner = photo_data.get("photo", "") or photo_data.get("url", "") or ""
+		if isinstance(inner, dict):
+			frappe.log_error(
+				f"Nested photo dict received -- frontend sending wrong format: {photo_data}",
+				"Photo Payload Warning",
+			)
+			inner = inner.get("photo", "") or inner.get("url", "") or ""
+		photo_data = inner
 
-    if photo_data and isinstance(photo_data, str):
-        # save_base64_image handles both base64 data URLs and plain URLs
-        # Returns a short file URL like /files/bei_maintenance_completion_abc123.jpg
-        completion.after_photos = save_base64_image(
-            photo_data,
-            "BEI Maintenance Completion",
-            fieldname="after_photos"
-        )
-    else:
-        completion.after_photos = None
+	if photo_data and isinstance(photo_data, str):
+		# save_base64_image handles both base64 data URLs and plain URLs
+		# Returns a short file URL like /files/bei_maintenance_completion_abc123.jpg
+		completion.after_photos = save_base64_image(
+			photo_data, "BEI Maintenance Completion", fieldname="after_photos"
+		)
+	else:
+		completion.after_photos = None
 
-    completion.submitted_by = frappe.session.user
-    completion.submitted_at = now_datetime()
+	completion.submitted_by = frappe.session.user
+	completion.submitted_at = now_datetime()
 
-    try:
-        sp = frappe.db.savepoint("maintenance_completion")
+	try:
+		frappe.db.savepoint("maintenance_completion")
 
-        completion.flags.ignore_permissions = True
-        completion.insert()
+		completion.flags.ignore_permissions = True
+		completion.insert()
 
-        # Link photo file to the newly created completion doc
-        if completion.after_photos:
-            file_doc = frappe.db.get_value(
-                "File", {"file_url": completion.after_photos, "attached_to_name": ("is", "not set")},
-                "name"
-            )
-            if file_doc:
-                frappe.db.set_value("File", file_doc, {
-                    "attached_to_doctype": "BEI Maintenance Completion",
-                    "attached_to_name": completion.name,
-                    "attached_to_field": "after_photos"
-                })
+		# Link photo file to the newly created completion doc
+		if completion.after_photos:
+			file_doc = frappe.db.get_value(
+				"File", {"file_url": completion.after_photos, "attached_to_name": ("is", "not set")}, "name"
+			)
+			if file_doc:
+				frappe.db.set_value(
+					"File",
+					file_doc,
+					{
+						"attached_to_doctype": "BEI Maintenance Completion",
+						"attached_to_name": completion.name,
+						"attached_to_field": "after_photos",
+					},
+				)
 
-        # Reload request to get latest modified timestamp (avoids version conflict)
-        request_doc.reload()
+		# Reload request to get latest modified timestamp (avoids version conflict)
+		request_doc.reload()
 
-        # Update request with completion link and status
-        request_doc.completion = completion.name
-        request_doc.status = "Completed"
-        request_doc.resolved_date = completion_date
-        request_doc.flags.ignore_permissions = True
-        request_doc.save()
+		# Update request with completion link and status
+		request_doc.completion = completion.name
+		request_doc.status = "Completed"
+		request_doc.resolved_date = completion_date
+		request_doc.flags.ignore_permissions = True
+		request_doc.save()
 
-    except Exception:
-        frappe.db.rollback(save_point="maintenance_completion")
-        raise
+	except Exception:
+		frappe.db.rollback(save_point="maintenance_completion")
+		raise
 
-    return {
-        "success": True,
-        "message": _("Completion recorded for {0}. Pending store verification.").format(request_id),
-        "completion": completion.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Completion recorded for {0}. Pending store verification.").format(request_id),
+		"completion": completion.as_dict(),
+	}
 
 
 # ==============================================================================
@@ -734,63 +742,67 @@ def record_maintenance_completion(
 
 @frappe.whitelist()
 def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
-    """
-    Get aggregated stats for Projects dashboard.
+	"""
+	Get aggregated stats for Projects dashboard.
 
-    Args:
-        date_from: Filter by request_date >= date_from
-        date_to: Filter by request_date <= date_to
-        store: Filter by specific store
+	Args:
+	    date_from: Filter by request_date >= date_from
+	    date_to: Filter by request_date <= date_to
+	    store: Filter by specific store
 
-    Returns:
-        {
-            "total_open": int,
-            "total_assigned": int,
-            "total_in_progress": int,
-            "total_completed_pending_verification": int,
-            "urgent_count": int,
-            "by_category": {"Electrical": 5, "Plumbing": 3, ...},
-            "by_store": {"BGC": 10, "Makati": 8, ...},
-            "avg_resolution_days": float,
-            "total_cost_mtd": float
-        }
-    """
-    # Auth guard: reject unauthenticated requests
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {
+	        "total_open": int,
+	        "total_assigned": int,
+	        "total_in_progress": int,
+	        "total_completed_pending_verification": int,
+	        "urgent_count": int,
+	        "by_category": {"Electrical": 5, "Plumbing": 3, ...},
+	        "by_store": {"BGC": 10, "Makati": 8, ...},
+	        "avg_resolution_days": float,
+	        "total_cost_mtd": float
+	    }
+	"""
+	# Auth guard: reject unauthenticated requests
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    # Build filter conditions
-    conditions = []
-    values = {}
+	# Build filter conditions
+	conditions = []
+	values = {}
 
-    if date_from:
-        conditions.append("mr.request_date >= %(date_from)s")
-        values["date_from"] = date_from
+	if date_from:
+		conditions.append("mr.request_date >= %(date_from)s")
+		values["date_from"] = date_from
 
-    if date_to:
-        conditions.append("mr.request_date <= %(date_to)s")
-        values["date_to"] = date_to
+	if date_to:
+		conditions.append("mr.request_date <= %(date_to)s")
+		values["date_to"] = date_to
 
-    if store:
-        conditions.append("mr.store = %(store)s")
-        values["store"] = store
+	if store:
+		conditions.append("mr.store = %(store)s")
+		values["store"] = store
 
-    where_clause = " AND " + " AND ".join(conditions) if conditions else ""
+	where_clause = " AND " + " AND ".join(conditions) if conditions else ""
 
-    # Get status counts
-    status_counts = frappe.db.sql(f"""
+	# Get status counts
+	status_counts = frappe.db.sql(
+		f"""
         SELECT
             status,
             COUNT(*) as count
         FROM `tabBEI Maintenance Request` mr
         WHERE 1=1 {where_clause}
         GROUP BY status
-    """, values, as_dict=True)
+    """,
+		values,
+		as_dict=True,
+	)
 
-    status_map = {row.status: row.count for row in status_counts}
+	status_map = {row.status: row.count for row in status_counts}
 
-    # Count completed with pending verification
-    completed_pending_sql = f"""
+	# Count completed with pending verification
+	completed_pending_sql = f"""
         SELECT COUNT(*) as count
         FROM `tabBEI Maintenance Request` mr
         JOIN `tabBEI Maintenance Completion` mc ON mc.maintenance_request = mr.name
@@ -798,20 +810,20 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
         AND mc.status = 'Pending Verification'
         {where_clause}
     """
-    completed_pending = frappe.db.sql(completed_pending_sql, values, as_dict=True)[0].count
+	completed_pending = frappe.db.sql(completed_pending_sql, values, as_dict=True)[0].count
 
-    # Get urgent count (across all non-closed statuses)
-    urgent_sql = f"""
+	# Get urgent count (across all non-closed statuses)
+	urgent_sql = f"""
         SELECT COUNT(*) as count
         FROM `tabBEI Maintenance Request` mr
         WHERE mr.priority = 'Urgent'
         AND mr.status NOT IN ('Verified', 'Cancelled')
         {where_clause}
     """
-    urgent_count = frappe.db.sql(urgent_sql, values, as_dict=True)[0].count
+	urgent_count = frappe.db.sql(urgent_sql, values, as_dict=True)[0].count
 
-    # Get counts by category
-    category_sql = f"""
+	# Get counts by category
+	category_sql = f"""
         SELECT
             issue_category,
             COUNT(*) as count
@@ -820,11 +832,11 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
         {where_clause}
         GROUP BY issue_category
     """
-    category_counts = frappe.db.sql(category_sql, values, as_dict=True)
-    by_category = {row.issue_category: row.count for row in category_counts}
+	category_counts = frappe.db.sql(category_sql, values, as_dict=True)
+	by_category = {row.issue_category: row.count for row in category_counts}
 
-    # Get counts by store
-    store_sql = f"""
+	# Get counts by store
+	store_sql = f"""
         SELECT
             store_code,
             COUNT(*) as count
@@ -833,11 +845,11 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
         {where_clause}
         GROUP BY store_code
     """
-    store_counts = frappe.db.sql(store_sql, values, as_dict=True)
-    by_store = {row.store_code: row.count for row in store_counts}
+	store_counts = frappe.db.sql(store_sql, values, as_dict=True)
+	by_store = {row.store_code: row.count for row in store_counts}
 
-    # Calculate average resolution time (for completed/verified requests)
-    resolution_sql = f"""
+	# Calculate average resolution time (for completed/verified requests)
+	resolution_sql = f"""
         SELECT
             AVG(DATEDIFF(mr.resolved_date, mr.request_date)) as avg_days
         FROM `tabBEI Maintenance Request` mr
@@ -845,41 +857,41 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
         AND mr.resolved_date IS NOT NULL
         {where_clause}
     """
-    resolution_result = frappe.db.sql(resolution_sql, values, as_dict=True)
-    avg_resolution_days = flt(resolution_result[0].avg_days) if resolution_result[0].avg_days else 0
+	resolution_result = frappe.db.sql(resolution_sql, values, as_dict=True)
+	avg_resolution_days = flt(resolution_result[0].avg_days) if resolution_result[0].avg_days else 0
 
-    # Get total cost MTD (from completion records)
-    today = nowdate()
-    mtd_start = today[:8] + "01"  # First day of current month
+	# Get total cost MTD (from completion records)
+	today = nowdate()
+	mtd_start = today[:8] + "01"  # First day of current month
 
-    cost_sql = """
+	cost_sql = """
         SELECT COALESCE(SUM(mc.actual_cost), 0) as total_cost
         FROM `tabBEI Maintenance Completion` mc
         WHERE mc.completion_date >= %(mtd_start)s
         AND mc.completion_date <= %(today)s
     """
-    cost_values = {"mtd_start": mtd_start, "today": today}
-    if store:
-        cost_sql += " AND mc.store = %(store)s"
-        cost_values["store"] = store
+	cost_values = {"mtd_start": mtd_start, "today": today}
+	if store:
+		cost_sql += " AND mc.store = %(store)s"
+		cost_values["store"] = store
 
-    cost_result = frappe.db.sql(cost_sql, cost_values, as_dict=True)
-    total_cost_mtd = flt(cost_result[0].total_cost) if cost_result else 0
+	cost_result = frappe.db.sql(cost_sql, cost_values, as_dict=True)
+	total_cost_mtd = flt(cost_result[0].total_cost) if cost_result else 0
 
-    return {
-        "total_open": status_map.get("Open", 0),
-        "total_assigned": status_map.get("Assigned", 0),
-        "total_in_progress": status_map.get("In Progress", 0),
-        "total_completed_pending_verification": completed_pending,
-        "total_verified": status_map.get("Verified", 0),
-        "total_cancelled": status_map.get("Cancelled", 0),
-        "urgent_count": urgent_count,
-        "by_category": by_category,
-        "by_store": by_store,
-        "by_status": dict(status_map),
-        "avg_resolution_days": round(avg_resolution_days, 1),
-        "total_cost_mtd": total_cost_mtd
-    }
+	return {
+		"total_open": status_map.get("Open", 0),
+		"total_assigned": status_map.get("Assigned", 0),
+		"total_in_progress": status_map.get("In Progress", 0),
+		"total_completed_pending_verification": completed_pending,
+		"total_verified": status_map.get("Verified", 0),
+		"total_cancelled": status_map.get("Cancelled", 0),
+		"urgent_count": urgent_count,
+		"by_category": by_category,
+		"by_store": by_store,
+		"by_status": dict(status_map),
+		"avg_resolution_days": round(avg_resolution_days, 1),
+		"total_cost_mtd": total_cost_mtd,
+	}
 
 
 # ==============================================================================
@@ -888,96 +900,98 @@ def get_maintenance_dashboard_stats(date_from=None, date_to=None, store=None):
 
 
 @frappe.whitelist()
-def export_maintenance_requests(
-    status=None,
-    date_from=None,
-    date_to=None,
-    store=None,
-    format="xlsx"
-):
-    """
-    Export maintenance requests to Excel file.
+def export_maintenance_requests(status=None, date_from=None, date_to=None, store=None, format="xlsx"):
+	"""
+	Export maintenance requests to Excel file.
 
-    Args:
-        status: Filter by status (can be comma-separated)
-        date_from: Filter by request_date >= date_from
-        date_to: Filter by request_date <= date_to
-        store: Filter by specific store
-        format: Export format (xlsx or csv)
+	Args:
+	    status: Filter by status (can be comma-separated)
+	    date_from: Filter by request_date >= date_from
+	    date_to: Filter by request_date <= date_to
+	    store: Filter by specific store
+	    format: Export format (xlsx or csv)
 
-    Returns:
-        {"file_url": "..."} - URL to download the file
-    """
-    # RBAC: Only Projects Manager and above can export
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"file_url": "..."} - URL to download the file
+	"""
+	# RBAC: Only Projects Manager and above can export
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    # Get filtered requests
-    result = get_maintenance_queue(
-        status=status,
-        date_from=date_from,
-        date_to=date_to,
-        store=store,
-        page=1,
-        page_size=10000  # Get all matching records
-    )
+	# Get filtered requests
+	result = get_maintenance_queue(
+		status=status,
+		date_from=date_from,
+		date_to=date_to,
+		store=store,
+		page=1,
+		page_size=10000,  # Get all matching records
+	)
 
-    requests = result.get("requests", [])
+	requests = result.get("requests", [])
 
-    if not requests:
-        frappe.throw(_("No requests found matching the filters"))
+	if not requests:
+		frappe.throw(_("No requests found matching the filters"))
 
-    # Prepare data for export
-    export_data = []
-    headers = [
-        "Request ID", "Store", "Store Code", "Request Date", "Status", "Priority",
-        "Category", "Equipment/Area", "Description", "Assigned To", "Vendor",
-        "Scheduled Date", "Estimated Cost", "Resolved Date", "Age (Days)",
-        "Reported By", "Reported At"
-    ]
+	# Prepare data for export
+	export_data = []
+	headers = [
+		"Request ID",
+		"Store",
+		"Store Code",
+		"Request Date",
+		"Status",
+		"Priority",
+		"Category",
+		"Equipment/Area",
+		"Description",
+		"Assigned To",
+		"Vendor",
+		"Scheduled Date",
+		"Estimated Cost",
+		"Resolved Date",
+		"Age (Days)",
+		"Reported By",
+		"Reported At",
+	]
 
-    for req in requests:
-        export_data.append([
-            req.get("name", ""),
-            req.get("store", ""),
-            req.get("store_code", ""),
-            str(req.get("request_date", "")),
-            req.get("status", ""),
-            req.get("priority", ""),
-            req.get("issue_category", ""),
-            req.get("equipment_area", ""),
-            (req.get("description", "") or "")[:500],  # Truncate long descriptions
-            req.get("assignee_name", "") or req.get("assigned_to", ""),
-            req.get("vendor", ""),
-            str(req.get("scheduled_date", "") or ""),
-            flt(req.get("estimated_cost", 0)),
-            str(req.get("resolved_date", "") or ""),
-            req.get("age_days", 0),
-            req.get("reporter_name", "") or req.get("reported_by", ""),
-            str(req.get("reported_at", "") or "")
-        ])
+	for req in requests:
+		export_data.append(
+			[
+				req.get("name", ""),
+				req.get("store", ""),
+				req.get("store_code", ""),
+				str(req.get("request_date", "")),
+				req.get("status", ""),
+				req.get("priority", ""),
+				req.get("issue_category", ""),
+				req.get("equipment_area", ""),
+				(req.get("description", "") or "")[:500],  # Truncate long descriptions
+				req.get("assignee_name", "") or req.get("assigned_to", ""),
+				req.get("vendor", ""),
+				str(req.get("scheduled_date", "") or ""),
+				flt(req.get("estimated_cost", 0)),
+				str(req.get("resolved_date", "") or ""),
+				req.get("age_days", 0),
+				req.get("reporter_name", "") or req.get("reported_by", ""),
+				str(req.get("reported_at", "") or ""),
+			]
+		)
 
-    # Generate file
-    from frappe.utils.xlsxutils import make_xlsx
+	# Generate file
+	from frappe.utils.xlsxutils import make_xlsx
 
-    xlsx_data = [headers] + export_data
+	xlsx_data = [headers, *export_data]
 
-    filename = f"maintenance_requests_{nowdate()}.xlsx"
-    xlsx_file = make_xlsx(xlsx_data, filename)
+	filename = f"maintenance_requests_{nowdate()}.xlsx"
+	xlsx_file = make_xlsx(xlsx_data, filename)
 
-    # Save file
-    file_doc = frappe.get_doc({
-        "doctype": "File",
-        "file_name": filename,
-        "content": xlsx_file.getvalue(),
-        "is_private": 1
-    })
-    file_doc.insert()
+	# Save file
+	file_doc = frappe.get_doc(
+		{"doctype": "File", "file_name": filename, "content": xlsx_file.getvalue(), "is_private": 1}
+	)
+	file_doc.insert()
 
-    return {
-        "file_url": file_doc.file_url,
-        "file_name": filename,
-        "record_count": len(requests)
-    }
+	return {"file_url": file_doc.file_url, "file_name": filename, "record_count": len(requests)}
 
 
 # ==============================================================================
@@ -987,48 +1001,51 @@ def export_maintenance_requests(
 
 @frappe.whitelist()
 def get_projects_team_users():
-    """
-    Get list of users with Projects User role for assignment dropdown.
+	"""
+	Get list of users with Projects User role for assignment dropdown.
 
-    Returns:
-        {"users": [{"name": "user@email.com", "full_name": "User Name"}, ...]}
-    """
-    # Auth guard: reject unauthenticated requests
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {"users": [{"name": "user@email.com", "full_name": "User Name"}, ...]}
+	"""
+	# Auth guard: reject unauthenticated requests
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    users = frappe.db.sql("""
+	users = frappe.db.sql(
+		"""
         SELECT DISTINCT u.name, u.full_name
         FROM `tabUser` u
         JOIN `tabHas Role` hr ON hr.parent = u.name
         WHERE hr.role = 'Projects User'
         AND u.enabled = 1
         ORDER BY u.full_name
-    """, as_dict=True)
+    """,
+		as_dict=True,
+	)
 
-    return {"users": users}
+	return {"users": users}
 
 
 @frappe.whitelist()
 def get_stores_list():
-    """
-    Get list of stores/warehouses for filter dropdown.
+	"""
+	Get list of stores/warehouses for filter dropdown.
 
-    Returns:
-        {"stores": [{"name": "WH-BGC - BEI", "store_code": "BGC"}, ...]}
-    """
-    # Auth guard: reject unauthenticated requests
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {"stores": [{"name": "WH-BGC - BEI", "store_code": "BGC"}, ...]}
+	"""
+	# Auth guard: reject unauthenticated requests
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    stores = frappe.get_all(
-        "Warehouse",
-        filters={"is_group": 0, "disabled": 0},
-        fields=["name", "warehouse_name as store_code"],
-        order_by="warehouse_name"
-    )
+	stores = frappe.get_all(
+		"Warehouse",
+		filters={"is_group": 0, "disabled": 0},
+		fields=["name", "warehouse_name as store_code"],
+		order_by="warehouse_name",
+	)
 
-    return {"stores": stores}
+	return {"stores": stores}
 
 
 # ==============================================================================
@@ -1038,415 +1055,429 @@ def get_stores_list():
 
 @frappe.whitelist()
 def assess_maintenance_request(request_id, concern_type, notes=None):
-    """
-    Technician assesses the request and sets concern type.
+	"""
+	Technician assesses the request and sets concern type.
 
-    Args:
-        request_id: The maintenance request name
-        concern_type: "Wear & Tear", "Supplier Deficiency", "Contractor Deficiency"
-        notes: Optional assessment notes
+	Args:
+	    request_id: The maintenance request name
+	    concern_type: "Wear & Tear", "Supplier Deficiency", "Contractor Deficiency"
+	    notes: Optional assessment notes
 
-    Returns:
-        {"success": True, "message": "...", "request": {...}}
-    """
-    # RBAC: Only Projects User/Manager can assess requests
-    user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "System Manager"]
-    if not any(role in user_roles for role in allowed_roles):
-        frappe.throw(_("You do not have permission to assess maintenance requests"), frappe.PermissionError)
+	Returns:
+	    {"success": True, "message": "...", "request": {...}}
+	"""
+	# RBAC: Only Projects User/Manager can assess requests
+	user_roles = frappe.get_roles(frappe.session.user)
+	allowed_roles = ["Projects User", "Projects Manager", "System Manager"]
+	if not any(role in user_roles for role in allowed_roles):
+		frappe.throw(_("You do not have permission to assess maintenance requests"), frappe.PermissionError)
 
-    if not request_id:
-        frappe.throw(_("Request ID is required"))
+	if not request_id:
+		frappe.throw(_("Request ID is required"))
 
-    valid_concern_types = ["Wear & Tear", "Supplier Deficiency", "Contractor Deficiency"]
-    if concern_type not in valid_concern_types:
-        frappe.throw(_("Invalid concern type. Must be one of: {0}").format(", ".join(valid_concern_types)))
+	valid_concern_types = ["Wear & Tear", "Supplier Deficiency", "Contractor Deficiency"]
+	if concern_type not in valid_concern_types:
+		frappe.throw(_("Invalid concern type. Must be one of: {0}").format(", ".join(valid_concern_types)))
 
-    if not frappe.db.exists("BEI Maintenance Request", request_id):
-        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+	if not frappe.db.exists("BEI Maintenance Request", request_id):
+		frappe.throw(_("Maintenance request {0} not found").format(request_id))
 
-    doc = frappe.get_doc("BEI Maintenance Request", request_id)
-    doc.concern_type = concern_type
+	doc = frappe.get_doc("BEI Maintenance Request", request_id)
+	doc.concern_type = concern_type
 
-    if notes:
-        doc.add_comment("Comment", f"Assessment: {notes}")
+	if notes:
+		doc.add_comment("Comment", f"Assessment: {notes}")
 
-    doc.flags.ignore_permissions = True
-    doc.save()
+	doc.flags.ignore_permissions = True
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Request {0} assessed as {1}").format(request_id, concern_type),
-        "request": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Request {0} assessed as {1}").format(request_id, concern_type),
+		"request": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def set_maintenance_charge(request_id, charge_amount, charging_reason):
-    """
-    Set a charge to store for a maintenance request.
+	"""
+	Set a charge to store for a maintenance request.
 
-    Args:
-        request_id: The maintenance request name
-        charge_amount: Amount to charge
-        charging_reason: Reason for the charge
+	Args:
+	    request_id: The maintenance request name
+	    charge_amount: Amount to charge
+	    charging_reason: Reason for the charge
 
-    Returns:
-        {"success": True, "message": "...", "request": {...}}
-    """
-    # RBAC: Only Projects User/Manager can set charges
-    user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "System Manager"]
-    if not any(role in user_roles for role in allowed_roles):
-        frappe.throw(_("You do not have permission to set maintenance charges"), frappe.PermissionError)
+	Returns:
+	    {"success": True, "message": "...", "request": {...}}
+	"""
+	# RBAC: Only Projects User/Manager can set charges
+	user_roles = frappe.get_roles(frappe.session.user)
+	allowed_roles = ["Projects User", "Projects Manager", "System Manager"]
+	if not any(role in user_roles for role in allowed_roles):
+		frappe.throw(_("You do not have permission to set maintenance charges"), frappe.PermissionError)
 
-    if not request_id:
-        frappe.throw(_("Request ID is required"))
+	if not request_id:
+		frappe.throw(_("Request ID is required"))
 
-    if not charge_amount or flt(charge_amount) <= 0:
-        frappe.throw(_("Charge amount must be greater than 0"))
+	if not charge_amount or flt(charge_amount) <= 0:
+		frappe.throw(_("Charge amount must be greater than 0"))
 
-    if not charging_reason:
-        frappe.throw(_("Charging reason is required"))
+	if not charging_reason:
+		frappe.throw(_("Charging reason is required"))
 
-    if not frappe.db.exists("BEI Maintenance Request", request_id):
-        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+	if not frappe.db.exists("BEI Maintenance Request", request_id):
+		frappe.throw(_("Maintenance request {0} not found").format(request_id))
 
-    doc = frappe.get_doc("BEI Maintenance Request", request_id)
-    doc.charge_to_store = 1
-    doc.charge_amount = flt(charge_amount)
-    doc.charging_reason = charging_reason
-    doc.status = "Pending Acknowledgement"
-    doc.flags.ignore_permissions = True
-    doc.save()
-    _notify_maintenance_charge_pending_ack(doc)
+	doc = frappe.get_doc("BEI Maintenance Request", request_id)
+	doc.charge_to_store = 1
+	doc.charge_amount = flt(charge_amount)
+	doc.charging_reason = charging_reason
+	doc.status = "Pending Acknowledgement"
+	doc.flags.ignore_permissions = True
+	doc.save()
+	_notify_maintenance_charge_pending_ack(doc)
 
-    return {
-        "success": True,
-        "message": _("Charge of {0} set for {1}. Pending store acknowledgement.").format(
-            doc.charge_amount, request_id
-        ),
-        "request": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Charge of {0} set for {1}. Pending store acknowledgement.").format(
+			doc.charge_amount, request_id
+		),
+		"request": doc.as_dict(),
+	}
 
 
 def _notify_maintenance_charge_pending_ack(doc):
-    """Notify store and ops channels when a maintenance charge awaits acknowledgement."""
-    try:
-        from hrms.api.google_chat import send_message_to_space
-        from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
+	"""Notify store and ops channels when a maintenance charge awaits acknowledgement."""
+	try:
+		from hrms.api.google_chat import send_message_to_space
+		from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
 
-        spaces = []
-        if getattr(doc, "store", None):
-            store_space = frappe.db.get_value("Warehouse", doc.store, "custom_gchat_space")
-            if store_space:
-                spaces.append(store_space)
+		spaces = []
+		if getattr(doc, "store", None):
+			store_space = frappe.db.get_value("Warehouse", doc.store, "custom_gchat_space")
+			if store_space:
+				spaces.append(store_space)
 
-        fallback_space = get_chat_space(SPACE_NOTIFICATIONS)
-        if fallback_space:
-            spaces.append(fallback_space)
+		fallback_space = get_chat_space(SPACE_NOTIFICATIONS)
+		if fallback_space:
+			spaces.append(fallback_space)
 
-        if not spaces:
-            return
+		if not spaces:
+			return
 
-        message = (
-            "*Maintenance Charge Pending Acknowledgement*\n\n"
-            f"*Request:* {doc.name}\n"
-            f"*Store:* {doc.store or '-'}\n"
-            f"*Amount:* PHP {flt(doc.charge_amount or 0):,.2f}\n"
-            f"*Reason:* {doc.charging_reason or '-'}\n"
-            f"*Set By:* {frappe.session.user}"
-        )
+		message = (
+			"*Maintenance Charge Pending Acknowledgement*\n\n"
+			f"*Request:* {doc.name}\n"
+			f"*Store:* {doc.store or '-'}\n"
+			f"*Amount:* PHP {flt(doc.charge_amount or 0):,.2f}\n"
+			f"*Reason:* {doc.charging_reason or '-'}\n"
+			f"*Set By:* {frappe.session.user}"
+		)
 
-        for space in dict.fromkeys(spaces):
-            send_message_to_space(space, message)
-    except Exception as exc:
-        frappe.log_error(
-            title="Maintenance Charge Notification Error",
-            message=f"request={getattr(doc, 'name', None)}, error={str(exc)[:300]}",
-        )
+		for space in dict.fromkeys(spaces):
+			send_message_to_space(space, message)
+	except Exception as exc:
+		frappe.log_error(
+			title="Maintenance Charge Notification Error",
+			message=f"request={getattr(doc, 'name', None)}, error={str(exc)[:300]}",
+		)
 
 
 @frappe.whitelist()
 def acknowledge_maintenance_charge(request_id):
-    """
-    Store supervisor acknowledges charge to store.
+	"""
+	Store supervisor acknowledges charge to store.
 
-    Args:
-        request_id: The maintenance request name
+	Args:
+	    request_id: The maintenance request name
 
-    Returns:
-        {"success": True, "message": "..."}
-    """
-    # RBAC: Projects users/managers and store roles can acknowledge charges
-    user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = [
-        "Projects User",
-        "Projects Manager",
-        "Store Supervisor",
-        "Store Staff",
-        "Store OIC",
-        "System Manager",
-    ]
-    if not any(role in user_roles for role in allowed_roles):
-        frappe.throw(_("You do not have permission to acknowledge maintenance charges"), frappe.PermissionError)
+	Returns:
+	    {"success": True, "message": "..."}
+	"""
+	# RBAC: Projects users/managers and store roles can acknowledge charges
+	user_roles = frappe.get_roles(frappe.session.user)
+	allowed_roles = [
+		"Projects User",
+		"Projects Manager",
+		"Store Supervisor",
+		"Store Staff",
+		"Store OIC",
+		"System Manager",
+	]
+	if not any(role in user_roles for role in allowed_roles):
+		frappe.throw(
+			_("You do not have permission to acknowledge maintenance charges"), frappe.PermissionError
+		)
 
-    if not request_id:
-        frappe.throw(_("Request ID is required"))
+	if not request_id:
+		frappe.throw(_("Request ID is required"))
 
-    if not frappe.db.exists("BEI Maintenance Request", request_id):
-        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+	if not frappe.db.exists("BEI Maintenance Request", request_id):
+		frappe.throw(_("Maintenance request {0} not found").format(request_id))
 
-    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+	doc = frappe.get_doc("BEI Maintenance Request", request_id)
 
-    # B-10: Store-binding check — store roles can only acknowledge their own store's charges
-    bypass_roles = ["System Manager", "Projects Manager"]
-    if not any(role in user_roles for role in bypass_roles):
-        user_employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
-        if user_employee:
-            user_branch = frappe.db.get_value("Employee", user_employee, "branch")
-            user_branch_key = _normalize_store_identity(user_branch)
-            doc_store_keys = {
-                key
-                for key in (
-                    _normalize_store_identity(getattr(doc, "store", None)),
-                    _normalize_store_identity(getattr(doc, "store_code", None)),
-                )
-                if key
-            }
-            if user_branch_key and doc_store_keys and user_branch_key not in doc_store_keys:
-                frappe.throw(_("You can only acknowledge charges for your own store"), frappe.PermissionError)
+	# B-10: Store-binding check — store roles can only acknowledge their own store's charges
+	bypass_roles = ["System Manager", "Projects Manager"]
+	if not any(role in user_roles for role in bypass_roles):
+		user_employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
+		if user_employee:
+			user_branch = frappe.db.get_value("Employee", user_employee, "branch")
+			user_branch_key = _normalize_store_identity(user_branch)
+			doc_store_keys = {
+				key
+				for key in (
+					_normalize_store_identity(getattr(doc, "store", None)),
+					_normalize_store_identity(getattr(doc, "store_code", None)),
+				)
+				if key
+			}
+			if user_branch_key and doc_store_keys and user_branch_key not in doc_store_keys:
+				frappe.throw(_("You can only acknowledge charges for your own store"), frappe.PermissionError)
 
-    if not doc.charge_to_store:
-        frappe.throw(_("This request has no charge to acknowledge"))
+	if not doc.charge_to_store:
+		frappe.throw(_("This request has no charge to acknowledge"))
 
-    if doc.store_acknowledged:
-        frappe.throw(_("Charge already acknowledged"))
+	if doc.store_acknowledged:
+		frappe.throw(_("Charge already acknowledged"))
 
-    doc.store_acknowledged = 1
-    doc.acknowledged_by = frappe.session.user
-    doc.acknowledgement_date = nowdate()
-    doc.status = "Verified"
-    doc.flags.ignore_permissions = True
-    doc.save()
+	doc.store_acknowledged = 1
+	doc.acknowledged_by = frappe.session.user
+	doc.acknowledgement_date = nowdate()
+	doc.status = "Verified"
+	doc.flags.ignore_permissions = True
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Charge acknowledged for {0}").format(request_id)
-    }
+	return {"success": True, "message": _("Charge acknowledged for {0}").format(request_id)}
 
 
 @frappe.whitelist()
 def get_pending_charges(store=None, page=1, page_size=20):
-    """
-    Get maintenance requests with pending store charges.
+	"""
+	Get maintenance requests with pending store charges.
 
-    Args:
-        store: Filter by specific store (optional)
-        page: Page number (default: 1)
-        page_size: Items per page (default: 20)
+	Args:
+	    store: Filter by specific store (optional)
+	    page: Page number (default: 1)
+	    page_size: Items per page (default: 20)
 
-    Returns:
-        {
-            "requests": [...],
-            "total": int,
-            "page": int,
-            "page_size": int
-        }
-    """
-    # RBAC: Projects and store management roles can view pending charges
-    user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = [
-        "Projects User",
-        "Projects Manager",
-        "Store Supervisor",
-        "Store Staff",
-        "Store OIC",
-        "Area Supervisor",
-        "System Manager",
-    ]
-    if not any(role in user_roles for role in allowed_roles):
-        frappe.throw(_("You do not have permission to view pending charges"), frappe.PermissionError)
+	Returns:
+	    {
+	        "requests": [...],
+	        "total": int,
+	        "page": int,
+	        "page_size": int
+	    }
+	"""
+	# RBAC: Projects and store management roles can view pending charges
+	user_roles = frappe.get_roles(frappe.session.user)
+	allowed_roles = [
+		"Projects User",
+		"Projects Manager",
+		"Store Supervisor",
+		"Store Staff",
+		"Store OIC",
+		"Area Supervisor",
+		"System Manager",
+	]
+	if not any(role in user_roles for role in allowed_roles):
+		frappe.throw(_("You do not have permission to view pending charges"), frappe.PermissionError)
 
-    filters = {
-        "charge_to_store": 1,
-        "store_acknowledged": 0,
-        "status": ["in", ["Completed", "Pending Acknowledgement"]]
-    }
+	filters = {
+		"charge_to_store": 1,
+		"store_acknowledged": 0,
+		"status": ["in", ["Completed", "Pending Acknowledgement"]],
+	}
 
-    if store:
-        filters["store"] = store
+	if store:
+		filters["store"] = store
 
-    page = int(page)
-    page_size = int(page_size)
+	page = int(page)
+	page_size = int(page_size)
 
-    total = frappe.db.count("BEI Maintenance Request", filters)
+	total = frappe.db.count("BEI Maintenance Request", filters)
 
-    requests = frappe.get_all(
-        "BEI Maintenance Request",
-        filters=filters,
-        fields=[
-            "name", "store", "store_code", "request_date", "issue_category",
-            "description", "charge_amount", "charging_reason", "concern_type",
-            "priority", "status"
-        ],
-        order_by="request_date desc",
-        limit_page_length=page_size,
-        limit_start=(page - 1) * page_size
-    )
+	requests = frappe.get_all(
+		"BEI Maintenance Request",
+		filters=filters,
+		fields=[
+			"name",
+			"store",
+			"store_code",
+			"request_date",
+			"issue_category",
+			"description",
+			"charge_amount",
+			"charging_reason",
+			"concern_type",
+			"priority",
+			"status",
+		],
+		order_by="request_date desc",
+		limit_page_length=page_size,
+		limit_start=(page - 1) * page_size,
+	)
 
-    # Get store names
-    for req in requests:
-        if req.store:
-            req["store_name"] = frappe.db.get_value("Warehouse", req.store, "warehouse_name")
+	# Get store names
+	for req in requests:
+		if req.store:
+			req["store_name"] = frappe.db.get_value("Warehouse", req.store, "warehouse_name")
 
-    return {
-        "requests": requests,
-        "total": total,
-        "page": page,
-        "page_size": page_size
-    }
+	return {"requests": requests, "total": total, "page": page, "page_size": page_size}
 
 
 @frappe.whitelist()
 def add_maintenance_materials(request_id, materials):
-    """
-    Add materials to a maintenance request.
+	"""
+	Add materials to a maintenance request.
 
-    Args:
-        request_id: The maintenance request name
-        materials: List of materials [{material, quantity, unit, unit_cost}, ...]
+	Args:
+	    request_id: The maintenance request name
+	    materials: List of materials [{material, quantity, unit, unit_cost}, ...]
 
-    Returns:
-        {"success": True, "message": "...", "request": {...}}
-    """
-    # RBAC: Only Projects User/Manager can add materials
-    user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "System Manager"]
-    if not any(role in user_roles for role in allowed_roles):
-        frappe.throw(_("You do not have permission to add maintenance materials"), frappe.PermissionError)
+	Returns:
+	    {"success": True, "message": "...", "request": {...}}
+	"""
+	# RBAC: Only Projects User/Manager can add materials
+	user_roles = frappe.get_roles(frappe.session.user)
+	allowed_roles = ["Projects User", "Projects Manager", "System Manager"]
+	if not any(role in user_roles for role in allowed_roles):
+		frappe.throw(_("You do not have permission to add maintenance materials"), frappe.PermissionError)
 
-    if not request_id:
-        frappe.throw(_("Request ID is required"))
+	if not request_id:
+		frappe.throw(_("Request ID is required"))
 
-    if not frappe.db.exists("BEI Maintenance Request", request_id):
-        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+	if not frappe.db.exists("BEI Maintenance Request", request_id):
+		frappe.throw(_("Maintenance request {0} not found").format(request_id))
 
-    if isinstance(materials, str):
-        try:
-            materials = json.loads(materials)
-        except (json.JSONDecodeError, ValueError):
-            frappe.throw(_("Invalid materials format: must be valid JSON"))
+	if isinstance(materials, str):
+		try:
+			materials = json.loads(materials)
+		except (json.JSONDecodeError, ValueError):
+			frappe.throw(_("Invalid materials format: must be valid JSON"))
 
-    if not materials or not isinstance(materials, list):
-        frappe.throw(_("Materials must be a non-empty list"))
+	if not materials or not isinstance(materials, list):
+		frappe.throw(_("Materials must be a non-empty list"))
 
-    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+	doc = frappe.get_doc("BEI Maintenance Request", request_id)
 
-    total_materials_cost = 0
-    for mat in materials:
-        quantity = flt(mat.get("quantity", 1))
-        unit_cost = flt(mat.get("unit_cost", 0))
+	total_materials_cost = 0
+	for mat in materials:
+		quantity = flt(mat.get("quantity", 1))
+		unit_cost = flt(mat.get("unit_cost", 0))
 
-        if quantity <= 0:
-            frappe.throw(_("Material quantity must be positive"))
-        if unit_cost < 0:
-            frappe.throw(_("Material unit cost cannot be negative"))
+		if quantity <= 0:
+			frappe.throw(_("Material quantity must be positive"))
+		if unit_cost < 0:
+			frappe.throw(_("Material unit cost cannot be negative"))
 
-        total_cost = quantity * unit_cost
-        total_materials_cost += total_cost
+		total_cost = quantity * unit_cost
+		total_materials_cost += total_cost
 
-        doc.append("materials", {
-            "material": mat.get("material"),
-            "quantity": quantity,
-            "unit": mat.get("unit", "pcs"),
-            "unit_cost": unit_cost,
-            "total_cost": total_cost
-        })
+		doc.append(
+			"materials",
+			{
+				"material": mat.get("material"),
+				"quantity": quantity,
+				"unit": mat.get("unit", "pcs"),
+				"unit_cost": unit_cost,
+				"total_cost": total_cost,
+			},
+		)
 
-    doc.materials_cost = flt(doc.materials_cost or 0) + total_materials_cost
-    doc.total_cost = flt(doc.materials_cost) + flt(doc.labor_cost or 0) + flt(doc.vendor_cost or 0)
-    doc.flags.ignore_permissions = True
-    doc.save()
+	doc.materials_cost = flt(doc.materials_cost or 0) + total_materials_cost
+	doc.total_cost = flt(doc.materials_cost) + flt(doc.labor_cost or 0) + flt(doc.vendor_cost or 0)
+	doc.flags.ignore_permissions = True
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("{0} materials added to {1}").format(len(materials), request_id),
-        "request": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("{0} materials added to {1}").format(len(materials), request_id),
+		"request": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def update_maintenance_costs(request_id, labor_hours=None, labor_cost=None, vendor_cost=None):
-    """
-    Update labor costs for a maintenance request.
+	"""
+	Update labor costs for a maintenance request.
 
-    Args:
-        request_id: The maintenance request name
-        labor_hours: Hours of labor
-        labor_cost: Cost of labor
-        vendor_cost: External contractor invoice amount
+	Args:
+	    request_id: The maintenance request name
+	    labor_hours: Hours of labor
+	    labor_cost: Cost of labor
+	    vendor_cost: External contractor invoice amount
 
-    Returns:
-        {"success": True, "message": "...", "request": {...}}
-    """
-    # RBAC: Only Projects User/Manager can update maintenance costs
-    user_roles = frappe.get_roles(frappe.session.user)
-    allowed_roles = ["Projects User", "Projects Manager", "System Manager"]
-    if not any(role in user_roles for role in allowed_roles):
-        frappe.throw(_("You do not have permission to update maintenance costs"), frappe.PermissionError)
+	Returns:
+	    {"success": True, "message": "...", "request": {...}}
+	"""
+	# RBAC: Only Projects User/Manager can update maintenance costs
+	user_roles = frappe.get_roles(frappe.session.user)
+	allowed_roles = ["Projects User", "Projects Manager", "System Manager"]
+	if not any(role in user_roles for role in allowed_roles):
+		frappe.throw(_("You do not have permission to update maintenance costs"), frappe.PermissionError)
 
-    if not request_id:
-        frappe.throw(_("Request ID is required"))
+	if not request_id:
+		frappe.throw(_("Request ID is required"))
 
-    if not frappe.db.exists("BEI Maintenance Request", request_id):
-        frappe.throw(_("Maintenance request {0} not found").format(request_id))
+	if not frappe.db.exists("BEI Maintenance Request", request_id):
+		frappe.throw(_("Maintenance request {0} not found").format(request_id))
 
-    doc = frappe.get_doc("BEI Maintenance Request", request_id)
+	doc = frappe.get_doc("BEI Maintenance Request", request_id)
 
-    if labor_hours is not None:
-        doc.labor_hours = flt(labor_hours)
+	if labor_hours is not None:
+		doc.labor_hours = flt(labor_hours)
 
-    if labor_cost is not None:
-        doc.labor_cost = flt(labor_cost)
+	if labor_cost is not None:
+		doc.labor_cost = flt(labor_cost)
 
-    if vendor_cost is not None:
-        doc.vendor_cost = flt(vendor_cost)
+	if vendor_cost is not None:
+		doc.vendor_cost = flt(vendor_cost)
 
-    # Recalculate total cost
-    doc.total_cost = flt(doc.materials_cost or 0) + flt(doc.labor_cost or 0) + flt(doc.vendor_cost or 0)
-    doc.flags.ignore_permissions = True
-    doc.save()
+	# Recalculate total cost
+	doc.total_cost = flt(doc.materials_cost or 0) + flt(doc.labor_cost or 0) + flt(doc.vendor_cost or 0)
+	doc.flags.ignore_permissions = True
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Costs updated for {0}").format(request_id),
-        "request": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Costs updated for {0}").format(request_id),
+		"request": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def get_maintenance_categories():
-    """
-    Get list of maintenance categories for filter dropdown.
+	"""
+	Get list of maintenance categories for filter dropdown.
 
-    Returns:
-        {"categories": ["Electrical", "Plumbing", ...]}
-    """
-    # Auth guard: reject unauthenticated requests
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {"categories": ["Electrical", "Plumbing", ...]}
+	"""
+	# Auth guard: reject unauthenticated requests
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    # Get categories from DocType options
-    meta = frappe.get_meta("BEI Maintenance Request")
-    field = meta.get_field("issue_category")
+	# Get categories from DocType options
+	meta = frappe.get_meta("BEI Maintenance Request")
+	field = meta.get_field("issue_category")
 
-    if field and field.options:
-        categories = [opt.strip() for opt in field.options.split("\n") if opt.strip()]
-    else:
-        categories = ["Electrical", "Plumbing", "Mechanical", "Pest", "Security", "Network", "Architectural", "Other"]
+	if field and field.options:
+		categories = [opt.strip() for opt in field.options.split("\n") if opt.strip()]
+	else:
+		categories = [
+			"Electrical",
+			"Plumbing",
+			"Mechanical",
+			"Pest",
+			"Security",
+			"Network",
+			"Architectural",
+			"Other",
+		]
 
-    return {"categories": categories}
+	return {"categories": categories}
 
 
 # ==============================================================================
@@ -1456,271 +1487,293 @@ def get_maintenance_categories():
 
 @frappe.whitelist()
 def get_project_dashboard():
-    """
-    Get projects grouped by stage for kanban dashboard.
+	"""
+	Get projects grouped by stage for kanban dashboard.
 
-    Returns:
-        {
-            "pre_design": [...],
-            "design": [...],
-            ...
-            "summary": {"total_active": int, "total_budget": float}
-        }
-    """
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {
+	        "pre_design": [...],
+	        "design": [...],
+	        ...
+	        "summary": {"total_active": int, "total_budget": float}
+	    }
+	"""
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    stages = ["Pre-Design", "Design", "Bidding", "Pre-Construction",
-              "Construction", "Post-Construction", "Completed"]
+	stages = [
+		"Pre-Design",
+		"Design",
+		"Bidding",
+		"Pre-Construction",
+		"Construction",
+		"Post-Construction",
+		"Completed",
+	]
 
-    result = {}
-    for stage in stages:
-        projects = frappe.get_all(
-            "BEI Project",
-            filters={"stage": stage, "status": ["!=", "Cancelled"]},
-            fields=[
-                "name", "project_name", "project_type", "store", "store_code",
-                "target_opening_date", "progress_percent", "contract_amount",
-                "priority", "project_manager"
-            ],
-            order_by="priority desc, target_opening_date asc"
-        )
+	result = {}
+	for stage in stages:
+		projects = frappe.get_all(
+			"BEI Project",
+			filters={"stage": stage, "status": ["!=", "Cancelled"]},
+			fields=[
+				"name",
+				"project_name",
+				"project_type",
+				"store",
+				"store_code",
+				"target_opening_date",
+				"progress_percent",
+				"contract_amount",
+				"priority",
+				"project_manager",
+			],
+			order_by="priority desc, target_opening_date asc",
+		)
 
-        # Get project manager names
-        for proj in projects:
-            if proj.project_manager:
-                proj["project_manager_name"] = frappe.db.get_value(
-                    "Employee", proj.project_manager, "employee_name"
-                )
+		# Get project manager names
+		for proj in projects:
+			if proj.project_manager:
+				proj["project_manager_name"] = frappe.db.get_value(
+					"Employee", proj.project_manager, "employee_name"
+				)
 
-        key = stage.lower().replace("-", "_").replace(" ", "_")
-        result[key] = projects
+		key = stage.lower().replace("-", "_").replace(" ", "_")
+		result[key] = projects
 
-    # Summary stats
-    total_active = frappe.db.count("BEI Project", {
-        "stage": ["not in", ["Completed", "Cancelled", "On Hold"]],
-        "status": ["!=", "Cancelled"]
-    })
+	# Summary stats
+	total_active = frappe.db.count(
+		"BEI Project",
+		{"stage": ["not in", ["Completed", "Cancelled", "On Hold"]], "status": ["!=", "Cancelled"]},
+	)
 
-    total_budget = frappe.db.sql("""
+	total_budget = frappe.db.sql("""
         SELECT COALESCE(SUM(contract_amount), 0)
         FROM `tabBEI Project`
         WHERE stage NOT IN ('Completed', 'Cancelled', 'On Hold')
         AND status != 'Cancelled'
     """)[0][0]
 
-    result["summary"] = {
-        "total_active": total_active,
-        "total_budget": flt(total_budget),
-        "stages": stages
-    }
+	result["summary"] = {"total_active": total_active, "total_budget": flt(total_budget), "stages": stages}
 
-    return result
+	return result
 
 
 @frappe.whitelist()
 def get_project_detail(project):
-    """
-    Get full project detail with related documents.
+	"""
+	Get full project detail with related documents.
 
-    Args:
-        project: The project name (e.g., PROJ-2026-0001)
+	Args:
+	    project: The project name (e.g., PROJ-2026-0001)
 
-    Returns:
-        {
-            "project": {...},
-            "site_inspections": [...],
-            "bids": [...],
-            "permits": [...],
-            "milestones": [...],
-            "open_punchlist": [...],
-            "punchlist_count": int
-        }
-    """
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {
+	        "project": {...},
+	        "site_inspections": [...],
+	        "bids": [...],
+	        "permits": [...],
+	        "milestones": [...],
+	        "open_punchlist": [...],
+	        "punchlist_count": int
+	    }
+	"""
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    if not project:
-        frappe.throw(_("Project name is required"))
+	if not project:
+		frappe.throw(_("Project name is required"))
 
-    if not frappe.db.exists("BEI Project", project):
-        frappe.throw(_("Project {0} not found").format(project))
+	if not frappe.db.exists("BEI Project", project):
+		frappe.throw(_("Project {0} not found").format(project))
 
-    doc = frappe.get_doc("BEI Project", project)
-    project_data = doc.as_dict()
+	doc = frappe.get_doc("BEI Project", project)
+	project_data = doc.as_dict()
 
-    # Get project manager name
-    if doc.project_manager:
-        project_data["project_manager_name"] = frappe.db.get_value(
-            "Employee", doc.project_manager, "employee_name"
-        )
+	# Get project manager name
+	if doc.project_manager:
+		project_data["project_manager_name"] = frappe.db.get_value(
+			"Employee", doc.project_manager, "employee_name"
+		)
 
-    # Get contractor name
-    if doc.contractor:
-        project_data["contractor_name"] = frappe.db.get_value(
-            "BEI Supplier", doc.contractor, "supplier_name"
-        )
+	# Get contractor name
+	if doc.contractor:
+		project_data["contractor_name"] = frappe.db.get_value("BEI Supplier", doc.contractor, "supplier_name")
 
-    # Get site inspections
-    site_inspections = frappe.get_all(
-        "BEI Site Inspection",
-        filters={"project": project},
-        fields=["name", "inspection_date", "inspection_type", "status",
-                "overall_status", "inspector_name"],
-        order_by="inspection_date desc"
-    )
+	# Get site inspections
+	site_inspections = frappe.get_all(
+		"BEI Site Inspection",
+		filters={"project": project},
+		fields=["name", "inspection_date", "inspection_type", "status", "overall_status", "inspector_name"],
+		order_by="inspection_date desc",
+	)
 
-    # Get bids
-    bids = frappe.get_all(
-        "BEI Project Bid",
-        filters={"project": project},
-        fields=["name", "contractor", "contractor_name", "total_amount",
-                "final_amount", "status", "is_awarded", "submission_date"],
-        order_by="submission_date desc"
-    )
+	# Get bids
+	bids = frappe.get_all(
+		"BEI Project Bid",
+		filters={"project": project},
+		fields=[
+			"name",
+			"contractor",
+			"contractor_name",
+			"total_amount",
+			"final_amount",
+			"status",
+			"is_awarded",
+			"submission_date",
+		],
+		order_by="submission_date desc",
+	)
 
-    # Get permits
-    permits = frappe.get_all(
-        "BEI Project Permit",
-        filters={"project": project},
-        fields=["name", "permit_type", "status", "permit_number",
-                "approval_date", "expiry_date"],
-        order_by="permit_type"
-    )
+	# Get permits
+	permits = frappe.get_all(
+		"BEI Project Permit",
+		filters={"project": project},
+		fields=["name", "permit_type", "status", "permit_number", "approval_date", "expiry_date"],
+		order_by="permit_type",
+	)
 
-    # Get milestones
-    milestones = frappe.get_all(
-        "BEI Project Milestone",
-        filters={"project": project},
-        fields=["name", "milestone_name", "milestone_type", "status",
-                "target_date", "actual_date", "completion_percentage",
-                "billing_amount", "payment_status"],
-        order_by="sequence asc"
-    )
+	# Get milestones
+	milestones = frappe.get_all(
+		"BEI Project Milestone",
+		filters={"project": project},
+		fields=[
+			"name",
+			"milestone_name",
+			"milestone_type",
+			"status",
+			"target_date",
+			"actual_date",
+			"completion_percentage",
+			"billing_amount",
+			"payment_status",
+		],
+		order_by="sequence asc",
+	)
 
-    # Get open punchlist items
-    punchlist = frappe.get_all(
-        "BEI Punchlist Item",
-        filters={"project": project, "status": ["not in", ["Closed", "Waived"]]},
-        fields=["name", "category", "severity", "status", "location",
-                "description", "due_date"],
-        order_by="severity desc, due_date asc"
-    )
+	# Get open punchlist items
+	punchlist = frappe.get_all(
+		"BEI Punchlist Item",
+		filters={"project": project, "status": ["not in", ["Closed", "Waived"]]},
+		fields=["name", "category", "severity", "status", "location", "description", "due_date"],
+		order_by="severity desc, due_date asc",
+	)
 
-    # Count total punchlist items
-    total_punchlist = frappe.db.count("BEI Punchlist Item", {"project": project})
-    closed_punchlist = frappe.db.count("BEI Punchlist Item", {
-        "project": project,
-        "status": ["in", ["Closed", "Waived"]]
-    })
+	# Count total punchlist items
+	total_punchlist = frappe.db.count("BEI Punchlist Item", {"project": project})
+	closed_punchlist = frappe.db.count(
+		"BEI Punchlist Item", {"project": project, "status": ["in", ["Closed", "Waived"]]}
+	)
 
-    return {
-        "project": project_data,
-        "site_inspections": site_inspections,
-        "bids": bids,
-        "permits": permits,
-        "milestones": milestones,
-        "open_punchlist": punchlist,
-        "punchlist_count": {
-            "total": total_punchlist,
-            "open": len(punchlist),
-            "closed": closed_punchlist
-        }
-    }
+	return {
+		"project": project_data,
+		"site_inspections": site_inspections,
+		"bids": bids,
+		"permits": permits,
+		"milestones": milestones,
+		"open_punchlist": punchlist,
+		"punchlist_count": {"total": total_punchlist, "open": len(punchlist), "closed": closed_punchlist},
+	}
 
 
 @frappe.whitelist()
 def advance_project_stage(project, new_stage, notes=None):
-    """
-    Move project to a new stage.
+	"""
+	Move project to a new stage.
 
-    Args:
-        project: The project name
-        new_stage: The new stage
-        notes: Optional notes for the stage change
+	Args:
+	    project: The project name
+	    new_stage: The new stage
+	    notes: Optional notes for the stage change
 
-    Returns:
-        {"success": True, "message": "...", "project": {...}}
-    """
-    # RBAC: Only Projects Manager and above can advance project stages
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "project": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can advance project stages
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    valid_stages = ["Pre-Design", "Design", "Bidding", "Pre-Construction",
-                    "Construction", "Post-Construction", "Completed",
-                    "On Hold", "Cancelled"]
+	valid_stages = [
+		"Pre-Design",
+		"Design",
+		"Bidding",
+		"Pre-Construction",
+		"Construction",
+		"Post-Construction",
+		"Completed",
+		"On Hold",
+		"Cancelled",
+	]
 
-    if new_stage not in valid_stages:
-        frappe.throw(_("Invalid stage: {0}").format(new_stage))
+	if new_stage not in valid_stages:
+		frappe.throw(_("Invalid stage: {0}").format(new_stage))
 
-    if not frappe.db.exists("BEI Project", project):
-        frappe.throw(_("Project {0} not found").format(project))
+	if not frappe.db.exists("BEI Project", project):
+		frappe.throw(_("Project {0} not found").format(project))
 
-    doc = frappe.get_doc("BEI Project", project)
-    old_stage = doc.stage
-    doc.stage = new_stage
-    doc.last_update_date = nowdate()
+	doc = frappe.get_doc("BEI Project", project)
+	old_stage = doc.stage
+	doc.stage = new_stage
+	doc.last_update_date = nowdate()
 
-    if notes:
-        doc.notes = notes
-        doc.add_comment("Comment", f"Stage changed from {old_stage} to {new_stage}: {notes}")
+	if notes:
+		doc.notes = notes
+		doc.add_comment("Comment", f"Stage changed from {old_stage} to {new_stage}: {notes}")
 
-    # Update status based on stage
-    if new_stage == "Completed":
-        doc.status = "Completed"
-        doc.actual_completion_date = nowdate()
-    elif new_stage in ["On Hold", "Cancelled"]:
-        doc.status = new_stage
-    else:
-        doc.status = "Active"
+	# Update status based on stage
+	if new_stage == "Completed":
+		doc.status = "Completed"
+		doc.actual_completion_date = nowdate()
+	elif new_stage in ["On Hold", "Cancelled"]:
+		doc.status = new_stage
+	else:
+		doc.status = "Active"
 
-    doc.save()
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Project {0} moved from {1} to {2}").format(
-            project, old_stage, new_stage
-        ),
-        "project": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Project {0} moved from {1} to {2}").format(project, old_stage, new_stage),
+		"project": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def update_project_progress(project, progress_percent, notes=None):
-    """
-    Update project progress percentage.
+	"""
+	Update project progress percentage.
 
-    Args:
-        project: The project name
-        progress_percent: New progress percentage (0-100)
-        notes: Optional progress notes
+	Args:
+	    project: The project name
+	    progress_percent: New progress percentage (0-100)
+	    notes: Optional progress notes
 
-    Returns:
-        {"success": True, "message": "...", "project": {...}}
-    """
-    # RBAC: Only Projects Manager and above can update project progress
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "project": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can update project progress
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Project", project):
-        frappe.throw(_("Project {0} not found").format(project))
+	if not frappe.db.exists("BEI Project", project):
+		frappe.throw(_("Project {0} not found").format(project))
 
-    progress = flt(progress_percent)
-    if progress < 0 or progress > 100:
-        frappe.throw(_("Progress must be between 0 and 100"))
+	progress = flt(progress_percent)
+	if progress < 0 or progress > 100:
+		frappe.throw(_("Progress must be between 0 and 100"))
 
-    doc = frappe.get_doc("BEI Project", project)
-    doc.progress_percent = progress
-    doc.last_update_date = nowdate()
+	doc = frappe.get_doc("BEI Project", project)
+	doc.progress_percent = progress
+	doc.last_update_date = nowdate()
 
-    if notes:
-        doc.notes = notes
+	if notes:
+		doc.notes = notes
 
-    doc.save()
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Project {0} progress updated to {1}%").format(project, progress),
-        "project": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Project {0} progress updated to {1}%").format(project, progress),
+		"project": doc.as_dict(),
+	}
 
 
 # ==============================================================================
@@ -1730,112 +1783,112 @@ def update_project_progress(project, progress_percent, notes=None):
 
 @frappe.whitelist()
 def submit_site_inspection(inspection_id):
-    """
-    Submit a site inspection for approval.
+	"""
+	Submit a site inspection for approval.
 
-    Args:
-        inspection_id: The site inspection name
+	Args:
+	    inspection_id: The site inspection name
 
-    Returns:
-        {"success": True, "message": "...", "inspection": {...}}
-    """
-    # RBAC: Only Projects Manager and above can submit site inspections
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "inspection": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can submit site inspections
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Site Inspection", inspection_id):
-        frappe.throw(_("Site inspection {0} not found").format(inspection_id))
+	if not frappe.db.exists("BEI Site Inspection", inspection_id):
+		frappe.throw(_("Site inspection {0} not found").format(inspection_id))
 
-    doc = frappe.get_doc("BEI Site Inspection", inspection_id)
+	doc = frappe.get_doc("BEI Site Inspection", inspection_id)
 
-    if doc.status != "Draft":
-        frappe.throw(_("Only draft inspections can be submitted"))
+	if doc.status != "Draft":
+		frappe.throw(_("Only draft inspections can be submitted"))
 
-    doc.status = "Submitted"
-    doc.submitted_by = frappe.session.user
-    doc.submitted_at = now_datetime()
-    doc.save()
+	doc.status = "Submitted"
+	doc.submitted_by = frappe.session.user
+	doc.submitted_at = now_datetime()
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Site inspection {0} submitted for approval").format(inspection_id),
-        "inspection": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Site inspection {0} submitted for approval").format(inspection_id),
+		"inspection": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def approve_site_inspection(inspection_id, approval_notes=None):
-    """
-    Approve a submitted site inspection.
+	"""
+	Approve a submitted site inspection.
 
-    Args:
-        inspection_id: The site inspection name
-        approval_notes: Optional approval notes
+	Args:
+	    inspection_id: The site inspection name
+	    approval_notes: Optional approval notes
 
-    Returns:
-        {"success": True, "message": "...", "inspection": {...}}
-    """
-    # RBAC: Only Projects Manager and above can approve site inspections
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "inspection": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can approve site inspections
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Site Inspection", inspection_id):
-        frappe.throw(_("Site inspection {0} not found").format(inspection_id))
+	if not frappe.db.exists("BEI Site Inspection", inspection_id):
+		frappe.throw(_("Site inspection {0} not found").format(inspection_id))
 
-    doc = frappe.get_doc("BEI Site Inspection", inspection_id)
+	doc = frappe.get_doc("BEI Site Inspection", inspection_id)
 
-    if doc.status != "Submitted":
-        frappe.throw(_("Only submitted inspections can be approved"))
+	if doc.status != "Submitted":
+		frappe.throw(_("Only submitted inspections can be approved"))
 
-    doc.status = "Approved"
-    doc.approved_by = frappe.session.user
-    doc.approved_date = nowdate()
+	doc.status = "Approved"
+	doc.approved_by = frappe.session.user
+	doc.approved_date = nowdate()
 
-    if approval_notes:
-        doc.add_comment("Comment", f"Approved: {approval_notes}")
+	if approval_notes:
+		doc.add_comment("Comment", f"Approved: {approval_notes}")
 
-    doc.save()
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Site inspection {0} approved").format(inspection_id),
-        "inspection": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Site inspection {0} approved").format(inspection_id),
+		"inspection": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def reject_site_inspection(inspection_id, rejection_reason):
-    """
-    Reject a submitted site inspection.
+	"""
+	Reject a submitted site inspection.
 
-    Args:
-        inspection_id: The site inspection name
-        rejection_reason: Reason for rejection
+	Args:
+	    inspection_id: The site inspection name
+	    rejection_reason: Reason for rejection
 
-    Returns:
-        {"success": True, "message": "...", "inspection": {...}}
-    """
-    # RBAC: Only Projects Manager and above can reject site inspections
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "inspection": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can reject site inspections
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not rejection_reason:
-        frappe.throw(_("Rejection reason is required"))
+	if not rejection_reason:
+		frappe.throw(_("Rejection reason is required"))
 
-    if not frappe.db.exists("BEI Site Inspection", inspection_id):
-        frappe.throw(_("Site inspection {0} not found").format(inspection_id))
+	if not frappe.db.exists("BEI Site Inspection", inspection_id):
+		frappe.throw(_("Site inspection {0} not found").format(inspection_id))
 
-    doc = frappe.get_doc("BEI Site Inspection", inspection_id)
+	doc = frappe.get_doc("BEI Site Inspection", inspection_id)
 
-    if doc.status != "Submitted":
-        frappe.throw(_("Only submitted inspections can be rejected"))
+	if doc.status != "Submitted":
+		frappe.throw(_("Only submitted inspections can be rejected"))
 
-    doc.status = "Rejected"
-    doc.rejection_reason = rejection_reason
-    doc.save()
+	doc.status = "Rejected"
+	doc.rejection_reason = rejection_reason
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Site inspection {0} rejected").format(inspection_id),
-        "inspection": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Site inspection {0} rejected").format(inspection_id),
+		"inspection": doc.as_dict(),
+	}
 
 
 # ==============================================================================
@@ -1845,165 +1898,173 @@ def reject_site_inspection(inspection_id, rejection_reason):
 
 @frappe.whitelist()
 def get_bid_comparison(project):
-    """
-    Get bid comparison for a project.
+	"""
+	Get bid comparison for a project.
 
-    Args:
-        project: The project name
+	Args:
+	    project: The project name
 
-    Returns:
-        {
-            "project": {...},
-            "bids": [...],
-            "lowest_bid": {...} or None,
-            "awarded_bid": {...} or None
-        }
-    """
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
-    if not frappe.db.exists("BEI Project", project):
-        frappe.throw(_("Project {0} not found").format(project))
+	Returns:
+	    {
+	        "project": {...},
+	        "bids": [...],
+	        "lowest_bid": {...} or None,
+	        "awarded_bid": {...} or None
+	    }
+	"""
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	if not frappe.db.exists("BEI Project", project):
+		frappe.throw(_("Project {0} not found").format(project))
 
-    project_doc = frappe.get_doc("BEI Project", project)
+	project_doc = frappe.get_doc("BEI Project", project)
 
-    bids = frappe.get_all(
-        "BEI Project Bid",
-        filters={"project": project, "status": ["!=", "Withdrawn"]},
-        fields=[
-            "name", "contractor", "contractor_name", "submission_date",
-            "base_amount", "vat_amount", "total_amount", "final_amount",
-            "status", "technical_score", "financial_score", "overall_score",
-            "is_awarded"
-        ],
-        order_by="total_amount asc"
-    )
+	bids = frappe.get_all(
+		"BEI Project Bid",
+		filters={"project": project, "status": ["!=", "Withdrawn"]},
+		fields=[
+			"name",
+			"contractor",
+			"contractor_name",
+			"submission_date",
+			"base_amount",
+			"vat_amount",
+			"total_amount",
+			"final_amount",
+			"status",
+			"technical_score",
+			"financial_score",
+			"overall_score",
+			"is_awarded",
+		],
+		order_by="total_amount asc",
+	)
 
-    lowest_bid = bids[0] if bids else None
-    awarded_bid = next((b for b in bids if b.is_awarded), None)
+	lowest_bid = bids[0] if bids else None
+	awarded_bid = next((b for b in bids if b.is_awarded), None)
 
-    return {
-        "project": {
-            "name": project_doc.name,
-            "project_name": project_doc.project_name,
-            "approved_budget": project_doc.approved_budget
-        },
-        "bids": bids,
-        "lowest_bid": lowest_bid,
-        "awarded_bid": awarded_bid,
-        "bid_count": len(bids)
-    }
+	return {
+		"project": {
+			"name": project_doc.name,
+			"project_name": project_doc.project_name,
+			"approved_budget": project_doc.approved_budget,
+		},
+		"bids": bids,
+		"lowest_bid": lowest_bid,
+		"awarded_bid": awarded_bid,
+		"bid_count": len(bids),
+	}
 
 
 @frappe.whitelist()
 def evaluate_bid(bid_id, technical_score, financial_score, evaluation_notes=None):
-    """
-    Evaluate a project bid.
+	"""
+	Evaluate a project bid.
 
-    Args:
-        bid_id: The bid name
-        technical_score: Technical evaluation score (0-100)
-        financial_score: Financial evaluation score (0-100)
-        evaluation_notes: Optional notes
+	Args:
+	    bid_id: The bid name
+	    technical_score: Technical evaluation score (0-100)
+	    financial_score: Financial evaluation score (0-100)
+	    evaluation_notes: Optional notes
 
-    Returns:
-        {"success": True, "message": "...", "bid": {...}}
-    """
-    # RBAC: Only Projects Manager and above can evaluate bids
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "bid": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can evaluate bids
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Project Bid", bid_id):
-        frappe.throw(_("Bid {0} not found").format(bid_id))
+	if not frappe.db.exists("BEI Project Bid", bid_id):
+		frappe.throw(_("Bid {0} not found").format(bid_id))
 
-    tech = flt(technical_score)
-    fin = flt(financial_score)
+	tech = flt(technical_score)
+	fin = flt(financial_score)
 
-    if tech < 0 or tech > 100 or fin < 0 or fin > 100:
-        frappe.throw(_("Scores must be between 0 and 100"))
+	if tech < 0 or tech > 100 or fin < 0 or fin > 100:
+		frappe.throw(_("Scores must be between 0 and 100"))
 
-    doc = frappe.get_doc("BEI Project Bid", bid_id)
-    doc.technical_score = tech
-    doc.financial_score = fin
-    doc.overall_score = (tech * 0.6) + (fin * 0.4)  # 60% technical, 40% financial
-    doc.status = "Under Review"
+	doc = frappe.get_doc("BEI Project Bid", bid_id)
+	doc.technical_score = tech
+	doc.financial_score = fin
+	doc.overall_score = (tech * 0.6) + (fin * 0.4)  # 60% technical, 40% financial
+	doc.status = "Under Review"
 
-    if evaluation_notes:
-        doc.evaluation_notes = evaluation_notes
+	if evaluation_notes:
+		doc.evaluation_notes = evaluation_notes
 
-    doc.save()
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Bid {0} evaluated with overall score {1}%").format(
-            bid_id, round(doc.overall_score, 1)
-        ),
-        "bid": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Bid {0} evaluated with overall score {1}%").format(bid_id, round(doc.overall_score, 1)),
+		"bid": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def award_bid(bid_id, final_amount=None, award_notes=None):
-    """
-    Award a bid to a contractor.
+	"""
+	Award a bid to a contractor.
 
-    Args:
-        bid_id: The bid name
-        final_amount: Negotiated final amount (optional)
-        award_notes: Award notes (optional)
+	Args:
+	    bid_id: The bid name
+	    final_amount: Negotiated final amount (optional)
+	    award_notes: Award notes (optional)
 
-    Returns:
-        {"success": True, "message": "...", "bid": {...}}
-    """
-    # RBAC: Only Projects Manager and above can award bids
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "bid": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can award bids
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Project Bid", bid_id):
-        frappe.throw(_("Bid {0} not found").format(bid_id))
+	if not frappe.db.exists("BEI Project Bid", bid_id):
+		frappe.throw(_("Bid {0} not found").format(bid_id))
 
-    doc = frappe.get_doc("BEI Project Bid", bid_id)
+	doc = frappe.get_doc("BEI Project Bid", bid_id)
 
-    # Check no other bid is awarded for this project
-    existing_award = frappe.db.exists("BEI Project Bid", {
-        "project": doc.project,
-        "is_awarded": 1,
-        "name": ["!=", bid_id]
-    })
+	# Check no other bid is awarded for this project
+	existing_award = frappe.db.exists(
+		"BEI Project Bid", {"project": doc.project, "is_awarded": 1, "name": ["!=", bid_id]}
+	)
 
-    if existing_award:
-        frappe.throw(_("Another bid is already awarded for this project"))
+	if existing_award:
+		frappe.throw(_("Another bid is already awarded for this project"))
 
-    doc.is_awarded = 1
-    doc.status = "Awarded"
-    doc.award_date = nowdate()
-    doc.awarded_by = frappe.session.user
+	doc.is_awarded = 1
+	doc.status = "Awarded"
+	doc.award_date = nowdate()
+	doc.awarded_by = frappe.session.user
 
-    if final_amount:
-        doc.final_amount = flt(final_amount)
-    else:
-        doc.final_amount = doc.total_amount
+	if final_amount:
+		doc.final_amount = flt(final_amount)
+	else:
+		doc.final_amount = doc.total_amount
 
-    if award_notes:
-        doc.award_notes = award_notes
+	if award_notes:
+		doc.award_notes = award_notes
 
-    doc.save()
+	doc.save()
 
-    # Update project with contractor info
-    project = frappe.get_doc("BEI Project", doc.project)
-    project.contractor = doc.contractor
-    project.contract_amount = doc.final_amount
-    project.save()
+	# Update project with contractor info
+	project = frappe.get_doc("BEI Project", doc.project)
+	project.contractor = doc.contractor
+	project.contract_amount = doc.final_amount
+	project.save()
 
-    # Mark other bids as not awarded
-    frappe.db.sql("""
+	# Mark other bids as not awarded
+	frappe.db.sql(
+		"""
         UPDATE `tabBEI Project Bid`
         SET status = 'Not Awarded'
         WHERE project = %s AND name != %s AND status NOT IN ('Withdrawn', 'Awarded')
-    """, (doc.project, bid_id))
+    """,
+		(doc.project, bid_id),
+	)
 
-    return {
-        "success": True,
-        "message": _("Bid {0} awarded to {1}").format(bid_id, doc.contractor_name),
-        "bid": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Bid {0} awarded to {1}").format(bid_id, doc.contractor_name),
+		"bid": doc.as_dict(),
+	}
 
 
 # ==============================================================================
@@ -2013,150 +2074,148 @@ def award_bid(bid_id, final_amount=None, award_notes=None):
 
 @frappe.whitelist()
 def complete_milestone(milestone_id, actual_date=None, notes=None):
-    """
-    Mark a milestone as completed.
+	"""
+	Mark a milestone as completed.
 
-    Args:
-        milestone_id: The milestone name
-        actual_date: Actual completion date (defaults to today)
-        notes: Completion notes
+	Args:
+	    milestone_id: The milestone name
+	    actual_date: Actual completion date (defaults to today)
+	    notes: Completion notes
 
-    Returns:
-        {"success": True, "message": "...", "milestone": {...}}
-    """
-    # RBAC: Only Projects Manager and above can complete milestones
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "milestone": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can complete milestones
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Project Milestone", milestone_id):
-        frappe.throw(_("Milestone {0} not found").format(milestone_id))
+	if not frappe.db.exists("BEI Project Milestone", milestone_id):
+		frappe.throw(_("Milestone {0} not found").format(milestone_id))
 
-    doc = frappe.get_doc("BEI Project Milestone", milestone_id)
-    doc.status = "Completed"
-    doc.completion_percentage = 100
-    doc.actual_date = actual_date or nowdate()
+	doc = frappe.get_doc("BEI Project Milestone", milestone_id)
+	doc.status = "Completed"
+	doc.completion_percentage = 100
+	doc.actual_date = actual_date or nowdate()
 
-    # Calculate variance
-    if doc.target_date and doc.actual_date:
-        doc.days_variance = date_diff(doc.actual_date, doc.target_date)
+	# Calculate variance
+	if doc.target_date and doc.actual_date:
+		doc.days_variance = date_diff(doc.actual_date, doc.target_date)
 
-    doc.save()
+	doc.save()
 
-    # Update project progress based on completed milestones
-    _update_project_progress_from_milestones(doc.project)
+	# Update project progress based on completed milestones
+	_update_project_progress_from_milestones(doc.project)
 
-    return {
-        "success": True,
-        "message": _("Milestone {0} completed").format(doc.milestone_name),
-        "milestone": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Milestone {0} completed").format(doc.milestone_name),
+		"milestone": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def verify_milestone(milestone_id, verification_notes=None):
-    """
-    Verify a completed milestone.
+	"""
+	Verify a completed milestone.
 
-    Args:
-        milestone_id: The milestone name
-        verification_notes: Verification notes
+	Args:
+	    milestone_id: The milestone name
+	    verification_notes: Verification notes
 
-    Returns:
-        {"success": True, "message": "...", "milestone": {...}}
-    """
-    # RBAC: Only Projects Manager and above can verify milestones
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "milestone": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can verify milestones
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Project Milestone", milestone_id):
-        frappe.throw(_("Milestone {0} not found").format(milestone_id))
+	if not frappe.db.exists("BEI Project Milestone", milestone_id):
+		frappe.throw(_("Milestone {0} not found").format(milestone_id))
 
-    doc = frappe.get_doc("BEI Project Milestone", milestone_id)
+	doc = frappe.get_doc("BEI Project Milestone", milestone_id)
 
-    if doc.status != "Completed":
-        frappe.throw(_("Only completed milestones can be verified"))
+	if doc.status != "Completed":
+		frappe.throw(_("Only completed milestones can be verified"))
 
-    doc.status = "Verified"
-    doc.verified = 1
-    doc.verified_by = frappe.session.user
-    doc.verification_date = nowdate()
+	doc.status = "Verified"
+	doc.verified = 1
+	doc.verified_by = frappe.session.user
+	doc.verification_date = nowdate()
 
-    if verification_notes:
-        doc.verification_notes = verification_notes
+	if verification_notes:
+		doc.verification_notes = verification_notes
 
-    doc.save()
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Milestone {0} verified").format(doc.milestone_name),
-        "milestone": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Milestone {0} verified").format(doc.milestone_name),
+		"milestone": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def create_milestone_billing(milestone_id):
-    """
-    Create a payment request for a verified milestone.
+	"""
+	Create a payment request for a verified milestone.
 
-    Args:
-        milestone_id: The milestone name
+	Args:
+	    milestone_id: The milestone name
 
-    Returns:
-        {"success": True, "message": "...", "milestone": {...}, "payment_request": {...}}
-    """
-    # RBAC: Only Projects Manager and above can create milestone billing
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "milestone": {...}, "payment_request": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can create milestone billing
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Project Milestone", milestone_id):
-        frappe.throw(_("Milestone {0} not found").format(milestone_id))
+	if not frappe.db.exists("BEI Project Milestone", milestone_id):
+		frappe.throw(_("Milestone {0} not found").format(milestone_id))
 
-    doc = frappe.get_doc("BEI Project Milestone", milestone_id)
+	doc = frappe.get_doc("BEI Project Milestone", milestone_id)
 
-    if doc.status != "Verified":
-        frappe.throw(_("Only verified milestones can be billed"))
+	if doc.status != "Verified":
+		frappe.throw(_("Only verified milestones can be billed"))
 
-    if doc.payment_request:
-        frappe.throw(_("Payment request already exists: {0}").format(doc.payment_request))
+	if doc.payment_request:
+		frappe.throw(_("Payment request already exists: {0}").format(doc.payment_request))
 
-    if not doc.billing_amount or flt(doc.billing_amount) <= 0:
-        frappe.throw(_("Billing amount must be greater than 0"))
+	if not doc.billing_amount or flt(doc.billing_amount) <= 0:
+		frappe.throw(_("Billing amount must be greater than 0"))
 
-    # Get project details
-    project = frappe.get_doc("BEI Project", doc.project)
+	# Get project details
+	project = frappe.get_doc("BEI Project", doc.project)
 
-    # Create payment request
-    payment_request = frappe.new_doc("BEI Payment Request")
-    payment_request.supplier = project.contractor
-    payment_request.amount = doc.billing_amount
-    payment_request.description = f"Progress billing for {project.project_name} - {doc.milestone_name}"
-    payment_request.insert()
+	# Create payment request
+	payment_request = frappe.new_doc("BEI Payment Request")
+	payment_request.supplier = project.contractor
+	payment_request.amount = doc.billing_amount
+	payment_request.description = f"Progress billing for {project.project_name} - {doc.milestone_name}"
+	payment_request.insert()
 
-    # Link payment request to milestone
-    doc.payment_request = payment_request.name
-    doc.payment_status = "Billed"
-    doc.save()
+	# Link payment request to milestone
+	doc.payment_request = payment_request.name
+	doc.payment_status = "Billed"
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Payment request {0} created for milestone {1}").format(
-            payment_request.name, doc.milestone_name
-        ),
-        "milestone": doc.as_dict(),
-        "payment_request": payment_request.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Payment request {0} created for milestone {1}").format(
+			payment_request.name, doc.milestone_name
+		),
+		"milestone": doc.as_dict(),
+		"payment_request": payment_request.as_dict(),
+	}
 
 
 def _update_project_progress_from_milestones(project_name):
-    """
-    Internal: Update project progress based on milestone completion.
-    """
-    milestones = frappe.get_all(
-        "BEI Project Milestone",
-        filters={"project": project_name},
-        fields=["completion_percentage"]
-    )
+	"""
+	Internal: Update project progress based on milestone completion.
+	"""
+	milestones = frappe.get_all(
+		"BEI Project Milestone", filters={"project": project_name}, fields=["completion_percentage"]
+	)
 
-    if milestones:
-        avg_progress = sum(m.completion_percentage or 0 for m in milestones) / len(milestones)
-        frappe.db.set_value("BEI Project", project_name, "progress_percent", avg_progress)
+	if milestones:
+		avg_progress = sum(m.completion_percentage or 0 for m in milestones) / len(milestones)
+		frappe.db.set_value("BEI Project", project_name, "progress_percent", avg_progress)
 
 
 # ==============================================================================
@@ -2166,260 +2225,253 @@ def _update_project_progress_from_milestones(project_name):
 
 @frappe.whitelist()
 def get_punchlist(project, status=None, category=None, severity=None, page=1, page_size=50):
-    """
-    Get punchlist items for a project.
+	"""
+	Get punchlist items for a project.
 
-    Args:
-        project: The project name
-        status: Filter by status (optional)
-        category: Filter by category (optional)
-        severity: Filter by severity (optional)
-        page: Page number
-        page_size: Items per page
+	Args:
+	    project: The project name
+	    status: Filter by status (optional)
+	    category: Filter by category (optional)
+	    severity: Filter by severity (optional)
+	    page: Page number
+	    page_size: Items per page
 
-    Returns:
-        {
-            "items": [...],
-            "total": int,
-            "page": int,
-            "summary": {...}
-        }
-    """
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {
+	        "items": [...],
+	        "total": int,
+	        "page": int,
+	        "summary": {...}
+	    }
+	"""
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    if not frappe.db.exists("BEI Project", project):
-        frappe.throw(_("Project {0} not found").format(project))
+	if not frappe.db.exists("BEI Project", project):
+		frappe.throw(_("Project {0} not found").format(project))
 
-    filters = {"project": project}
+	filters = {"project": project}
 
-    if status:
-        filters["status"] = status
+	if status:
+		filters["status"] = status
 
-    if category:
-        filters["category"] = category
+	if category:
+		filters["category"] = category
 
-    if severity:
-        filters["severity"] = severity
+	if severity:
+		filters["severity"] = severity
 
-    page = int(page)
-    page_size = int(page_size)
+	page = int(page)
+	page_size = int(page_size)
 
-    total = frappe.db.count("BEI Punchlist Item", filters)
+	total = frappe.db.count("BEI Punchlist Item", filters)
 
-    items = frappe.get_all(
-        "BEI Punchlist Item",
-        filters=filters,
-        fields=[
-            "name", "category", "severity", "status", "location",
-            "description", "due_date", "assigned_to", "contractor",
-            "photo", "resolved_date"
-        ],
-        order_by="severity desc, status asc, due_date asc",
-        limit_page_length=page_size,
-        limit_start=(page - 1) * page_size
-    )
+	items = frappe.get_all(
+		"BEI Punchlist Item",
+		filters=filters,
+		fields=[
+			"name",
+			"category",
+			"severity",
+			"status",
+			"location",
+			"description",
+			"due_date",
+			"assigned_to",
+			"contractor",
+			"photo",
+			"resolved_date",
+		],
+		order_by="severity desc, status asc, due_date asc",
+		limit_page_length=page_size,
+		limit_start=(page - 1) * page_size,
+	)
 
-    # Get summary by severity
-    summary = {}
-    for sev in ["Critical", "Major", "Minor", "Cosmetic"]:
-        summary[sev.lower()] = frappe.db.count("BEI Punchlist Item", {
-            "project": project,
-            "severity": sev,
-            "status": ["not in", ["Closed", "Waived"]]
-        })
+	# Get summary by severity
+	summary = {}
+	for sev in ["Critical", "Major", "Minor", "Cosmetic"]:
+		summary[sev.lower()] = frappe.db.count(
+			"BEI Punchlist Item",
+			{"project": project, "severity": sev, "status": ["not in", ["Closed", "Waived"]]},
+		)
 
-    return {
-        "items": items,
-        "total": total,
-        "page": page,
-        "page_size": page_size,
-        "summary": summary
-    }
+	return {"items": items, "total": total, "page": page, "page_size": page_size, "summary": summary}
 
 
 @frappe.whitelist()
 def add_punchlist_item(
-    project,
-    category,
-    location,
-    description,
-    severity="Minor",
-    photo=None,
-    assigned_to=None,
-    contractor=None,
-    due_date=None
+	project,
+	category,
+	location,
+	description,
+	severity="Minor",
+	photo=None,
+	assigned_to=None,
+	contractor=None,
+	due_date=None,
 ):
-    """
-    Add a punchlist item to a project.
+	"""
+	Add a punchlist item to a project.
 
-    Args:
-        project: The project name
-        category: Issue category
-        location: Location in the project
-        description: Issue description
-        severity: Critical, Major, Minor, Cosmetic (default: Minor)
-        photo: Photo attachment (optional)
-        assigned_to: Assigned user (optional)
-        contractor: Assigned contractor (optional)
-        due_date: Due date (optional)
+	Args:
+	    project: The project name
+	    category: Issue category
+	    location: Location in the project
+	    description: Issue description
+	    severity: Critical, Major, Minor, Cosmetic (default: Minor)
+	    photo: Photo attachment (optional)
+	    assigned_to: Assigned user (optional)
+	    contractor: Assigned contractor (optional)
+	    due_date: Due date (optional)
 
-    Returns:
-        {"success": True, "message": "...", "item": {...}}
-    """
-    # RBAC: Only Projects Manager and above can add punchlist items
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "item": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can add punchlist items
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Project", project):
-        frappe.throw(_("Project {0} not found").format(project))
+	if not frappe.db.exists("BEI Project", project):
+		frappe.throw(_("Project {0} not found").format(project))
 
-    doc = frappe.new_doc("BEI Punchlist Item")
-    doc.project = project
-    doc.category = category
-    doc.location = location
-    doc.description = description
-    doc.severity = severity
-    doc.status = "Open"
-    doc.reported_by = frappe.session.user
-    doc.reported_at = now_datetime()
+	doc = frappe.new_doc("BEI Punchlist Item")
+	doc.project = project
+	doc.category = category
+	doc.location = location
+	doc.description = description
+	doc.severity = severity
+	doc.status = "Open"
+	doc.reported_by = frappe.session.user
+	doc.reported_at = now_datetime()
 
-    if photo:
-        doc.photo = photo
+	if photo:
+		doc.photo = photo
 
-    if assigned_to:
-        doc.assigned_to = assigned_to
+	if assigned_to:
+		doc.assigned_to = assigned_to
 
-    if contractor:
-        doc.contractor = contractor
+	if contractor:
+		doc.contractor = contractor
 
-    if due_date:
-        doc.due_date = due_date
+	if due_date:
+		doc.due_date = due_date
 
-    doc.insert()
+	doc.insert()
 
-    return {
-        "success": True,
-        "message": _("Punchlist item {0} created").format(doc.name),
-        "item": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Punchlist item {0} created").format(doc.name),
+		"item": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def resolve_punchlist_item(item_id, resolution_notes, after_photo=None):
-    """
-    Mark a punchlist item as resolved.
+	"""
+	Mark a punchlist item as resolved.
 
-    Args:
-        item_id: The punchlist item name
-        resolution_notes: Notes about the resolution
-        after_photo: Photo after fix (optional)
+	Args:
+	    item_id: The punchlist item name
+	    resolution_notes: Notes about the resolution
+	    after_photo: Photo after fix (optional)
 
-    Returns:
-        {"success": True, "message": "...", "item": {...}}
-    """
-    # RBAC: Only Projects Manager and above can resolve punchlist items
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "item": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can resolve punchlist items
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not resolution_notes:
-        frappe.throw(_("Resolution notes are required"))
+	if not resolution_notes:
+		frappe.throw(_("Resolution notes are required"))
 
-    if not frappe.db.exists("BEI Punchlist Item", item_id):
-        frappe.throw(_("Punchlist item {0} not found").format(item_id))
+	if not frappe.db.exists("BEI Punchlist Item", item_id):
+		frappe.throw(_("Punchlist item {0} not found").format(item_id))
 
-    doc = frappe.get_doc("BEI Punchlist Item", item_id)
+	doc = frappe.get_doc("BEI Punchlist Item", item_id)
 
-    if doc.status in ["Closed", "Waived"]:
-        frappe.throw(_("Item is already closed"))
+	if doc.status in ["Closed", "Waived"]:
+		frappe.throw(_("Item is already closed"))
 
-    doc.status = "Resolved"
-    doc.resolution_notes = resolution_notes
-    doc.resolved_date = nowdate()
-    doc.resolved_by = frappe.session.user
+	doc.status = "Resolved"
+	doc.resolution_notes = resolution_notes
+	doc.resolved_date = nowdate()
+	doc.resolved_by = frappe.session.user
 
-    if after_photo:
-        doc.after_photo = after_photo
+	if after_photo:
+		doc.after_photo = after_photo
 
-    doc.save()
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Punchlist item {0} resolved").format(item_id),
-        "item": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Punchlist item {0} resolved").format(item_id),
+		"item": doc.as_dict(),
+	}
 
 
 @frappe.whitelist()
 def close_punchlist_item(item_id):
-    """
-    Close a resolved punchlist item after verification.
+	"""
+	Close a resolved punchlist item after verification.
 
-    Args:
-        item_id: The punchlist item name
+	Args:
+	    item_id: The punchlist item name
 
-    Returns:
-        {"success": True, "message": "...", "item": {...}}
-    """
-    # RBAC: Only Projects Manager and above can close punchlist items
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "item": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can close punchlist items
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not frappe.db.exists("BEI Punchlist Item", item_id):
-        frappe.throw(_("Punchlist item {0} not found").format(item_id))
+	if not frappe.db.exists("BEI Punchlist Item", item_id):
+		frappe.throw(_("Punchlist item {0} not found").format(item_id))
 
-    doc = frappe.get_doc("BEI Punchlist Item", item_id)
+	doc = frappe.get_doc("BEI Punchlist Item", item_id)
 
-    if doc.status != "Resolved":
-        frappe.throw(_("Only resolved items can be closed"))
+	if doc.status != "Resolved":
+		frappe.throw(_("Only resolved items can be closed"))
 
-    doc.status = "Closed"
-    doc.verified = 1
-    doc.verified_by = frappe.session.user
-    doc.verification_date = nowdate()
-    doc.save()
+	doc.status = "Closed"
+	doc.verified = 1
+	doc.verified_by = frappe.session.user
+	doc.verification_date = nowdate()
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Punchlist item {0} closed").format(item_id),
-        "item": doc.as_dict()
-    }
+	return {"success": True, "message": _("Punchlist item {0} closed").format(item_id), "item": doc.as_dict()}
 
 
 @frappe.whitelist()
 def waive_punchlist_item(item_id, reason):
-    """
-    Waive a punchlist item (accept as-is).
+	"""
+	Waive a punchlist item (accept as-is).
 
-    Args:
-        item_id: The punchlist item name
-        reason: Reason for waiving
+	Args:
+	    item_id: The punchlist item name
+	    reason: Reason for waiving
 
-    Returns:
-        {"success": True, "message": "...", "item": {...}}
-    """
-    # RBAC: Only Projects Manager and above can waive punchlist items
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "item": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can waive punchlist items
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    if not reason:
-        frappe.throw(_("Waiver reason is required"))
+	if not reason:
+		frappe.throw(_("Waiver reason is required"))
 
-    if not frappe.db.exists("BEI Punchlist Item", item_id):
-        frappe.throw(_("Punchlist item {0} not found").format(item_id))
+	if not frappe.db.exists("BEI Punchlist Item", item_id):
+		frappe.throw(_("Punchlist item {0} not found").format(item_id))
 
-    doc = frappe.get_doc("BEI Punchlist Item", item_id)
+	doc = frappe.get_doc("BEI Punchlist Item", item_id)
 
-    if doc.status in ["Closed", "Waived"]:
-        frappe.throw(_("Item is already closed"))
+	if doc.status in ["Closed", "Waived"]:
+		frappe.throw(_("Item is already closed"))
 
-    doc.status = "Waived"
-    doc.resolution_notes = f"WAIVED: {reason}"
-    doc.resolved_date = nowdate()
-    doc.resolved_by = frappe.session.user
-    doc.save()
+	doc.status = "Waived"
+	doc.resolution_notes = f"WAIVED: {reason}"
+	doc.resolved_date = nowdate()
+	doc.resolved_by = frappe.session.user
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Punchlist item {0} waived").format(item_id),
-        "item": doc.as_dict()
-    }
+	return {"success": True, "message": _("Punchlist item {0} waived").format(item_id), "item": doc.as_dict()}
 
 
 # ==============================================================================
@@ -2429,170 +2481,196 @@ def waive_punchlist_item(item_id, reason):
 
 @frappe.whitelist()
 def get_permit_checklist(project):
-    """
-    Get permit status checklist for a project.
+	"""
+	Get permit status checklist for a project.
 
-    Args:
-        project: The project name
+	Args:
+	    project: The project name
 
-    Returns:
-        {
-            "project": {...},
-            "permits": [...],
-            "summary": {"total": int, "approved": int, "pending": int}
-        }
-    """
-    if frappe.session.user == "Guest":
-        frappe.throw(_("Authentication required"), frappe.AuthenticationError)
+	Returns:
+	    {
+	        "project": {...},
+	        "permits": [...],
+	        "summary": {"total": int, "approved": int, "pending": int}
+	    }
+	"""
+	if frappe.session.user == "Guest":
+		frappe.throw(_("Authentication required"), frappe.AuthenticationError)
 
-    if not frappe.db.exists("BEI Project", project):
-        frappe.throw(_("Project {0} not found").format(project))
+	if not frappe.db.exists("BEI Project", project):
+		frappe.throw(_("Project {0} not found").format(project))
 
-    project_doc = frappe.get_doc("BEI Project", project)
+	project_doc = frappe.get_doc("BEI Project", project)
 
-    permits = frappe.get_all(
-        "BEI Project Permit",
-        filters={"project": project},
-        fields=[
-            "name", "permit_type", "permit_number", "status",
-            "issuing_authority", "application_date", "approval_date",
-            "expiry_date", "total_fees"
-        ],
-        order_by="permit_type"
-    )
+	permits = frappe.get_all(
+		"BEI Project Permit",
+		filters={"project": project},
+		fields=[
+			"name",
+			"permit_type",
+			"permit_number",
+			"status",
+			"issuing_authority",
+			"application_date",
+			"approval_date",
+			"expiry_date",
+			"total_fees",
+		],
+		order_by="permit_type",
+	)
 
-    # Summary
-    total = len(permits)
-    approved = len([p for p in permits if p.status == "Approved"])
-    pending = len([p for p in permits if p.status in ["Not Started", "In Progress", "Pending Requirements", "Submitted"]])
+	# Summary
+	total = len(permits)
+	approved = len([p for p in permits if p.status == "Approved"])
+	pending = len(
+		[
+			p
+			for p in permits
+			if p.status in ["Not Started", "In Progress", "Pending Requirements", "Submitted"]
+		]
+	)
 
-    return {
-        "project": {
-            "name": project_doc.name,
-            "project_name": project_doc.project_name,
-            "store_code": project_doc.store_code
-        },
-        "permits": permits,
-        "summary": {
-            "total": total,
-            "approved": approved,
-            "pending": pending,
-            "completion_rate": round((approved / total * 100), 1) if total > 0 else 0
-        }
-    }
+	return {
+		"project": {
+			"name": project_doc.name,
+			"project_name": project_doc.project_name,
+			"store_code": project_doc.store_code,
+		},
+		"permits": permits,
+		"summary": {
+			"total": total,
+			"approved": approved,
+			"pending": pending,
+			"completion_rate": round((approved / total * 100), 1) if total > 0 else 0,
+		},
+	}
 
 
 @frappe.whitelist()
-def update_permit_status(permit_id, status, permit_number=None, approval_date=None, expiry_date=None, remarks=None):
-    """
-    Update permit status and details.
+def update_permit_status(
+	permit_id, status, permit_number=None, approval_date=None, expiry_date=None, remarks=None
+):
+	"""
+	Update permit status and details.
 
-    Args:
-        permit_id: The permit name
-        status: New status
-        permit_number: Permit number (if approved)
-        approval_date: Approval date (if approved)
-        expiry_date: Expiry date (if applicable)
-        remarks: Optional remarks
+	Args:
+	    permit_id: The permit name
+	    status: New status
+	    permit_number: Permit number (if approved)
+	    approval_date: Approval date (if approved)
+	    expiry_date: Expiry date (if applicable)
+	    remarks: Optional remarks
 
-    Returns:
-        {"success": True, "message": "...", "permit": {...}}
-    """
-    # RBAC: Only Projects Manager and above can update permit status
-    frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
+	Returns:
+	    {"success": True, "message": "...", "permit": {...}}
+	"""
+	# RBAC: Only Projects Manager and above can update permit status
+	frappe.only_for(["Projects Manager", "System Manager", "Administrator"])
 
-    valid_statuses = ["Not Started", "In Progress", "Pending Requirements",
-                      "Submitted", "Approved", "Rejected", "Expired", "Renewed"]
+	valid_statuses = [
+		"Not Started",
+		"In Progress",
+		"Pending Requirements",
+		"Submitted",
+		"Approved",
+		"Rejected",
+		"Expired",
+		"Renewed",
+	]
 
-    if status not in valid_statuses:
-        frappe.throw(_("Invalid status: {0}").format(status))
+	if status not in valid_statuses:
+		frappe.throw(_("Invalid status: {0}").format(status))
 
-    if not frappe.db.exists("BEI Project Permit", permit_id):
-        frappe.throw(_("Permit {0} not found").format(permit_id))
+	if not frappe.db.exists("BEI Project Permit", permit_id):
+		frappe.throw(_("Permit {0} not found").format(permit_id))
 
-    doc = frappe.get_doc("BEI Project Permit", permit_id)
-    old_status = doc.status
-    doc.status = status
+	doc = frappe.get_doc("BEI Project Permit", permit_id)
+	old_status = doc.status
+	doc.status = status
 
-    if permit_number:
-        doc.permit_number = permit_number
+	if permit_number:
+		doc.permit_number = permit_number
 
-    if approval_date:
-        doc.approval_date = approval_date
+	if approval_date:
+		doc.approval_date = approval_date
 
-    if expiry_date:
-        doc.expiry_date = expiry_date
+	if expiry_date:
+		doc.expiry_date = expiry_date
 
-    if remarks:
-        doc.remarks = remarks
+	if remarks:
+		doc.remarks = remarks
 
-    # Calculate total fees
-    doc.total_fees = flt(doc.application_fee or 0) + flt(doc.permit_fee or 0)
+	# Calculate total fees
+	doc.total_fees = flt(doc.application_fee or 0) + flt(doc.permit_fee or 0)
 
-    doc.save()
+	doc.save()
 
-    return {
-        "success": True,
-        "message": _("Permit {0} status updated from {1} to {2}").format(
-            doc.permit_type, old_status, status
-        ),
-        "permit": doc.as_dict()
-    }
+	return {
+		"success": True,
+		"message": _("Permit {0} status updated from {1} to {2}").format(doc.permit_type, old_status, status),
+		"permit": doc.as_dict(),
+	}
+
 
 def check_sla_violations():
-    """Scheduled: send one grouped maintenance SLA digest instead of raw hourly triplets."""
-    from datetime import timedelta
+	"""Scheduled: send one grouped maintenance SLA digest instead of raw hourly triplets."""
+	from datetime import timedelta
 
-    from hrms.api.google_chat import send_notification_event
+	from hrms.api.google_chat import send_notification_event
 
-    SLA_HOURS = {"Urgent": 4, "High": 24, "Normal": 72}
-    now = now_datetime()
-    breached_rows = []
-    counts_by_priority = {"Urgent": 0, "High": 0, "Normal": 0}
+	SLA_HOURS = {"Urgent": 4, "High": 24, "Normal": 72}
+	now = now_datetime()
+	breached_rows = []
+	counts_by_priority = {"Urgent": 0, "High": 0, "Normal": 0}
 
-    for priority, hours in SLA_HOURS.items():
-        threshold_dt = now - timedelta(hours=hours)
-        breached = frappe.get_all(
-            "BEI Maintenance Request",
-            filters={
-                "priority": priority,
-                "status": ["in", ["Open", "Assigned"]],
-                "creation": ["<", threshold_dt],
-            },
-            fields=["name", "store", "priority", "issue_category", "description", "creation"],
-        )
-        counts_by_priority[priority] = len(breached)
-        for req in breached:
-            age_hrs = round((now - req.creation).total_seconds() / 3600, 1)
-            breached_rows.append(
-                {
-                    "name": req.name,
-                    "store": req.store,
-                    "priority": req.priority,
-                    "issue_category": req.issue_category,
-                    "description": req.description,
-                    "age_hours": age_hrs,
-                }
-            )
+	for priority, hours in SLA_HOURS.items():
+		threshold_dt = now - timedelta(hours=hours)
+		breached = frappe.get_all(
+			"BEI Maintenance Request",
+			filters={
+				"priority": priority,
+				"status": ["in", ["Open", "Assigned"]],
+				"creation": ["<", threshold_dt],
+			},
+			fields=["name", "store", "priority", "issue_category", "description", "creation"],
+		)
+		counts_by_priority[priority] = len(breached)
+		for req in breached:
+			age_hrs = round((now - req.creation).total_seconds() / 3600, 1)
+			breached_rows.append(
+				{
+					"name": req.name,
+					"store": req.store,
+					"priority": req.priority,
+					"issue_category": req.issue_category,
+					"description": req.description,
+					"age_hours": age_hrs,
+				}
+			)
 
-    if not breached_rows:
-        return
+	if not breached_rows:
+		return
 
-    severity = "critical" if counts_by_priority.get("Urgent") else "high" if counts_by_priority.get("High") else "medium"
-    sent = send_notification_event(
-        {
-            "family": "maintenance_sla_backlog",
-            "source_system": "frappe",
-            "source_ref": f"maintenance_sla:{nowdate()}",
-            "severity": severity,
-            "owner": "Projects Manager",
-            "facts": {
-                "report_date": nowdate(),
-                "counts_by_priority": counts_by_priority,
-                "breaches": breached_rows,
-            },
-        }
-    )
-    if not sent:
-        frappe.log_error("SLA alert failed", "Maintenance SLA")
-
+	severity = (
+		"critical"
+		if counts_by_priority.get("Urgent")
+		else "high"
+		if counts_by_priority.get("High")
+		else "medium"
+	)
+	sent = send_notification_event(
+		{
+			"family": "maintenance_sla_backlog",
+			"source_system": "frappe",
+			"source_ref": f"maintenance_sla:{nowdate()}",
+			"severity": severity,
+			"owner": "Projects Manager",
+			"facts": {
+				"report_date": nowdate(),
+				"counts_by_priority": counts_by_priority,
+				"breaches": breached_rows,
+			},
+		}
+	)
+	if not sent:
+		frappe.log_error("SLA alert failed", "Maintenance SLA")

--- a/hrms/api/projects.py
+++ b/hrms/api/projects.py
@@ -2540,13 +2540,15 @@ def update_permit_status(permit_id, status, permit_number=None, approval_date=No
     }
 
 def check_sla_violations():
-    """Scheduled: check for SLA breaches on maintenance requests, send Google Chat alerts."""
-    from hrms.api.google_chat import send_message_to_space
-    from hrms.utils.bei_config import get_chat_space, SPACE_NOTIFICATIONS
+    """Scheduled: send one grouped maintenance SLA digest instead of raw hourly triplets."""
     from datetime import timedelta
+
+    from hrms.api.google_chat import send_notification_event
 
     SLA_HOURS = {"Urgent": 4, "High": 24, "Normal": 72}
     now = now_datetime()
+    breached_rows = []
+    counts_by_priority = {"Urgent": 0, "High": 0, "Normal": 0}
 
     for priority, hours in SLA_HOURS.items():
         threshold_dt = now - timedelta(hours=hours)
@@ -2555,20 +2557,42 @@ def check_sla_violations():
             filters={
                 "priority": priority,
                 "status": ["in", ["Open", "Assigned"]],
-                "creation": ["<", threshold_dt]
+                "creation": ["<", threshold_dt],
             },
-            fields=["name", "store", "priority", "issue_category", "description", "creation"]
+            fields=["name", "store", "priority", "issue_category", "description", "creation"],
         )
+        counts_by_priority[priority] = len(breached)
+        for req in breached:
+            age_hrs = round((now - req.creation).total_seconds() / 3600, 1)
+            breached_rows.append(
+                {
+                    "name": req.name,
+                    "store": req.store,
+                    "priority": req.priority,
+                    "issue_category": req.issue_category,
+                    "description": req.description,
+                    "age_hours": age_hrs,
+                }
+            )
 
-        if breached:
-            lines = [f"*SLA BREACH — {priority} ({hours}hr SLA)*"]
-            for req in breached:
-                age_hrs = round((now - req.creation).total_seconds() / 3600, 1)
-                lines.append(f"• {req.name} — {req.store} | {req.issue_category} | Age: {age_hrs}h")
-            message = "\n".join(lines)
-            try:
-                space = get_chat_space(SPACE_NOTIFICATIONS)
-                send_message_to_space(space, message)
-            except Exception:
-                frappe.log_error("SLA alert failed", "Maintenance SLA")
+    if not breached_rows:
+        return
+
+    severity = "critical" if counts_by_priority.get("Urgent") else "high" if counts_by_priority.get("High") else "medium"
+    sent = send_notification_event(
+        {
+            "family": "maintenance_sla_backlog",
+            "source_system": "frappe",
+            "source_ref": f"maintenance_sla:{nowdate()}",
+            "severity": severity,
+            "owner": "Projects Manager",
+            "facts": {
+                "report_date": nowdate(),
+                "counts_by_priority": counts_by_priority,
+                "breaches": breached_rows,
+            },
+        }
+    )
+    if not sent:
+        frappe.log_error("SLA alert failed", "Maintenance SLA")
 

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -15,7 +15,7 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, cint, flt, get_datetime, getdate, now_datetime, nowdate
 
-from hrms.utils.bei_config import get_company
+from hrms.utils.bei_config import SPACE_OPS, get_chat_space, get_company
 from hrms.utils.scm_roles import SCM_APPROVAL_ROLES, check_scm_permission
 from hrms.utils.supply_chain_contracts import (
 	FINANCE_TREATMENT_SAME_COMPANY,
@@ -37,13 +37,22 @@ MANUAL_POS_UPLOAD_DISABLED_MESSAGE = _(
 )
 
 
-def _notify_store_ops(msg):
-	"""Send a non-blocking GChat notification to the Store Ops notifications space."""
-	try:
-		from hrms.api.google_chat import send_message_to_space
-		from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
+def _notify_store_ops(msg=None, *, event=None, requested_space=None):
+	"""Send a non-blocking Store Ops notification.
 
-		send_message_to_space(get_chat_space(SPACE_NOTIFICATIONS), msg)
+	Legacy raw text is kept for non-migrated callers. Sprint 38 structured events
+	should use the ``event`` path.
+	"""
+	try:
+		from hrms.api.google_chat import send_message_to_space, send_notification_event
+
+		if event:
+			payload = dict(event)
+			payload.setdefault("requested_space", requested_space or get_chat_space(SPACE_OPS))
+			send_notification_event(payload)
+			return
+		if msg:
+			send_message_to_space(get_chat_space(SPACE_OPS), msg)
 	except Exception:
 		pass
 
@@ -1755,10 +1764,6 @@ def submit_order(
 
 	order.insert(ignore_permissions=True)
 
-	_notify_store_ops(
-		f"New store order {order.name} from {warehouse} -- {len(items)} items. Review: my.bebang.ph/dashboard/store-ops/order-approvals"
-	)
-
 	warning = None
 	queue_status = "not_required"
 	queue_name = None
@@ -1835,6 +1840,26 @@ def submit_order(
 	}
 	if warning:
 		result["warning"] = warning
+	_notify_store_ops(
+		event={
+			"family": "store_order_new",
+			"source_system": "frappe",
+			"source_ref": order.name,
+			"severity": "critical" if is_emergency_flag else "medium",
+			"owner": "Store Ops / Warehouse",
+			"facts": {
+				"order_name": order.name,
+				"warehouse": warehouse,
+				"item_count": len(items),
+				"is_emergency": bool(is_emergency_flag),
+				"queue_status": queue_status,
+				"approval_queue_name": queue_name,
+				"approval_assigned_approver": first_approver if requires_manual_approval else None,
+				"dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
+			},
+		},
+		requested_space=get_chat_space(SPACE_OPS),
+	)
 	return result
 
 
@@ -2009,7 +2034,22 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 			)
 
 		_notify_store_ops(
-			f"Store order {order_name} approved by Area Supervisor {user} and routed to Regional Manager {regional_approver}."
+			event={
+				"family": "store_order_approved",
+				"source_system": "frappe",
+				"source_ref": order_name,
+				"severity": "high",
+				"owner": regional_approver or "Regional Manager",
+				"facts": {
+					"order_name": order_name,
+					"stage": "area_supervisor_forwarded",
+					"store": order.store,
+					"approved_by": user,
+					"regional_approver": regional_approver,
+					"dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
+				},
+			},
+			requested_space=get_chat_space(SPACE_OPS),
 		)
 		return {
 			"success": True,
@@ -2041,8 +2081,29 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 			).format(order_name)
 		)
 
+	store_space = None
+	try:
+		store_space = frappe.db.get_value("Warehouse", order.store, "custom_gchat_space")
+	except Exception:
+		store_space = None
+
 	_notify_store_ops(
-		f"Store order {order_name} approved by {user}. Warehouse dispatch request {mr_name} is ready."
+		event={
+			"family": "store_order_approved",
+			"source_system": "frappe",
+			"source_ref": order_name,
+			"severity": "medium",
+			"owner": "Warehouse / Store Ops",
+			"facts": {
+				"order_name": order_name,
+				"stage": "approved",
+				"store": order.store,
+				"approved_by": user,
+				"material_request": mr_name,
+				"dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
+			},
+		},
+		requested_space=store_space or get_chat_space(SPACE_OPS),
 	)
 	final_stage = "regional_manager" if requires_dual_stage else current_stage
 
@@ -4509,3 +4570,4 @@ def verify_maintenance_from_closing(
 		if not verification_notes:
 			frappe.throw(_("Rejection reason is required"))
 		return doc.reject_completion(notes=verification_notes)
+

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -4570,4 +4570,3 @@ def verify_maintenance_from_closing(
 		if not verification_notes:
 			frappe.throw(_("Rejection reason is required"))
 		return doc.reject_completion(notes=verification_notes)
-

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -31,10 +31,12 @@ from hrms.utils.supply_chain_contracts import (
 	stamp_stock_entry_contract,
 )
 
-MANUAL_POS_UPLOAD_DISABLED_MESSAGE = _(
-	"Manual POS uploads are disabled. Sales now sync automatically via API. "
-	"Use Closing Report for X/Z-reading evidence, cash control, and POS-down exceptions."
-)
+
+def _manual_pos_upload_disabled_message() -> str:
+	return _(
+		"Manual POS uploads are disabled. Sales now sync automatically via API. "
+		"Use Closing Report for X/Z-reading evidence, cash control, and POS-down exceptions."
+	)
 
 
 def _notify_store_ops(msg=None, *, event=None, requested_space=None):
@@ -3436,7 +3438,7 @@ def upload_pos_data(
 	    notes: Optional notes
 	    skip_date_validation: Skip date validation (for back-dated uploads with supervisor approval)
 	"""
-	frappe.throw(MANUAL_POS_UPLOAD_DISABLED_MESSAGE)
+	frappe.throw(_manual_pos_upload_disabled_message())
 	validate_store_ops_role()
 
 	if not store:

--- a/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py
+++ b/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py
@@ -125,11 +125,8 @@ def get_open_requests_for_store(store):
 	"""Get all open maintenance requests for a store."""
 	return frappe.get_all(
 		"BEI Maintenance Request",
-		filters={
-			"store": store,
-			"status": ["in", ["Open", "Assigned", "In Progress"]]
-		},
-		fields=["name", "issue_category", "priority", "status", "scheduled_date", "description"]
+		filters={"store": store, "status": ["in", ["Open", "Assigned", "In Progress"]]},
+		fields=["name", "issue_category", "priority", "status", "scheduled_date", "description"],
 	)
 
 
@@ -138,11 +135,7 @@ def get_scheduled_maintenance_today(store):
 	"""Check if store has scheduled maintenance today."""
 	return frappe.db.exists(
 		"BEI Maintenance Request",
-		{
-			"store": store,
-			"scheduled_date": today(),
-			"status": ["in", ["Assigned", "In Progress"]]
-		}
+		{"store": store, "scheduled_date": today(), "status": ["in", ["Assigned", "In Progress"]]},
 	)
 
 

--- a/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py
+++ b/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+from typing import Any
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -81,7 +83,7 @@ class BEIMaintenanceRequest(Document):
 		)
 
 	@frappe.whitelist()
-	def assign_to_user(self, user, scheduled_date=None, estimated_cost=None):
+	def assign_to_user(self, user: Any, scheduled_date: Any = None, estimated_cost: Any = None):
 		"""Assign maintenance request to internal user."""
 		self.assigned_to = user
 		self.status = "Assigned"
@@ -93,7 +95,7 @@ class BEIMaintenanceRequest(Document):
 		return {"status": "success", "message": _("Request assigned to {0}").format(user)}
 
 	@frappe.whitelist()
-	def assign_to_vendor(self, vendor, scheduled_date=None, estimated_cost=None):
+	def assign_to_vendor(self, vendor: Any, scheduled_date: Any = None, estimated_cost: Any = None):
 		"""Assign maintenance request to external vendor."""
 		self.vendor = vendor
 		self.status = "Assigned"
@@ -112,7 +114,7 @@ class BEIMaintenanceRequest(Document):
 		return {"status": "success"}
 
 	@frappe.whitelist()
-	def cancel_request(self, reason):
+	def cancel_request(self, reason: Any):
 		"""Cancel maintenance request."""
 		self.status = "Cancelled"
 		self.add_comment("Comment", _("Cancelled: {0}").format(reason))
@@ -121,7 +123,7 @@ class BEIMaintenanceRequest(Document):
 
 
 @frappe.whitelist()
-def get_open_requests_for_store(store):
+def get_open_requests_for_store(store: Any):
 	"""Get all open maintenance requests for a store."""
 	return frappe.get_all(
 		"BEI Maintenance Request",
@@ -131,7 +133,7 @@ def get_open_requests_for_store(store):
 
 
 @frappe.whitelist()
-def get_scheduled_maintenance_today(store):
+def get_scheduled_maintenance_today(store: Any):
 	"""Check if store has scheduled maintenance today."""
 	return frappe.db.exists(
 		"BEI Maintenance Request",

--- a/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py
+++ b/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py
@@ -38,9 +38,18 @@ class BEIMaintenanceRequest(Document):
 		if self.description:
 			lines.append(f"*Issue:* {self.description}")
 		_notify_maintenance_event(
-			title=f"*New Maintenance Request*\\n{self.name}",
+			title=f"*New Maintenance Request*\n{self.name}",
 			lines=lines,
 			store=self.store,
+			request_name=self.name,
+			event_kind="created",
+			status=self.status or "Open",
+			priority=self.priority,
+			issue_category=self.issue_category,
+			description=self.description,
+			assigned_to=self.assigned_to,
+			vendor=self.vendor,
+			scheduled_date=self.scheduled_date,
 		)
 
 	def send_status_notification(self):
@@ -57,9 +66,18 @@ class BEIMaintenanceRequest(Document):
 		if self.scheduled_date:
 			lines.append(f"*Scheduled Date:* {self.scheduled_date}")
 		_notify_maintenance_event(
-			title=f"*Maintenance Status Updated*\\n{self.name}",
+			title=f"*Maintenance Status Updated*\n{self.name}",
 			lines=lines,
 			store=self.store,
+			request_name=self.name,
+			event_kind="status_change",
+			status=self.status,
+			priority=self.priority,
+			issue_category=self.issue_category,
+			description=self.description,
+			assigned_to=self.assigned_to,
+			vendor=self.vendor,
+			scheduled_date=self.scheduled_date,
 		)
 
 	@frappe.whitelist()
@@ -128,30 +146,42 @@ def get_scheduled_maintenance_today(store):
 	)
 
 
-def _notify_maintenance_event(title, lines, store=None):
+def _notify_maintenance_event(title, lines, store=None, **event_fields):
 	"""Best-effort Google Chat notification for maintenance lifecycle events."""
+	status = str(event_fields.get("status") or "").strip()
+	event_kind = str(event_fields.get("event_kind") or "status_change").strip()
+	if event_kind == "status_change" and status in {"Assigned", "In Progress"}:
+		return
+
 	try:
-		from hrms.api.google_chat import send_message_to_space
-		from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
+		from hrms.api.google_chat import send_notification_event
+		from hrms.utils.bei_config import SPACE_OPS, get_chat_space
 
-		spaces = []
-		store_space = _resolve_store_chat_space(store)
-		if store_space:
-			spaces.append(store_space)
-
-		default_space = get_chat_space(SPACE_NOTIFICATIONS)
-		if default_space:
-			spaces.append(default_space)
-
-		if not spaces:
-			return
-
-		message = title
-		if lines:
-			message = f"{title}\\n\\n" + "\\n".join(lines)
-
-		for space in dict.fromkeys(spaces):
-			send_message_to_space(space, message)
+		requested_space = _resolve_store_chat_space(store) or get_chat_space(SPACE_OPS)
+		severity = "high" if str(event_fields.get("priority") or "").strip() == "Urgent" else "medium"
+		send_notification_event(
+			{
+				"family": "maintenance_status_update",
+				"source_system": "frappe",
+				"source_ref": event_fields.get("request_name") or title,
+				"severity": severity,
+				"owner": "Store Manager" if status == "Completed" else "Projects Team / Store Manager",
+				"requested_space": requested_space,
+				"facts": {
+					"request_name": event_fields.get("request_name") or title,
+					"event_kind": event_kind,
+					"status": status or "Open",
+					"store": store,
+					"priority": event_fields.get("priority"),
+					"issue_category": event_fields.get("issue_category"),
+					"description": event_fields.get("description"),
+					"assigned_to": event_fields.get("assigned_to"),
+					"vendor": event_fields.get("vendor"),
+					"scheduled_date": event_fields.get("scheduled_date"),
+					"legacy_lines": lines,
+				},
+			}
+		)
 	except Exception as e:
 		frappe.log_error(
 			title="Maintenance Notification Error",

--- a/hrms/services/sheets_receiver/notifications.py
+++ b/hrms/services/sheets_receiver/notifications.py
@@ -65,9 +65,11 @@ logger = logging.getLogger(__name__)
 
 # Import database for notification tracking
 try:
+	from .frappe_client import get_frappe_client
 	from .models import get_db
 except ImportError:
 	# Fallback for when module is run directly
+	from frappe_client import get_frappe_client
 	from models import get_db
 
 # Google Chat Configuration
@@ -431,76 +433,61 @@ def send_sheets_sync_critical_alert(
 	rows_failed: int,
 	errors: list[str] | None = None,
 	alerts: list[str] | None = None,
+	spreadsheet_id: str | None = None,
 ) -> str | None:
-	"""
-	Send critical alert for Sheets sync failures and suspicious change patterns.
-
-	This path is used by the sheet sync pipeline to escalate operational issues
-	that can impact finance/store reporting.
-	"""
+	"""Send structured Sheets sync alerts through the Frappe notification contract."""
 	errors = errors or []
 	alerts = alerts or []
 
 	if not (reasons or rows_failed or errors or alerts):
 		return None
 
-	reason_map = {
-		"sync_exception": "Sync process exception",
-		"sync_result_failed": "Frappe sync returned failed status",
-		"rows_failed": "One or more rows failed during sync",
-		"sync_errors_reported": "Sync result returned error details",
-		"suspicious_change_alert": "Suspicious data-change pattern detected",
-	}
-
 	try:
-		chat = get_chat_service()
-		trigger_label = "scheduled (6-hour fallback)" if trigger == "scheduled" else trigger
-		reason_lines = [f"  - {reason_map.get(reason, reason)}" for reason in sorted(set(reasons))]
-		error_lines = [f"  - {err}" for err in _unique_preserve_order(errors)]
-		alert_lines = [f"  - {msg}" for msg in _unique_preserve_order(alerts)]
-
-		message_parts = [
-			"*SHEETS SYNC CRITICAL ALERT*",
-			"",
-			f"*Sheet:* {spreadsheet_name} / {sheet_name}",
-			f"*Trigger:* {trigger_label}",
-			f"*Rows:* processed={rows_processed}, failed={rows_failed}",
-		]
-
-		if reason_lines:
-			message_parts.extend(["", "*Reasons:*", *reason_lines])
-		if error_lines:
-			message_parts.extend(["", "*Top Errors:*", *error_lines])
-		if alert_lines:
-			message_parts.extend(["", "*Change Alerts:*", *alert_lines])
-
-		message_parts.extend(["", f"<users/{DAVE_USER_ID}> <users/{EDLICE_USER_ID}>"])
-		message = "\n".join(message_parts)
-
-		result = (
-			chat.spaces()
-			.messages()
-			.create(
-				parent=_get_target_space(),
-				body={"text": message},
-			)
-			.execute()
+		client = get_frappe_client()
+		result = client.call_method(
+			"hrms.api.google_chat.ingest_notification_event",
+			data={
+				"event": {
+					"family": "sheets_sync_critical",
+					"source_system": "sheets_receiver",
+					"source_ref": f"{spreadsheet_name} / {sheet_name}",
+					"severity": "critical" if rows_failed else "high",
+					"owner": "Dave Martinez / Edlice Dela Cruz",
+					"facts": {
+						"spreadsheet_name": spreadsheet_name,
+						"sheet_name": sheet_name,
+						"spreadsheet_id": spreadsheet_id,
+						"trigger": trigger,
+						"reasons": sorted(set(reasons or [])),
+						"rows_processed": rows_processed,
+						"rows_failed": rows_failed,
+						"errors": _unique_preserve_order(errors),
+						"alerts": _unique_preserve_order(alerts),
+					},
+				}
+			},
 		)
-		message_id = result.get("name")
+		message_id = (result or {}).get("message_id")
+		rendered_text = str((result or {}).get("rendered_text") or "")
 
-		# Best-effort audit trail; never block sync path.
 		try:
 			db = get_db()
 			db.log_notification(
-				message_id=message_id,
+				message_id=message_id or "frappe_ingest",
 				message_type="sheets_sync_critical",
-				message_preview=message[:100],
+				message_preview=rendered_text[:100],
 			)
 		except Exception as log_error:
 			logger.warning(f"Failed to log critical sync alert to database: {log_error}")
 
-		logger.info(f"Sent sheets sync critical alert for {spreadsheet_name}/{sheet_name}")
-		return message_id
+		logger.info(
+			"Sent sheets sync critical alert via Frappe for %s/%s sent=%s skipped=%s",
+			spreadsheet_name,
+			sheet_name,
+			(result or {}).get("sent"),
+			(result or {}).get("skipped"),
+		)
+		return message_id or ("frappe_ingest" if (result or {}).get("success") else None)
 	except Exception as e:
 		logger.error(f"Failed to send sheets sync critical alert: {e}")
 		return None

--- a/hrms/services/sheets_receiver/notifications.py
+++ b/hrms/services/sheets_receiver/notifications.py
@@ -30,14 +30,13 @@ except ModuleNotFoundError:
 		context: str | None = None,
 	) -> str:
 		requested = (requested_space or "").strip()
-		blip_space = (
-			(os.environ.get("BEI_BLIP_NOTIFICATIONS_SPACE") or "").strip() or "spaces/AAQABiNmpBg"
-		)
-		lockdown_enabled = (os.environ.get("BEI_CHAT_LOCKDOWN_ENABLED") or "true").strip().lower() in _TRUE_VALUES
+		blip_space = (os.environ.get("BEI_BLIP_NOTIFICATIONS_SPACE") or "").strip() or "spaces/AAQABiNmpBg"
+		lockdown_enabled = (
+			os.environ.get("BEI_CHAT_LOCKDOWN_ENABLED") or "true"
+		).strip().lower() in _TRUE_VALUES
 		allow_non_blip = (
-			(os.environ.get("BEI_ALLOW_NON_BLIP_CHAT_DESTINATIONS") or "false").strip().lower()
-			in _TRUE_VALUES
-		)
+			os.environ.get("BEI_ALLOW_NON_BLIP_CHAT_DESTINATIONS") or "false"
+		).strip().lower() in _TRUE_VALUES
 		allowed_spaces = {
 			space.strip()
 			for space in (os.environ.get("BEI_ALLOWED_CHAT_SPACES") or "").split(",")
@@ -60,6 +59,7 @@ except ModuleNotFoundError:
 				context or "unspecified",
 			)
 		return blip_space
+
 
 logger = logging.getLogger(__name__)
 

--- a/hrms/services/sheets_receiver/processor.py
+++ b/hrms/services/sheets_receiver/processor.py
@@ -96,6 +96,7 @@ class ChangeProcessor:
 			send_sheets_sync_critical_alert(
 				spreadsheet_name=sheet_config.name,
 				sheet_name=sheet_config.sheet_name,
+				spreadsheet_id=sheet_config.spreadsheet_id,
 				trigger=trigger,
 				reasons=reasons,
 				rows_processed=rows_processed,

--- a/hrms/tests/test_discount_abuse_api_s12.py
+++ b/hrms/tests/test_discount_abuse_api_s12.py
@@ -943,12 +943,17 @@ class TestDiscountAbuseApiS12(unittest.TestCase):
 		bei_config_mod.SPACE_ACCOUNTING = "ACCOUNTING"
 		bei_config_mod.get_chat_space = lambda _space: "spaces/AAAA9RN0JZQ"
 
-		with patch.dict(sys.modules, {"hrms.api.google_chat": google_chat_mod, "hrms.utils.bei_config": bei_config_mod}, clear=False), patch.object(
-			discount_abuse, "_notifications_enabled_for_day", return_value=True
-		), patch.object(discount_abuse, "_query_same_day_rows", return_value=rows), patch.object(
-			discount_abuse, "_sort_same_day_rows", side_effect=lambda payload: payload
-		), patch.object(discount_abuse, "_parse_email_recipients", return_value=[]), patch.object(
-			discount_abuse, "_mark_alerts_notified", return_value=1
+		with (
+			patch.dict(
+				sys.modules,
+				{"hrms.api.google_chat": google_chat_mod, "hrms.utils.bei_config": bei_config_mod},
+				clear=False,
+			),
+			patch.object(discount_abuse, "_notifications_enabled_for_day", return_value=True),
+			patch.object(discount_abuse, "_query_same_day_rows", return_value=rows),
+			patch.object(discount_abuse, "_sort_same_day_rows", side_effect=lambda payload: payload),
+			patch.object(discount_abuse, "_parse_email_recipients", return_value=[]),
+			patch.object(discount_abuse, "_mark_alerts_notified", return_value=1),
 		):
 			result = discount_abuse._send_critical_discount_alert_notifications_internal(date(2026, 3, 12))
 

--- a/hrms/tests/test_discount_abuse_api_s12.py
+++ b/hrms/tests/test_discount_abuse_api_s12.py
@@ -8,7 +8,7 @@ import types
 import unittest
 from datetime import date
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
@@ -926,6 +926,37 @@ class TestDiscountAbuseApiS12(unittest.TestCase):
 		self.assertEqual(rows[0]["total_gross_sales"], 1400.0)
 		self.assertEqual(rows[0]["fp_orders"], 2)
 		self.assertEqual(rows[0]["fp_gross_sales"], 200.0)
+
+	def test_send_critical_notifications_emit_structured_chat_event(self):
+		rows = [
+			{
+				"store_name": "SM North EDSA",
+				"identity_key": "25402",
+				"order_count": 2,
+				"discount_amount_total": "70.72",
+			}
+		]
+		fake_send = MagicMock(return_value=True)
+		google_chat_mod = types.ModuleType("hrms.api.google_chat")
+		google_chat_mod.send_notification_event = fake_send
+		bei_config_mod = types.ModuleType("hrms.utils.bei_config")
+		bei_config_mod.SPACE_ACCOUNTING = "ACCOUNTING"
+		bei_config_mod.get_chat_space = lambda _space: "spaces/AAAA9RN0JZQ"
+
+		with patch.dict(sys.modules, {"hrms.api.google_chat": google_chat_mod, "hrms.utils.bei_config": bei_config_mod}, clear=False), patch.object(
+			discount_abuse, "_notifications_enabled_for_day", return_value=True
+		), patch.object(discount_abuse, "_query_same_day_rows", return_value=rows), patch.object(
+			discount_abuse, "_sort_same_day_rows", side_effect=lambda payload: payload
+		), patch.object(discount_abuse, "_parse_email_recipients", return_value=[]), patch.object(
+			discount_abuse, "_mark_alerts_notified", return_value=1
+		):
+			result = discount_abuse._send_critical_discount_alert_notifications_internal(date(2026, 3, 12))
+
+		event = fake_send.call_args.args[0]
+		self.assertEqual(event["family"], "discount_critical_digest")
+		self.assertEqual(event["facts"]["business_date"], "2026-03-12")
+		self.assertEqual(event["facts"]["review_url"], discount_abuse.PORTAL_QUEUE_URL)
+		self.assertTrue(result["data"]["chat_sent"])
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -520,6 +520,37 @@ class TestErpSyncRuntime(unittest.TestCase):
 		self.assertEqual(store_area["status"], "red")
 		self.assertEqual(store_area["pending_store_codes"], ["AMM"])
 
+	def test_scheduled_generate_morning_sync_health_report_sends_digest(self):
+		report = {
+			"report_date": "2026-01-01",
+			"status": "yellow",
+			"areas": [
+				{"key": "store_inventory_shadow_sync", "label": "Store Inventory Shadow Sync", "status": "green"},
+				{"key": "ap_procurement_baselines", "label": "AP / Procurement Baselines", "status": "yellow"},
+			],
+			"sync_target_pht_time": "07:00",
+			"ready_deadline_pht_time": "09:00",
+			"artifacts": {"markdown_path": str(ROOT / "tmp" / "morning.md")},
+		}
+		fake_send = MagicMock(return_value=True)
+		api_pkg = types.ModuleType("hrms.api")
+		api_pkg.__path__ = []
+		google_chat_mod = types.ModuleType("hrms.api.google_chat")
+		google_chat_mod.send_notification_event = fake_send
+
+		with patch.object(erp_sync, "_collect_morning_sync_health_report", return_value=dict(report)), patch.dict(
+			sys.modules,
+			{"hrms.api": api_pkg, "hrms.api.google_chat": google_chat_mod},
+			clear=False,
+		):
+			result = erp_sync.scheduled_generate_morning_sync_health_report(report_date="2026-01-01")
+
+		event = fake_send.call_args.args[0]
+		self.assertEqual(event["family"], "morning_readiness_digest")
+		self.assertEqual(event["severity"], "high")
+		self.assertEqual(event["facts"]["artifact_markdown_path"], str(ROOT / "tmp" / "morning.md"))
+		self.assertTrue(result["notification_sent"])
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -525,8 +525,16 @@ class TestErpSyncRuntime(unittest.TestCase):
 			"report_date": "2026-01-01",
 			"status": "yellow",
 			"areas": [
-				{"key": "store_inventory_shadow_sync", "label": "Store Inventory Shadow Sync", "status": "green"},
-				{"key": "ap_procurement_baselines", "label": "AP / Procurement Baselines", "status": "yellow"},
+				{
+					"key": "store_inventory_shadow_sync",
+					"label": "Store Inventory Shadow Sync",
+					"status": "green",
+				},
+				{
+					"key": "ap_procurement_baselines",
+					"label": "AP / Procurement Baselines",
+					"status": "yellow",
+				},
 			],
 			"sync_target_pht_time": "07:00",
 			"ready_deadline_pht_time": "09:00",
@@ -538,10 +546,13 @@ class TestErpSyncRuntime(unittest.TestCase):
 		google_chat_mod = types.ModuleType("hrms.api.google_chat")
 		google_chat_mod.send_notification_event = fake_send
 
-		with patch.object(erp_sync, "_collect_morning_sync_health_report", return_value=dict(report)), patch.dict(
-			sys.modules,
-			{"hrms.api": api_pkg, "hrms.api.google_chat": google_chat_mod},
-			clear=False,
+		with (
+			patch.object(erp_sync, "_collect_morning_sync_health_report", return_value=dict(report)),
+			patch.dict(
+				sys.modules,
+				{"hrms.api": api_pkg, "hrms.api.google_chat": google_chat_mod},
+				clear=False,
+			),
 		):
 			result = erp_sync.scheduled_generate_morning_sync_health_report(report_date="2026-01-01")
 

--- a/hrms/tests/test_google_chat_notification_routing.py
+++ b/hrms/tests/test_google_chat_notification_routing.py
@@ -8,142 +8,234 @@ from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-	sys.path.insert(0, str(ROOT))
+    sys.path.insert(0, str(ROOT))
 
 
-def _install_fake_frappe():
-	frappe_mod = types.ModuleType("frappe")
-	frappe_mod.logger = lambda _name=None: types.SimpleNamespace(
-		info=lambda *_args, **_kwargs: None,
-		warning=lambda *_args, **_kwargs: None,
-		error=lambda *_args, **_kwargs: None,
-	)
-	frappe_mod.log_error = lambda *args, **kwargs: None
-	frappe_mod.whitelist = lambda *args, **kwargs: (lambda fn: fn)
-	frappe_mod.session = types.SimpleNamespace(user="sam@bebang.ph")
-	sys.modules["frappe"] = frappe_mod
+class _FakeCache:
+    def __init__(self):
+        self.values = {}
 
+    def get_value(self, key):
+        return self.values.get(key)
 
-def _install_fake_hrms_package():
-	hrms_pkg = types.ModuleType("hrms")
-	hrms_pkg.__path__ = [str(ROOT / "hrms")]
-	sys.modules["hrms"] = hrms_pkg
-
-	utils_pkg = types.ModuleType("hrms.utils")
-	utils_pkg.__path__ = [str(ROOT / "hrms" / "utils")]
-	sys.modules["hrms.utils"] = utils_pkg
-
-	api_pkg = types.ModuleType("hrms.api")
-	api_pkg.__path__ = [str(ROOT / "hrms" / "api")]
-	sys.modules["hrms.api"] = api_pkg
-
-
-def _install_fake_google_oauth():
-	google_oauth_mod = types.ModuleType("hrms.utils.google_oauth")
-	google_oauth_mod.force_refresh_access_token = lambda _user: "token"
-	google_oauth_mod.get_valid_access_token = lambda _user: "token"
-	google_oauth_mod.has_valid_token = lambda _user: True
-	sys.modules["hrms.utils.google_oauth"] = google_oauth_mod
-
-
-def _install_fake_bei_config():
-	bei_config_mod = types.ModuleType("hrms.utils.bei_config")
-	bei_config_mod.get_service_account_path = lambda: "credentials/task-manager-service.json"
-	sys.modules["hrms.utils.bei_config"] = bei_config_mod
-
-
-def _install_fake_google_modules(fake_chat):
-	if "google" not in sys.modules:
-		sys.modules["google"] = types.ModuleType("google")
-
-	if "google.oauth2" not in sys.modules:
-		sys.modules["google.oauth2"] = types.ModuleType("google.oauth2")
-
-	service_account_mod = types.ModuleType("google.oauth2.service_account")
-
-	class _Credentials:
-		@staticmethod
-		def from_service_account_file(_path, scopes=None):
-			return types.SimpleNamespace(scopes=scopes or [])
-
-	service_account_mod.Credentials = _Credentials
-	sys.modules["google.oauth2.service_account"] = service_account_mod
-
-	discovery_mod = types.ModuleType("googleapiclient.discovery")
-	discovery_mod.build = lambda *_args, **_kwargs: fake_chat
-	sys.modules["googleapiclient.discovery"] = discovery_mod
+    def set_value(self, key, value, expires_in_sec=None):
+        self.values[key] = value
 
 
 class _FakeMessagesAPI:
-	def __init__(self):
-		self.last_parent = None
-		self.last_body = None
+    def __init__(self):
+        self.last_parent = None
+        self.last_body = None
+        self.call_count = 0
 
-	def create(self, parent, body):
-		self.last_parent = parent
-		self.last_body = body
-		return types.SimpleNamespace(execute=lambda: {"name": "spaces/AAQABiNmpBg/messages/123"})
+    def create(self, parent, body):
+        self.last_parent = parent
+        self.last_body = body
+        self.call_count += 1
+        return types.SimpleNamespace(execute=lambda: {"name": f"{parent}/messages/{self.call_count}"})
 
 
 class _FakeChatAPI:
-	def __init__(self):
-		self.messages_api = _FakeMessagesAPI()
+    def __init__(self):
+        self.messages_api = _FakeMessagesAPI()
 
-	def spaces(self):
-		return types.SimpleNamespace(messages=lambda: self.messages_api)
+    def spaces(self):
+        return types.SimpleNamespace(messages=lambda: self.messages_api)
+
+
+def _install_fake_frappe():
+    frappe_mod = types.ModuleType("frappe")
+    cache = _FakeCache()
+
+    def whitelist(*args, **kwargs):
+        if args and callable(args[0]) and len(args) == 1 and not kwargs:
+            return args[0]
+
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    frappe_mod.logger = lambda _name=None: types.SimpleNamespace(
+        info=lambda *_args, **_kwargs: None,
+        warning=lambda *_args, **_kwargs: None,
+        error=lambda *_args, **_kwargs: None,
+    )
+    frappe_mod.log_error = lambda *args, **kwargs: None
+    frappe_mod.whitelist = whitelist
+    frappe_mod.session = types.SimpleNamespace(user="sam@bebang.ph")
+    frappe_mod.conf = {}
+    frappe_mod.cache = lambda: cache
+    frappe_mod.AuthenticationError = RuntimeError
+    frappe_mod.get_site_path = lambda *parts: str(ROOT.joinpath(*parts))
+    sys.modules["frappe"] = frappe_mod
+
+
+def _install_fake_hrms_package():
+    hrms_pkg = types.ModuleType("hrms")
+    hrms_pkg.__path__ = [str(ROOT / "hrms")]
+    sys.modules["hrms"] = hrms_pkg
+
+    utils_pkg = types.ModuleType("hrms.utils")
+    utils_pkg.__path__ = [str(ROOT / "hrms" / "utils")]
+    sys.modules["hrms.utils"] = utils_pkg
+
+    api_pkg = types.ModuleType("hrms.api")
+    api_pkg.__path__ = [str(ROOT / "hrms" / "api")]
+    sys.modules["hrms.api"] = api_pkg
+
+
+def _install_fake_google_oauth():
+    google_oauth_mod = types.ModuleType("hrms.utils.google_oauth")
+    google_oauth_mod.force_refresh_access_token = lambda _user: "token"
+    google_oauth_mod.get_valid_access_token = lambda _user: "token"
+    google_oauth_mod.has_valid_token = lambda _user: True
+    sys.modules["hrms.utils.google_oauth"] = google_oauth_mod
+
+
+def _install_fake_bei_config():
+    bei_config_mod = types.ModuleType("hrms.utils.bei_config")
+    bei_config_mod.get_service_account_path = lambda: "credentials/task-manager-service.json"
+    sys.modules["hrms.utils.bei_config"] = bei_config_mod
+
+
+def _install_fake_google_modules(fake_chat):
+    if "google" not in sys.modules:
+        sys.modules["google"] = types.ModuleType("google")
+
+    if "google.oauth2" not in sys.modules:
+        sys.modules["google.oauth2"] = types.ModuleType("google.oauth2")
+
+    service_account_mod = types.ModuleType("google.oauth2.service_account")
+
+    class _Credentials:
+        @staticmethod
+        def from_service_account_file(_path, scopes=None):
+            return types.SimpleNamespace(scopes=scopes or [])
+
+    service_account_mod.Credentials = _Credentials
+    sys.modules["google.oauth2.service_account"] = service_account_mod
+
+    discovery_mod = types.ModuleType("googleapiclient.discovery")
+    discovery_mod.build = lambda *_args, **_kwargs: fake_chat
+    sys.modules["googleapiclient.discovery"] = discovery_mod
 
 
 class TestGoogleChatNotificationRouting(unittest.TestCase):
-	def _load_module(self):
-		module_name = "hrms.api.google_chat_routing_under_test"
-		if module_name in sys.modules:
-			del sys.modules[module_name]
-		spec = importlib.util.spec_from_file_location(
-			module_name,
-			ROOT / "hrms" / "api" / "google_chat.py",
-		)
-		module = importlib.util.module_from_spec(spec)
-		spec.loader.exec_module(module)
-		return module
+    def _load_module(self):
+        module_name = "hrms.api.google_chat_routing_under_test"
+        for key in [module_name, "hrms.utils.notification_intelligence", "hrms.utils.chat_space_lockdown"]:
+            if key in sys.modules:
+                del sys.modules[key]
+        spec = importlib.util.spec_from_file_location(
+            module_name,
+            ROOT / "hrms" / "api" / "google_chat.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
 
-	def test_send_message_to_space_reroutes_to_blip_notifications_by_default(self):
-		fake_chat = _FakeChatAPI()
-		_install_fake_frappe()
-		_install_fake_hrms_package()
-		_install_fake_google_oauth()
-		_install_fake_bei_config()
-		_install_fake_google_modules(fake_chat)
-		module = self._load_module()
+    def setUp(self):
+        fake_chat = _FakeChatAPI()
+        _install_fake_frappe()
+        _install_fake_hrms_package()
+        _install_fake_google_oauth()
+        _install_fake_bei_config()
+        _install_fake_google_modules(fake_chat)
+        self.fake_chat = fake_chat
+        self.module = self._load_module()
 
-		with patch.object(module.os.path, "exists", return_value=True), patch.dict(
-			os.environ, {}, clear=False
-		):
-			self.assertTrue(module.send_message_to_space("spaces/AAAAvDZdY-o", "hello"))
+    def test_send_message_to_space_reroutes_to_blip_notifications_by_default(self):
+        with patch.object(self.module.os.path, "exists", return_value=True), patch.dict(os.environ, {}, clear=False):
+            self.assertTrue(self.module.send_message_to_space("spaces/AAAAvDZdY-o", "hello"))
 
-		self.assertEqual(fake_chat.messages_api.last_parent, "spaces/AAQABiNmpBg")
-		self.assertEqual(fake_chat.messages_api.last_body, {"text": "hello"})
+        self.assertEqual(self.fake_chat.messages_api.last_parent, "spaces/AAQABiNmpBg")
+        self.assertEqual(self.fake_chat.messages_api.last_body, {"text": "hello"})
 
-	def test_send_message_to_space_allows_explicit_override(self):
-		fake_chat = _FakeChatAPI()
-		_install_fake_frappe()
-		_install_fake_hrms_package()
-		_install_fake_google_oauth()
-		_install_fake_bei_config()
-		_install_fake_google_modules(fake_chat)
-		module = self._load_module()
+    def test_send_message_to_space_allows_explicit_override(self):
+        with patch.object(self.module.os.path, "exists", return_value=True), patch.dict(
+            os.environ,
+            {
+                "BEI_ALLOW_NON_BLIP_CHAT_DESTINATIONS": "true",
+                "BEI_ALLOWED_CHAT_SPACES": "spaces/AAAAvDZdY-o",
+            },
+            clear=False,
+        ):
+            self.assertTrue(self.module.send_message_to_space("spaces/AAAAvDZdY-o", "hello"))
 
-		with patch.object(module.os.path, "exists", return_value=True), patch.dict(
-			os.environ,
-			{
-				"BEI_ALLOW_NON_BLIP_CHAT_DESTINATIONS": "true",
-				"BEI_ALLOWED_CHAT_SPACES": "spaces/AAAAvDZdY-o",
-			},
-			clear=False,
-		):
-			self.assertTrue(module.send_message_to_space("spaces/AAAAvDZdY-o", "hello"))
+        self.assertEqual(self.fake_chat.messages_api.last_parent, "spaces/AAAAvDZdY-o")
 
-		self.assertEqual(fake_chat.messages_api.last_parent, "spaces/AAAAvDZdY-o")
+    def test_ingest_notification_event_dry_run_renders_contract_sections(self):
+        result = self.module.ingest_notification_event(
+            event={
+                "family": "approval_queue_new",
+                "source_system": "frappe",
+                "source_ref": "APQ-0001",
+                "severity": "high",
+                "owner": "Assigned Approver",
+                "facts": {
+                    "queue_name": "APQ-0001",
+                    "reference_doctype": "BEI Store Order",
+                    "reference_name": "BEI-ORD-0001",
+                    "store": "Ayala Evo",
+                },
+            },
+            dry_run=True,
+        )
+
+        self.assertTrue(result["success"])
+        self.assertFalse(result["sent"])
+        self.assertIn("*Summary*", result["rendered_text"])
+        self.assertIn("*Recommended fix*", result["rendered_text"])
+
+    def test_send_notification_event_respects_family_allowed_space(self):
+        event = {
+            "family": "maintenance_status_update",
+            "source_system": "frappe",
+            "source_ref": "MR-0001",
+            "severity": "medium",
+            "owner": "Projects Team / Store Manager",
+            "requested_space": "spaces/AAAAvDZdY-o",
+            "facts": {
+                "request_name": "MR-0001",
+                "status": "Completed",
+                "store": "Ayala Evo",
+                "event_kind": "status_change",
+            },
+        }
+
+        with patch.object(self.module.os.path, "exists", return_value=True), patch.dict(os.environ, {}, clear=False):
+            result = self.module.ingest_notification_event(event=event)
+
+        self.assertTrue(result["success"])
+        self.assertTrue(result["sent"])
+        self.assertEqual(self.fake_chat.messages_api.last_parent, "spaces/AAAAvDZdY-o")
+        self.assertIn("maintenance status update", self.fake_chat.messages_api.last_body["text"].lower())
+
+    def test_ingest_notification_event_dedups_within_policy_window(self):
+        event = {
+            "family": "maintenance_sla_backlog",
+            "source_system": "frappe",
+            "source_ref": "maintenance_sla:2026-03-13",
+            "severity": "critical",
+            "owner": "Projects Manager",
+            "facts": {
+                "report_date": "2026-03-13",
+                "counts_by_priority": {"Urgent": 1, "High": 0, "Normal": 0},
+                "breaches": [{"name": "MR-1", "store": "AFT", "priority": "Urgent", "age_hours": 6}],
+            },
+        }
+
+        with patch.object(self.module.os.path, "exists", return_value=True), patch.dict(os.environ, {}, clear=False):
+            first = self.module.ingest_notification_event(event=event)
+            second = self.module.ingest_notification_event(event=event)
+
+        self.assertTrue(first["sent"])
+        self.assertTrue(second["success"])
+        self.assertTrue(second["skipped"])
+        self.assertEqual(self.fake_chat.messages_api.call_count, 1)
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/hrms/tests/test_google_chat_notification_routing.py
+++ b/hrms/tests/test_google_chat_notification_routing.py
@@ -8,234 +8,246 @@ from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+	sys.path.insert(0, str(ROOT))
 
 
 class _FakeCache:
-    def __init__(self):
-        self.values = {}
+	def __init__(self):
+		self.values = {}
 
-    def get_value(self, key):
-        return self.values.get(key)
+	def get_value(self, key):
+		return self.values.get(key)
 
-    def set_value(self, key, value, expires_in_sec=None):
-        self.values[key] = value
+	def set_value(self, key, value, expires_in_sec=None):
+		self.values[key] = value
 
 
 class _FakeMessagesAPI:
-    def __init__(self):
-        self.last_parent = None
-        self.last_body = None
-        self.call_count = 0
+	def __init__(self):
+		self.last_parent = None
+		self.last_body = None
+		self.call_count = 0
 
-    def create(self, parent, body):
-        self.last_parent = parent
-        self.last_body = body
-        self.call_count += 1
-        return types.SimpleNamespace(execute=lambda: {"name": f"{parent}/messages/{self.call_count}"})
+	def create(self, parent, body):
+		self.last_parent = parent
+		self.last_body = body
+		self.call_count += 1
+		return types.SimpleNamespace(execute=lambda: {"name": f"{parent}/messages/{self.call_count}"})
 
 
 class _FakeChatAPI:
-    def __init__(self):
-        self.messages_api = _FakeMessagesAPI()
+	def __init__(self):
+		self.messages_api = _FakeMessagesAPI()
 
-    def spaces(self):
-        return types.SimpleNamespace(messages=lambda: self.messages_api)
+	def spaces(self):
+		return types.SimpleNamespace(messages=lambda: self.messages_api)
 
 
 def _install_fake_frappe():
-    frappe_mod = types.ModuleType("frappe")
-    cache = _FakeCache()
+	frappe_mod = types.ModuleType("frappe")
+	cache = _FakeCache()
 
-    def whitelist(*args, **kwargs):
-        if args and callable(args[0]) and len(args) == 1 and not kwargs:
-            return args[0]
+	def whitelist(*args, **kwargs):
+		if args and callable(args[0]) and len(args) == 1 and not kwargs:
+			return args[0]
 
-        def decorator(fn):
-            return fn
+		def decorator(fn):
+			return fn
 
-        return decorator
+		return decorator
 
-    frappe_mod.logger = lambda _name=None: types.SimpleNamespace(
-        info=lambda *_args, **_kwargs: None,
-        warning=lambda *_args, **_kwargs: None,
-        error=lambda *_args, **_kwargs: None,
-    )
-    frappe_mod.log_error = lambda *args, **kwargs: None
-    frappe_mod.whitelist = whitelist
-    frappe_mod.session = types.SimpleNamespace(user="sam@bebang.ph")
-    frappe_mod.conf = {}
-    frappe_mod.cache = lambda: cache
-    frappe_mod.AuthenticationError = RuntimeError
-    frappe_mod.get_site_path = lambda *parts: str(ROOT.joinpath(*parts))
-    sys.modules["frappe"] = frappe_mod
+	frappe_mod.logger = lambda _name=None: types.SimpleNamespace(
+		info=lambda *_args, **_kwargs: None,
+		warning=lambda *_args, **_kwargs: None,
+		error=lambda *_args, **_kwargs: None,
+	)
+	frappe_mod.log_error = lambda *args, **kwargs: None
+	frappe_mod.whitelist = whitelist
+	frappe_mod.session = types.SimpleNamespace(user="sam@bebang.ph")
+	frappe_mod.conf = {}
+	frappe_mod.cache = lambda: cache
+	frappe_mod.AuthenticationError = RuntimeError
+	frappe_mod.get_site_path = lambda *parts: str(ROOT.joinpath(*parts))
+	sys.modules["frappe"] = frappe_mod
 
 
 def _install_fake_hrms_package():
-    hrms_pkg = types.ModuleType("hrms")
-    hrms_pkg.__path__ = [str(ROOT / "hrms")]
-    sys.modules["hrms"] = hrms_pkg
+	hrms_pkg = types.ModuleType("hrms")
+	hrms_pkg.__path__ = [str(ROOT / "hrms")]
+	sys.modules["hrms"] = hrms_pkg
 
-    utils_pkg = types.ModuleType("hrms.utils")
-    utils_pkg.__path__ = [str(ROOT / "hrms" / "utils")]
-    sys.modules["hrms.utils"] = utils_pkg
+	utils_pkg = types.ModuleType("hrms.utils")
+	utils_pkg.__path__ = [str(ROOT / "hrms" / "utils")]
+	sys.modules["hrms.utils"] = utils_pkg
 
-    api_pkg = types.ModuleType("hrms.api")
-    api_pkg.__path__ = [str(ROOT / "hrms" / "api")]
-    sys.modules["hrms.api"] = api_pkg
+	api_pkg = types.ModuleType("hrms.api")
+	api_pkg.__path__ = [str(ROOT / "hrms" / "api")]
+	sys.modules["hrms.api"] = api_pkg
 
 
 def _install_fake_google_oauth():
-    google_oauth_mod = types.ModuleType("hrms.utils.google_oauth")
-    google_oauth_mod.force_refresh_access_token = lambda _user: "token"
-    google_oauth_mod.get_valid_access_token = lambda _user: "token"
-    google_oauth_mod.has_valid_token = lambda _user: True
-    sys.modules["hrms.utils.google_oauth"] = google_oauth_mod
+	google_oauth_mod = types.ModuleType("hrms.utils.google_oauth")
+	google_oauth_mod.force_refresh_access_token = lambda _user: "token"
+	google_oauth_mod.get_valid_access_token = lambda _user: "token"
+	google_oauth_mod.has_valid_token = lambda _user: True
+	sys.modules["hrms.utils.google_oauth"] = google_oauth_mod
 
 
 def _install_fake_bei_config():
-    bei_config_mod = types.ModuleType("hrms.utils.bei_config")
-    bei_config_mod.get_service_account_path = lambda: "credentials/task-manager-service.json"
-    sys.modules["hrms.utils.bei_config"] = bei_config_mod
+	bei_config_mod = types.ModuleType("hrms.utils.bei_config")
+	bei_config_mod.get_service_account_path = lambda: "credentials/task-manager-service.json"
+	sys.modules["hrms.utils.bei_config"] = bei_config_mod
 
 
 def _install_fake_google_modules(fake_chat):
-    if "google" not in sys.modules:
-        sys.modules["google"] = types.ModuleType("google")
+	if "google" not in sys.modules:
+		sys.modules["google"] = types.ModuleType("google")
 
-    if "google.oauth2" not in sys.modules:
-        sys.modules["google.oauth2"] = types.ModuleType("google.oauth2")
+	if "google.oauth2" not in sys.modules:
+		sys.modules["google.oauth2"] = types.ModuleType("google.oauth2")
 
-    service_account_mod = types.ModuleType("google.oauth2.service_account")
+	service_account_mod = types.ModuleType("google.oauth2.service_account")
 
-    class _Credentials:
-        @staticmethod
-        def from_service_account_file(_path, scopes=None):
-            return types.SimpleNamespace(scopes=scopes or [])
+	class _Credentials:
+		@staticmethod
+		def from_service_account_file(_path, scopes=None):
+			return types.SimpleNamespace(scopes=scopes or [])
 
-    service_account_mod.Credentials = _Credentials
-    sys.modules["google.oauth2.service_account"] = service_account_mod
+	service_account_mod.Credentials = _Credentials
+	sys.modules["google.oauth2.service_account"] = service_account_mod
 
-    discovery_mod = types.ModuleType("googleapiclient.discovery")
-    discovery_mod.build = lambda *_args, **_kwargs: fake_chat
-    sys.modules["googleapiclient.discovery"] = discovery_mod
+	discovery_mod = types.ModuleType("googleapiclient.discovery")
+	discovery_mod.build = lambda *_args, **_kwargs: fake_chat
+	sys.modules["googleapiclient.discovery"] = discovery_mod
 
 
 class TestGoogleChatNotificationRouting(unittest.TestCase):
-    def _load_module(self):
-        module_name = "hrms.api.google_chat_routing_under_test"
-        for key in [module_name, "hrms.utils.notification_intelligence", "hrms.utils.chat_space_lockdown"]:
-            if key in sys.modules:
-                del sys.modules[key]
-        spec = importlib.util.spec_from_file_location(
-            module_name,
-            ROOT / "hrms" / "api" / "google_chat.py",
-        )
-        module = importlib.util.module_from_spec(spec)
-        assert spec.loader is not None
-        spec.loader.exec_module(module)
-        return module
+	def _load_module(self):
+		module_name = "hrms.api.google_chat_routing_under_test"
+		for key in [module_name, "hrms.utils.notification_intelligence", "hrms.utils.chat_space_lockdown"]:
+			if key in sys.modules:
+				del sys.modules[key]
+		spec = importlib.util.spec_from_file_location(
+			module_name,
+			ROOT / "hrms" / "api" / "google_chat.py",
+		)
+		module = importlib.util.module_from_spec(spec)
+		assert spec.loader is not None
+		spec.loader.exec_module(module)
+		return module
 
-    def setUp(self):
-        fake_chat = _FakeChatAPI()
-        _install_fake_frappe()
-        _install_fake_hrms_package()
-        _install_fake_google_oauth()
-        _install_fake_bei_config()
-        _install_fake_google_modules(fake_chat)
-        self.fake_chat = fake_chat
-        self.module = self._load_module()
+	def setUp(self):
+		fake_chat = _FakeChatAPI()
+		_install_fake_frappe()
+		_install_fake_hrms_package()
+		_install_fake_google_oauth()
+		_install_fake_bei_config()
+		_install_fake_google_modules(fake_chat)
+		self.fake_chat = fake_chat
+		self.module = self._load_module()
 
-    def test_send_message_to_space_reroutes_to_blip_notifications_by_default(self):
-        with patch.object(self.module.os.path, "exists", return_value=True), patch.dict(os.environ, {}, clear=False):
-            self.assertTrue(self.module.send_message_to_space("spaces/AAAAvDZdY-o", "hello"))
+	def test_send_message_to_space_reroutes_to_blip_notifications_by_default(self):
+		with (
+			patch.object(self.module.os.path, "exists", return_value=True),
+			patch.dict(os.environ, {}, clear=False),
+		):
+			self.assertTrue(self.module.send_message_to_space("spaces/AAAAvDZdY-o", "hello"))
 
-        self.assertEqual(self.fake_chat.messages_api.last_parent, "spaces/AAQABiNmpBg")
-        self.assertEqual(self.fake_chat.messages_api.last_body, {"text": "hello"})
+		self.assertEqual(self.fake_chat.messages_api.last_parent, "spaces/AAQABiNmpBg")
+		self.assertEqual(self.fake_chat.messages_api.last_body, {"text": "hello"})
 
-    def test_send_message_to_space_allows_explicit_override(self):
-        with patch.object(self.module.os.path, "exists", return_value=True), patch.dict(
-            os.environ,
-            {
-                "BEI_ALLOW_NON_BLIP_CHAT_DESTINATIONS": "true",
-                "BEI_ALLOWED_CHAT_SPACES": "spaces/AAAAvDZdY-o",
-            },
-            clear=False,
-        ):
-            self.assertTrue(self.module.send_message_to_space("spaces/AAAAvDZdY-o", "hello"))
+	def test_send_message_to_space_allows_explicit_override(self):
+		with (
+			patch.object(self.module.os.path, "exists", return_value=True),
+			patch.dict(
+				os.environ,
+				{
+					"BEI_ALLOW_NON_BLIP_CHAT_DESTINATIONS": "true",
+					"BEI_ALLOWED_CHAT_SPACES": "spaces/AAAAvDZdY-o",
+				},
+				clear=False,
+			),
+		):
+			self.assertTrue(self.module.send_message_to_space("spaces/AAAAvDZdY-o", "hello"))
 
-        self.assertEqual(self.fake_chat.messages_api.last_parent, "spaces/AAAAvDZdY-o")
+		self.assertEqual(self.fake_chat.messages_api.last_parent, "spaces/AAAAvDZdY-o")
 
-    def test_ingest_notification_event_dry_run_renders_contract_sections(self):
-        result = self.module.ingest_notification_event(
-            event={
-                "family": "approval_queue_new",
-                "source_system": "frappe",
-                "source_ref": "APQ-0001",
-                "severity": "high",
-                "owner": "Assigned Approver",
-                "facts": {
-                    "queue_name": "APQ-0001",
-                    "reference_doctype": "BEI Store Order",
-                    "reference_name": "BEI-ORD-0001",
-                    "store": "Ayala Evo",
-                },
-            },
-            dry_run=True,
-        )
+	def test_ingest_notification_event_dry_run_renders_contract_sections(self):
+		result = self.module.ingest_notification_event(
+			event={
+				"family": "approval_queue_new",
+				"source_system": "frappe",
+				"source_ref": "APQ-0001",
+				"severity": "high",
+				"owner": "Assigned Approver",
+				"facts": {
+					"queue_name": "APQ-0001",
+					"reference_doctype": "BEI Store Order",
+					"reference_name": "BEI-ORD-0001",
+					"store": "Ayala Evo",
+				},
+			},
+			dry_run=True,
+		)
 
-        self.assertTrue(result["success"])
-        self.assertFalse(result["sent"])
-        self.assertIn("*Summary*", result["rendered_text"])
-        self.assertIn("*Recommended fix*", result["rendered_text"])
+		self.assertTrue(result["success"])
+		self.assertFalse(result["sent"])
+		self.assertIn("*Summary*", result["rendered_text"])
+		self.assertIn("*Recommended fix*", result["rendered_text"])
 
-    def test_send_notification_event_respects_family_allowed_space(self):
-        event = {
-            "family": "maintenance_status_update",
-            "source_system": "frappe",
-            "source_ref": "MR-0001",
-            "severity": "medium",
-            "owner": "Projects Team / Store Manager",
-            "requested_space": "spaces/AAAAvDZdY-o",
-            "facts": {
-                "request_name": "MR-0001",
-                "status": "Completed",
-                "store": "Ayala Evo",
-                "event_kind": "status_change",
-            },
-        }
+	def test_send_notification_event_respects_family_allowed_space(self):
+		event = {
+			"family": "maintenance_status_update",
+			"source_system": "frappe",
+			"source_ref": "MR-0001",
+			"severity": "medium",
+			"owner": "Projects Team / Store Manager",
+			"requested_space": "spaces/AAAAvDZdY-o",
+			"facts": {
+				"request_name": "MR-0001",
+				"status": "Completed",
+				"store": "Ayala Evo",
+				"event_kind": "status_change",
+			},
+		}
 
-        with patch.object(self.module.os.path, "exists", return_value=True), patch.dict(os.environ, {}, clear=False):
-            result = self.module.ingest_notification_event(event=event)
+		with (
+			patch.object(self.module.os.path, "exists", return_value=True),
+			patch.dict(os.environ, {}, clear=False),
+		):
+			result = self.module.ingest_notification_event(event=event)
 
-        self.assertTrue(result["success"])
-        self.assertTrue(result["sent"])
-        self.assertEqual(self.fake_chat.messages_api.last_parent, "spaces/AAAAvDZdY-o")
-        self.assertIn("maintenance status update", self.fake_chat.messages_api.last_body["text"].lower())
+		self.assertTrue(result["success"])
+		self.assertTrue(result["sent"])
+		self.assertEqual(self.fake_chat.messages_api.last_parent, "spaces/AAAAvDZdY-o")
+		self.assertIn("maintenance status update", self.fake_chat.messages_api.last_body["text"].lower())
 
-    def test_ingest_notification_event_dedups_within_policy_window(self):
-        event = {
-            "family": "maintenance_sla_backlog",
-            "source_system": "frappe",
-            "source_ref": "maintenance_sla:2026-03-13",
-            "severity": "critical",
-            "owner": "Projects Manager",
-            "facts": {
-                "report_date": "2026-03-13",
-                "counts_by_priority": {"Urgent": 1, "High": 0, "Normal": 0},
-                "breaches": [{"name": "MR-1", "store": "AFT", "priority": "Urgent", "age_hours": 6}],
-            },
-        }
+	def test_ingest_notification_event_dedups_within_policy_window(self):
+		event = {
+			"family": "maintenance_sla_backlog",
+			"source_system": "frappe",
+			"source_ref": "maintenance_sla:2026-03-13",
+			"severity": "critical",
+			"owner": "Projects Manager",
+			"facts": {
+				"report_date": "2026-03-13",
+				"counts_by_priority": {"Urgent": 1, "High": 0, "Normal": 0},
+				"breaches": [{"name": "MR-1", "store": "AFT", "priority": "Urgent", "age_hours": 6}],
+			},
+		}
 
-        with patch.object(self.module.os.path, "exists", return_value=True), patch.dict(os.environ, {}, clear=False):
-            first = self.module.ingest_notification_event(event=event)
-            second = self.module.ingest_notification_event(event=event)
+		with (
+			patch.object(self.module.os.path, "exists", return_value=True),
+			patch.dict(os.environ, {}, clear=False),
+		):
+			first = self.module.ingest_notification_event(event=event)
+			second = self.module.ingest_notification_event(event=event)
 
-        self.assertTrue(first["sent"])
-        self.assertTrue(second["success"])
-        self.assertTrue(second["skipped"])
-        self.assertEqual(self.fake_chat.messages_api.call_count, 1)
+		self.assertTrue(first["sent"])
+		self.assertTrue(second["success"])
+		self.assertTrue(second["skipped"])
+		self.assertEqual(self.fake_chat.messages_api.call_count, 1)
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_notification_intelligence_s38.py
+++ b/hrms/tests/test_notification_intelligence_s38.py
@@ -1,0 +1,82 @@
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from hrms.utils import notification_intelligence as ni
+
+
+class TestNotificationIntelligenceS38(unittest.TestCase):
+    def test_certified_manifest_and_exclusion_counts_are_locked(self):
+        self.assertEqual(len(ni.build_certified_family_manifest_rows()), 8)
+        self.assertGreaterEqual(len(ni.build_exclusion_rows()), 4)
+
+    def test_build_notification_event_fills_defaults_and_rendered_sections(self):
+        event = ni.build_notification_event(
+            {
+                "family": "morning_readiness_digest",
+                "facts": {
+                    "report_date": "2026-03-13",
+                    "status": "yellow",
+                    "areas": [
+                        {"label": "Store Inventory Shadow Sync", "status": "green"},
+                        {"label": "AP / Procurement Baselines", "status": "yellow"},
+                    ],
+                    "sync_target_pht_time": "07:00",
+                    "ready_deadline_pht_time": "09:00",
+                    "artifact_markdown_path": "F:/tmp/report.md",
+                },
+            }
+        )
+
+        self.assertEqual(event["delivery_class"], "action_digest")
+        self.assertEqual(event["requested_space"], ni.SPACE_NOTIFICATIONS)
+        self.assertTrue(event["dedup_key"].startswith("morning_readiness_digest:"))
+        rendered = ni.render_notification_text(event)
+        self.assertIn("*Summary*", rendered)
+        self.assertIn("*Why this matters*", rendered)
+        self.assertIn("report.md", rendered)
+
+    def test_discount_digest_renderer_mentions_review_queue(self):
+        event = ni.build_notification_event(
+            {
+                "family": "discount_critical_digest",
+                "facts": {
+                    "business_date": "2026-03-12",
+                    "rows": [
+                        {"store_name": "SM North EDSA", "identity_key": "25402", "order_count": 2},
+                        {"store_name": "SM Megamall", "identity_key": "153", "order_count": 2},
+                    ],
+                    "review_url": "https://my.bebang.ph/dashboard/accounting/discount-abuse",
+                },
+            }
+        )
+
+        rendered = ni.render_notification_text(event)
+        self.assertIn("Discount audit found 2 critical clusters", rendered)
+        self.assertIn("discount-abuse", rendered)
+
+    def test_store_order_approved_renderer_covers_fulfillment_signal(self):
+        event = ni.build_notification_event(
+            {
+                "family": "store_order_approved",
+                "facts": {
+                    "order_name": "BEI-ORD-0001",
+                    "store": "Ayala Evo",
+                    "approved_by": "test.hr@bebang.ph",
+                    "material_request": "MAT-REQ-0001",
+                    "dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
+                },
+            }
+        )
+
+        rendered = ni.render_notification_text(event)
+        self.assertIn("dispatch request MAT-REQ-0001 is ready", rendered)
+        self.assertIn("Warehouse / Store Ops", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hrms/tests/test_notification_intelligence_s38.py
+++ b/hrms/tests/test_notification_intelligence_s38.py
@@ -4,79 +4,79 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+	sys.path.insert(0, str(ROOT))
 
 from hrms.utils import notification_intelligence as ni
 
 
 class TestNotificationIntelligenceS38(unittest.TestCase):
-    def test_certified_manifest_and_exclusion_counts_are_locked(self):
-        self.assertEqual(len(ni.build_certified_family_manifest_rows()), 8)
-        self.assertGreaterEqual(len(ni.build_exclusion_rows()), 4)
+	def test_certified_manifest_and_exclusion_counts_are_locked(self):
+		self.assertEqual(len(ni.build_certified_family_manifest_rows()), 8)
+		self.assertGreaterEqual(len(ni.build_exclusion_rows()), 4)
 
-    def test_build_notification_event_fills_defaults_and_rendered_sections(self):
-        event = ni.build_notification_event(
-            {
-                "family": "morning_readiness_digest",
-                "facts": {
-                    "report_date": "2026-03-13",
-                    "status": "yellow",
-                    "areas": [
-                        {"label": "Store Inventory Shadow Sync", "status": "green"},
-                        {"label": "AP / Procurement Baselines", "status": "yellow"},
-                    ],
-                    "sync_target_pht_time": "07:00",
-                    "ready_deadline_pht_time": "09:00",
-                    "artifact_markdown_path": "F:/tmp/report.md",
-                },
-            }
-        )
+	def test_build_notification_event_fills_defaults_and_rendered_sections(self):
+		event = ni.build_notification_event(
+			{
+				"family": "morning_readiness_digest",
+				"facts": {
+					"report_date": "2026-03-13",
+					"status": "yellow",
+					"areas": [
+						{"label": "Store Inventory Shadow Sync", "status": "green"},
+						{"label": "AP / Procurement Baselines", "status": "yellow"},
+					],
+					"sync_target_pht_time": "07:00",
+					"ready_deadline_pht_time": "09:00",
+					"artifact_markdown_path": "F:/tmp/report.md",
+				},
+			}
+		)
 
-        self.assertEqual(event["delivery_class"], "action_digest")
-        self.assertEqual(event["requested_space"], ni.SPACE_NOTIFICATIONS)
-        self.assertTrue(event["dedup_key"].startswith("morning_readiness_digest:"))
-        rendered = ni.render_notification_text(event)
-        self.assertIn("*Summary*", rendered)
-        self.assertIn("*Why this matters*", rendered)
-        self.assertIn("report.md", rendered)
+		self.assertEqual(event["delivery_class"], "action_digest")
+		self.assertEqual(event["requested_space"], ni.SPACE_NOTIFICATIONS)
+		self.assertTrue(event["dedup_key"].startswith("morning_readiness_digest:"))
+		rendered = ni.render_notification_text(event)
+		self.assertIn("*Summary*", rendered)
+		self.assertIn("*Why this matters*", rendered)
+		self.assertIn("report.md", rendered)
 
-    def test_discount_digest_renderer_mentions_review_queue(self):
-        event = ni.build_notification_event(
-            {
-                "family": "discount_critical_digest",
-                "facts": {
-                    "business_date": "2026-03-12",
-                    "rows": [
-                        {"store_name": "SM North EDSA", "identity_key": "25402", "order_count": 2},
-                        {"store_name": "SM Megamall", "identity_key": "153", "order_count": 2},
-                    ],
-                    "review_url": "https://my.bebang.ph/dashboard/accounting/discount-abuse",
-                },
-            }
-        )
+	def test_discount_digest_renderer_mentions_review_queue(self):
+		event = ni.build_notification_event(
+			{
+				"family": "discount_critical_digest",
+				"facts": {
+					"business_date": "2026-03-12",
+					"rows": [
+						{"store_name": "SM North EDSA", "identity_key": "25402", "order_count": 2},
+						{"store_name": "SM Megamall", "identity_key": "153", "order_count": 2},
+					],
+					"review_url": "https://my.bebang.ph/dashboard/accounting/discount-abuse",
+				},
+			}
+		)
 
-        rendered = ni.render_notification_text(event)
-        self.assertIn("Discount audit found 2 critical clusters", rendered)
-        self.assertIn("discount-abuse", rendered)
+		rendered = ni.render_notification_text(event)
+		self.assertIn("Discount audit found 2 critical clusters", rendered)
+		self.assertIn("discount-abuse", rendered)
 
-    def test_store_order_approved_renderer_covers_fulfillment_signal(self):
-        event = ni.build_notification_event(
-            {
-                "family": "store_order_approved",
-                "facts": {
-                    "order_name": "BEI-ORD-0001",
-                    "store": "Ayala Evo",
-                    "approved_by": "test.hr@bebang.ph",
-                    "material_request": "MAT-REQ-0001",
-                    "dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
-                },
-            }
-        )
+	def test_store_order_approved_renderer_covers_fulfillment_signal(self):
+		event = ni.build_notification_event(
+			{
+				"family": "store_order_approved",
+				"facts": {
+					"order_name": "BEI-ORD-0001",
+					"store": "Ayala Evo",
+					"approved_by": "test.hr@bebang.ph",
+					"material_request": "MAT-REQ-0001",
+					"dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
+				},
+			}
+		)
 
-        rendered = ni.render_notification_text(event)
-        self.assertIn("dispatch request MAT-REQ-0001 is ready", rendered)
-        self.assertIn("Warehouse / Store Ops", rendered)
+		rendered = ni.render_notification_text(event)
+		self.assertIn("dispatch request MAT-REQ-0001 is ready", rendered)
+		self.assertIn("Warehouse / Store Ops", rendered)
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_projects_notifications_s06.py
+++ b/hrms/tests/test_projects_notifications_s06.py
@@ -8,321 +8,327 @@ from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+	sys.path.insert(0, str(ROOT))
 
 
 def _install_fake_frappe():
-    frappe = types.ModuleType("frappe")
+	frappe = types.ModuleType("frappe")
 
-    class PermissionError(Exception):
-        pass
+	class PermissionError(Exception):
+		pass
 
-    class AuthenticationError(Exception):
-        pass
+	class AuthenticationError(Exception):
+		pass
 
-    def whitelist(*args, **kwargs):
-        if args and callable(args[0]) and len(args) == 1 and not kwargs:
-            return args[0]
+	def whitelist(*args, **kwargs):
+		if args and callable(args[0]) and len(args) == 1 and not kwargs:
+			return args[0]
 
-        def decorator(fn):
-            return fn
+		def decorator(fn):
+			return fn
 
-        return decorator
+		return decorator
 
-    def _throw(message, exc=None):
-        if isinstance(exc, type) and issubclass(exc, Exception):
-            raise exc(message)
-        raise Exception(message)
+	def _throw(message, exc=None):
+		if isinstance(exc, type) and issubclass(exc, Exception):
+			raise exc(message)
+		raise Exception(message)
 
-    frappe.PermissionError = PermissionError
-    frappe.AuthenticationError = AuthenticationError
-    frappe.whitelist = whitelist
-    frappe.throw = _throw
-    frappe._ = lambda text: text
-    frappe.log_error = lambda *args, **kwargs: None
-    frappe.logger = lambda *args, **kwargs: types.SimpleNamespace(
-        info=lambda *a, **k: None,
-        warning=lambda *a, **k: None,
-        error=lambda *a, **k: None,
-    )
-    frappe.session = types.SimpleNamespace(user="test.user@bebang.ph")
-    frappe.db = types.SimpleNamespace(
-        exists=lambda *args, **kwargs: None,
-        get_value=lambda *args, **kwargs: None,
-        count=lambda *args, **kwargs: 0,
-    )
-    frappe.get_roles = lambda *args, **kwargs: []
-    frappe.get_doc = lambda *args, **kwargs: None
-    frappe.get_all = lambda *args, **kwargs: []
-    sys.modules["frappe"] = frappe
+	frappe.PermissionError = PermissionError
+	frappe.AuthenticationError = AuthenticationError
+	frappe.whitelist = whitelist
+	frappe.throw = _throw
+	frappe._ = lambda text: text
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.logger = lambda *args, **kwargs: types.SimpleNamespace(
+		info=lambda *a, **k: None,
+		warning=lambda *a, **k: None,
+		error=lambda *a, **k: None,
+	)
+	frappe.session = types.SimpleNamespace(user="test.user@bebang.ph")
+	frappe.db = types.SimpleNamespace(
+		exists=lambda *args, **kwargs: None,
+		get_value=lambda *args, **kwargs: None,
+		count=lambda *args, **kwargs: 0,
+	)
+	frappe.get_roles = lambda *args, **kwargs: []
+	frappe.get_doc = lambda *args, **kwargs: None
+	frappe.get_all = lambda *args, **kwargs: []
+	sys.modules["frappe"] = frappe
 
-    utils_mod = types.ModuleType("frappe.utils")
-    utils_mod.now_datetime = lambda: datetime(2026, 3, 13, 10, 0, 0)
-    utils_mod.today = lambda: "2026-03-13"
-    utils_mod.nowdate = lambda: "2026-03-13"
-    utils_mod.getdate = lambda value=None: value
-    utils_mod.date_diff = lambda end, start: 0
-    utils_mod.flt = lambda value: float(value or 0)
-    utils_mod.sbool = lambda value: str(value).strip().lower() in {"1", "true", "yes", "on"}
-    sys.modules["frappe.utils"] = utils_mod
+	utils_mod = types.ModuleType("frappe.utils")
+	utils_mod.now_datetime = lambda: datetime(2026, 3, 13, 10, 0, 0)
+	utils_mod.today = lambda: "2026-03-13"
+	utils_mod.nowdate = lambda: "2026-03-13"
+	utils_mod.getdate = lambda value=None: value
+	utils_mod.date_diff = lambda end, start: 0
+	utils_mod.flt = lambda value: float(value or 0)
+	utils_mod.sbool = lambda value: str(value).strip().lower() in {"1", "true", "yes", "on"}
+	sys.modules["frappe.utils"] = utils_mod
 
-    model_mod = types.ModuleType("frappe.model")
-    sys.modules["frappe.model"] = model_mod
-    document_mod = types.ModuleType("frappe.model.document")
-    document_mod.Document = object
-    sys.modules["frappe.model.document"] = document_mod
+	model_mod = types.ModuleType("frappe.model")
+	sys.modules["frappe.model"] = model_mod
+	document_mod = types.ModuleType("frappe.model.document")
+	document_mod.Document = object
+	sys.modules["frappe.model.document"] = document_mod
 
 
 def _install_fake_hrms_package():
-    hrms_pkg = types.ModuleType("hrms")
-    hrms_pkg.__path__ = [str(ROOT / "hrms")]
-    sys.modules["hrms"] = hrms_pkg
+	hrms_pkg = types.ModuleType("hrms")
+	hrms_pkg.__path__ = [str(ROOT / "hrms")]
+	sys.modules["hrms"] = hrms_pkg
 
-    api_pkg = types.ModuleType("hrms.api")
-    api_pkg.__path__ = [str(ROOT / "hrms" / "api")]
-    sys.modules["hrms.api"] = api_pkg
+	api_pkg = types.ModuleType("hrms.api")
+	api_pkg.__path__ = [str(ROOT / "hrms" / "api")]
+	sys.modules["hrms.api"] = api_pkg
 
-    hr_pkg = types.ModuleType("hrms.hr")
-    hr_pkg.__path__ = [str(ROOT / "hrms" / "hr")]
-    sys.modules["hrms.hr"] = hr_pkg
+	hr_pkg = types.ModuleType("hrms.hr")
+	hr_pkg.__path__ = [str(ROOT / "hrms" / "hr")]
+	sys.modules["hrms.hr"] = hr_pkg
 
-    doctype_pkg = types.ModuleType("hrms.hr.doctype")
-    doctype_pkg.__path__ = [str(ROOT / "hrms" / "hr" / "doctype")]
-    sys.modules["hrms.hr.doctype"] = doctype_pkg
+	doctype_pkg = types.ModuleType("hrms.hr.doctype")
+	doctype_pkg.__path__ = [str(ROOT / "hrms" / "hr" / "doctype")]
+	sys.modules["hrms.hr.doctype"] = doctype_pkg
 
-    mr_pkg = types.ModuleType("hrms.hr.doctype.bei_maintenance_request")
-    mr_pkg.__path__ = [str(ROOT / "hrms" / "hr" / "doctype" / "bei_maintenance_request")]
-    sys.modules["hrms.hr.doctype.bei_maintenance_request"] = mr_pkg
+	mr_pkg = types.ModuleType("hrms.hr.doctype.bei_maintenance_request")
+	mr_pkg.__path__ = [str(ROOT / "hrms" / "hr" / "doctype" / "bei_maintenance_request")]
+	sys.modules["hrms.hr.doctype.bei_maintenance_request"] = mr_pkg
 
 
 def _load_module(module_name: str, relative_path: str):
-    if module_name in sys.modules:
-        del sys.modules[module_name]
-    spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    assert spec.loader is not None
-    spec.loader.exec_module(module)
-    return module
+	if module_name in sys.modules:
+		del sys.modules[module_name]
+	spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[module_name] = module
+	assert spec.loader is not None
+	spec.loader.exec_module(module)
+	return module
 
 
 _install_fake_frappe()
 _install_fake_hrms_package()
 maintenance_module = _load_module(
-    "hrms.hr.doctype.bei_maintenance_request.bei_maintenance_request",
-    "hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py",
+	"hrms.hr.doctype.bei_maintenance_request.bei_maintenance_request",
+	"hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py",
 )
 projects = _load_module("hrms.api.projects", "hrms/api/projects.py")
 BEIMaintenanceRequest = maintenance_module.BEIMaintenanceRequest
 
 
 class _DummyMaintenanceDoc:
-    def __init__(self):
-        self.name = "MR-S06-0001"
-        self.store = "AYALA EVO - BEI"
-        self.priority = "High"
-        self.issue_category = "Electrical"
-        self.impact_on_operations = "Limited Operations"
-        self.description = "Main outlet sparking near prep area"
-        self.assigned_to = "projects.staff@bebang.ph"
-        self.vendor = ""
-        self.scheduled_date = "2026-02-27"
-        self.status = "Assigned"
+	def __init__(self):
+		self.name = "MR-S06-0001"
+		self.store = "AYALA EVO - BEI"
+		self.priority = "High"
+		self.issue_category = "Electrical"
+		self.impact_on_operations = "Limited Operations"
+		self.description = "Main outlet sparking near prep area"
+		self.assigned_to = "projects.staff@bebang.ph"
+		self.vendor = ""
+		self.scheduled_date = "2026-02-27"
+		self.status = "Assigned"
 
 
 class _ChargeDoc:
-    def __init__(self):
-        self.name = "MR-S06-0002"
-        self.store = "AYALA EVO - BEI"
-        self.charge_amount = 0
-        self.charging_reason = ""
-        self.charge_to_store = 0
-        self.status = "Open"
-        self.flags = types.SimpleNamespace(ignore_permissions=False)
-        self.saved = False
+	def __init__(self):
+		self.name = "MR-S06-0002"
+		self.store = "AYALA EVO - BEI"
+		self.charge_amount = 0
+		self.charging_reason = ""
+		self.charge_to_store = 0
+		self.status = "Open"
+		self.flags = types.SimpleNamespace(ignore_permissions=False)
+		self.saved = False
 
-    def save(self):
-        self.saved = True
+	def save(self):
+		self.saved = True
 
-    def as_dict(self):
-        return {
-            "name": self.name,
-            "store": self.store,
-            "charge_amount": self.charge_amount,
-            "charging_reason": self.charging_reason,
-            "status": self.status,
-        }
+	def as_dict(self):
+		return {
+			"name": self.name,
+			"store": self.store,
+			"charge_amount": self.charge_amount,
+			"charging_reason": self.charging_reason,
+			"status": self.status,
+		}
 
 
 class _AttrDict(dict):
-    __getattr__ = dict.get
+	__getattr__ = dict.get
 
 
 class _AckDoc:
-    def __init__(self):
-        self.name = "MR-S06-ACK-0001"
-        self.charge_to_store = 1
-        self.store = "AYALA EVO - BEI"
-        self.store_code = "AYALA EVO"
-        self.store_acknowledged = 0
-        self.acknowledged_by = None
-        self.acknowledgement_date = None
-        self.status = "Pending Acknowledgement"
-        self.flags = types.SimpleNamespace(ignore_permissions=False)
-        self.saved = False
+	def __init__(self):
+		self.name = "MR-S06-ACK-0001"
+		self.charge_to_store = 1
+		self.store = "AYALA EVO - BEI"
+		self.store_code = "AYALA EVO"
+		self.store_acknowledged = 0
+		self.acknowledged_by = None
+		self.acknowledgement_date = None
+		self.status = "Pending Acknowledgement"
+		self.flags = types.SimpleNamespace(ignore_permissions=False)
+		self.saved = False
 
-    def save(self):
-        self.saved = True
+	def save(self):
+		self.saved = True
 
 
 class TestProjectsNotificationsS06(unittest.TestCase):
-    def test_new_request_notification_dispatches_event(self):
-        doc = _DummyMaintenanceDoc()
-        with patch.object(maintenance_module, "_notify_maintenance_event") as notify_mock:
-            BEIMaintenanceRequest.send_notification(doc)
+	def test_new_request_notification_dispatches_event(self):
+		doc = _DummyMaintenanceDoc()
+		with patch.object(maintenance_module, "_notify_maintenance_event") as notify_mock:
+			BEIMaintenanceRequest.send_notification(doc)
 
-        notify_mock.assert_called_once()
-        call_args = notify_mock.call_args.kwargs
-        self.assertIn("New Maintenance Request", call_args["title"])
-        self.assertEqual(call_args["store"], doc.store)
-        self.assertEqual(call_args["event_kind"], "created")
-        self.assertEqual(call_args["request_name"], doc.name)
+		notify_mock.assert_called_once()
+		call_args = notify_mock.call_args.kwargs
+		self.assertIn("New Maintenance Request", call_args["title"])
+		self.assertEqual(call_args["store"], doc.store)
+		self.assertEqual(call_args["event_kind"], "created")
+		self.assertEqual(call_args["request_name"], doc.name)
 
-    def test_status_notification_dispatches_event(self):
-        doc = _DummyMaintenanceDoc()
-        with patch.object(maintenance_module, "_notify_maintenance_event") as notify_mock:
-            BEIMaintenanceRequest.send_status_notification(doc)
+	def test_status_notification_dispatches_event(self):
+		doc = _DummyMaintenanceDoc()
+		with patch.object(maintenance_module, "_notify_maintenance_event") as notify_mock:
+			BEIMaintenanceRequest.send_status_notification(doc)
 
-        notify_mock.assert_called_once()
-        call_args = notify_mock.call_args.kwargs
-        self.assertIn("Maintenance Status Updated", call_args["title"])
-        self.assertEqual(call_args["store"], doc.store)
-        self.assertEqual(call_args["event_kind"], "status_change")
-        self.assertEqual(call_args["status"], doc.status)
+		notify_mock.assert_called_once()
+		call_args = notify_mock.call_args.kwargs
+		self.assertIn("Maintenance Status Updated", call_args["title"])
+		self.assertEqual(call_args["store"], doc.store)
+		self.assertEqual(call_args["event_kind"], "status_change")
+		self.assertEqual(call_args["status"], doc.status)
 
-    def test_set_maintenance_charge_triggers_pending_ack_notification(self):
-        doc = _ChargeDoc()
+	def test_set_maintenance_charge_triggers_pending_ack_notification(self):
+		doc = _ChargeDoc()
 
-        with patch.object(projects.frappe, "get_roles", return_value=["Projects Manager"]), patch.object(
-            projects.frappe.db, "exists", return_value=True
-        ), patch.object(projects.frappe, "get_doc", return_value=doc), patch.object(
-            projects, "_notify_maintenance_charge_pending_ack"
-        ) as notify_mock:
-            result = projects.set_maintenance_charge(
-                request_id=doc.name,
-                charge_amount=1250,
-                charging_reason="Parts replacement",
-            )
+		with (
+			patch.object(projects.frappe, "get_roles", return_value=["Projects Manager"]),
+			patch.object(projects.frappe.db, "exists", return_value=True),
+			patch.object(projects.frappe, "get_doc", return_value=doc),
+			patch.object(projects, "_notify_maintenance_charge_pending_ack") as notify_mock,
+		):
+			result = projects.set_maintenance_charge(
+				request_id=doc.name,
+				charge_amount=1250,
+				charging_reason="Parts replacement",
+			)
 
-        self.assertTrue(result["success"])
-        self.assertTrue(doc.saved)
-        self.assertEqual(doc.status, "Pending Acknowledgement")
-        self.assertEqual(doc.charge_amount, 1250)
-        notify_mock.assert_called_once_with(doc)
+		self.assertTrue(result["success"])
+		self.assertTrue(doc.saved)
+		self.assertEqual(doc.status, "Pending Acknowledgement")
+		self.assertEqual(doc.charge_amount, 1250)
+		notify_mock.assert_called_once_with(doc)
 
-    def test_acknowledge_charge_allows_store_staff(self):
-        doc = _AckDoc()
+	def test_acknowledge_charge_allows_store_staff(self):
+		doc = _AckDoc()
 
-        def _db_get_value(doctype, filters_or_name=None, fieldname=None):
-            if doctype == "Employee" and isinstance(filters_or_name, dict):
-                return "HR-EMP-TEST-0001"
-            if doctype == "Employee" and filters_or_name == "HR-EMP-TEST-0001" and fieldname == "branch":
-                return "AYALA EVO - BEI"
-            if doctype == "BEI Maintenance Request" and fieldname == "store":
-                return "AYALA EVO - BEI"
-            return None
+		def _db_get_value(doctype, filters_or_name=None, fieldname=None):
+			if doctype == "Employee" and isinstance(filters_or_name, dict):
+				return "HR-EMP-TEST-0001"
+			if doctype == "Employee" and filters_or_name == "HR-EMP-TEST-0001" and fieldname == "branch":
+				return "AYALA EVO - BEI"
+			if doctype == "BEI Maintenance Request" and fieldname == "store":
+				return "AYALA EVO - BEI"
+			return None
 
-        with patch.object(projects.frappe, "get_roles", return_value=["Store Staff"]), patch.object(
-            projects.frappe.db, "exists", return_value=True
-        ), patch.object(projects.frappe.db, "get_value", side_effect=_db_get_value), patch.object(
-            projects.frappe, "get_doc", return_value=doc
-        ):
-            result = projects.acknowledge_maintenance_charge(request_id=doc.name)
+		with (
+			patch.object(projects.frappe, "get_roles", return_value=["Store Staff"]),
+			patch.object(projects.frappe.db, "exists", return_value=True),
+			patch.object(projects.frappe.db, "get_value", side_effect=_db_get_value),
+			patch.object(projects.frappe, "get_doc", return_value=doc),
+		):
+			result = projects.acknowledge_maintenance_charge(request_id=doc.name)
 
-        self.assertTrue(result["success"])
-        self.assertTrue(doc.saved)
-        self.assertEqual(doc.status, "Verified")
-        self.assertEqual(doc.store_acknowledged, 1)
+		self.assertTrue(result["success"])
+		self.assertTrue(doc.saved)
+		self.assertEqual(doc.status, "Verified")
+		self.assertEqual(doc.store_acknowledged, 1)
 
-    def test_get_pending_charges_allows_store_staff(self):
-        rows = [
-            _AttrDict({
-                "name": "MR-S06-ACK-0002",
-                "store": "AYALA EVO - BEI",
-                "store_code": "AYALA EVO",
-                "request_date": "2026-02-27",
-                "issue_category": "Electrical",
-                "description": "Pending ack sample",
-                "charge_amount": 750.0,
-                "charging_reason": "Wire replacement",
-                "concern_type": "Wear & Tear",
-                "priority": "High",
-                "status": "Pending Acknowledgement",
-            })
-        ]
+	def test_get_pending_charges_allows_store_staff(self):
+		rows = [
+			_AttrDict(
+				{
+					"name": "MR-S06-ACK-0002",
+					"store": "AYALA EVO - BEI",
+					"store_code": "AYALA EVO",
+					"request_date": "2026-02-27",
+					"issue_category": "Electrical",
+					"description": "Pending ack sample",
+					"charge_amount": 750.0,
+					"charging_reason": "Wire replacement",
+					"concern_type": "Wear & Tear",
+					"priority": "High",
+					"status": "Pending Acknowledgement",
+				}
+			)
+		]
 
-        with patch.object(projects.frappe, "get_roles", return_value=["Store Staff"]), patch.object(
-            projects.frappe.db, "count", return_value=1
-        ), patch.object(projects.frappe, "get_all", return_value=rows), patch.object(
-            projects.frappe.db, "get_value", return_value="Ayala Evo"
-        ):
-            result = projects.get_pending_charges(page=1, page_size=20)
+		with (
+			patch.object(projects.frappe, "get_roles", return_value=["Store Staff"]),
+			patch.object(projects.frappe.db, "count", return_value=1),
+			patch.object(projects.frappe, "get_all", return_value=rows),
+			patch.object(projects.frappe.db, "get_value", return_value="Ayala Evo"),
+		):
+			result = projects.get_pending_charges(page=1, page_size=20)
 
-        self.assertEqual(result["total"], 1)
-        self.assertEqual(len(result["requests"]), 1)
-        self.assertEqual(result["requests"][0]["name"], "MR-S06-ACK-0002")
+		self.assertEqual(result["total"], 1)
+		self.assertEqual(len(result["requests"]), 1)
+		self.assertEqual(result["requests"][0]["name"], "MR-S06-ACK-0002")
 
-    def test_check_sla_violations_sends_grouped_digest(self):
-        now = datetime(2026, 3, 13, 10, 0, 0)
+	def test_check_sla_violations_sends_grouped_digest(self):
+		now = datetime(2026, 3, 13, 10, 0, 0)
 
-        def fake_get_all(_doctype, filters=None, fields=None):
-            priority = (filters or {}).get("priority")
-            if priority == "Urgent":
-                return [
-                    types.SimpleNamespace(
-                        name="MR-SLA-URG-0001",
-                        store="AYALA EVO - BEI",
-                        priority="Urgent",
-                        issue_category="Electrical",
-                        description="Outlet sparking",
-                        creation=now - timedelta(hours=6),
-                    )
-                ]
-            if priority == "High":
-                return [
-                    types.SimpleNamespace(
-                        name="MR-SLA-HIGH-0001",
-                        store="AYALA EVO - BEI",
-                        priority="High",
-                        issue_category="Plumbing",
-                        description="Leaking sink",
-                        creation=now - timedelta(hours=30),
-                    )
-                ]
-            return []
+		def fake_get_all(_doctype, filters=None, fields=None):
+			priority = (filters or {}).get("priority")
+			if priority == "Urgent":
+				return [
+					types.SimpleNamespace(
+						name="MR-SLA-URG-0001",
+						store="AYALA EVO - BEI",
+						priority="Urgent",
+						issue_category="Electrical",
+						description="Outlet sparking",
+						creation=now - timedelta(hours=6),
+					)
+				]
+			if priority == "High":
+				return [
+					types.SimpleNamespace(
+						name="MR-SLA-HIGH-0001",
+						store="AYALA EVO - BEI",
+						priority="High",
+						issue_category="Plumbing",
+						description="Leaking sink",
+						creation=now - timedelta(hours=30),
+					)
+				]
+			return []
 
-        google_chat_mod = types.ModuleType("hrms.api.google_chat")
-        captured = {}
+		google_chat_mod = types.ModuleType("hrms.api.google_chat")
+		captured = {}
 
-        def _send(event):
-            captured["event"] = event
-            return True
+		def _send(event):
+			captured["event"] = event
+			return True
 
-        google_chat_mod.send_notification_event = _send
+		google_chat_mod.send_notification_event = _send
 
-        with patch.dict(sys.modules, {"hrms.api.google_chat": google_chat_mod}, clear=False), patch.object(
-            projects, "now_datetime", return_value=now
-        ), patch.object(projects, "nowdate", return_value="2026-03-13"), patch.object(
-            projects.frappe, "get_all", side_effect=fake_get_all
-        ):
-            projects.check_sla_violations()
+		with (
+			patch.dict(sys.modules, {"hrms.api.google_chat": google_chat_mod}, clear=False),
+			patch.object(projects, "now_datetime", return_value=now),
+			patch.object(projects, "nowdate", return_value="2026-03-13"),
+			patch.object(projects.frappe, "get_all", side_effect=fake_get_all),
+		):
+			projects.check_sla_violations()
 
-        event = captured["event"]
-        self.assertEqual(event["family"], "maintenance_sla_backlog")
-        self.assertEqual(event["severity"], "critical")
-        self.assertEqual(event["facts"]["counts_by_priority"]["Urgent"], 1)
-        self.assertEqual(len(event["facts"]["breaches"]), 2)
+		event = captured["event"]
+		self.assertEqual(event["family"], "maintenance_sla_backlog")
+		self.assertEqual(event["severity"], "critical")
+		self.assertEqual(event["facts"]["counts_by_priority"]["Urgent"], 1)
+		self.assertEqual(len(event["facts"]["breaches"]), 2)
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_projects_notifications_s06.py
+++ b/hrms/tests/test_projects_notifications_s06.py
@@ -45,8 +45,8 @@ def _install_fake_frappe():
 		warning=lambda *a, **k: None,
 		error=lambda *a, **k: None,
 	)
-	frappe.session = types.SimpleNamespace(user="test.user@bebang.ph")
-	frappe.db = types.SimpleNamespace(
+	frappe.__dict__["session"] = types.SimpleNamespace(user="test.user@bebang.ph")
+	frappe.__dict__["db"] = types.SimpleNamespace(
 		exists=lambda *args, **kwargs: None,
 		get_value=lambda *args, **kwargs: None,
 		count=lambda *args, **kwargs: 0,

--- a/hrms/tests/test_projects_notifications_s06.py
+++ b/hrms/tests/test_projects_notifications_s06.py
@@ -1,158 +1,328 @@
+import importlib.util
+import sys
 import types
 import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
 from unittest.mock import patch
 
-from hrms.api import projects
-from hrms.hr.doctype.bei_maintenance_request.bei_maintenance_request import (
-	BEIMaintenanceRequest,
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_frappe():
+    frappe = types.ModuleType("frappe")
+
+    class PermissionError(Exception):
+        pass
+
+    class AuthenticationError(Exception):
+        pass
+
+    def whitelist(*args, **kwargs):
+        if args and callable(args[0]) and len(args) == 1 and not kwargs:
+            return args[0]
+
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    def _throw(message, exc=None):
+        if isinstance(exc, type) and issubclass(exc, Exception):
+            raise exc(message)
+        raise Exception(message)
+
+    frappe.PermissionError = PermissionError
+    frappe.AuthenticationError = AuthenticationError
+    frappe.whitelist = whitelist
+    frappe.throw = _throw
+    frappe._ = lambda text: text
+    frappe.log_error = lambda *args, **kwargs: None
+    frappe.logger = lambda *args, **kwargs: types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    frappe.session = types.SimpleNamespace(user="test.user@bebang.ph")
+    frappe.db = types.SimpleNamespace(
+        exists=lambda *args, **kwargs: None,
+        get_value=lambda *args, **kwargs: None,
+        count=lambda *args, **kwargs: 0,
+    )
+    frappe.get_roles = lambda *args, **kwargs: []
+    frappe.get_doc = lambda *args, **kwargs: None
+    frappe.get_all = lambda *args, **kwargs: []
+    sys.modules["frappe"] = frappe
+
+    utils_mod = types.ModuleType("frappe.utils")
+    utils_mod.now_datetime = lambda: datetime(2026, 3, 13, 10, 0, 0)
+    utils_mod.today = lambda: "2026-03-13"
+    utils_mod.nowdate = lambda: "2026-03-13"
+    utils_mod.getdate = lambda value=None: value
+    utils_mod.date_diff = lambda end, start: 0
+    utils_mod.flt = lambda value: float(value or 0)
+    utils_mod.sbool = lambda value: str(value).strip().lower() in {"1", "true", "yes", "on"}
+    sys.modules["frappe.utils"] = utils_mod
+
+    model_mod = types.ModuleType("frappe.model")
+    sys.modules["frappe.model"] = model_mod
+    document_mod = types.ModuleType("frappe.model.document")
+    document_mod.Document = object
+    sys.modules["frappe.model.document"] = document_mod
+
+
+def _install_fake_hrms_package():
+    hrms_pkg = types.ModuleType("hrms")
+    hrms_pkg.__path__ = [str(ROOT / "hrms")]
+    sys.modules["hrms"] = hrms_pkg
+
+    api_pkg = types.ModuleType("hrms.api")
+    api_pkg.__path__ = [str(ROOT / "hrms" / "api")]
+    sys.modules["hrms.api"] = api_pkg
+
+    hr_pkg = types.ModuleType("hrms.hr")
+    hr_pkg.__path__ = [str(ROOT / "hrms" / "hr")]
+    sys.modules["hrms.hr"] = hr_pkg
+
+    doctype_pkg = types.ModuleType("hrms.hr.doctype")
+    doctype_pkg.__path__ = [str(ROOT / "hrms" / "hr" / "doctype")]
+    sys.modules["hrms.hr.doctype"] = doctype_pkg
+
+    mr_pkg = types.ModuleType("hrms.hr.doctype.bei_maintenance_request")
+    mr_pkg.__path__ = [str(ROOT / "hrms" / "hr" / "doctype" / "bei_maintenance_request")]
+    sys.modules["hrms.hr.doctype.bei_maintenance_request"] = mr_pkg
+
+
+def _load_module(module_name: str, relative_path: str):
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_fake_frappe()
+_install_fake_hrms_package()
+maintenance_module = _load_module(
+    "hrms.hr.doctype.bei_maintenance_request.bei_maintenance_request",
+    "hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py",
 )
+projects = _load_module("hrms.api.projects", "hrms/api/projects.py")
+BEIMaintenanceRequest = maintenance_module.BEIMaintenanceRequest
 
 
 class _DummyMaintenanceDoc:
-	def __init__(self):
-		self.name = "MR-S06-0001"
-		self.store = "AYALA EVO - BEI"
-		self.priority = "High"
-		self.issue_category = "Electrical"
-		self.impact_on_operations = "Limited Operations"
-		self.description = "Main outlet sparking near prep area"
-		self.assigned_to = "projects.staff@bebang.ph"
-		self.vendor = ""
-		self.scheduled_date = "2026-02-27"
-		self.status = "Assigned"
+    def __init__(self):
+        self.name = "MR-S06-0001"
+        self.store = "AYALA EVO - BEI"
+        self.priority = "High"
+        self.issue_category = "Electrical"
+        self.impact_on_operations = "Limited Operations"
+        self.description = "Main outlet sparking near prep area"
+        self.assigned_to = "projects.staff@bebang.ph"
+        self.vendor = ""
+        self.scheduled_date = "2026-02-27"
+        self.status = "Assigned"
 
 
 class _ChargeDoc:
-	def __init__(self):
-		self.name = "MR-S06-0002"
-		self.store = "AYALA EVO - BEI"
-		self.charge_amount = 0
-		self.charging_reason = ""
-		self.charge_to_store = 0
-		self.status = "Open"
-		self.flags = types.SimpleNamespace(ignore_permissions=False)
-		self.saved = False
+    def __init__(self):
+        self.name = "MR-S06-0002"
+        self.store = "AYALA EVO - BEI"
+        self.charge_amount = 0
+        self.charging_reason = ""
+        self.charge_to_store = 0
+        self.status = "Open"
+        self.flags = types.SimpleNamespace(ignore_permissions=False)
+        self.saved = False
 
-	def save(self):
-		self.saved = True
+    def save(self):
+        self.saved = True
 
-	def as_dict(self):
-		return {
-			"name": self.name,
-			"store": self.store,
-			"charge_amount": self.charge_amount,
-			"charging_reason": self.charging_reason,
-			"status": self.status,
-		}
+    def as_dict(self):
+        return {
+            "name": self.name,
+            "store": self.store,
+            "charge_amount": self.charge_amount,
+            "charging_reason": self.charging_reason,
+            "status": self.status,
+        }
+
+
+class _AttrDict(dict):
+    __getattr__ = dict.get
+
 
 class _AckDoc:
-	def __init__(self):
-		self.name = "MR-S06-ACK-0001"
-		self.charge_to_store = 1
-		self.store_acknowledged = 0
-		self.acknowledged_by = None
-		self.acknowledgement_date = None
-		self.status = "Pending Acknowledgement"
-		self.flags = types.SimpleNamespace(ignore_permissions=False)
-		self.saved = False
+    def __init__(self):
+        self.name = "MR-S06-ACK-0001"
+        self.charge_to_store = 1
+        self.store = "AYALA EVO - BEI"
+        self.store_code = "AYALA EVO"
+        self.store_acknowledged = 0
+        self.acknowledged_by = None
+        self.acknowledgement_date = None
+        self.status = "Pending Acknowledgement"
+        self.flags = types.SimpleNamespace(ignore_permissions=False)
+        self.saved = False
 
-	def save(self):
-		self.saved = True
+    def save(self):
+        self.saved = True
 
 
 class TestProjectsNotificationsS06(unittest.TestCase):
-	def test_new_request_notification_dispatches_event(self):
-		doc = _DummyMaintenanceDoc()
-		with patch(
-			"hrms.hr.doctype.bei_maintenance_request.bei_maintenance_request._notify_maintenance_event"
-		) as notify_mock:
-			BEIMaintenanceRequest.send_notification(doc)
+    def test_new_request_notification_dispatches_event(self):
+        doc = _DummyMaintenanceDoc()
+        with patch.object(maintenance_module, "_notify_maintenance_event") as notify_mock:
+            BEIMaintenanceRequest.send_notification(doc)
 
-		notify_mock.assert_called_once()
-		call_args = notify_mock.call_args.kwargs
-		self.assertIn("New Maintenance Request", call_args["title"])
-		self.assertEqual(call_args["store"], doc.store)
+        notify_mock.assert_called_once()
+        call_args = notify_mock.call_args.kwargs
+        self.assertIn("New Maintenance Request", call_args["title"])
+        self.assertEqual(call_args["store"], doc.store)
+        self.assertEqual(call_args["event_kind"], "created")
+        self.assertEqual(call_args["request_name"], doc.name)
 
-	def test_status_notification_dispatches_event(self):
-		doc = _DummyMaintenanceDoc()
-		with patch(
-			"hrms.hr.doctype.bei_maintenance_request.bei_maintenance_request._notify_maintenance_event"
-		) as notify_mock:
-			BEIMaintenanceRequest.send_status_notification(doc)
+    def test_status_notification_dispatches_event(self):
+        doc = _DummyMaintenanceDoc()
+        with patch.object(maintenance_module, "_notify_maintenance_event") as notify_mock:
+            BEIMaintenanceRequest.send_status_notification(doc)
 
-		notify_mock.assert_called_once()
-		call_args = notify_mock.call_args.kwargs
-		self.assertIn("Maintenance Status Updated", call_args["title"])
-		self.assertEqual(call_args["store"], doc.store)
+        notify_mock.assert_called_once()
+        call_args = notify_mock.call_args.kwargs
+        self.assertIn("Maintenance Status Updated", call_args["title"])
+        self.assertEqual(call_args["store"], doc.store)
+        self.assertEqual(call_args["event_kind"], "status_change")
+        self.assertEqual(call_args["status"], doc.status)
 
-	def test_set_maintenance_charge_triggers_pending_ack_notification(self):
-		doc = _ChargeDoc()
+    def test_set_maintenance_charge_triggers_pending_ack_notification(self):
+        doc = _ChargeDoc()
 
-		with patch("frappe.get_roles", return_value=["Projects Manager"]), patch(
-			"frappe.db.exists", return_value=True
-		), patch("frappe.get_doc", return_value=doc), patch(
-			"hrms.api.projects._notify_maintenance_charge_pending_ack"
-		) as notify_mock:
-			result = projects.set_maintenance_charge(
-				request_id=doc.name,
-				charge_amount=1250,
-				charging_reason="Parts replacement",
-			)
+        with patch.object(projects.frappe, "get_roles", return_value=["Projects Manager"]), patch.object(
+            projects.frappe.db, "exists", return_value=True
+        ), patch.object(projects.frappe, "get_doc", return_value=doc), patch.object(
+            projects, "_notify_maintenance_charge_pending_ack"
+        ) as notify_mock:
+            result = projects.set_maintenance_charge(
+                request_id=doc.name,
+                charge_amount=1250,
+                charging_reason="Parts replacement",
+            )
 
-		self.assertTrue(result["success"])
-		self.assertTrue(doc.saved)
-		self.assertEqual(doc.status, "Pending Acknowledgement")
-		self.assertEqual(doc.charge_amount, 1250)
-		notify_mock.assert_called_once_with(doc)
+        self.assertTrue(result["success"])
+        self.assertTrue(doc.saved)
+        self.assertEqual(doc.status, "Pending Acknowledgement")
+        self.assertEqual(doc.charge_amount, 1250)
+        notify_mock.assert_called_once_with(doc)
 
-	def test_acknowledge_charge_allows_store_staff(self):
-		doc = _AckDoc()
+    def test_acknowledge_charge_allows_store_staff(self):
+        doc = _AckDoc()
 
-		def _db_get_value(doctype, filters_or_name=None, fieldname=None):
-			if doctype == "Employee" and isinstance(filters_or_name, dict):
-				return "HR-EMP-TEST-0001"
-			if doctype == "Employee" and filters_or_name == "HR-EMP-TEST-0001" and fieldname == "branch":
-				return "AYALA EVO - BEI"
-			if doctype == "BEI Maintenance Request" and fieldname == "store":
-				return "AYALA EVO - BEI"
-			return None
+        def _db_get_value(doctype, filters_or_name=None, fieldname=None):
+            if doctype == "Employee" and isinstance(filters_or_name, dict):
+                return "HR-EMP-TEST-0001"
+            if doctype == "Employee" and filters_or_name == "HR-EMP-TEST-0001" and fieldname == "branch":
+                return "AYALA EVO - BEI"
+            if doctype == "BEI Maintenance Request" and fieldname == "store":
+                return "AYALA EVO - BEI"
+            return None
 
-		with patch("frappe.get_roles", return_value=["Store Staff"]), patch(
-			"frappe.db.exists", return_value=True
-		), patch("frappe.db.get_value", side_effect=_db_get_value), patch(
-			"frappe.get_doc", return_value=doc
-		):
-			result = projects.acknowledge_maintenance_charge(request_id=doc.name)
+        with patch.object(projects.frappe, "get_roles", return_value=["Store Staff"]), patch.object(
+            projects.frappe.db, "exists", return_value=True
+        ), patch.object(projects.frappe.db, "get_value", side_effect=_db_get_value), patch.object(
+            projects.frappe, "get_doc", return_value=doc
+        ):
+            result = projects.acknowledge_maintenance_charge(request_id=doc.name)
 
-		self.assertTrue(result["success"])
-		self.assertTrue(doc.saved)
-		self.assertEqual(doc.status, "Verified")
-		self.assertEqual(doc.store_acknowledged, 1)
+        self.assertTrue(result["success"])
+        self.assertTrue(doc.saved)
+        self.assertEqual(doc.status, "Verified")
+        self.assertEqual(doc.store_acknowledged, 1)
 
-	def test_get_pending_charges_allows_store_staff(self):
-		rows = [
-			{
-				"name": "MR-S06-ACK-0002",
-				"store": "AYALA EVO - BEI",
-				"store_code": "AYALA EVO",
-				"request_date": "2026-02-27",
-				"issue_category": "Electrical",
-				"description": "Pending ack sample",
-				"charge_amount": 750.0,
-				"charging_reason": "Wire replacement",
-				"concern_type": "Wear & Tear",
-				"priority": "High",
-				"status": "Pending Acknowledgement",
-			}
-		]
+    def test_get_pending_charges_allows_store_staff(self):
+        rows = [
+            _AttrDict({
+                "name": "MR-S06-ACK-0002",
+                "store": "AYALA EVO - BEI",
+                "store_code": "AYALA EVO",
+                "request_date": "2026-02-27",
+                "issue_category": "Electrical",
+                "description": "Pending ack sample",
+                "charge_amount": 750.0,
+                "charging_reason": "Wire replacement",
+                "concern_type": "Wear & Tear",
+                "priority": "High",
+                "status": "Pending Acknowledgement",
+            })
+        ]
 
-		with patch("frappe.get_roles", return_value=["Store Staff"]), patch(
-			"frappe.db.count", return_value=1
-		), patch("frappe.get_all", return_value=rows), patch(
-			"frappe.db.get_value", return_value="Ayala Evo"
-		):
-			result = projects.get_pending_charges(page=1, page_size=20)
+        with patch.object(projects.frappe, "get_roles", return_value=["Store Staff"]), patch.object(
+            projects.frappe.db, "count", return_value=1
+        ), patch.object(projects.frappe, "get_all", return_value=rows), patch.object(
+            projects.frappe.db, "get_value", return_value="Ayala Evo"
+        ):
+            result = projects.get_pending_charges(page=1, page_size=20)
 
-		self.assertEqual(result["total"], 1)
-		self.assertEqual(len(result["requests"]), 1)
-		self.assertEqual(result["requests"][0]["name"], "MR-S06-ACK-0002")
+        self.assertEqual(result["total"], 1)
+        self.assertEqual(len(result["requests"]), 1)
+        self.assertEqual(result["requests"][0]["name"], "MR-S06-ACK-0002")
+
+    def test_check_sla_violations_sends_grouped_digest(self):
+        now = datetime(2026, 3, 13, 10, 0, 0)
+
+        def fake_get_all(_doctype, filters=None, fields=None):
+            priority = (filters or {}).get("priority")
+            if priority == "Urgent":
+                return [
+                    types.SimpleNamespace(
+                        name="MR-SLA-URG-0001",
+                        store="AYALA EVO - BEI",
+                        priority="Urgent",
+                        issue_category="Electrical",
+                        description="Outlet sparking",
+                        creation=now - timedelta(hours=6),
+                    )
+                ]
+            if priority == "High":
+                return [
+                    types.SimpleNamespace(
+                        name="MR-SLA-HIGH-0001",
+                        store="AYALA EVO - BEI",
+                        priority="High",
+                        issue_category="Plumbing",
+                        description="Leaking sink",
+                        creation=now - timedelta(hours=30),
+                    )
+                ]
+            return []
+
+        google_chat_mod = types.ModuleType("hrms.api.google_chat")
+        captured = {}
+
+        def _send(event):
+            captured["event"] = event
+            return True
+
+        google_chat_mod.send_notification_event = _send
+
+        with patch.dict(sys.modules, {"hrms.api.google_chat": google_chat_mod}, clear=False), patch.object(
+            projects, "now_datetime", return_value=now
+        ), patch.object(projects, "nowdate", return_value="2026-03-13"), patch.object(
+            projects.frappe, "get_all", side_effect=fake_get_all
+        ):
+            projects.check_sla_violations()
+
+        event = captured["event"]
+        self.assertEqual(event["family"], "maintenance_sla_backlog")
+        self.assertEqual(event["severity"], "critical")
+        self.assertEqual(event["facts"]["counts_by_priority"]["Urgent"], 1)
+        self.assertEqual(len(event["facts"]["breaches"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hrms/tests/test_s19_emergency_duplicate_bypass.py
+++ b/hrms/tests/test_s19_emergency_duplicate_bypass.py
@@ -91,7 +91,11 @@ def _install_stubs():
 	utils.flt = _flt
 	utils.cint = _cint
 	utils.getdate = _getdate
-	utils.get_datetime = lambda value=None: datetime(2026, 3, 2, 10, 0, 0) if value in (None, "") else datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S")
+	utils.get_datetime = (
+		lambda value=None: datetime(2026, 3, 2, 10, 0, 0)
+		if value in (None, "")
+		else datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S")
+	)
 
 	sys.modules["frappe"] = frappe
 	sys.modules["frappe.utils"] = utils
@@ -185,6 +189,7 @@ def test_emergency_duplicate_bypasses_duplicate_gate():
 	assert result["status"] == "Pending Approval"
 	assert result["cargo_category"] == "DRY"
 
+
 def test_emergency_submit_emits_store_order_new_event():
 	store_mod = _load_store_module()
 	notifications = []
@@ -212,4 +217,3 @@ def test_emergency_submit_emits_store_order_new_event():
 	assert event["family"] == "store_order_new"
 	assert event["facts"]["order_name"] == "BEI-ORD-TEST-0001"
 	assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"
-

--- a/hrms/tests/test_s19_emergency_duplicate_bypass.py
+++ b/hrms/tests/test_s19_emergency_duplicate_bypass.py
@@ -21,6 +21,10 @@ def _install_stubs():
 		def get_single_value(*args, **kwargs):
 			return None
 
+		@staticmethod
+		def get_value(*args, **kwargs):
+			return None
+
 	class _OrderDoc:
 		def __init__(self):
 			self.name = "BEI-ORD-TEST-0001"
@@ -87,6 +91,7 @@ def _install_stubs():
 	utils.flt = _flt
 	utils.cint = _cint
 	utils.getdate = _getdate
+	utils.get_datetime = lambda value=None: datetime(2026, 3, 2, 10, 0, 0) if value in (None, "") else datetime.strptime(str(value), "%Y-%m-%d %H:%M:%S")
 
 	sys.modules["frappe"] = frappe
 	sys.modules["frappe.utils"] = utils
@@ -96,16 +101,32 @@ def _install_stubs():
 	utils_pkg = types.ModuleType("hrms.utils")
 	utils_pkg.__path__ = []
 	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.SPACE_OPS = "OPS"
+	bei_config.get_chat_space = lambda _space: "spaces/AAAAvDZdY-o"
 	bei_config.get_company = lambda: "Bebang Enterprise Inc."
 
 	scm_roles = types.ModuleType("hrms.utils.scm_roles")
 	scm_roles.SCM_APPROVAL_ROLES = []
 	scm_roles.check_scm_permission = lambda *args, **kwargs: None
 
+	supply_chain_contracts = types.ModuleType("hrms.utils.supply_chain_contracts")
+	supply_chain_contracts.FINANCE_TREATMENT_SAME_COMPANY = "same_company"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_DISPOSAL = "store_disposal"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_ORDER = "store_order"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_RETURN = "store_return"
+	supply_chain_contracts.infer_finance_treatment = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_material_request_contract = lambda *args, **kwargs: {}
+	supply_chain_contracts.resolve_route_source_warehouse = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_store_buyer_entity = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_warehouse_company = lambda *args, **kwargs: "Bebang Enterprise Inc."
+	supply_chain_contracts.stamp_material_request_contract = lambda *args, **kwargs: None
+	supply_chain_contracts.stamp_stock_entry_contract = lambda *args, **kwargs: None
+
 	sys.modules["hrms"] = hrms_pkg
 	sys.modules["hrms.utils"] = utils_pkg
 	sys.modules["hrms.utils.bei_config"] = bei_config
 	sys.modules["hrms.utils.scm_roles"] = scm_roles
+	sys.modules["hrms.utils.supply_chain_contracts"] = supply_chain_contracts
 
 
 def _load_store_module():
@@ -117,7 +138,7 @@ def _load_store_module():
 	spec.loader.exec_module(module)
 	module.resolve_warehouse = lambda store: store
 	module._get_area_supervisor_for_store = lambda _warehouse: None
-	module._notify_store_ops = lambda _msg: None
+	module._notify_store_ops = lambda *args, **kwargs: None
 	return module
 
 
@@ -163,3 +184,32 @@ def test_emergency_duplicate_bypasses_duplicate_gate():
 	assert result["success"] is True
 	assert result["status"] == "Pending Approval"
 	assert result["cargo_category"] == "DRY"
+
+def test_emergency_submit_emits_store_order_new_event():
+	store_mod = _load_store_module()
+	notifications = []
+	store_mod._notify_store_ops = lambda *args, **kwargs: notifications.append(kwargs)
+
+	result = store_mod.submit_order(
+		store="TEST-STORE-BGC",
+		items=[
+			{
+				"item_code": "ITEM-001",
+				"qty_requested": 1,
+				"recommended_qty": 1,
+				"suggested_qty": 1,
+				"lane": "Dry",
+			}
+		],
+		cargo_category="DRY",
+		is_emergency=1,
+		notes="Emergency replenishment",
+	)
+
+	assert result["success"] is True
+	assert notifications
+	event = notifications[0]["event"]
+	assert event["family"] == "store_order_new"
+	assert event["facts"]["order_name"] == "BEI-ORD-TEST-0001"
+	assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"
+

--- a/hrms/tests/test_sheets_receiver_notifications.py
+++ b/hrms/tests/test_sheets_receiver_notifications.py
@@ -7,67 +7,69 @@ from unittest.mock import MagicMock, patch
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+	sys.path.insert(0, str(ROOT))
 
 
 def _install_fake_google_modules():
-    if "google" not in sys.modules:
-        sys.modules["google"] = types.ModuleType("google")
+	if "google" not in sys.modules:
+		sys.modules["google"] = types.ModuleType("google")
 
-    if "google.oauth2" not in sys.modules:
-        sys.modules["google.oauth2"] = types.ModuleType("google.oauth2")
+	if "google.oauth2" not in sys.modules:
+		sys.modules["google.oauth2"] = types.ModuleType("google.oauth2")
 
-    if "google.oauth2.service_account" not in sys.modules:
-        service_account_mod = types.ModuleType("google.oauth2.service_account")
+	if "google.oauth2.service_account" not in sys.modules:
+		service_account_mod = types.ModuleType("google.oauth2.service_account")
 
-        class _Credentials:
-            @staticmethod
-            def from_service_account_file(_path, scopes=None):
-                return types.SimpleNamespace(scopes=scopes or [])
+		class _Credentials:
+			@staticmethod
+			def from_service_account_file(_path, scopes=None):
+				return types.SimpleNamespace(scopes=scopes or [])
 
-        service_account_mod.Credentials = _Credentials
-        sys.modules["google.oauth2.service_account"] = service_account_mod
+		service_account_mod.Credentials = _Credentials
+		sys.modules["google.oauth2.service_account"] = service_account_mod
 
-    if "googleapiclient" not in sys.modules:
-        sys.modules["googleapiclient"] = types.ModuleType("googleapiclient")
+	if "googleapiclient" not in sys.modules:
+		sys.modules["googleapiclient"] = types.ModuleType("googleapiclient")
 
-    if "googleapiclient.discovery" not in sys.modules:
-        discovery_mod = types.ModuleType("googleapiclient.discovery")
-        discovery_mod.build = lambda *_args, **_kwargs: types.SimpleNamespace()
-        sys.modules["googleapiclient.discovery"] = discovery_mod
+	if "googleapiclient.discovery" not in sys.modules:
+		discovery_mod = types.ModuleType("googleapiclient.discovery")
+		discovery_mod.build = lambda *_args, **_kwargs: types.SimpleNamespace()
+		sys.modules["googleapiclient.discovery"] = discovery_mod
 
 
 def _install_fake_package_path():
-    hrms_pkg = types.ModuleType("hrms")
-    hrms_pkg.__path__ = [str(ROOT / "hrms")]
-    sys.modules["hrms"] = hrms_pkg
+	hrms_pkg = types.ModuleType("hrms")
+	hrms_pkg.__path__ = [str(ROOT / "hrms")]
+	sys.modules["hrms"] = hrms_pkg
 
-    utils_pkg = types.ModuleType("hrms.utils")
-    utils_pkg.__path__ = [str(ROOT / "hrms" / "utils")]
-    sys.modules["hrms.utils"] = utils_pkg
+	utils_pkg = types.ModuleType("hrms.utils")
+	utils_pkg.__path__ = [str(ROOT / "hrms" / "utils")]
+	sys.modules["hrms.utils"] = utils_pkg
 
-    services_pkg = types.ModuleType("hrms.services")
-    services_pkg.__path__ = [str(ROOT / "hrms" / "services")]
-    sys.modules["hrms.services"] = services_pkg
+	services_pkg = types.ModuleType("hrms.services")
+	services_pkg.__path__ = [str(ROOT / "hrms" / "services")]
+	sys.modules["hrms.services"] = services_pkg
 
-    sheets_pkg = types.ModuleType("hrms.services.sheets_receiver")
-    sheets_pkg.__path__ = [str(ROOT / "hrms" / "services" / "sheets_receiver")]
-    sys.modules["hrms.services.sheets_receiver"] = sheets_pkg
+	sheets_pkg = types.ModuleType("hrms.services.sheets_receiver")
+	sheets_pkg.__path__ = [str(ROOT / "hrms" / "services" / "sheets_receiver")]
+	sys.modules["hrms.services.sheets_receiver"] = sheets_pkg
 
-    frappe_client_mod = types.ModuleType("hrms.services.sheets_receiver.frappe_client")
-    frappe_client_mod.get_frappe_client = lambda: types.SimpleNamespace(call_method=lambda *_args, **_kwargs: {})
-    sys.modules["hrms.services.sheets_receiver.frappe_client"] = frappe_client_mod
+	frappe_client_mod = types.ModuleType("hrms.services.sheets_receiver.frappe_client")
+	frappe_client_mod.get_frappe_client = lambda: types.SimpleNamespace(
+		call_method=lambda *_args, **_kwargs: {}
+	)
+	sys.modules["hrms.services.sheets_receiver.frappe_client"] = frappe_client_mod
 
-    models_mod = types.ModuleType("hrms.services.sheets_receiver.models")
-    models_mod.get_db = lambda: types.SimpleNamespace(log_notification=lambda **_kwargs: None)
-    sys.modules["hrms.services.sheets_receiver.models"] = models_mod
+	models_mod = types.ModuleType("hrms.services.sheets_receiver.models")
+	models_mod.get_db = lambda: types.SimpleNamespace(log_notification=lambda **_kwargs: None)
+	sys.modules["hrms.services.sheets_receiver.models"] = models_mod
 
 
 _install_fake_google_modules()
 _install_fake_package_path()
 notif_spec = importlib.util.spec_from_file_location(
-    "hrms.services.sheets_receiver.notifications_under_test",
-    ROOT / "hrms" / "services" / "sheets_receiver" / "notifications.py",
+	"hrms.services.sheets_receiver.notifications_under_test",
+	ROOT / "hrms" / "services" / "sheets_receiver" / "notifications.py",
 )
 notifications = importlib.util.module_from_spec(notif_spec)
 assert notif_spec.loader is not None
@@ -75,110 +77,112 @@ notif_spec.loader.exec_module(notifications)
 
 
 class TestSheetsReceiverNotifications(unittest.TestCase):
-    def test_send_sheets_sync_critical_alert_ingests_structured_event_and_logs(self):
-        fake_client = types.SimpleNamespace(
-            call_method=MagicMock(
-                return_value={
-                    "success": True,
-                    "sent": True,
-                    "message_id": "spaces/AAA/messages/123",
-                    "rendered_text": "Structured alert text",
-                }
-            )
-        )
-        fake_db = types.SimpleNamespace(log_notification=MagicMock())
+	def test_send_sheets_sync_critical_alert_ingests_structured_event_and_logs(self):
+		fake_client = types.SimpleNamespace(
+			call_method=MagicMock(
+				return_value={
+					"success": True,
+					"sent": True,
+					"message_id": "spaces/AAA/messages/123",
+					"rendered_text": "Structured alert text",
+				}
+			)
+		)
+		fake_db = types.SimpleNamespace(log_notification=MagicMock())
 
-        with (
-            patch.object(notifications, "get_frappe_client", return_value=fake_client),
-            patch.object(notifications, "get_db", return_value=fake_db),
-        ):
-            message_id = notifications.send_sheets_sync_critical_alert(
-                spreadsheet_name="AR Aging",
-                sheet_name="AR",
-                trigger="webhook",
-                reasons=["rows_failed", "suspicious_change_alert"],
-                rows_processed=120,
-                rows_failed=3,
-                errors=["missing supplier", "invalid amount"],
-                alerts=["MASS EDIT: 12 rows modified"],
-                spreadsheet_id="sheet-123",
-            )
+		with (
+			patch.object(notifications, "get_frappe_client", return_value=fake_client),
+			patch.object(notifications, "get_db", return_value=fake_db),
+		):
+			message_id = notifications.send_sheets_sync_critical_alert(
+				spreadsheet_name="AR Aging",
+				sheet_name="AR",
+				trigger="webhook",
+				reasons=["rows_failed", "suspicious_change_alert"],
+				rows_processed=120,
+				rows_failed=3,
+				errors=["missing supplier", "invalid amount"],
+				alerts=["MASS EDIT: 12 rows modified"],
+				spreadsheet_id="sheet-123",
+			)
 
-        self.assertEqual(message_id, "spaces/AAA/messages/123")
-        fake_client.call_method.assert_called_once()
-        method_name = fake_client.call_method.call_args.args[0]
-        payload = fake_client.call_method.call_args.kwargs["data"]["event"]
-        self.assertEqual(method_name, "hrms.api.google_chat.ingest_notification_event")
-        self.assertEqual(payload["family"], "sheets_sync_critical")
-        self.assertEqual(payload["facts"]["spreadsheet_id"], "sheet-123")
-        self.assertEqual(payload["facts"]["rows_failed"], 3)
-        fake_db.log_notification.assert_called_once()
+		self.assertEqual(message_id, "spaces/AAA/messages/123")
+		fake_client.call_method.assert_called_once()
+		method_name = fake_client.call_method.call_args.args[0]
+		payload = fake_client.call_method.call_args.kwargs["data"]["event"]
+		self.assertEqual(method_name, "hrms.api.google_chat.ingest_notification_event")
+		self.assertEqual(payload["family"], "sheets_sync_critical")
+		self.assertEqual(payload["facts"]["spreadsheet_id"], "sheet-123")
+		self.assertEqual(payload["facts"]["rows_failed"], 3)
+		fake_db.log_notification.assert_called_once()
 
-    def test_send_sheets_sync_critical_alert_skips_empty_payload(self):
-        with patch.object(notifications, "get_frappe_client") as get_frappe_client:
-            result = notifications.send_sheets_sync_critical_alert(
-                spreadsheet_name="AR Aging",
-                sheet_name="AR",
-                trigger="manual",
-                reasons=[],
-                rows_processed=0,
-                rows_failed=0,
-                errors=[],
-                alerts=[],
-            )
+	def test_send_sheets_sync_critical_alert_skips_empty_payload(self):
+		with patch.object(notifications, "get_frappe_client") as get_frappe_client:
+			result = notifications.send_sheets_sync_critical_alert(
+				spreadsheet_name="AR Aging",
+				sheet_name="AR",
+				trigger="manual",
+				reasons=[],
+				rows_processed=0,
+				rows_failed=0,
+				errors=[],
+				alerts=[],
+			)
 
-        self.assertIsNone(result)
-        get_frappe_client.assert_not_called()
+		self.assertIsNone(result)
+		get_frappe_client.assert_not_called()
 
-    def test_send_sheets_sync_critical_alert_handles_ingest_error(self):
-        with patch.object(notifications, "get_frappe_client", side_effect=RuntimeError("frappe down")):
-            result = notifications.send_sheets_sync_critical_alert(
-                spreadsheet_name="AR Aging",
-                sheet_name="AR",
-                trigger="scheduled",
-                reasons=["sync_exception"],
-                rows_processed=0,
-                rows_failed=1,
-                errors=["timeout"],
-                alerts=[],
-            )
+	def test_send_sheets_sync_critical_alert_handles_ingest_error(self):
+		with patch.object(notifications, "get_frappe_client", side_effect=RuntimeError("frappe down")):
+			result = notifications.send_sheets_sync_critical_alert(
+				spreadsheet_name="AR Aging",
+				sheet_name="AR",
+				trigger="scheduled",
+				reasons=["sync_exception"],
+				rows_processed=0,
+				rows_failed=1,
+				errors=["timeout"],
+				alerts=[],
+			)
 
-        self.assertIsNone(result)
+		self.assertIsNone(result)
 
-    def test_send_sheets_sync_critical_alert_dedupes_errors_alerts_and_reasons(self):
-        fake_client = types.SimpleNamespace(call_method=MagicMock(return_value={"success": True, "sent": False}))
+	def test_send_sheets_sync_critical_alert_dedupes_errors_alerts_and_reasons(self):
+		fake_client = types.SimpleNamespace(
+			call_method=MagicMock(return_value={"success": True, "sent": False})
+		)
 
-        with patch.object(notifications, "get_frappe_client", return_value=fake_client):
-            notifications.send_sheets_sync_critical_alert(
-                spreadsheet_name="AR Aging",
-                sheet_name="AR",
-                trigger="scheduled",
-                reasons=["rows_failed", "rows_failed", "sync_errors_reported"],
-                rows_processed=1674,
-                rows_failed=1674,
-                errors=[
-                    "Missing invoice_no in AR invoice row",
-                    "Missing invoice_no in AR invoice row",
-                    "Missing invoice_no in AR invoice row",
-                ],
-                alerts=[
-                    "⚠️ MASS EDIT: 1502 rows modified",
-                    "⚠️ MASS EDIT: 1502 rows modified",
-                    "⚠️ UNUSUAL PATTERN: More modifications than additions",
-                ],
-            )
+		with patch.object(notifications, "get_frappe_client", return_value=fake_client):
+			notifications.send_sheets_sync_critical_alert(
+				spreadsheet_name="AR Aging",
+				sheet_name="AR",
+				trigger="scheduled",
+				reasons=["rows_failed", "rows_failed", "sync_errors_reported"],
+				rows_processed=1674,
+				rows_failed=1674,
+				errors=[
+					"Missing invoice_no in AR invoice row",
+					"Missing invoice_no in AR invoice row",
+					"Missing invoice_no in AR invoice row",
+				],
+				alerts=[
+					"⚠️ MASS EDIT: 1502 rows modified",
+					"⚠️ MASS EDIT: 1502 rows modified",
+					"⚠️ UNUSUAL PATTERN: More modifications than additions",
+				],
+			)
 
-        payload = fake_client.call_method.call_args.kwargs["data"]["event"]
-        self.assertEqual(payload["facts"]["reasons"], ["rows_failed", "sync_errors_reported"])
-        self.assertEqual(payload["facts"]["errors"], ["Missing invoice_no in AR invoice row"])
-        self.assertEqual(
-            payload["facts"]["alerts"],
-            [
-                "⚠️ MASS EDIT: 1502 rows modified",
-                "⚠️ UNUSUAL PATTERN: More modifications than additions",
-            ],
-        )
+		payload = fake_client.call_method.call_args.kwargs["data"]["event"]
+		self.assertEqual(payload["facts"]["reasons"], ["rows_failed", "sync_errors_reported"])
+		self.assertEqual(payload["facts"]["errors"], ["Missing invoice_no in AR invoice row"])
+		self.assertEqual(
+			payload["facts"]["alerts"],
+			[
+				"⚠️ MASS EDIT: 1502 rows modified",
+				"⚠️ UNUSUAL PATTERN: More modifications than additions",
+			],
+		)
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_sheets_receiver_notifications.py
+++ b/hrms/tests/test_sheets_receiver_notifications.py
@@ -7,184 +7,178 @@ from unittest.mock import MagicMock, patch
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-	sys.path.insert(0, str(ROOT))
+    sys.path.insert(0, str(ROOT))
 
 
 def _install_fake_google_modules():
-	if "google" not in sys.modules:
-		sys.modules["google"] = types.ModuleType("google")
+    if "google" not in sys.modules:
+        sys.modules["google"] = types.ModuleType("google")
 
-	if "google.oauth2" not in sys.modules:
-		sys.modules["google.oauth2"] = types.ModuleType("google.oauth2")
+    if "google.oauth2" not in sys.modules:
+        sys.modules["google.oauth2"] = types.ModuleType("google.oauth2")
 
-	if "google.oauth2.service_account" not in sys.modules:
-		service_account_mod = types.ModuleType("google.oauth2.service_account")
+    if "google.oauth2.service_account" not in sys.modules:
+        service_account_mod = types.ModuleType("google.oauth2.service_account")
 
-		class _Credentials:
-			@staticmethod
-			def from_service_account_file(_path, scopes=None):
-				return types.SimpleNamespace(scopes=scopes or [])
+        class _Credentials:
+            @staticmethod
+            def from_service_account_file(_path, scopes=None):
+                return types.SimpleNamespace(scopes=scopes or [])
 
-		service_account_mod.Credentials = _Credentials
-		sys.modules["google.oauth2.service_account"] = service_account_mod
+        service_account_mod.Credentials = _Credentials
+        sys.modules["google.oauth2.service_account"] = service_account_mod
 
-	if "googleapiclient" not in sys.modules:
-		sys.modules["googleapiclient"] = types.ModuleType("googleapiclient")
+    if "googleapiclient" not in sys.modules:
+        sys.modules["googleapiclient"] = types.ModuleType("googleapiclient")
 
-	if "googleapiclient.discovery" not in sys.modules:
-		discovery_mod = types.ModuleType("googleapiclient.discovery")
-		discovery_mod.build = lambda *_args, **_kwargs: types.SimpleNamespace()
-		sys.modules["googleapiclient.discovery"] = discovery_mod
+    if "googleapiclient.discovery" not in sys.modules:
+        discovery_mod = types.ModuleType("googleapiclient.discovery")
+        discovery_mod.build = lambda *_args, **_kwargs: types.SimpleNamespace()
+        sys.modules["googleapiclient.discovery"] = discovery_mod
 
 
 def _install_fake_package_path():
-	if "hrms" not in sys.modules:
-		hrms_pkg = types.ModuleType("hrms")
-		hrms_pkg.__path__ = [str(ROOT / "hrms")]
-		sys.modules["hrms"] = hrms_pkg
+    hrms_pkg = types.ModuleType("hrms")
+    hrms_pkg.__path__ = [str(ROOT / "hrms")]
+    sys.modules["hrms"] = hrms_pkg
 
-	if "hrms.utils" not in sys.modules:
-		utils_pkg = types.ModuleType("hrms.utils")
-		utils_pkg.__path__ = [str(ROOT / "hrms" / "utils")]
-		sys.modules["hrms.utils"] = utils_pkg
+    utils_pkg = types.ModuleType("hrms.utils")
+    utils_pkg.__path__ = [str(ROOT / "hrms" / "utils")]
+    sys.modules["hrms.utils"] = utils_pkg
 
-	if "hrms.services" not in sys.modules:
-		services_pkg = types.ModuleType("hrms.services")
-		services_pkg.__path__ = [str(ROOT / "hrms" / "services")]
-		sys.modules["hrms.services"] = services_pkg
+    services_pkg = types.ModuleType("hrms.services")
+    services_pkg.__path__ = [str(ROOT / "hrms" / "services")]
+    sys.modules["hrms.services"] = services_pkg
 
-	if "hrms.services.sheets_receiver" not in sys.modules:
-		sheets_pkg = types.ModuleType("hrms.services.sheets_receiver")
-		sheets_pkg.__path__ = [str(ROOT / "hrms" / "services" / "sheets_receiver")]
-		sys.modules["hrms.services.sheets_receiver"] = sheets_pkg
+    sheets_pkg = types.ModuleType("hrms.services.sheets_receiver")
+    sheets_pkg.__path__ = [str(ROOT / "hrms" / "services" / "sheets_receiver")]
+    sys.modules["hrms.services.sheets_receiver"] = sheets_pkg
 
-	if "hrms.services.sheets_receiver.models" not in sys.modules:
-		models_mod = types.ModuleType("hrms.services.sheets_receiver.models")
-		models_mod.get_db = lambda: types.SimpleNamespace(log_notification=lambda **_kwargs: None)
-		sys.modules["hrms.services.sheets_receiver.models"] = models_mod
+    frappe_client_mod = types.ModuleType("hrms.services.sheets_receiver.frappe_client")
+    frappe_client_mod.get_frappe_client = lambda: types.SimpleNamespace(call_method=lambda *_args, **_kwargs: {})
+    sys.modules["hrms.services.sheets_receiver.frappe_client"] = frappe_client_mod
+
+    models_mod = types.ModuleType("hrms.services.sheets_receiver.models")
+    models_mod.get_db = lambda: types.SimpleNamespace(log_notification=lambda **_kwargs: None)
+    sys.modules["hrms.services.sheets_receiver.models"] = models_mod
 
 
 _install_fake_google_modules()
 _install_fake_package_path()
 notif_spec = importlib.util.spec_from_file_location(
-	"hrms.services.sheets_receiver.notifications_under_test",
-	ROOT / "hrms" / "services" / "sheets_receiver" / "notifications.py",
+    "hrms.services.sheets_receiver.notifications_under_test",
+    ROOT / "hrms" / "services" / "sheets_receiver" / "notifications.py",
 )
 notifications = importlib.util.module_from_spec(notif_spec)
+assert notif_spec.loader is not None
 notif_spec.loader.exec_module(notifications)
 
 
-class _FakeMessagesAPI:
-	def __init__(self):
-		self.last_parent = None
-		self.last_body = None
-
-	def create(self, parent, body):
-		self.last_parent = parent
-		self.last_body = body
-		return types.SimpleNamespace(execute=lambda: {"name": "spaces/AAA/messages/123"})
-
-
-class _FakeChatAPI:
-	def __init__(self):
-		self.messages_api = _FakeMessagesAPI()
-
-	def spaces(self):
-		return types.SimpleNamespace(messages=lambda: self.messages_api)
-
-
 class TestSheetsReceiverNotifications(unittest.TestCase):
-	def test_send_sheets_sync_critical_alert_sends_message_and_logs(self):
-		fake_chat = _FakeChatAPI()
-		fake_db = types.SimpleNamespace(log_notification=MagicMock())
+    def test_send_sheets_sync_critical_alert_ingests_structured_event_and_logs(self):
+        fake_client = types.SimpleNamespace(
+            call_method=MagicMock(
+                return_value={
+                    "success": True,
+                    "sent": True,
+                    "message_id": "spaces/AAA/messages/123",
+                    "rendered_text": "Structured alert text",
+                }
+            )
+        )
+        fake_db = types.SimpleNamespace(log_notification=MagicMock())
 
-		with (
-			patch.object(notifications, "get_chat_service", return_value=fake_chat),
-			patch.object(notifications, "get_db", return_value=fake_db),
-		):
-			message_id = notifications.send_sheets_sync_critical_alert(
-				spreadsheet_name="AR Aging",
-				sheet_name="AR",
-				trigger="webhook",
-				reasons=["rows_failed", "suspicious_change_alert"],
-				rows_processed=120,
-				rows_failed=3,
-				errors=["missing supplier", "invalid amount"],
-				alerts=["MASS EDIT: 12 rows modified"],
-			)
+        with (
+            patch.object(notifications, "get_frappe_client", return_value=fake_client),
+            patch.object(notifications, "get_db", return_value=fake_db),
+        ):
+            message_id = notifications.send_sheets_sync_critical_alert(
+                spreadsheet_name="AR Aging",
+                sheet_name="AR",
+                trigger="webhook",
+                reasons=["rows_failed", "suspicious_change_alert"],
+                rows_processed=120,
+                rows_failed=3,
+                errors=["missing supplier", "invalid amount"],
+                alerts=["MASS EDIT: 12 rows modified"],
+                spreadsheet_id="sheet-123",
+            )
 
-		self.assertEqual(message_id, "spaces/AAA/messages/123")
-		self.assertEqual(fake_chat.messages_api.last_parent, "spaces/AAQABiNmpBg")
-		text = fake_chat.messages_api.last_body.get("text", "")
-		self.assertIn("SHEETS SYNC CRITICAL ALERT", text)
-		self.assertIn("AR Aging / AR", text)
-		self.assertIn("processed=120, failed=3", text)
-		self.assertIn("MASS EDIT", text)
-		fake_db.log_notification.assert_called_once()
+        self.assertEqual(message_id, "spaces/AAA/messages/123")
+        fake_client.call_method.assert_called_once()
+        method_name = fake_client.call_method.call_args.args[0]
+        payload = fake_client.call_method.call_args.kwargs["data"]["event"]
+        self.assertEqual(method_name, "hrms.api.google_chat.ingest_notification_event")
+        self.assertEqual(payload["family"], "sheets_sync_critical")
+        self.assertEqual(payload["facts"]["spreadsheet_id"], "sheet-123")
+        self.assertEqual(payload["facts"]["rows_failed"], 3)
+        fake_db.log_notification.assert_called_once()
 
-	def test_send_sheets_sync_critical_alert_skips_empty_payload(self):
-		with patch.object(notifications, "get_chat_service") as get_chat_service:
-			result = notifications.send_sheets_sync_critical_alert(
-				spreadsheet_name="AR Aging",
-				sheet_name="AR",
-				trigger="manual",
-				reasons=[],
-				rows_processed=0,
-				rows_failed=0,
-				errors=[],
-				alerts=[],
-			)
+    def test_send_sheets_sync_critical_alert_skips_empty_payload(self):
+        with patch.object(notifications, "get_frappe_client") as get_frappe_client:
+            result = notifications.send_sheets_sync_critical_alert(
+                spreadsheet_name="AR Aging",
+                sheet_name="AR",
+                trigger="manual",
+                reasons=[],
+                rows_processed=0,
+                rows_failed=0,
+                errors=[],
+                alerts=[],
+            )
 
-		self.assertIsNone(result)
-		get_chat_service.assert_not_called()
+        self.assertIsNone(result)
+        get_frappe_client.assert_not_called()
 
-	def test_send_sheets_sync_critical_alert_handles_chat_error(self):
-		with patch.object(notifications, "get_chat_service", side_effect=RuntimeError("chat down")):
-			result = notifications.send_sheets_sync_critical_alert(
-				spreadsheet_name="AR Aging",
-				sheet_name="AR",
-				trigger="scheduled",
-				reasons=["sync_exception"],
-				rows_processed=0,
-				rows_failed=1,
-				errors=["timeout"],
-				alerts=[],
-			)
+    def test_send_sheets_sync_critical_alert_handles_ingest_error(self):
+        with patch.object(notifications, "get_frappe_client", side_effect=RuntimeError("frappe down")):
+            result = notifications.send_sheets_sync_critical_alert(
+                spreadsheet_name="AR Aging",
+                sheet_name="AR",
+                trigger="scheduled",
+                reasons=["sync_exception"],
+                rows_processed=0,
+                rows_failed=1,
+                errors=["timeout"],
+                alerts=[],
+            )
 
-		self.assertIsNone(result)
+        self.assertIsNone(result)
 
-	def test_send_sheets_sync_critical_alert_dedupes_errors_and_labels_scheduled_trigger(self):
-		fake_chat = _FakeChatAPI()
-		fake_db = types.SimpleNamespace(log_notification=MagicMock())
+    def test_send_sheets_sync_critical_alert_dedupes_errors_alerts_and_reasons(self):
+        fake_client = types.SimpleNamespace(call_method=MagicMock(return_value={"success": True, "sent": False}))
 
-		with (
-			patch.object(notifications, "get_chat_service", return_value=fake_chat),
-			patch.object(notifications, "get_db", return_value=fake_db),
-		):
-			notifications.send_sheets_sync_critical_alert(
-				spreadsheet_name="AR Aging",
-				sheet_name="AR",
-				trigger="scheduled",
-				reasons=["rows_failed", "sync_errors_reported"],
-				rows_processed=1674,
-				rows_failed=1674,
-				errors=[
-					"Missing invoice_no in AR invoice row",
-					"Missing invoice_no in AR invoice row",
-					"Missing invoice_no in AR invoice row",
-				],
-				alerts=[
-					"⚠️ MASS EDIT: 1502 rows modified",
-					"⚠️ MASS EDIT: 1502 rows modified",
-					"⚠️ UNUSUAL PATTERN: More modifications than additions",
-				],
-			)
+        with patch.object(notifications, "get_frappe_client", return_value=fake_client):
+            notifications.send_sheets_sync_critical_alert(
+                spreadsheet_name="AR Aging",
+                sheet_name="AR",
+                trigger="scheduled",
+                reasons=["rows_failed", "rows_failed", "sync_errors_reported"],
+                rows_processed=1674,
+                rows_failed=1674,
+                errors=[
+                    "Missing invoice_no in AR invoice row",
+                    "Missing invoice_no in AR invoice row",
+                    "Missing invoice_no in AR invoice row",
+                ],
+                alerts=[
+                    "⚠️ MASS EDIT: 1502 rows modified",
+                    "⚠️ MASS EDIT: 1502 rows modified",
+                    "⚠️ UNUSUAL PATTERN: More modifications than additions",
+                ],
+            )
 
-		text = fake_chat.messages_api.last_body.get("text", "")
-		self.assertIn("scheduled (6-hour fallback)", text)
-		self.assertEqual(text.count("Missing invoice_no in AR invoice row"), 1)
-		self.assertEqual(text.count("⚠️ MASS EDIT: 1502 rows modified"), 1)
+        payload = fake_client.call_method.call_args.kwargs["data"]["event"]
+        self.assertEqual(payload["facts"]["reasons"], ["rows_failed", "sync_errors_reported"])
+        self.assertEqual(payload["facts"]["errors"], ["Missing invoice_no in AR invoice row"])
+        self.assertEqual(
+            payload["facts"]["alerts"],
+            [
+                "⚠️ MASS EDIT: 1502 rows modified",
+                "⚠️ UNUSUAL PATTERN: More modifications than additions",
+            ],
+        )
 
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/hrms/tests/test_store_approval_notifications_s38.py
+++ b/hrms/tests/test_store_approval_notifications_s38.py
@@ -1,0 +1,250 @@
+import importlib.util
+import pathlib
+import sys
+import types
+from datetime import datetime, date
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _install_stubs():
+    frappe = types.ModuleType("frappe")
+
+    class _DB:
+        @staticmethod
+        def exists(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def get_value(*args, **kwargs):
+            return None
+
+        @staticmethod
+        def get_single_value(*args, **kwargs):
+            return None
+
+    def _flt(value, precision=None):
+        num = float(value or 0)
+        return round(num, precision) if precision is not None else num
+
+    def _cint(value):
+        return int(value or 0)
+
+    def _getdate(value=None):
+        if value in (None, ""):
+            return date(2026, 3, 13)
+        if isinstance(value, date):
+            return value
+        return datetime.strptime(str(value), "%Y-%m-%d").date()
+
+    def _get_datetime(value=None):
+        if value in (None, ""):
+            return datetime(2026, 3, 13, 10, 0, 0)
+        if isinstance(value, datetime):
+            return value
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+    def _throw(msg, *args, **kwargs):
+        raise RuntimeError(msg)
+
+    def _whitelist(fn=None, **kwargs):
+        if fn is None:
+            return lambda inner: inner
+        return fn
+
+    frappe.local = types.SimpleNamespace(
+        db=_DB(),
+        session=types.SimpleNamespace(user="test.area@bebang.ph"),
+    )
+    frappe.__dict__["db"] = frappe.local.db
+    frappe.__dict__["session"] = frappe.local.session
+    frappe.PermissionError = RuntimeError
+    frappe.log_error = lambda *args, **kwargs: None
+    frappe.get_roles = lambda *args, **kwargs: ["Store Supervisor"]
+    frappe.get_all = lambda *args, **kwargs: []
+    frappe.get_meta = lambda _doctype: types.SimpleNamespace(has_field=lambda _field: False)
+    frappe.new_doc = lambda doctype: None
+    frappe.get_doc = lambda *args, **kwargs: None
+    frappe.parse_json = lambda payload: payload
+    frappe.throw = _throw
+    frappe.whitelist = _whitelist
+    frappe._ = lambda msg: msg
+    frappe.utils = types.SimpleNamespace(cint=_cint, now=lambda: "2026-03-13 10:00:00")
+
+    utils = types.ModuleType("frappe.utils")
+    utils.nowdate = lambda: "2026-03-13"
+    utils.add_days = lambda _d, _n: "2026-03-14"
+    utils.now_datetime = lambda: datetime(2026, 3, 13, 10, 0, 0)
+    utils.flt = _flt
+    utils.cint = _cint
+    utils.getdate = _getdate
+    utils.get_datetime = _get_datetime
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = utils
+
+    hrms_pkg = types.ModuleType("hrms")
+    hrms_pkg.__path__ = []
+    utils_pkg = types.ModuleType("hrms.utils")
+    utils_pkg.__path__ = []
+    bei_config = types.ModuleType("hrms.utils.bei_config")
+    bei_config.SPACE_OPS = "OPS"
+    bei_config.get_chat_space = lambda _space: "spaces/AAAAvDZdY-o"
+    bei_config.get_company = lambda: "Bebang Enterprise Inc."
+
+    scm_roles = types.ModuleType("hrms.utils.scm_roles")
+    scm_roles.SCM_APPROVAL_ROLES = []
+    scm_roles.check_scm_permission = lambda *args, **kwargs: None
+
+    supply_chain_contracts = types.ModuleType("hrms.utils.supply_chain_contracts")
+    supply_chain_contracts.FINANCE_TREATMENT_SAME_COMPANY = "same_company"
+    supply_chain_contracts.REQUEST_SOURCE_STORE_DISPOSAL = "store_disposal"
+    supply_chain_contracts.REQUEST_SOURCE_STORE_ORDER = "store_order"
+    supply_chain_contracts.REQUEST_SOURCE_STORE_RETURN = "store_return"
+    supply_chain_contracts.infer_finance_treatment = lambda *args, **kwargs: None
+    supply_chain_contracts.resolve_material_request_contract = lambda *args, **kwargs: {}
+    supply_chain_contracts.resolve_route_source_warehouse = lambda *args, **kwargs: None
+    supply_chain_contracts.resolve_store_buyer_entity = lambda *args, **kwargs: None
+    supply_chain_contracts.resolve_warehouse_company = lambda *args, **kwargs: "Bebang Enterprise Inc."
+    supply_chain_contracts.stamp_material_request_contract = lambda *args, **kwargs: None
+    supply_chain_contracts.stamp_stock_entry_contract = lambda *args, **kwargs: None
+
+    sys.modules["hrms"] = hrms_pkg
+    sys.modules["hrms.utils"] = utils_pkg
+    sys.modules["hrms.utils.bei_config"] = bei_config
+    sys.modules["hrms.utils.scm_roles"] = scm_roles
+    sys.modules["hrms.utils.supply_chain_contracts"] = supply_chain_contracts
+
+
+def _load_store_module():
+    _install_stubs()
+    file_path = ROOT / "hrms" / "api" / "store.py"
+    spec = importlib.util.spec_from_file_location("s38_store_notifications_under_test", file_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeOrder:
+    def __init__(self, name="BEI-ORD-TEST-0001", status="Pending Approval", store_name="TEST-STORE - BEI"):
+        self.name = name
+        self.status = status
+        self.is_emergency = 1
+        self.store = store_name
+        self.creation = "2026-03-13 12:30:00"
+        self.approved_by = None
+        self.approved_at = None
+        self.items = [
+            SimpleNamespace(item_code="ITEM-001", qty_requested=3, qty_approved=0),
+            SimpleNamespace(item_code="ITEM-002", qty_requested=5, qty_approved=0),
+        ]
+        self._save_count = 0
+
+    def save(self, ignore_permissions=True):
+        self._save_count += 1
+
+
+class _FakeQueueDoc:
+    def __init__(self, name):
+        self.name = name
+        self.status = "Pending"
+        self.approved_by = None
+        self.approved_at = None
+        self._save_count = 0
+
+    def save(self, ignore_permissions=True):
+        self._save_count += 1
+
+
+def test_area_stage_emits_forwarded_store_order_approved_event():
+    store_mod = _load_store_module()
+    fake_order = _FakeOrder()
+    fake_queue_doc = _FakeQueueDoc("BEI-APQ-AREA-0001")
+    store_mod.frappe.session.user = "test.area@bebang.ph"
+    notifications = []
+
+    def fake_get_doc(doctype, name):
+        if doctype == "BEI Store Order":
+            return fake_order
+        if doctype == "BEI Approval Queue":
+            return fake_queue_doc
+        raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
+
+    with patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc), patch.object(
+        store_mod, "_get_pending_approval_entries",
+        return_value=[{"name": "BEI-APQ-AREA-0001", "assigned_approver": "test.area@bebang.ph"}],
+    ), patch.object(store_mod, "_is_system_approver", return_value=False), patch.object(
+        store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"
+    ), patch.object(
+        store_mod, "_get_regional_manager_for_store", return_value=("test.hr@bebang.ph", "employee.reports_to")
+    ), patch.object(
+        store_mod, "_create_approval_queue_entry", return_value=SimpleNamespace(name="BEI-APQ-REG-0001")
+    ), patch.object(store_mod, "_assign_order_for_approval", return_value=True), patch.object(
+        store_mod, "_append_order_comment"
+    ), patch.object(store_mod, "_close_order_assignments"), patch.object(
+        store_mod, "_create_mr_for_store_order"
+    ) as create_mr:
+        store_mod._notify_store_ops = lambda *args, **kwargs: notifications.append(kwargs)
+        result = store_mod.approve_order(
+            order_name=fake_order.name,
+            approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],
+        )
+
+    assert result["success"] is True
+    assert result["stage"] == "area_supervisor"
+    assert notifications
+    event = notifications[0]["event"]
+    assert event["family"] == "store_order_approved"
+    assert event["facts"]["stage"] == "area_supervisor_forwarded"
+    assert event["facts"]["regional_approver"] == "test.hr@bebang.ph"
+    assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"
+    assert not create_mr.called
+
+
+def test_final_stage_emits_store_order_approved_material_request_signal():
+    store_mod = _load_store_module()
+    fake_order = _FakeOrder()
+    fake_queue_doc = _FakeQueueDoc("BEI-APQ-REG-0001")
+    store_mod.frappe.session.user = "test.hr@bebang.ph"
+    notifications = []
+
+    def fake_get_doc(doctype, name):
+        if doctype == "BEI Store Order":
+            return fake_order
+        if doctype == "BEI Approval Queue":
+            return fake_queue_doc
+        raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
+
+    with patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc), patch.object(
+        store_mod, "_get_pending_approval_entries",
+        return_value=[{"name": "BEI-APQ-REG-0001", "assigned_approver": "test.hr@bebang.ph"}],
+    ), patch.object(store_mod, "_is_system_approver", return_value=False), patch.object(
+        store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"
+    ), patch.object(
+        store_mod, "_get_regional_manager_for_store", return_value=("test.hr@bebang.ph", "employee.reports_to")
+    ), patch.object(store_mod, "_has_approved_stage_entry", return_value=True), patch.object(store_mod, "_close_order_assignments"), patch.object(
+        store_mod, "_create_mr_for_store_order", return_value="MAT-REQ-0001"
+    ) as create_mr, patch.object(store_mod.frappe.db, "get_value", return_value=None):
+        store_mod._notify_store_ops = lambda *args, **kwargs: notifications.append(kwargs)
+        result = store_mod.approve_order(
+            order_name=fake_order.name,
+            approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 3}],
+        )
+
+    assert result["success"] is True
+    assert result["stage"] == "regional_manager"
+    assert result["material_request"] == "MAT-REQ-0001"
+    assert create_mr.call_count == 1
+    assert notifications
+    event = notifications[0]["event"]
+    assert event["family"] == "store_order_approved"
+    assert event["facts"]["stage"] == "approved"
+    assert event["facts"]["material_request"] == "MAT-REQ-0001"
+    assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"

--- a/hrms/tests/test_store_approval_notifications_s38.py
+++ b/hrms/tests/test_store_approval_notifications_s38.py
@@ -2,7 +2,7 @@ import importlib.util
 import pathlib
 import sys
 import types
-from datetime import datetime, date
+from datetime import date, datetime
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -10,241 +10,258 @@ import pytest
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+	sys.path.insert(0, str(ROOT))
 
 
 def _install_stubs():
-    frappe = types.ModuleType("frappe")
+	frappe = types.ModuleType("frappe")
 
-    class _DB:
-        @staticmethod
-        def exists(*args, **kwargs):
-            return None
+	class _DB:
+		@staticmethod
+		def exists(*args, **kwargs):
+			return None
 
-        @staticmethod
-        def get_value(*args, **kwargs):
-            return None
+		@staticmethod
+		def get_value(*args, **kwargs):
+			return None
 
-        @staticmethod
-        def get_single_value(*args, **kwargs):
-            return None
+		@staticmethod
+		def get_single_value(*args, **kwargs):
+			return None
 
-    def _flt(value, precision=None):
-        num = float(value or 0)
-        return round(num, precision) if precision is not None else num
+	def _flt(value, precision=None):
+		num = float(value or 0)
+		return round(num, precision) if precision is not None else num
 
-    def _cint(value):
-        return int(value or 0)
+	def _cint(value):
+		return int(value or 0)
 
-    def _getdate(value=None):
-        if value in (None, ""):
-            return date(2026, 3, 13)
-        if isinstance(value, date):
-            return value
-        return datetime.strptime(str(value), "%Y-%m-%d").date()
+	def _getdate(value=None):
+		if value in (None, ""):
+			return date(2026, 3, 13)
+		if isinstance(value, date):
+			return value
+		return datetime.strptime(str(value), "%Y-%m-%d").date()
 
-    def _get_datetime(value=None):
-        if value in (None, ""):
-            return datetime(2026, 3, 13, 10, 0, 0)
-        if isinstance(value, datetime):
-            return value
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+	def _get_datetime(value=None):
+		if value in (None, ""):
+			return datetime(2026, 3, 13, 10, 0, 0)
+		if isinstance(value, datetime):
+			return value
+		return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
 
-    def _throw(msg, *args, **kwargs):
-        raise RuntimeError(msg)
+	def _throw(msg, *args, **kwargs):
+		raise RuntimeError(msg)
 
-    def _whitelist(fn=None, **kwargs):
-        if fn is None:
-            return lambda inner: inner
-        return fn
+	def _whitelist(fn=None, **kwargs):
+		if fn is None:
+			return lambda inner: inner
+		return fn
 
-    frappe.local = types.SimpleNamespace(
-        db=_DB(),
-        session=types.SimpleNamespace(user="test.area@bebang.ph"),
-    )
-    frappe.__dict__["db"] = frappe.local.db
-    frappe.__dict__["session"] = frappe.local.session
-    frappe.PermissionError = RuntimeError
-    frappe.log_error = lambda *args, **kwargs: None
-    frappe.get_roles = lambda *args, **kwargs: ["Store Supervisor"]
-    frappe.get_all = lambda *args, **kwargs: []
-    frappe.get_meta = lambda _doctype: types.SimpleNamespace(has_field=lambda _field: False)
-    frappe.new_doc = lambda doctype: None
-    frappe.get_doc = lambda *args, **kwargs: None
-    frappe.parse_json = lambda payload: payload
-    frappe.throw = _throw
-    frappe.whitelist = _whitelist
-    frappe._ = lambda msg: msg
-    frappe.utils = types.SimpleNamespace(cint=_cint, now=lambda: "2026-03-13 10:00:00")
+	frappe.local = types.SimpleNamespace(
+		db=_DB(),
+		session=types.SimpleNamespace(user="test.area@bebang.ph"),
+	)
+	frappe.__dict__["db"] = frappe.local.db
+	frappe.__dict__["session"] = frappe.local.session
+	frappe.PermissionError = RuntimeError
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.get_roles = lambda *args, **kwargs: ["Store Supervisor"]
+	frappe.get_all = lambda *args, **kwargs: []
+	frappe.get_meta = lambda _doctype: types.SimpleNamespace(has_field=lambda _field: False)
+	frappe.new_doc = lambda doctype: None
+	frappe.get_doc = lambda *args, **kwargs: None
+	frappe.parse_json = lambda payload: payload
+	frappe.throw = _throw
+	frappe.whitelist = _whitelist
+	frappe._ = lambda msg: msg
+	frappe.utils = types.SimpleNamespace(cint=_cint, now=lambda: "2026-03-13 10:00:00")
 
-    utils = types.ModuleType("frappe.utils")
-    utils.nowdate = lambda: "2026-03-13"
-    utils.add_days = lambda _d, _n: "2026-03-14"
-    utils.now_datetime = lambda: datetime(2026, 3, 13, 10, 0, 0)
-    utils.flt = _flt
-    utils.cint = _cint
-    utils.getdate = _getdate
-    utils.get_datetime = _get_datetime
+	utils = types.ModuleType("frappe.utils")
+	utils.nowdate = lambda: "2026-03-13"
+	utils.add_days = lambda _d, _n: "2026-03-14"
+	utils.now_datetime = lambda: datetime(2026, 3, 13, 10, 0, 0)
+	utils.flt = _flt
+	utils.cint = _cint
+	utils.getdate = _getdate
+	utils.get_datetime = _get_datetime
 
-    sys.modules["frappe"] = frappe
-    sys.modules["frappe.utils"] = utils
+	sys.modules["frappe"] = frappe
+	sys.modules["frappe.utils"] = utils
 
-    hrms_pkg = types.ModuleType("hrms")
-    hrms_pkg.__path__ = []
-    utils_pkg = types.ModuleType("hrms.utils")
-    utils_pkg.__path__ = []
-    bei_config = types.ModuleType("hrms.utils.bei_config")
-    bei_config.SPACE_OPS = "OPS"
-    bei_config.get_chat_space = lambda _space: "spaces/AAAAvDZdY-o"
-    bei_config.get_company = lambda: "Bebang Enterprise Inc."
+	hrms_pkg = types.ModuleType("hrms")
+	hrms_pkg.__path__ = []
+	utils_pkg = types.ModuleType("hrms.utils")
+	utils_pkg.__path__ = []
+	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.SPACE_OPS = "OPS"
+	bei_config.get_chat_space = lambda _space: "spaces/AAAAvDZdY-o"
+	bei_config.get_company = lambda: "Bebang Enterprise Inc."
 
-    scm_roles = types.ModuleType("hrms.utils.scm_roles")
-    scm_roles.SCM_APPROVAL_ROLES = []
-    scm_roles.check_scm_permission = lambda *args, **kwargs: None
+	scm_roles = types.ModuleType("hrms.utils.scm_roles")
+	scm_roles.SCM_APPROVAL_ROLES = []
+	scm_roles.check_scm_permission = lambda *args, **kwargs: None
 
-    supply_chain_contracts = types.ModuleType("hrms.utils.supply_chain_contracts")
-    supply_chain_contracts.FINANCE_TREATMENT_SAME_COMPANY = "same_company"
-    supply_chain_contracts.REQUEST_SOURCE_STORE_DISPOSAL = "store_disposal"
-    supply_chain_contracts.REQUEST_SOURCE_STORE_ORDER = "store_order"
-    supply_chain_contracts.REQUEST_SOURCE_STORE_RETURN = "store_return"
-    supply_chain_contracts.infer_finance_treatment = lambda *args, **kwargs: None
-    supply_chain_contracts.resolve_material_request_contract = lambda *args, **kwargs: {}
-    supply_chain_contracts.resolve_route_source_warehouse = lambda *args, **kwargs: None
-    supply_chain_contracts.resolve_store_buyer_entity = lambda *args, **kwargs: None
-    supply_chain_contracts.resolve_warehouse_company = lambda *args, **kwargs: "Bebang Enterprise Inc."
-    supply_chain_contracts.stamp_material_request_contract = lambda *args, **kwargs: None
-    supply_chain_contracts.stamp_stock_entry_contract = lambda *args, **kwargs: None
+	supply_chain_contracts = types.ModuleType("hrms.utils.supply_chain_contracts")
+	supply_chain_contracts.FINANCE_TREATMENT_SAME_COMPANY = "same_company"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_DISPOSAL = "store_disposal"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_ORDER = "store_order"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_RETURN = "store_return"
+	supply_chain_contracts.infer_finance_treatment = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_material_request_contract = lambda *args, **kwargs: {}
+	supply_chain_contracts.resolve_route_source_warehouse = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_store_buyer_entity = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_warehouse_company = lambda *args, **kwargs: "Bebang Enterprise Inc."
+	supply_chain_contracts.stamp_material_request_contract = lambda *args, **kwargs: None
+	supply_chain_contracts.stamp_stock_entry_contract = lambda *args, **kwargs: None
 
-    sys.modules["hrms"] = hrms_pkg
-    sys.modules["hrms.utils"] = utils_pkg
-    sys.modules["hrms.utils.bei_config"] = bei_config
-    sys.modules["hrms.utils.scm_roles"] = scm_roles
-    sys.modules["hrms.utils.supply_chain_contracts"] = supply_chain_contracts
+	sys.modules["hrms"] = hrms_pkg
+	sys.modules["hrms.utils"] = utils_pkg
+	sys.modules["hrms.utils.bei_config"] = bei_config
+	sys.modules["hrms.utils.scm_roles"] = scm_roles
+	sys.modules["hrms.utils.supply_chain_contracts"] = supply_chain_contracts
 
 
 def _load_store_module():
-    _install_stubs()
-    file_path = ROOT / "hrms" / "api" / "store.py"
-    spec = importlib.util.spec_from_file_location("s38_store_notifications_under_test", file_path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    spec.loader.exec_module(module)
-    return module
+	_install_stubs()
+	file_path = ROOT / "hrms" / "api" / "store.py"
+	spec = importlib.util.spec_from_file_location("s38_store_notifications_under_test", file_path)
+	module = importlib.util.module_from_spec(spec)
+	assert spec and spec.loader
+	spec.loader.exec_module(module)
+	return module
 
 
 class _FakeOrder:
-    def __init__(self, name="BEI-ORD-TEST-0001", status="Pending Approval", store_name="TEST-STORE - BEI"):
-        self.name = name
-        self.status = status
-        self.is_emergency = 1
-        self.store = store_name
-        self.creation = "2026-03-13 12:30:00"
-        self.approved_by = None
-        self.approved_at = None
-        self.items = [
-            SimpleNamespace(item_code="ITEM-001", qty_requested=3, qty_approved=0),
-            SimpleNamespace(item_code="ITEM-002", qty_requested=5, qty_approved=0),
-        ]
-        self._save_count = 0
+	def __init__(self, name="BEI-ORD-TEST-0001", status="Pending Approval", store_name="TEST-STORE - BEI"):
+		self.name = name
+		self.status = status
+		self.is_emergency = 1
+		self.store = store_name
+		self.creation = "2026-03-13 12:30:00"
+		self.approved_by = None
+		self.approved_at = None
+		self.items = [
+			SimpleNamespace(item_code="ITEM-001", qty_requested=3, qty_approved=0),
+			SimpleNamespace(item_code="ITEM-002", qty_requested=5, qty_approved=0),
+		]
+		self._save_count = 0
 
-    def save(self, ignore_permissions=True):
-        self._save_count += 1
+	def save(self, ignore_permissions=True):
+		self._save_count += 1
 
 
 class _FakeQueueDoc:
-    def __init__(self, name):
-        self.name = name
-        self.status = "Pending"
-        self.approved_by = None
-        self.approved_at = None
-        self._save_count = 0
+	def __init__(self, name):
+		self.name = name
+		self.status = "Pending"
+		self.approved_by = None
+		self.approved_at = None
+		self._save_count = 0
 
-    def save(self, ignore_permissions=True):
-        self._save_count += 1
+	def save(self, ignore_permissions=True):
+		self._save_count += 1
 
 
 def test_area_stage_emits_forwarded_store_order_approved_event():
-    store_mod = _load_store_module()
-    fake_order = _FakeOrder()
-    fake_queue_doc = _FakeQueueDoc("BEI-APQ-AREA-0001")
-    store_mod.frappe.session.user = "test.area@bebang.ph"
-    notifications = []
+	store_mod = _load_store_module()
+	fake_order = _FakeOrder()
+	fake_queue_doc = _FakeQueueDoc("BEI-APQ-AREA-0001")
+	store_mod.frappe.session.user = "test.area@bebang.ph"
+	notifications = []
 
-    def fake_get_doc(doctype, name):
-        if doctype == "BEI Store Order":
-            return fake_order
-        if doctype == "BEI Approval Queue":
-            return fake_queue_doc
-        raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
+	def fake_get_doc(doctype, name):
+		if doctype == "BEI Store Order":
+			return fake_order
+		if doctype == "BEI Approval Queue":
+			return fake_queue_doc
+		raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
 
-    with patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc), patch.object(
-        store_mod, "_get_pending_approval_entries",
-        return_value=[{"name": "BEI-APQ-AREA-0001", "assigned_approver": "test.area@bebang.ph"}],
-    ), patch.object(store_mod, "_is_system_approver", return_value=False), patch.object(
-        store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"
-    ), patch.object(
-        store_mod, "_get_regional_manager_for_store", return_value=("test.hr@bebang.ph", "employee.reports_to")
-    ), patch.object(
-        store_mod, "_create_approval_queue_entry", return_value=SimpleNamespace(name="BEI-APQ-REG-0001")
-    ), patch.object(store_mod, "_assign_order_for_approval", return_value=True), patch.object(
-        store_mod, "_append_order_comment"
-    ), patch.object(store_mod, "_close_order_assignments"), patch.object(
-        store_mod, "_create_mr_for_store_order"
-    ) as create_mr:
-        store_mod._notify_store_ops = lambda *args, **kwargs: notifications.append(kwargs)
-        result = store_mod.approve_order(
-            order_name=fake_order.name,
-            approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],
-        )
+	with (
+		patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc),
+		patch.object(
+			store_mod,
+			"_get_pending_approval_entries",
+			return_value=[{"name": "BEI-APQ-AREA-0001", "assigned_approver": "test.area@bebang.ph"}],
+		),
+		patch.object(store_mod, "_is_system_approver", return_value=False),
+		patch.object(store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"),
+		patch.object(
+			store_mod,
+			"_get_regional_manager_for_store",
+			return_value=("test.hr@bebang.ph", "employee.reports_to"),
+		),
+		patch.object(
+			store_mod, "_create_approval_queue_entry", return_value=SimpleNamespace(name="BEI-APQ-REG-0001")
+		),
+		patch.object(store_mod, "_assign_order_for_approval", return_value=True),
+		patch.object(store_mod, "_append_order_comment"),
+		patch.object(store_mod, "_close_order_assignments"),
+		patch.object(store_mod, "_create_mr_for_store_order") as create_mr,
+	):
+		store_mod._notify_store_ops = lambda *args, **kwargs: notifications.append(kwargs)
+		result = store_mod.approve_order(
+			order_name=fake_order.name,
+			approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],
+		)
 
-    assert result["success"] is True
-    assert result["stage"] == "area_supervisor"
-    assert notifications
-    event = notifications[0]["event"]
-    assert event["family"] == "store_order_approved"
-    assert event["facts"]["stage"] == "area_supervisor_forwarded"
-    assert event["facts"]["regional_approver"] == "test.hr@bebang.ph"
-    assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"
-    assert not create_mr.called
+	assert result["success"] is True
+	assert result["stage"] == "area_supervisor"
+	assert notifications
+	event = notifications[0]["event"]
+	assert event["family"] == "store_order_approved"
+	assert event["facts"]["stage"] == "area_supervisor_forwarded"
+	assert event["facts"]["regional_approver"] == "test.hr@bebang.ph"
+	assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"
+	assert not create_mr.called
 
 
 def test_final_stage_emits_store_order_approved_material_request_signal():
-    store_mod = _load_store_module()
-    fake_order = _FakeOrder()
-    fake_queue_doc = _FakeQueueDoc("BEI-APQ-REG-0001")
-    store_mod.frappe.session.user = "test.hr@bebang.ph"
-    notifications = []
+	store_mod = _load_store_module()
+	fake_order = _FakeOrder()
+	fake_queue_doc = _FakeQueueDoc("BEI-APQ-REG-0001")
+	store_mod.frappe.session.user = "test.hr@bebang.ph"
+	notifications = []
 
-    def fake_get_doc(doctype, name):
-        if doctype == "BEI Store Order":
-            return fake_order
-        if doctype == "BEI Approval Queue":
-            return fake_queue_doc
-        raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
+	def fake_get_doc(doctype, name):
+		if doctype == "BEI Store Order":
+			return fake_order
+		if doctype == "BEI Approval Queue":
+			return fake_queue_doc
+		raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
 
-    with patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc), patch.object(
-        store_mod, "_get_pending_approval_entries",
-        return_value=[{"name": "BEI-APQ-REG-0001", "assigned_approver": "test.hr@bebang.ph"}],
-    ), patch.object(store_mod, "_is_system_approver", return_value=False), patch.object(
-        store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"
-    ), patch.object(
-        store_mod, "_get_regional_manager_for_store", return_value=("test.hr@bebang.ph", "employee.reports_to")
-    ), patch.object(store_mod, "_has_approved_stage_entry", return_value=True), patch.object(store_mod, "_close_order_assignments"), patch.object(
-        store_mod, "_create_mr_for_store_order", return_value="MAT-REQ-0001"
-    ) as create_mr, patch.object(store_mod.frappe.db, "get_value", return_value=None):
-        store_mod._notify_store_ops = lambda *args, **kwargs: notifications.append(kwargs)
-        result = store_mod.approve_order(
-            order_name=fake_order.name,
-            approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 3}],
-        )
+	with (
+		patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc),
+		patch.object(
+			store_mod,
+			"_get_pending_approval_entries",
+			return_value=[{"name": "BEI-APQ-REG-0001", "assigned_approver": "test.hr@bebang.ph"}],
+		),
+		patch.object(store_mod, "_is_system_approver", return_value=False),
+		patch.object(store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"),
+		patch.object(
+			store_mod,
+			"_get_regional_manager_for_store",
+			return_value=("test.hr@bebang.ph", "employee.reports_to"),
+		),
+		patch.object(store_mod, "_has_approved_stage_entry", return_value=True),
+		patch.object(store_mod, "_close_order_assignments"),
+		patch.object(store_mod, "_create_mr_for_store_order", return_value="MAT-REQ-0001") as create_mr,
+		patch.object(store_mod.frappe.db, "get_value", return_value=None),
+	):
+		store_mod._notify_store_ops = lambda *args, **kwargs: notifications.append(kwargs)
+		result = store_mod.approve_order(
+			order_name=fake_order.name,
+			approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 3}],
+		)
 
-    assert result["success"] is True
-    assert result["stage"] == "regional_manager"
-    assert result["material_request"] == "MAT-REQ-0001"
-    assert create_mr.call_count == 1
-    assert notifications
-    event = notifications[0]["event"]
-    assert event["family"] == "store_order_approved"
-    assert event["facts"]["stage"] == "approved"
-    assert event["facts"]["material_request"] == "MAT-REQ-0001"
-    assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"
+	assert result["success"] is True
+	assert result["stage"] == "regional_manager"
+	assert result["material_request"] == "MAT-REQ-0001"
+	assert create_mr.call_count == 1
+	assert notifications
+	event = notifications[0]["event"]
+	assert event["family"] == "store_order_approved"
+	assert event["facts"]["stage"] == "approved"
+	assert event["facts"]["material_request"] == "MAT-REQ-0001"
+	assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"

--- a/hrms/utils/chat_space_lockdown.py
+++ b/hrms/utils/chat_space_lockdown.py
@@ -10,6 +10,8 @@ import os
 
 from hrms.utils.notification_intelligence import (
 	SPACE_NOTIFICATIONS as DEFAULT_BLIP_NOTIFICATIONS_SPACE,
+)
+from hrms.utils.notification_intelligence import (
 	family_allows_requested_space,
 	get_family_allowed_spaces,
 )

--- a/hrms/utils/chat_space_lockdown.py
+++ b/hrms/utils/chat_space_lockdown.py
@@ -8,7 +8,11 @@ from __future__ import annotations
 
 import os
 
-DEFAULT_BLIP_NOTIFICATIONS_SPACE = "spaces/AAQABiNmpBg"
+from hrms.utils.notification_intelligence import (
+	SPACE_NOTIFICATIONS as DEFAULT_BLIP_NOTIFICATIONS_SPACE,
+	family_allows_requested_space,
+	get_family_allowed_spaces,
+)
 
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _LOCKDOWN_ENV = "BEI_CHAT_LOCKDOWN_ENABLED"
@@ -47,6 +51,7 @@ def route_outbound_chat_space(
 	*,
 	logger=None,
 	context: str | None = None,
+	family: str | None = None,
 ) -> str:
 	"""Return the only permitted outbound chat space for the current policy."""
 	requested = (requested_space or "").strip()
@@ -61,14 +66,22 @@ def route_outbound_chat_space(
 	if requested == blip_space:
 		return requested
 
+	if family:
+		family_allowed_spaces = get_family_allowed_spaces(family)
+		if requested in family_allowed_spaces:
+			return requested
+		if family_allows_requested_space(family):
+			return requested
+
 	if allow_non_blip_chat_destinations() and requested in get_explicitly_allowed_chat_spaces():
 		return requested
 
 	if logger is not None:
 		logger.warning(
-			"Outbound Google Chat destination rerouted to ! Blip Notifications; requested=%s effective=%s context=%s",
+			"Outbound Google Chat destination rerouted to ! Blip Notifications; requested=%s effective=%s family=%s context=%s",
 			requested,
 			blip_space,
+			family or "legacy",
 			context or "unspecified",
 		)
 

--- a/hrms/utils/notification_intelligence.py
+++ b/hrms/utils/notification_intelligence.py
@@ -328,7 +328,9 @@ def _sheet_recommended_fix(facts: dict[str, Any]) -> str:
 	if "supplier" in errors:
 		return "Fill the missing supplier/invoice fields on real rows and delete blank tail rows before rerunning."
 	if "suspicious_change_alert" in reasons and not int(facts.get("rows_failed") or 0):
-		return "Confirm the mass edit/deletion was intentional before finance or ops rely on the updated sheet."
+		return (
+			"Confirm the mass edit/deletion was intentional before finance or ops rely on the updated sheet."
+		)
 	return "Fix the top sync errors or source-sheet schema mismatch, then rerun the sheet sync."
 
 
@@ -379,7 +381,11 @@ def _render_maintenance_sla_backlog(event: dict[str, Any]) -> dict[str, Any]:
 	breaches = list(facts.get("breaches") or [])
 	counts = facts.get("counts_by_priority") or {}
 	total = len(breaches)
-	count_bits = [f"{priority}: {int(counts.get(priority) or 0)}" for priority in ("Urgent", "High", "Normal") if int(counts.get(priority) or 0)]
+	count_bits = [
+		f"{priority}: {int(counts.get(priority) or 0)}"
+		for priority in ("Urgent", "High", "Normal")
+		if int(counts.get(priority) or 0)
+	]
 	top_rows = []
 	for row in breaches[:5]:
 		top_rows.append(
@@ -429,8 +435,12 @@ def _render_maintenance_status_update(event: dict[str, Any]) -> dict[str, Any]:
 		why = "A newly reported issue needs ownership before it becomes an SLA breach or store escalation."
 	elif status == "Completed":
 		summary = f"Maintenance request {request_name} is marked Completed for {store}."
-		action = "Store leadership should verify the work result and close the loop in the next maintenance check."
-		recommended = "Confirm the work quality and capture verification so the ticket does not linger unresolved."
+		action = (
+			"Store leadership should verify the work result and close the loop in the next maintenance check."
+		)
+		recommended = (
+			"Confirm the work quality and capture verification so the ticket does not linger unresolved."
+		)
 		why = "Completed work still needs store confirmation before the issue is truly closed."
 	elif status == "Verified":
 		summary = f"Maintenance request {request_name} has been verified for {store}."
@@ -476,7 +486,9 @@ def _render_approval_queue_new(event: dict[str, Any]) -> dict[str, Any]:
 	reference_name = _clean_text(facts.get("reference_name"), fallback=facts.get("subject"))
 	store = _clean_text(facts.get("store"))
 	queue_name = _clean_text(facts.get("queue_name"))
-	dashboard_url = _clean_text(facts.get("dashboard_url"), fallback=_portal_url("/dashboard/store-ops/order-approvals"))
+	dashboard_url = _clean_text(
+		facts.get("dashboard_url"), fallback=_portal_url("/dashboard/store-ops/order-approvals")
+	)
 	return {
 		"summary": f"{reference_doctype} {reference_name} is waiting for approval.",
 		"why_it_matters": "The workflow will not move forward until the assigned approver reviews the queue item.",
@@ -506,7 +518,9 @@ def _render_store_order_new(event: dict[str, Any]) -> dict[str, Any]:
 	is_emergency = bool(facts.get("is_emergency"))
 	queue_status = _clean_text(facts.get("queue_status"), fallback="unknown")
 	queue_name = _clean_text(facts.get("approval_queue_name"), fallback="")
-	dashboard_url = _clean_text(facts.get("dashboard_url"), fallback=_portal_url("/dashboard/store-ops/order-approvals"))
+	dashboard_url = _clean_text(
+		facts.get("dashboard_url"), fallback=_portal_url("/dashboard/store-ops/order-approvals")
+	)
 	if queue_status in {"failed", "unmapped"}:
 		action = "Fix the approval routing now so the order does not stall."
 		recommended = "Repair the approver mapping or assignment failure before the cutoff window closes."
@@ -642,7 +656,9 @@ def _render_morning_readiness_digest(event: dict[str, Any]) -> dict[str, Any]:
 	else:
 		summary = f"Morning syncs landed with exceptions for {_clean_text(facts.get('report_date'))}."
 		action = "Review the exception lane now and clear it before finance or ops uses the affected data."
-		recommended = "Resolve the exception rows or rerun the incomplete lane so the day starts from a clean baseline."
+		recommended = (
+			"Resolve the exception rows or rerun the incomplete lane so the day starts from a clean baseline."
+		)
 		why = "The morning data is present, but at least one lane still needs operator attention."
 	return {
 		"summary": summary,

--- a/hrms/utils/notification_intelligence.py
+++ b/hrms/utils/notification_intelligence.py
@@ -1,0 +1,742 @@
+"""Deterministic notification policy, rendering, and certification helpers.
+
+This module stays pure-Python so both Frappe and standalone services can share
+the same family definitions without importing the framework runtime.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from typing import Any
+
+SPACE_NOTIFICATIONS = "spaces/AAQABiNmpBg"
+SPACE_ERP_AUTOMATION = "spaces/AAQA3NVVR6c"
+SPACE_ACCOUNTING = "spaces/AAAA9RN0JZQ"
+SPACE_OPS = "spaces/AAAAvDZdY-o"
+
+PORTAL_BASE_URL = "https://my.bebang.ph"
+
+REQUIRED_EVENT_FIELDS = (
+	"family",
+	"source_system",
+	"source_ref",
+	"severity",
+	"delivery_class",
+	"owner",
+	"dedup_key",
+	"facts",
+	"requested_space",
+	"fallback_text",
+)
+
+
+def _portal_url(path: str) -> str:
+	path_text = str(path or "").strip()
+	if not path_text:
+		return PORTAL_BASE_URL
+	if path_text.startswith("http://") or path_text.startswith("https://"):
+		return path_text
+	if not path_text.startswith("/"):
+		path_text = f"/{path_text}"
+	return f"{PORTAL_BASE_URL}{path_text}"
+
+
+FAMILY_POLICIES: dict[str, dict[str, Any]] = {
+	"sheets_sync_critical": {
+		"family_label": "Sheets Sync Critical",
+		"delivery_class": "critical_immediate",
+		"default_space": SPACE_NOTIFICATIONS,
+		"allowed_spaces": (SPACE_NOTIFICATIONS, SPACE_ERP_AUTOMATION),
+		"allow_requested_space": False,
+		"default_severity": "critical",
+		"owner": "Dave Martinez / Edlice Dela Cruz",
+		"dedup_window_minutes": 90,
+		"routing_reason": "High-signal sync blocker for finance and operations.",
+	},
+	"maintenance_sla_backlog": {
+		"family_label": "Maintenance SLA Backlog",
+		"delivery_class": "action_digest",
+		"default_space": SPACE_NOTIFICATIONS,
+		"allowed_spaces": (SPACE_NOTIFICATIONS, SPACE_ERP_AUTOMATION),
+		"allow_requested_space": False,
+		"default_severity": "high",
+		"owner": "Projects Manager",
+		"dedup_window_minutes": 120,
+		"routing_reason": "Exec-facing backlog digest for overdue maintenance work.",
+	},
+	"maintenance_status_update": {
+		"family_label": "Maintenance Status Update",
+		"delivery_class": "action_digest",
+		"default_space": SPACE_OPS,
+		"allowed_spaces": (SPACE_OPS, SPACE_ERP_AUTOMATION),
+		"allow_requested_space": True,
+		"default_severity": "medium",
+		"owner": "Projects Team / Store Manager",
+		"dedup_window_minutes": 60,
+		"routing_reason": "Store and ops lifecycle update; does not belong in Blip by default.",
+	},
+	"approval_queue_new": {
+		"family_label": "Approval Queue New",
+		"delivery_class": "action_digest",
+		"default_space": SPACE_NOTIFICATIONS,
+		"allowed_spaces": (SPACE_NOTIFICATIONS, SPACE_ERP_AUTOMATION),
+		"allow_requested_space": False,
+		"default_severity": "high",
+		"owner": "Assigned Approver",
+		"dedup_window_minutes": 45,
+		"routing_reason": "Actionable approval brief for the approver / control cell.",
+	},
+	"store_order_new": {
+		"family_label": "Store Order New",
+		"delivery_class": "awareness_digest",
+		"default_space": SPACE_OPS,
+		"allowed_spaces": (SPACE_OPS, SPACE_ERP_AUTOMATION),
+		"allow_requested_space": False,
+		"default_severity": "medium",
+		"owner": "Store Ops / Warehouse",
+		"dedup_window_minutes": 45,
+		"routing_reason": "Ops awareness only; approval queue owns the Blip action signal.",
+	},
+	"store_order_approved": {
+		"family_label": "Store Order Approved",
+		"delivery_class": "action_digest",
+		"default_space": SPACE_OPS,
+		"allowed_spaces": (SPACE_OPS, SPACE_ERP_AUTOMATION),
+		"allow_requested_space": True,
+		"default_severity": "medium",
+		"owner": "Warehouse / Store Ops",
+		"dedup_window_minutes": 45,
+		"routing_reason": "Fulfilment and store follow-through update; not a Blip catch-all item.",
+	},
+	"discount_critical_digest": {
+		"family_label": "Discount Critical Digest",
+		"delivery_class": "critical_immediate",
+		"default_space": SPACE_ACCOUNTING,
+		"allowed_spaces": (SPACE_ACCOUNTING, SPACE_ERP_AUTOMATION),
+		"allow_requested_space": False,
+		"default_severity": "critical",
+		"owner": "Accounting",
+		"dedup_window_minutes": 180,
+		"routing_reason": "Private accounting alert for discount-abuse review.",
+	},
+	"morning_readiness_digest": {
+		"family_label": "Morning Readiness Digest",
+		"delivery_class": "action_digest",
+		"default_space": SPACE_NOTIFICATIONS,
+		"allowed_spaces": (SPACE_NOTIFICATIONS, SPACE_ERP_AUTOMATION),
+		"allow_requested_space": False,
+		"default_severity": "medium",
+		"owner": "ERP Automation / Ops",
+		"dedup_window_minutes": 180,
+		"routing_reason": "Daily readiness brief for store, warehouse, and finance syncs.",
+	},
+}
+
+EXCLUDED_FAMILIES: dict[str, dict[str, str]] = {
+	"meta_ads_digest": {
+		"owner": "Marketing",
+		"destination_policy": "Keep out of Blip; route to marketing-only reporting channels.",
+	},
+	"attendance_bridge_failure": {
+		"owner": "HR / Biometrics",
+		"destination_policy": "Route to biometric ops / HR support, not Blip catch-all.",
+	},
+	"biometric_daily_digest": {
+		"owner": "HR / Biometrics",
+		"destination_policy": "Route to biometric dashboard/digest destinations only.",
+	},
+	"unclassified_external_or_future_sender": {
+		"owner": "Control Cell",
+		"destination_policy": "Must be classified before using Blip policy routes.",
+	},
+}
+
+
+def get_notification_policy(family: str) -> dict[str, Any]:
+	try:
+		return deepcopy(FAMILY_POLICIES[family])
+	except KeyError as exc:
+		raise ValueError(f"Unknown notification family: {family}") from exc
+
+
+def get_family_allowed_spaces(family: str | None) -> set[str]:
+	if not family or family not in FAMILY_POLICIES:
+		return set()
+	return set(FAMILY_POLICIES[family].get("allowed_spaces") or ())
+
+
+def family_allows_requested_space(family: str | None) -> bool:
+	if not family or family not in FAMILY_POLICIES:
+		return False
+	return bool(FAMILY_POLICIES[family].get("allow_requested_space"))
+
+
+def list_certified_families() -> list[str]:
+	return list(FAMILY_POLICIES.keys())
+
+
+def build_certified_family_manifest_rows() -> list[dict[str, Any]]:
+	rows: list[dict[str, Any]] = []
+	for family, policy in FAMILY_POLICIES.items():
+		rows.append(
+			{
+				"family": family,
+				"family_label": policy["family_label"],
+				"delivery_class": policy["delivery_class"],
+				"default_space": policy["default_space"],
+				"allowed_spaces": ",".join(policy["allowed_spaces"]),
+				"allow_requested_space": "yes" if policy["allow_requested_space"] else "no",
+				"default_severity": policy["default_severity"],
+				"owner": policy["owner"],
+				"dedup_window_minutes": policy["dedup_window_minutes"],
+				"routing_reason": policy["routing_reason"],
+			}
+		)
+	return rows
+
+
+def build_exclusion_rows() -> list[dict[str, Any]]:
+	return [
+		{
+			"family": family,
+			"owner": meta["owner"],
+			"destination_policy": meta["destination_policy"],
+		}
+		for family, meta in EXCLUDED_FAMILIES.items()
+	]
+
+
+def build_routing_matrix_rows() -> list[dict[str, Any]]:
+	rows: list[dict[str, Any]] = []
+	for family, policy in FAMILY_POLICIES.items():
+		rows.append(
+			{
+				"family": family,
+				"delivery_class": policy["delivery_class"],
+				"default_space": policy["default_space"],
+				"allowed_spaces": ",".join(policy["allowed_spaces"]),
+				"allow_requested_space": "yes" if policy["allow_requested_space"] else "no",
+				"routing_reason": policy["routing_reason"],
+			}
+		)
+	return rows
+
+
+def _clean_text(value: Any, fallback: str = "-") -> str:
+	text = str(value or "").strip()
+	return text or fallback
+
+
+def _unique_texts(values: list[Any] | tuple[Any, ...], limit: int | None = None) -> list[str]:
+	result: list[str] = []
+	seen: set[str] = set()
+	for value in values:
+		text = str(value or "").strip()
+		if not text or text in seen:
+			continue
+		seen.add(text)
+		result.append(text)
+		if limit is not None and len(result) >= limit:
+			break
+	return result
+
+
+def _severity_label(value: str) -> str:
+	text = str(value or "").strip().lower()
+	if text == "critical":
+		return "Critical"
+	if text == "high":
+		return "High"
+	if text == "medium":
+		return "Medium"
+	if text == "low":
+		return "Low"
+	return text.title() or "Medium"
+
+
+def _build_sheet_url(facts: dict[str, Any]) -> str:
+	spreadsheet_id = _clean_text(facts.get("spreadsheet_id"), fallback="")
+	if not spreadsheet_id:
+		return ""
+	return f"https://docs.google.com/spreadsheets/d/{spreadsheet_id}/edit"
+
+
+def _build_default_source_ref(family: str, facts: dict[str, Any]) -> str:
+	if family == "sheets_sync_critical":
+		return f"{_clean_text(facts.get('spreadsheet_name'))} / {_clean_text(facts.get('sheet_name'))}"
+	if family == "maintenance_sla_backlog":
+		return f"maintenance_sla:{_clean_text(facts.get('report_date'), fallback='today')}"
+	if family == "maintenance_status_update":
+		return _clean_text(facts.get("request_name"), fallback="maintenance_request")
+	if family == "approval_queue_new":
+		return _clean_text(facts.get("queue_name"), fallback="approval_queue")
+	if family in {"store_order_new", "store_order_approved"}:
+		return _clean_text(facts.get("order_name"), fallback="store_order")
+	if family == "discount_critical_digest":
+		return f"discount_audit:{_clean_text(facts.get('business_date'), fallback='today')}"
+	if family == "morning_readiness_digest":
+		return f"morning_sync:{_clean_text(facts.get('report_date'), fallback='today')}"
+	return family
+
+
+def _build_default_dedup_key(family: str, facts: dict[str, Any], source_ref: str) -> str:
+	if family == "sheets_sync_critical":
+		payload = {
+			"source_ref": source_ref,
+			"trigger": facts.get("trigger"),
+			"rows_failed": facts.get("rows_failed", 0),
+			"reasons": sorted(_unique_texts(facts.get("reasons") or [])),
+			"errors": _unique_texts(facts.get("errors") or [], limit=3),
+			"alerts": _unique_texts(facts.get("alerts") or [], limit=3),
+		}
+	elif family == "maintenance_sla_backlog":
+		payload = {
+			"source_ref": source_ref,
+			"request_names": sorted(
+				_unique_texts(
+					[(row or {}).get("name") for row in (facts.get("breaches") or [])],
+				)
+			),
+		}
+	elif family == "morning_readiness_digest":
+		payload = {
+			"source_ref": source_ref,
+			"status": facts.get("status"),
+			"area_statuses": [
+				{
+					"key": (area or {}).get("key"),
+					"status": (area or {}).get("status"),
+					"ready_before_deadline": (area or {}).get("ready_before_deadline"),
+				}
+				for area in (facts.get("areas") or [])
+			],
+		}
+	else:
+		payload = {"source_ref": source_ref, "facts": facts}
+
+	digest = hashlib.sha1(json.dumps(payload, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:20]
+	return f"{family}:{digest}"
+
+
+def _sheet_recommended_fix(facts: dict[str, Any]) -> str:
+	errors = " ".join(_unique_texts(facts.get("errors") or [], limit=3)).lower()
+	reasons = set(_unique_texts(facts.get("reasons") or []))
+	if "invoice_no" in errors:
+		return "Restore invoice numbers on non-blank rows or correct the AR/AP transform before rerunning the sync."
+	if "supplier" in errors:
+		return "Fill the missing supplier/invoice fields on real rows and delete blank tail rows before rerunning."
+	if "suspicious_change_alert" in reasons and not int(facts.get("rows_failed") or 0):
+		return "Confirm the mass edit/deletion was intentional before finance or ops rely on the updated sheet."
+	return "Fix the top sync errors or source-sheet schema mismatch, then rerun the sheet sync."
+
+
+def _render_sheets_sync_critical(event: dict[str, Any]) -> dict[str, Any]:
+	facts = event["facts"]
+	rows_failed = int(facts.get("rows_failed") or 0)
+	rows_processed = int(facts.get("rows_processed") or 0)
+	reasons = _unique_texts(facts.get("reasons") or [])
+	errors = _unique_texts(facts.get("errors") or [], limit=3)
+	alerts = _unique_texts(facts.get("alerts") or [], limit=3)
+	trigger = _clean_text(facts.get("trigger"), fallback="manual")
+	if trigger == "scheduled":
+		trigger = "scheduled (6-hour fallback)"
+	sheet_ref = _build_default_source_ref("sheets_sync_critical", facts)
+	summary = (
+		f"{sheet_ref} needs intervention: {rows_failed} of {rows_processed} rows failed during {trigger}."
+		if rows_failed
+		else f"{sheet_ref} synced, but the change pattern looks unusual and needs review."
+	)
+	evidence_bits = [f"Sheet: {sheet_ref}", f"Trigger: {trigger}"]
+	if reasons:
+		evidence_bits.append("Reasons: " + ", ".join(reasons))
+	if errors:
+		evidence_bits.append("Top errors: " + "; ".join(errors))
+	if alerts:
+		evidence_bits.append("Change alerts: " + "; ".join(alerts))
+	sheet_url = _build_sheet_url(facts)
+	if sheet_url:
+		evidence_bits.append(sheet_url)
+	return {
+		"summary": summary,
+		"why_it_matters": "Finance and ops can end up working from stale or misleading sheet-backed data until this lane is verified.",
+		"action_now": (
+			"Open the source sheet, fix the blocking rows or schema issue, and rerun the sync now."
+			if rows_failed
+			else "Verify the reported edit/deletion pattern against the source sheet before the team relies on it."
+		),
+		"owner": event["owner"],
+		"recommended_fix": _sheet_recommended_fix(facts),
+		"evidence": " | ".join(evidence_bits),
+		"urgency": _severity_label(event["severity"]),
+		"event_count": max(rows_failed, len(alerts), len(errors), 1),
+	}
+
+
+def _render_maintenance_sla_backlog(event: dict[str, Any]) -> dict[str, Any]:
+	facts = event["facts"]
+	breaches = list(facts.get("breaches") or [])
+	counts = facts.get("counts_by_priority") or {}
+	total = len(breaches)
+	count_bits = [f"{priority}: {int(counts.get(priority) or 0)}" for priority in ("Urgent", "High", "Normal") if int(counts.get(priority) or 0)]
+	top_rows = []
+	for row in breaches[:5]:
+		top_rows.append(
+			"{name} ({store}, {priority}, age {age}h)".format(
+				name=_clean_text((row or {}).get("name")),
+				store=_clean_text((row or {}).get("store")),
+				priority=_clean_text((row or {}).get("priority")),
+				age=_clean_text((row or {}).get("age_hours")),
+			)
+		)
+	summary = f"{total} maintenance requests are past SLA."
+	if count_bits:
+		summary += " " + ", ".join(count_bits) + "."
+	return {
+		"summary": summary,
+		"why_it_matters": "Stores are carrying unresolved maintenance issues beyond target response time, which can keep operations exposed or degraded.",
+		"action_now": "Review the Projects queue now, assign or escalate the oldest urgent items first, and update each ticket with the next ETA.",
+		"owner": event["owner"],
+		"recommended_fix": "Clear urgent breaches first, then rebalance high/normal backlog and chase vendors with no confirmed schedule.",
+		"evidence": " | ".join(
+			_unique_texts(
+				[
+					f"Overdue count: {total}",
+					"Top tickets: " + "; ".join(top_rows) if top_rows else "",
+					f"Dashboard: {_portal_url('/dashboard/projects')}",
+				]
+			)
+		),
+		"urgency": _severity_label(event["severity"]),
+		"event_count": max(total, 1),
+	}
+
+
+def _render_maintenance_status_update(event: dict[str, Any]) -> dict[str, Any]:
+	facts = event["facts"]
+	request_name = _clean_text(facts.get("request_name"))
+	store = _clean_text(facts.get("store"))
+	status = _clean_text(facts.get("status"), fallback="Open")
+	event_kind = _clean_text(facts.get("event_kind"), fallback="status_change")
+	priority = _clean_text(facts.get("priority"))
+	category = _clean_text(facts.get("issue_category"))
+	description = _clean_text(facts.get("description"))
+	if event_kind == "created":
+		summary = f"New maintenance request {request_name} was filed for {store}."
+		action = "Projects should triage the issue, assign an owner, and confirm the response plan."
+		recommended = "Set the owner/SLA now and give the store a concrete next step."
+		why = "A newly reported issue needs ownership before it becomes an SLA breach or store escalation."
+	elif status == "Completed":
+		summary = f"Maintenance request {request_name} is marked Completed for {store}."
+		action = "Store leadership should verify the work result and close the loop in the next maintenance check."
+		recommended = "Confirm the work quality and capture verification so the ticket does not linger unresolved."
+		why = "Completed work still needs store confirmation before the issue is truly closed."
+	elif status == "Verified":
+		summary = f"Maintenance request {request_name} has been verified for {store}."
+		action = "No action needed unless the issue reappears."
+		recommended = "Keep the request closed and reopen only if the same issue returns."
+		why = "The maintenance lifecycle is complete and no further operator intervention is expected."
+	elif status == "Cancelled":
+		summary = f"Maintenance request {request_name} was cancelled for {store}."
+		action = "No action needed unless the underlying issue is still active."
+		recommended = "Refile the request only if the issue still affects operations."
+		why = "Cancelled requests should not keep creating follow-up chatter unless the problem remains unresolved."
+	else:
+		summary = f"Maintenance request {request_name} updated to {status} for {store}."
+		action = "Review the latest owner, schedule, or vendor update if the store still needs clarification."
+		recommended = "Keep the request moving and avoid silent status changes without a next step."
+		why = "Lifecycle updates should clarify what changed and who owns the next step."
+	return {
+		"summary": summary,
+		"why_it_matters": why,
+		"action_now": action,
+		"owner": event["owner"],
+		"recommended_fix": recommended,
+		"evidence": " | ".join(
+			_unique_texts(
+				[
+					f"Request: {request_name}",
+					f"Store: {store}",
+					f"Priority: {priority}",
+					f"Category: {category}",
+					f"Issue: {description}",
+					f"Projects queue: {_portal_url('/dashboard/projects')}",
+				]
+			)
+		),
+		"urgency": _severity_label(event["severity"]),
+		"event_count": 1,
+	}
+
+
+def _render_approval_queue_new(event: dict[str, Any]) -> dict[str, Any]:
+	facts = event["facts"]
+	reference_doctype = _clean_text(facts.get("reference_doctype"), fallback="Approval")
+	reference_name = _clean_text(facts.get("reference_name"), fallback=facts.get("subject"))
+	store = _clean_text(facts.get("store"))
+	queue_name = _clean_text(facts.get("queue_name"))
+	dashboard_url = _clean_text(facts.get("dashboard_url"), fallback=_portal_url("/dashboard/store-ops/order-approvals"))
+	return {
+		"summary": f"{reference_doctype} {reference_name} is waiting for approval.",
+		"why_it_matters": "The workflow will not move forward until the assigned approver reviews the queue item.",
+		"action_now": "Open the approval queue now and approve or reject with a clear reason.",
+		"owner": event["owner"],
+		"recommended_fix": "Review quantities, routing, and urgency before approving so the workflow does not stall later.",
+		"evidence": " | ".join(
+			_unique_texts(
+				[
+					f"Queue: {queue_name}",
+					f"Store: {store}",
+					f"Priority: {_clean_text(facts.get('priority'))}",
+					f"Dashboard: {dashboard_url}",
+				]
+			)
+		),
+		"urgency": _severity_label(event["severity"]),
+		"event_count": 1,
+	}
+
+
+def _render_store_order_new(event: dict[str, Any]) -> dict[str, Any]:
+	facts = event["facts"]
+	order_name = _clean_text(facts.get("order_name"))
+	store = _clean_text(facts.get("warehouse"), fallback=_clean_text(facts.get("store")))
+	item_count = int(facts.get("item_count") or 0)
+	is_emergency = bool(facts.get("is_emergency"))
+	queue_status = _clean_text(facts.get("queue_status"), fallback="unknown")
+	queue_name = _clean_text(facts.get("approval_queue_name"), fallback="")
+	dashboard_url = _clean_text(facts.get("dashboard_url"), fallback=_portal_url("/dashboard/store-ops/order-approvals"))
+	if queue_status in {"failed", "unmapped"}:
+		action = "Fix the approval routing now so the order does not stall."
+		recommended = "Repair the approver mapping or assignment failure before the cutoff window closes."
+	else:
+		action = "No action needed unless this is urgent or the approval queue stops moving."
+		recommended = "Monitor the order approval queue and watch for routing gaps on emergency orders."
+	return {
+		"summary": f"New store order {order_name} was submitted from {store} for {item_count} items.",
+		"why_it_matters": "Ops needs early visibility when emergency or approval-routing issues can delay dispatch.",
+		"action_now": action,
+		"owner": event["owner"],
+		"recommended_fix": recommended,
+		"evidence": " | ".join(
+			_unique_texts(
+				[
+					f"Order: {order_name}",
+					f"Store: {store}",
+					f"Emergency: {'Yes' if is_emergency else 'No'}",
+					f"Approval queue: {queue_name}" if queue_name and queue_name != "-" else "",
+					f"Queue status: {queue_status}",
+					f"Dashboard: {dashboard_url}",
+				]
+			)
+		),
+		"urgency": _severity_label(event["severity"]),
+		"event_count": 1,
+	}
+
+
+def _render_store_order_approved(event: dict[str, Any]) -> dict[str, Any]:
+	facts = event["facts"]
+	order_name = _clean_text(facts.get("order_name"))
+	stage = _clean_text(facts.get("stage"), fallback="approved")
+	store = _clean_text(facts.get("store"), fallback=_clean_text(facts.get("warehouse")))
+	if stage == "area_supervisor_forwarded":
+		action = "Regional Manager should review and finalize the queued emergency order."
+		recommended = "Approve or reject the forwarded emergency request so dispatch can proceed."
+		why = "The order is still blocked until the second approval stage completes."
+		summary = f"Store order {order_name} cleared Area Supervisor review and is waiting on Regional Manager sign-off."
+		evidence = [
+			f"Order: {order_name}",
+			f"Store: {store}",
+			f"Regional approver: {_clean_text(facts.get('regional_approver'))}",
+			f"Dashboard: {_clean_text(facts.get('dashboard_url'), fallback=_portal_url('/dashboard/store-ops/order-approvals'))}",
+		]
+	else:
+		action = "Warehouse should process the material request and the store can monitor dispatch."
+		recommended = "Pick, stage, and dispatch the linked material request without waiting for another chat follow-up."
+		why = "The order is approved and can now move into fulfilment."
+		summary = (
+			f"Store order {order_name} is approved and dispatch request {_clean_text(facts.get('material_request'))} is ready."
+			if facts.get("material_request")
+			else f"Store order {order_name} is approved."
+		)
+		evidence = [
+			f"Order: {order_name}",
+			f"Store: {store}",
+			f"Approved by: {_clean_text(facts.get('approved_by'))}",
+			f"Material Request: {_clean_text(facts.get('material_request'))}",
+			f"Dashboard: {_clean_text(facts.get('dashboard_url'), fallback=_portal_url('/dashboard/store-ops/order-approvals'))}",
+		]
+	return {
+		"summary": summary,
+		"why_it_matters": why,
+		"action_now": action,
+		"owner": event["owner"],
+		"recommended_fix": recommended,
+		"evidence": " | ".join(_unique_texts(evidence)),
+		"urgency": _severity_label(event["severity"]),
+		"event_count": 1,
+	}
+
+
+def _render_discount_critical_digest(event: dict[str, Any]) -> dict[str, Any]:
+	facts = event["facts"]
+	rows = list(facts.get("rows") or [])
+	business_date = _clean_text(facts.get("business_date"))
+	store_names = _unique_texts(
+		[(row or {}).get("store_name") for row in rows],
+		limit=5,
+	)
+	top_clusters = []
+	for row in rows[:5]:
+		top_clusters.append(
+			"{store} / {identity} / orders {orders}".format(
+				store=_clean_text((row or {}).get("store_name")),
+				identity=_clean_text((row or {}).get("identity_key")),
+				orders=int((row or {}).get("order_count") or 0),
+			)
+		)
+	return {
+		"summary": f"Discount audit found {len(rows)} critical clusters for {business_date}.",
+		"why_it_matters": "Potential SC/PWD abuse needs accounting review before the evidence trail gets colder and closeout confidence drops.",
+		"action_now": "Open the discount-abuse queue now and validate the flagged receipts or identities.",
+		"owner": event["owner"],
+		"recommended_fix": "Clear false positives, escalate real abuse patterns, and mark reviewed rows so the same clusters do not linger unresolved.",
+		"evidence": " | ".join(
+			_unique_texts(
+				[
+					"Stores: " + ", ".join(store_names) if store_names else "",
+					"Top clusters: " + "; ".join(top_clusters) if top_clusters else "",
+					f"Review queue: {_clean_text(facts.get('review_url'), fallback=_portal_url('/dashboard/accounting/discount-abuse'))}",
+				]
+			)
+		),
+		"urgency": _severity_label(event["severity"]),
+		"event_count": max(len(rows), 1),
+	}
+
+
+def _render_morning_readiness_digest(event: dict[str, Any]) -> dict[str, Any]:
+	facts = event["facts"]
+	status = _clean_text(facts.get("status"), fallback="yellow").lower()
+	areas = list(facts.get("areas") or [])
+	area_bits = []
+	for area in areas:
+		area_bits.append(
+			"{label}: {status}".format(
+				label=_clean_text((area or {}).get("label")),
+				status=_clean_text((area or {}).get("status")),
+			)
+		)
+	if status == "green":
+		summary = f"Morning syncs are ready for operations for {_clean_text(facts.get('report_date'))}."
+		action = "No action needed."
+		recommended = "Keep monitoring the daily readiness report, but no manual recovery is needed."
+		why = "Store ordering, warehouse inventory, and finance baselines all landed before the morning operating window."
+	elif status == "red":
+		summary = f"Morning syncs are not ready for {_clean_text(facts.get('report_date'))}."
+		action = "Escalate the failing lane now and rerun the missed sync before teams rely on the data."
+		recommended = "Open the morning sync report, recover the blocked lane, and clear the latest runtime error before 9:00 AM PHT."
+		why = "At least one operational data lane missed the readiness target or failed outright."
+	else:
+		summary = f"Morning syncs landed with exceptions for {_clean_text(facts.get('report_date'))}."
+		action = "Review the exception lane now and clear it before finance or ops uses the affected data."
+		recommended = "Resolve the exception rows or rerun the incomplete lane so the day starts from a clean baseline."
+		why = "The morning data is present, but at least one lane still needs operator attention."
+	return {
+		"summary": summary,
+		"why_it_matters": why,
+		"action_now": action,
+		"owner": event["owner"],
+		"recommended_fix": recommended,
+		"evidence": " | ".join(
+			_unique_texts(
+				[
+					"Areas: " + "; ".join(area_bits) if area_bits else "",
+					f"Target: {_clean_text(facts.get('sync_target_pht_time'))}",
+					f"Deadline: {_clean_text(facts.get('ready_deadline_pht_time'))}",
+					f"Artifact: {_clean_text(facts.get('artifact_markdown_path'))}",
+				]
+			)
+		),
+		"urgency": _severity_label(event["severity"]),
+		"event_count": max(len(areas), 1),
+	}
+
+
+RENDERERS = {
+	"sheets_sync_critical": _render_sheets_sync_critical,
+	"maintenance_sla_backlog": _render_maintenance_sla_backlog,
+	"maintenance_status_update": _render_maintenance_status_update,
+	"approval_queue_new": _render_approval_queue_new,
+	"store_order_new": _render_store_order_new,
+	"store_order_approved": _render_store_order_approved,
+	"discount_critical_digest": _render_discount_critical_digest,
+	"morning_readiness_digest": _render_morning_readiness_digest,
+}
+
+
+def build_notification_event(event: dict[str, Any]) -> dict[str, Any]:
+	if not isinstance(event, dict):
+		raise ValueError("Notification event must be a dict")
+	family = _clean_text(event.get("family"), fallback="")
+	if not family:
+		raise ValueError("Notification event missing family")
+	policy = get_notification_policy(family)
+	facts = deepcopy(event.get("facts") or {})
+	normalized = deepcopy(event)
+	normalized["family"] = family
+	normalized["facts"] = facts
+	normalized.setdefault("source_system", "frappe")
+	normalized.setdefault("requested_space", policy["default_space"])
+	normalized.setdefault("delivery_class", policy["delivery_class"])
+	normalized.setdefault("severity", policy["default_severity"])
+	normalized.setdefault("owner", policy["owner"])
+	normalized.setdefault("source_ref", _build_default_source_ref(family, facts))
+	normalized.setdefault("dedup_key", _build_default_dedup_key(family, facts, normalized["source_ref"]))
+	brief = RENDERERS[family](normalized)
+	normalized["brief"] = brief
+	normalized["event_count"] = brief.get("event_count") or normalized.get("event_count") or 1
+	normalized["fallback_text"] = normalized.get("fallback_text") or render_notification_text(normalized)
+	return normalized
+
+
+def validate_notification_event(event: dict[str, Any]) -> list[str]:
+	errors: list[str] = []
+	for field in REQUIRED_EVENT_FIELDS:
+		value = event.get(field)
+		if field == "facts" and isinstance(value, dict):
+			continue
+		if value in (None, "", []):
+			errors.append(field)
+	return errors
+
+
+def render_notification_text(event: dict[str, Any]) -> str:
+	brief = event.get("brief") or {}
+	lines = [
+		f"*{_clean_text(event.get('family')).replace('_', ' ').title()}*",
+		"",
+		"*Summary*",
+		_clean_text(brief.get("summary")),
+		"",
+		"*Why this matters*",
+		_clean_text(brief.get("why_it_matters")),
+		"",
+		"*Action now*",
+		_clean_text(brief.get("action_now")),
+		"",
+		"*Owner*",
+		_clean_text(brief.get("owner"), fallback=_clean_text(event.get("owner"))),
+		"",
+		"*Recommended fix*",
+		_clean_text(brief.get("recommended_fix")),
+		"",
+		"*Evidence / source link*",
+		_clean_text(brief.get("evidence"), fallback=_clean_text(event.get("source_ref"))),
+		"",
+		"*Urgency*",
+		_clean_text(brief.get("urgency"), fallback=_severity_label(event.get("severity"))),
+	]
+	return "\n".join(lines).strip()


### PR DESCRIPTION
## Summary
- add a structured notification intelligence contract and deterministic renderers for Sprint 38 families
- migrate sheets sync, maintenance, store-order, discount, and morning readiness notifications onto the shared sender
- add focused unit coverage for sender routing, receiver ingest, maintenance grouping, discount digests, morning readiness, and store approval notifications

## Verification
- python -m py_compile hrms/api/google_chat.py hrms/api/projects.py hrms/api/store.py hrms/api/discount_abuse.py hrms/api/erp_sync.py hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py hrms/services/sheets_receiver/notifications.py hrms/services/sheets_receiver/processor.py hrms/utils/chat_space_lockdown.py hrms/utils/notification_intelligence.py hrms/tests/test_google_chat_notification_routing.py hrms/tests/test_sheets_receiver_notifications.py hrms/tests/test_notification_intelligence_s38.py hrms/tests/test_projects_notifications_s06.py hrms/tests/test_discount_abuse_api_s12.py hrms/tests/test_erp_sync_runtime.py hrms/tests/test_s19_emergency_duplicate_bypass.py hrms/tests/test_store_approval_notifications_s38.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest hrms/tests/test_google_chat_notification_routing.py hrms/tests/test_sheets_receiver_notifications.py hrms/tests/test_notification_intelligence_s38.py hrms/tests/test_projects_notifications_s06.py hrms/tests/test_discount_abuse_api_s12.py hrms/tests/test_erp_sync_runtime.py hrms/tests/test_s19_emergency_duplicate_bypass.py hrms/tests/test_store_approval_notifications_s38.py hrms/tests/test_sheets_receiver_processor.py -q

## Docs
- no-docs: sprint execution artifacts and certification outputs are being tracked outside the repo in the Sprint 38 run packet.