### PR TITLE
Fix commissary pending inspection contract

### DIFF
--- a/hrms/api/commissary_quality.py
+++ b/hrms/api/commissary_quality.py
@@ -78,7 +78,8 @@ def get_pending_inspections() -> dict[str, Any]:
 	pending = frappe.db.sql(
 		"""
         SELECT
-            se.name,
+            sed.name as name,
+            se.name as reference_name,
             se.posting_date,
             sed.item_code,
             sed.item_name,

--- a/hrms/tests/test_s37_commissary_quality_contract.py
+++ b/hrms/tests/test_s37_commissary_quality_contract.py
@@ -138,7 +138,8 @@ class TestS37CommissaryQualityContract(unittest.TestCase):
 			captured["as_dict"] = as_dict
 			return [
 				{
-					"name": "MAT-STE-0001",
+					"name": "STE-ROW-0001",
+					"reference_name": "MAT-STE-0001",
 					"posting_date": "2026-03-12",
 					"item_code": "FG002-A",
 					"item_name": "BANANA CINNAMON",
@@ -154,7 +155,8 @@ class TestS37CommissaryQualityContract(unittest.TestCase):
 
 		self.assertTrue(result["success"])
 		self.assertEqual(result["total"], 1)
-		self.assertEqual(result["data"][0]["name"], "MAT-STE-0001")
+		self.assertEqual(result["data"][0]["name"], "STE-ROW-0001")
+		self.assertEqual(result["data"][0]["reference_name"], "MAT-STE-0001")
 		self.assertIn("Material Receipt", str(captured.get("query", "")))
 		self.assertIn("Production output", str(captured.get("query", "")))
 		self.assertEqual(captured.get("params"), "Shaw BLVD - BKI")


### PR DESCRIPTION
## Summary\n- return eference_name for pending commissary QC rows\n- use a unique row key for pending inspection entries instead of overloading the stock entry name\n- align the API contract with the portal QC workflow\n\n## Verification\n- python hrms\\tests\\test_s37_commissary_quality_contract.py\n- python -m py_compile hrms\\api\\commissary_quality.py hrms\\tests\\test_s37_commissary_quality_contract.py\n