### PR TITLE
fix: honor explicit supabase page limits

### DIFF
--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -202,20 +202,40 @@ def _merge_params(
 	return merged
 
 
+def _get_param_value(params: dict[str, Any] | list[tuple[str, Any]] | None, key: str) -> Any:
+	if params is None:
+		return None
+	if isinstance(params, dict):
+		return params.get(key)
+	for existing_key, value in reversed(params):
+		if existing_key == key:
+			return value
+	return None
+
+
 def _supabase_get_all(
 	resource: str,
 	params: dict[str, Any] | list[tuple[str, Any]] | None = None,
 	page_size: int = 1000,
 ) -> list[dict[str, Any]]:
 	rows: list[dict[str, Any]] = []
-	offset = 0
+	offset = int(_get_param_value(params, "offset") or 0)
+	requested_limit_value = _get_param_value(params, "limit")
+	requested_limit = int(requested_limit_value) if requested_limit_value is not None else None
 	while True:
-		page_params = _merge_params(params, [("limit", str(page_size)), ("offset", str(offset))])
+		remaining = requested_limit - len(rows) if requested_limit is not None else page_size
+		if remaining <= 0:
+			break
+		current_page_size = min(page_size, remaining)
+		page_params = _merge_params(
+			params,
+			[("limit", str(current_page_size)), ("offset", str(offset))],
+		)
 		page = _supabase_get(resource, page_params)
 		rows.extend(page)
-		if len(page) < page_size:
+		if len(page) < current_page_size:
 			break
-		offset += page_size
+		offset += current_page_size
 	return rows
 
 

--- a/hrms/tests/test_sales_dashboard_api.py
+++ b/hrms/tests/test_sales_dashboard_api.py
@@ -202,3 +202,31 @@ def test_data_quality_warning_flags_stale_foodpanda_cups():
 	warnings = module._build_data_quality_warnings(module.date(2026, 3, 14), freshness)
 
 	assert any("FoodPanda cups" in warning for warning in warnings)
+
+
+def test_supabase_get_all_honors_requested_limit():
+	_install_fake_frappe(["System Manager"])
+	module = _load_module(ROOT / "hrms" / "api" / "sales_dashboard.py", "sales_dashboard_paging_test")
+
+	calls: list[list[tuple[str, str]]] = []
+
+	def fake_supabase_get(resource, params=None):
+		assert resource == "daily_weather"
+		assert params is not None
+		calls.append(list(params))
+		return [{"business_date": "2026-03-14"}]
+
+	module._supabase_get = fake_supabase_get
+
+	rows = module._supabase_get_all(
+		"daily_weather",
+		[
+			("select", "business_date"),
+			("order", "business_date.desc"),
+			("limit", "1"),
+		],
+		page_size=1,
+	)
+
+	assert rows == [{"business_date": "2026-03-14"}]
+	assert len(calls) == 1


### PR DESCRIPTION
## Summary
- stop infinite Supabase pagination when a query already requests an explicit limit
- unblock sales dashboard freshness and access-context endpoints in production
- add regression coverage for the limit=1 case

## Documentation
- https://docs.frappe.io/framework/user/en/api/rest
