### PR TITLE
fix: finalize receiver topology for morning health

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -46,8 +46,11 @@ PHT_TIMEZONE = ZoneInfo("Asia/Manila")
 MORNING_SYNC_TARGET_PHT_TIME = datetime.time(hour=7, minute=0)
 MORNING_SYNC_READY_DEADLINE_PHT_TIME = datetime.time(hour=9, minute=0)
 MORNING_SYNC_REPORT_DIRNAME = "morning_sync_health_reports"
-DEFAULT_RECEIVER_API_BASE_URL = "https://hq.bebang.ph/sheets-api"
-DEFAULT_RECEIVER_WEBHOOK_PROXY_URL = "https://hq.bebang.ph/sheets-webhook"
+# The standalone sheets-receiver runs on the EC2 host, outside the Frappe Swarm.
+# Backend containers reach it through the host bridge, while Google webhooks land
+# on the public Frappe method route and are proxied internally from there.
+DEFAULT_RECEIVER_API_BASE_URL = "http://172.17.0.1:8765/api"
+DEFAULT_RECEIVER_WEBHOOK_PROXY_URL = "http://172.17.0.1:8765/webhook/sheets"
 PO_REFERENCE_RE = re.compile(r"^\s*(?:PO|PURCHASE\s*ORDER)\s*[-#:/]?\s*[A-Z0-9-]+\s*$", re.IGNORECASE)
 
 
@@ -2810,10 +2813,10 @@ def webhook():
 	and be forwarded to the Sheets Receiver service.
 
 	Google sends webhooks to:
-	https://hq.bebang.ph/api/method/hrms.api.sheets_receiver.webhook
+	https://hq.bebang.ph/api/method/hrms.api.erp_sync.webhook
 
 	We forward to:
