### PR TITLE
fix: make sales summary comparisons opt-in

### DIFF
--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -283,6 +283,12 @@ def _to_int(value: Any) -> int:
 		return 0
 
 
+def _to_bool(value: Any) -> bool:
+	if isinstance(value, bool):
+		return value
+	return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _coerce_date(value: str | date | datetime | None, default: date | None = None) -> date:
 	if isinstance(value, datetime):
 		return value.date()
@@ -684,6 +690,13 @@ def _build_comparisons(
 	}
 
 
+def _empty_comparisons() -> dict[str, dict[str, bool]]:
+	return {
+		"previous_period": {"available": False},
+		"same_period_last_year": {"available": False},
+	}
+
+
 def _calendar_map_for_scope(stores: list[dict[str, Any]], dates: set[str]) -> dict[str, dict[str, Any]]:
 	company_to_holiday_list: dict[str, str] = {}
 	for store in stores:
@@ -1021,6 +1034,7 @@ def get_sales_dashboard_summary(
 	stores: list[str] | str | None = None,
 	view_mode: str = "canonical",
 	channel: str = "all",
+	include_comparisons: str | int | bool = False,
 ) -> dict[str, Any]:
 	scope = _selected_scope(_parse_stores_param(stores))
 	start_day, end_day = _resolve_date_range(start_date, end_date)
@@ -1040,7 +1054,9 @@ def get_sales_dashboard_summary(
 		"mode_state": mode_state,
 		"summary": summary,
 		"freshness": freshness,
-		"comparisons": _build_comparisons(start_day, end_day, selected_location_ids, summary),
+		"comparisons": _build_comparisons(start_day, end_day, selected_location_ids, summary)
+		if _to_bool(include_comparisons)
+		else _empty_comparisons(),
 	}
 	if view_mode == "ops_matched" and mode_state.get("supported"):
 		response["ops_summary"] = _build_ops_summary()

--- a/hrms/fixtures/sales_dashboard_store_mapping.csv
+++ b/hrms/fixtures/sales_dashboard_store_mapping.csv
@@ -43,3 +43,5 @@ The Grid - Rockwell,The Grid - Rockwell - Bebang Enterprise Inc.,Bebang Enterpri
 The Terminal,The Terminal - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2319
 Up Town Mall BGC,Up Town Mall BGC - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2548
 Vista Mall Taguig,Vista Mall Taguig - Bebang Enterprise Inc.,Bebang Enterprise Inc.,2556
+TEST-STORE-BGC,TEST-STORE-BGC - BEI,Bebang Enterprise Inc.,2548
+TEST-STORE-MAKATI,TEST-STORE-MAKATI - BEI,Bebang Enterprise Inc.,2177

--- a/hrms/tests/test_sales_dashboard_api.py
+++ b/hrms/tests/test_sales_dashboard_api.py
@@ -254,3 +254,76 @@ def test_query_daily_rows_filters_scope_after_fetch():
 	assert rows == [{"location_id": 2217, "business_date": "2026-03-02", "store_name": "BF Homes"}]
 	assert captured["resource"] == module.SUPABASE_DAILY_VIEW
 	assert ("location_id", "in.(2217)") not in captured["params"]
+
+
+def test_summary_skips_comparisons_by_default():
+	_install_fake_frappe(["System Manager"])
+	module = _load_module(ROOT / "hrms" / "api" / "sales_dashboard.py", "sales_dashboard_summary_default_test")
+
+	module._parse_stores_param = lambda stores: stores
+	module._selected_scope = lambda stores: {
+		"selected_stores": [
+			{
+				"warehouse": "BF Homes - Bebang Enterprise Inc.",
+				"warehouse_name": "BF Homes",
+				"company": "Bebang Enterprise Inc.",
+				"location_id": 2217,
+			}
+		]
+	}
+	module._resolve_date_range = lambda start, end: (module.date(2026, 3, 2), module.date(2026, 3, 8))
+	module._query_daily_rows = lambda start, end, location_ids: [{"business_date": "2026-03-02"}]
+	module._aggregate_sales = lambda rows: {"gross_sales": 1000.0}
+	module._build_mode_state = lambda *args, **kwargs: {"view_mode": "canonical", "supported": True}
+	module._build_freshness = lambda location_ids: {}
+	module._build_data_quality_warnings = lambda end_day, freshness: []
+
+	captured = {"called": False}
+
+	def fake_build_comparisons(*args, **kwargs):
+		captured["called"] = True
+		return {"previous_period": {"available": True}}
+
+	module._build_comparisons = fake_build_comparisons
+
+	result = module.get_sales_dashboard_summary()
+
+	assert captured["called"] is False
+	assert result["comparisons"] == {
+		"previous_period": {"available": False},
+		"same_period_last_year": {"available": False},
+	}
+
+
+def test_summary_builds_comparisons_when_opted_in():
+	_install_fake_frappe(["System Manager"])
+	module = _load_module(ROOT / "hrms" / "api" / "sales_dashboard.py", "sales_dashboard_summary_optin_test")
+
+	module._parse_stores_param = lambda stores: stores
+	module._selected_scope = lambda stores: {
+		"selected_stores": [
+			{
+				"warehouse": "BF Homes - Bebang Enterprise Inc.",
+				"warehouse_name": "BF Homes",
+				"company": "Bebang Enterprise Inc.",
+				"location_id": 2217,
+			}
+		]
+	}
+	module._resolve_date_range = lambda start, end: (module.date(2026, 3, 2), module.date(2026, 3, 8))
+	module._query_daily_rows = lambda start, end, location_ids: [{"business_date": "2026-03-02"}]
+	module._aggregate_sales = lambda rows: {"gross_sales": 1000.0}
+	module._build_mode_state = lambda *args, **kwargs: {"view_mode": "canonical", "supported": True}
+	module._build_freshness = lambda location_ids: {}
+	module._build_data_quality_warnings = lambda end_day, freshness: []
+	module._build_comparisons = lambda *args, **kwargs: {
+		"previous_period": {"available": True, "gross_sales_delta": 100.0},
+		"same_period_last_year": {"available": False},
+	}
+
+	result = module.get_sales_dashboard_summary(include_comparisons="1")
+
+	assert result["comparisons"] == {
+		"previous_period": {"available": True, "gross_sales_delta": 100.0},
+		"same_period_last_year": {"available": False},
+	}


### PR DESCRIPTION
## Summary
- make sales dashboard summary comparisons opt-in so the default summary path does not scan extra historical periods
- preserve the comparisons payload shape by returning unavailable placeholders unless explicitly requested
- add regression tests for default skip and explicit opt-in behavior

## Verification
- $env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; pytest hrms/tests/test_sales_dashboard_api.py