### PR TITLE
fix: map synthetic sales dashboard test stores

### DIFF
--- a/hrms/fixtures/sales_dashboard_store_mapping.csv
+++ b/hrms/fixtures/sales_dashboard_store_mapping.csv
@@ -43,3 +43,5 @@ The Grid - Rockwell,The Grid - Rockwell - Bebang Enterprise Inc.,Bebang Enterpri
 The Terminal,The Terminal - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2319
 Up Town Mall BGC,Up Town Mall BGC - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2548
 Vista Mall Taguig,Vista Mall Taguig - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2556
+TEST-STORE-BGC,TEST-STORE-BGC - BEI,Bebang Enterprise Inc.,2548
+TEST-STORE-MAKATI,TEST-STORE-MAKATI - BEI,Bebang Enterprise Inc.,2177


### PR DESCRIPTION
## Summary
- map the existing synthetic TEST-STORE warehouses to governed live sales locations for role certification
- enable safe area and supervisor sales-dashboard testing without changing operational warehouse ownership
- keep the mapping layer as the single source of store-name aliases

## Documentation
- https://docs.frappe.io/framework/user/en/api/rest
