### PR TITLE
fix: add missing enrichment proof fields

### DIFF
--- a/hrms/fixtures/custom_field.json
+++ b/hrms/fixtures/custom_field.json
@@ -125,12 +125,92 @@
     },
     {
         "doctype": "Custom Field",
+        "name": "Employee-custom_tin_proof_url",
+        "dt": "Employee",
+        "fieldname": "custom_tin_proof_url",
+        "fieldtype": "Attach",
+        "label": "TIN Proof",
+        "insert_after": "custom_government_id_photo",
+        "description": "Latest supporting document for TIN verification"
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Employee-custom_tin_verified",
+        "dt": "Employee",
+        "fieldname": "custom_tin_verified",
+        "fieldtype": "Check",
+        "label": "TIN Verified",
+        "insert_after": "custom_tin_proof_url",
+        "read_only": 1
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Employee-custom_sss_proof_url",
+        "dt": "Employee",
+        "fieldname": "custom_sss_proof_url",
+        "fieldtype": "Attach",
+        "label": "SSS Proof",
+        "insert_after": "custom_tin_verified",
+        "description": "Latest supporting document for SSS verification"
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Employee-custom_sss_verified",
+        "dt": "Employee",
+        "fieldname": "custom_sss_verified",
+        "fieldtype": "Check",
+        "label": "SSS Verified",
+        "insert_after": "custom_sss_proof_url",
+        "read_only": 1
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Employee-custom_philhealth_proof_url",
+        "dt": "Employee",
+        "fieldname": "custom_philhealth_proof_url",
+        "fieldtype": "Attach",
+        "label": "PhilHealth Proof",
+        "insert_after": "custom_sss_verified",
+        "description": "Latest supporting document for PhilHealth verification"
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Employee-custom_philhealth_verified",
+        "dt": "Employee",
+        "fieldname": "custom_philhealth_verified",
+        "fieldtype": "Check",
+        "label": "PhilHealth Verified",
+        "insert_after": "custom_philhealth_proof_url",
+        "read_only": 1
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Employee-custom_pagibig_proof_url",
+        "dt": "Employee",
+        "fieldname": "custom_pagibig_proof_url",
+        "fieldtype": "Attach",
+        "label": "Pag-IBIG Proof",
+        "insert_after": "custom_philhealth_verified",
+        "description": "Latest supporting document for Pag-IBIG verification"
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Employee-custom_pagibig_verified",
+        "dt": "Employee",
+        "fieldname": "custom_pagibig_verified",
+        "fieldtype": "Check",
+        "label": "Pag-IBIG Verified",
+        "insert_after": "custom_pagibig_proof_url",
+        "read_only": 1
+    },
+    {
+        "doctype": "Custom Field",
         "name": "Employee-custom_enrichment_section",
         "dt": "Employee",
         "fieldname": "custom_enrichment_section",
         "fieldtype": "Section Break",
         "label": "Data Enrichment Status",
-        "insert_after": "custom_government_id_photo",
+        "insert_after": "custom_pagibig_verified",
         "collapsible": 1
     },
     {


### PR DESCRIPTION
## Summary
- add missing Employee custom fields for enrichment proof files and HR verification flags
- align production HRMS schema with the portal profile and onboarding approval flows shipped in S048
- unblock live employee profile reads and government ID approval writes

## Context
- follow-up to https://github.com/Bebang-Enterprise-Inc/hrms/pull/237

## Verification
- `python -c "import json, pathlib; json.loads(pathlib.Path(''hrms/fixtures/custom_field.json'').read_text(encoding=''utf-8'')); print(''custom_field.json OK'')"`
