### PR TITLE
fix: add missing sales dashboard store mappings

### DIFF
--- a/hrms/fixtures/sales_dashboard_store_mapping.csv
+++ b/hrms/fixtures/sales_dashboard_store_mapping.csv
@@ -34,7 +34,9 @@ SM North EDSA,SM North EDSA - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2284
 SM Pulilan,SM Pulilan - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2478
 SM Sangandaan,SM Sangandaan - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2482
 SM Southmall,SM Southmall - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2340
+SM Sta. Rosa,SM Sta. Rosa - BKI,Bebang Kitchen Inc.,2774
 SM Tanza,SM Tanza - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2411
+SM Taytay,SM Taytay - BKI,Bebang Kitchen Inc.,2812
 SM Valenzuela,SM Valenzuela - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2341
 Sta. Lucia East Grand Mall,Sta. Lucia East Grand Mall - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2558
 The Grid - Rockwell,The Grid - Rockwell - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2250


### PR DESCRIPTION
## Summary
- add missing SM Taytay and SM Sta. Rosa mappings for the sales dashboard allowlist
- align the Frappe warehouse allowlist with governed Supabase sales locations
- restore canonical dashboard totals to the validated warehouse snapshot

## Documentation
- https://docs.frappe.io/framework/user/en/api/rest
