### PR TITLE
fix: avoid slow sales dashboard view filters

### DIFF
--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -571,17 +571,17 @@ def _build_access_context(scope: dict[str, Any]) -> dict[str, Any]:
 def _query_daily_rows(start_day: date, end_day: date, location_ids: list[int]) -> list[dict[str, Any]]:
 	if not location_ids:
 		return []
-	location_filter = ",".join(str(location_id) for location_id in sorted(set(location_ids)))
-	return _supabase_get_all(
+	allowed_location_ids = set(location_ids)
+	rows = _supabase_get_all(
 		SUPABASE_DAILY_VIEW,
 		[
 			("select", DAILY_METRIC_SELECT),
 			("business_date", f"gte.{start_day.isoformat()}"),
 			("business_date", f"lte.{end_day.isoformat()}"),
-			("location_id", f"in.({location_filter})"),
 			("order", "business_date.asc,store_name.asc"),
 		],
 	)
+	return [row for row in rows if _to_int(row.get("location_id")) in allowed_location_ids]
 
 
 def _query_weather_rows(start_day: date, end_day: date, location_ids: list[int]) -> list[dict[str, Any]]:

--- a/hrms/tests/test_sales_dashboard_api.py
+++ b/hrms/tests/test_sales_dashboard_api.py
@@ -203,7 +203,6 @@ def test_data_quality_warning_flags_stale_foodpanda_cups():
 
 	assert any("FoodPanda cups" in warning for warning in warnings)
 
-
 def test_supabase_get_all_honors_requested_limit():
 	_install_fake_frappe(["System Manager"])
 	module = _load_module(ROOT / "hrms" / "api" / "sales_dashboard.py", "sales_dashboard_paging_test")
@@ -230,3 +229,27 @@ def test_supabase_get_all_honors_requested_limit():
 
 	assert rows == [{"business_date": "2026-03-14"}]
 	assert len(calls) == 1
+
+
+def test_query_daily_rows_filters_scope_after_fetch():
+	_install_fake_frappe(["System Manager"])
+	module = _load_module(ROOT / "hrms" / "api" / "sales_dashboard.py", "sales_dashboard_query_rows_test")
+
+	captured: dict[str, object] = {}
+
+	def fake_supabase_get_all(resource, params=None, page_size=1000):
+		captured["resource"] = resource
+		captured["params"] = params
+		captured["page_size"] = page_size
+		return [
+			{"location_id": 2217, "business_date": "2026-03-02", "store_name": "BF Homes"},
+			{"location_id": 2557, "business_date": "2026-03-02", "store_name": "Araneta Gateway"},
+		]
+
+	module._supabase_get_all = fake_supabase_get_all
+
+	rows = module._query_daily_rows(module.date(2026, 3, 2), module.date(2026, 3, 8), [2217])
+
+	assert rows == [{"location_id": 2217, "business_date": "2026-03-02", "store_name": "BF Homes"}]
+	assert captured["resource"] == module.SUPABASE_DAILY_VIEW
+	assert ("location_id", "in.(2217)") not in captured["params"]

--- a/hrms/tests/test_sales_dashboard_api.py
+++ b/hrms/tests/test_sales_dashboard_api.py
@@ -203,6 +203,7 @@ def test_data_quality_warning_flags_stale_foodpanda_cups():
 
 	assert any("FoodPanda cups" in warning for warning in warnings)
 
+
 def test_supabase_get_all_honors_requested_limit():
 	_install_fake_frappe(["System Manager"])
 	module = _load_module(ROOT / "hrms" / "api" / "sales_dashboard.py", "sales_dashboard_paging_test")


### PR DESCRIPTION
## Summary
- avoid pushing the location filter into the Supabase sales dashboard view query
- fetch the dated slice once and apply store scope in Python to bypass the bad PostgREST query plan
- add regression coverage for the view-query scope filtering behavior

## Documentation
- https://docs.frappe.io/framework/user/en/api/rest