-	http://sheets-receiver:8765/webhook/sheets
+	http://172.17.0.1:8765/webhook/sheets
 	"""
 	import requests
 

--- a/hrms/services/sheets_receiver/README.md
+++ b/hrms/services/sheets_receiver/README.md
@@ -53,7 +53,8 @@ AWS EC2 Instance
 └── Sheets Receiver (temporary)  ← THIS SERVICE
     └── sheets-receiver container
          ↓
-    nginx proxy (/sheets-webhook)
+    Frappe public webhook proxy
+    (/api/method/hrms.api.erp_sync.webhook)
          ↓
     Google Drive Watch API
 ```
@@ -95,9 +96,8 @@ echo "FRAPPE_API_SECRET=xxx" >> .env
 docker-compose build
 docker-compose up -d
 
-# Configure nginx
-sudo cp nginx-sheets-receiver.conf /etc/nginx/conf.d/
-sudo nginx -t && sudo systemctl reload nginx
+# Webhooks go through the public Frappe method route.
+# The legacy nginx helper file is optional and not required for normal operation.
 ```
 
 ### 3. Set Up Google Drive Watches
@@ -313,6 +313,7 @@ Every 6 hours, a scheduled job syncs all sheets as backup (in case webhooks were
 
 ### Webhook not receiving notifications
 1. Check PUBLIC_WEBHOOK_URL is accessible from internet
+   Expected production path: `https://hq.bebang.ph/api/method/hrms.api.erp_sync.webhook`
 2. Verify watches are set up: `GET /api/status`
 3. Check Google Cloud Console for webhook delivery status
 

--- a/hrms/services/sheets_receiver/config.py
+++ b/hrms/services/sheets_receiver/config.py
@@ -90,10 +90,13 @@ class ServiceConfig:
 	webhook_port: int = field(default_factory=lambda: int(os.environ.get("SHEETS_RECEIVER_PORT", "8765")))
 	webhook_path: str = "/webhook/sheets"
 
-	# Public URL for Google to send webhooks to
-	# Uses nginx proxy directly - NOT routed through Frappe
+	# Public URL for Google Drive notifications.
+	# This should stay on the public Frappe route, not the private receiver port.
 	public_webhook_url: str = field(
-		default_factory=lambda: os.environ.get("PUBLIC_WEBHOOK_URL", "https://hq.bebang.ph/sheets-webhook")
+		default_factory=lambda: os.environ.get(
+			"PUBLIC_WEBHOOK_URL",
+			"https://hq.bebang.ph/api/method/hrms.api.erp_sync.webhook",
+		)
 	)
 
 	# Database

--- a/hrms/services/sheets_receiver/deploy/deploy.sh
+++ b/hrms/services/sheets_receiver/deploy/deploy.sh
@@ -77,15 +77,16 @@ case "${1:-deploy}" in
         log "Starting service..."
         docker-compose up -d
 
-        # Configure nginx
-        log "Configuring nginx..."
-        sudo cp nginx-sheets-receiver.conf /etc/nginx/conf.d/ 2>/dev/null || \
-            warn "Could not copy nginx config - add manually"
-        sudo nginx -t && sudo systemctl reload nginx || \
-            warn "Nginx reload failed - check config manually"
+        # Legacy nginx proxy config is no longer required for the main webhook path,
+        # because Google hits the public Frappe method route directly. Keep the file
+        # available for optional host-local proxy use, but do not treat nginx as a
+        # deployment dependency.
+        if [ -f nginx-sheets-receiver.conf ]; then
+            log "Legacy nginx helper file refreshed (not required for webhook path)"
+        fi
 
         log "Deployment complete!"
-        log "Webhook URL: https://hq.bebang.ph/sheets-webhook"
+        log "Webhook URL: https://hq.bebang.ph/api/method/hrms.api.erp_sync.webhook"
         log "Status: docker-compose logs -f"
         ;;
 

--- a/hrms/services/sheets_receiver/deploy/docker-compose.yml
+++ b/hrms/services/sheets_receiver/deploy/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       FRAPPE_API_KEY: ${FRAPPE_API_KEY}
       FRAPPE_API_SECRET: ${FRAPPE_API_SECRET}
 
-      # Webhook - Google sends to this URL
-      PUBLIC_WEBHOOK_URL: https://hq.bebang.ph/sheets-webhook
+      # Webhook - Google sends to the public Frappe proxy method
+      PUBLIC_WEBHOOK_URL: https://hq.bebang.ph/api/method/hrms.api.erp_sync.webhook
       SHEETS_RECEIVER_PORT: 8765
 
       # Logging
@@ -46,7 +46,8 @@ services:
       - ./logs:/app/logs
 
     ports:
-      - "127.0.0.1:8765:8765"  # Only localhost - nginx will proxy
+      - "127.0.0.1:8765:8765"   # Host-local operator access
+      - "172.17.0.1:8765:8765"  # Backend containers reach receiver via Docker host bridge
 
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8765/health"]

--- a/hrms/services/sheets_receiver/docker-compose.sheets-receiver.yml
+++ b/hrms/services/sheets_receiver/docker-compose.sheets-receiver.yml
@@ -22,7 +22,7 @@ services:
       FRAPPE_API_SECRET: ${FRAPPE_API_SECRET}
 
       # Webhook
-      PUBLIC_WEBHOOK_URL: https://hq.bebang.ph/api/method/hrms.api.sheets_receiver.webhook
+      PUBLIC_WEBHOOK_URL: https://hq.bebang.ph/api/method/hrms.api.erp_sync.webhook
       SHEETS_RECEIVER_PORT: 8765
 
       # Logging

--- a/hrms/tests/test_erp_sync_runtime.py
+++ b/hrms/tests/test_erp_sync_runtime.py
@@ -297,10 +297,14 @@ class TestErpSyncRuntime(unittest.TestCase):
 		save_registry_mock.assert_called_once()
 		save_state_mock.assert_called_once()
 
-	def test_receiver_api_url_defaults_to_public_proxy(self):
+	def test_receiver_urls_default_to_host_bridge(self):
 		self.assertEqual(
 			erp_sync._receiver_api_url("morning-health"),
-			"https://hq.bebang.ph/sheets-api/morning-health",
+			"http://172.17.0.1:8765/api/morning-health",
+		)
+		self.assertEqual(
+			erp_sync._receiver_webhook_proxy_url(),
+			"http://172.17.0.1:8765/webhook/sheets",
 		)
 
 	def test_receiver_urls_honor_explicit_config(self):
@@ -311,7 +315,7 @@ class TestErpSyncRuntime(unittest.TestCase):
 		self.assertEqual(erp_sync._receiver_api_url("status"), "https://receiver.internal/api/status")
 		self.assertEqual(erp_sync._receiver_webhook_proxy_url(), "https://receiver.internal/webhook")
 
-	def test_get_sync_status_uses_public_receiver_proxy(self):
+	def test_get_sync_status_uses_host_bridge_receiver_proxy(self):
 		class _Response:
 			def json(self):
 				return {"status": "healthy"}
@@ -319,7 +323,7 @@ class TestErpSyncRuntime(unittest.TestCase):
 		with patch("requests.get", return_value=_Response()) as mock_get:
 			result = erp_sync.get_sync_status()
 
-		mock_get.assert_called_once_with("https://hq.bebang.ph/sheets-api/status", timeout=10)
+		mock_get.assert_called_once_with("http://172.17.0.1:8765/api/status", timeout=10)
 		self.assertEqual(result["status"], "healthy")
 
 	def test_get_morning_sync_health_report_is_yellow_when_receiver_has_exceptions(self):

--- a/hrms/tests/test_sheets_receiver_config.py
+++ b/hrms/tests/test_sheets_receiver_config.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 import sys
 import unittest
 from pathlib import Path
@@ -17,6 +18,18 @@ config_spec.loader.exec_module(config)
 
 
 class TestSheetsReceiverConfig(unittest.TestCase):
+	def test_default_public_webhook_url_uses_frappe_method_proxy(self):
+		original = os.environ.pop("PUBLIC_WEBHOOK_URL", None)
+		try:
+			service_config = config.ServiceConfig()
+			self.assertEqual(
+				service_config.public_webhook_url,
+				"https://hq.bebang.ph/api/method/hrms.api.erp_sync.webhook",
+			)
+		finally:
+			if original is not None:
+				os.environ["PUBLIC_WEBHOOK_URL"] = original
+
 	def test_ap_opening_balance_uses_supplier_soa_tab(self):
 		ap_config = config.get_sheet_config("ap_opening_balance")
 		supplier_soa_config = config.get_sheet_config("supplier_soa")


### PR DESCRIPTION
## Summary
- route backend-to-receiver API calls over the Docker host bridge instead of the dead public /sheets-api path
- move the receiver public webhook URL to the live Frappe method route
- update standalone receiver deploy defaults and docs to match the production topology

## Testing
- python -m py_compile hrms/api/erp_sync.py hrms/services/sheets_receiver/config.py hrms/tests/test_erp_sync_runtime.py hrms/tests/test_sheets_receiver_config.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest hrms/tests/test_erp_sync_runtime.py hrms/tests/test_sheets_receiver_config.py -q
- pre-commit run --files hrms/api/erp_sync.py hrms/services/sheets_receiver/config.py hrms/tests/test_erp_sync_runtime.py hrms/tests/test_sheets_receiver_config.py hrms/services/sheets_receiver/deploy/docker-compose.yml hrms/services/sheets_receiver/deploy/deploy.sh hrms/services/sheets_receiver/docker-compose.sheets-receiver.yml hrms/services/sheets_receiver/README.md