### PR TITLE
fix: harden enrichment review authorization

### DIFF
--- a/hrms/api/onboarding.py
+++ b/hrms/api/onboarding.py
@@ -49,6 +49,7 @@ def _as_dict(obj: Any) -> dict[str, Any]:
 
 HR_APPROVER_FALLBACK = "nad@bebang.ph,ana@bebang.ph"
 OFFICE_LIKE_BRANCHES = {"BRITTANY OFFICE", "CAPITAL HOUSE"}
+ADMIN_ROLE_SET = {"SYSTEM MANAGER", "ADMINISTRATOR"}
 SUPERVISOR_TITLE_KEYWORDS = (
     "SUPERVISOR",
     "MANAGER",
@@ -59,7 +60,25 @@ SUPERVISOR_TITLE_KEYWORDS = (
     "LEAD",
     "ARCHITECT",
 )
-OPERATIONS_SUPPORT_KEYWORDS = ("COMMISSARY", "WAREHOUSE", "LOGISTICS", "SUPPLY CHAIN")
+EXECUTIVE_TITLE_KEYWORDS = (
+    "CEO",
+    "PRESIDENT",
+    "OWNER",
+    "FOUNDER",
+    "CO-FOUNDER",
+    "EXECUTIVE",
+    "VICE PRESIDENT",
+    "AVP",
+    "GENERAL MANAGER",
+)
+COMMISSARY_KEYWORDS = ("COMMISSARY",)
+COMMISSARY_PRODUCTION_KEYWORDS = (
+    "PRODUCTION",
+    "COMMISSARY CREW",
+    "COMMISSARY SUPERVISOR",
+    "QC INSPECTOR",
+)
+OPERATIONS_SUPPORT_KEYWORDS = ("WAREHOUSE", "LOGISTICS", "SUPPLY CHAIN", "STOCKMAN", "DRIVER")
 IDENTITY_FIELDS = {
     "first_name",
     "middle_name",
@@ -71,6 +90,7 @@ IDENTITY_FIELDS = {
 GOVERNMENT_ID_FIELDS = {"tin_number", "sss_number", "philhealth_number", "pagibig_number"}
 BANK_FIELDS = {"bank_name", "bank_ac_no"}
 WORK_IDENTITY_FIELDS = {"company_email", "custom_work_phone"}
+EMPLOYMENT_STRUCTURE_FIELDS = {"reports_to", "employment_type", "date_of_joining"}
 PROOF_ATTACHMENTS = {
     "tin_proof_url": ("tin_number", "custom_tin_verified"),
     "sss_proof_url": ("sss_number", "custom_sss_verified"),
@@ -110,6 +130,9 @@ INPUT_TO_EMPLOYEE_FIELD_MAP = {
     "relation": "relation",
     "bank_name": "bank_name",
     "bank_ac_no": "bank_ac_no",
+    "reports_to": "reports_to",
+    "employment_type": "employment_type",
+    "date_of_joining": "date_of_joining",
     "tin_number": "tin_number",
     "sss_number": "sss_number",
     "philhealth_number": "philhealth_number",
@@ -155,6 +178,23 @@ def _normalize_requested_changes(changes: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
+def _parse_role_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [_norm_text(item).upper() for item in value if _norm_text(item)]
+    if isinstance(value, str):
+        parsed = _as_dict(value)
+        if parsed:
+            return _parse_role_list(parsed)
+        try:
+            loaded = json.loads(value)
+            if isinstance(loaded, list):
+                return [_norm_text(item).upper() for item in loaded if _norm_text(item)]
+        except Exception:
+            pass
+        return [_norm_text(part).upper() for part in value.split(",") if _norm_text(part)]
+    return []
+
+
 def _extract_requested_field_keys(changes: dict[str, Any]) -> list[str]:
     flat_changes = _flatten_requested_changes(changes)
     keys = []
@@ -171,16 +211,35 @@ def _extract_requested_field_keys(changes: dict[str, Any]) -> list[str]:
 def _classify_employee_policy(employee_row: dict[str, Any]) -> dict[str, Any]:
     branch = _norm_text(employee_row.get("branch")).upper()
     designation = _norm_text(employee_row.get("designation")).upper()
+    roles = _parse_role_list(employee_row.get("requester_roles") or employee_row.get("roles"))
+    is_admin_role = any(role in ADMIN_ROLE_SET for role in roles)
     is_area_supervisor = "AREA SUPERVISOR" in designation
     is_store_oic = "STORE OIC" in designation
-    is_office_like = branch in OFFICE_LIKE_BRANCHES
-    is_supervisor_grade = any(keyword in designation for keyword in SUPERVISOR_TITLE_KEYWORDS)
-    is_operations_support = any(keyword in branch for keyword in OPERATIONS_SUPPORT_KEYWORDS) or any(
+    is_executive_title = any(keyword in designation for keyword in EXECUTIVE_TITLE_KEYWORDS) or designation.startswith("VP ") or designation == "VP" or designation.startswith("AVP ") or designation == "AVP" or designation.startswith("GM ") or designation == "GM"
+    is_executive_or_admin = is_admin_role or is_executive_title
+    is_office_like = branch in OFFICE_LIKE_BRANCHES or is_executive_or_admin
+    is_supervisor_grade = is_executive_or_admin or is_area_supervisor or any(
+        keyword in designation for keyword in SUPERVISOR_TITLE_KEYWORDS
+    )
+    is_commissary = any(keyword in branch for keyword in COMMISSARY_KEYWORDS) or any(
+        keyword in designation for keyword in COMMISSARY_KEYWORDS
+    )
+    is_commissary_production = is_commissary and (
+        any(keyword in branch for keyword in COMMISSARY_PRODUCTION_KEYWORDS)
+        or any(keyword in designation for keyword in COMMISSARY_PRODUCTION_KEYWORDS)
+    )
+    is_operations_support = not is_commissary_production and (
+        any(keyword in branch for keyword in OPERATIONS_SUPPORT_KEYWORDS) or any(
         keyword in designation for keyword in OPERATIONS_SUPPORT_KEYWORDS
+        )
     )
 
     if is_area_supervisor:
         cohort = "area_supervisor"
+    elif is_executive_or_admin:
+        cohort = "executive_system_manager"
+    elif is_commissary_production:
+        cohort = "commissary_production"
     elif is_operations_support:
         cohort = "operations_support"
     elif is_store_oic:
@@ -194,13 +253,18 @@ def _classify_employee_policy(employee_row: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "cohort": cohort,
+        "roles": roles,
         "is_office_like": is_office_like,
         "is_supervisor_grade": is_supervisor_grade,
         "is_area_supervisor": is_area_supervisor,
+        "is_executive_or_admin": is_executive_or_admin,
+        "is_commissary_production": is_commissary_production,
+        "is_operations_support": is_operations_support,
         "uses_store_contact_policy": cohort in {"store_employee", "store_oic"},
+        "uses_commissary_contact_policy": cohort == "commissary_production",
         "has_office_email_fields": is_office_like or is_area_supervisor,
-        "has_supervisor_phone_fields": (is_office_like and is_supervisor_grade) or is_area_supervisor,
-        "has_uniform_size": cohort in {"store_employee", "store_oic"},
+        "has_supervisor_phone_fields": cohort in {"office_supervisor_manager", "area_supervisor", "executive_system_manager"},
+        "has_uniform_size": cohort in {"store_employee", "store_oic", "commissary_production"},
     }
 
 
@@ -212,6 +276,8 @@ def _determine_review_lane(requested_field_keys: list[str]) -> str:
         return "government_ids"
     if keys & BANK_FIELDS:
         return "payroll_bank"
+    if keys & EMPLOYMENT_STRUCTURE_FIELDS:
+        return "employment_org"
     if keys & WORK_IDENTITY_FIELDS:
         return "work_identity"
     return "non_sensitive_follow_up"
@@ -221,6 +287,8 @@ def _determine_risk_level(requested_field_keys: list[str]) -> str:
     keys = set(requested_field_keys)
     if keys & (IDENTITY_FIELDS | GOVERNMENT_ID_FIELDS | BANK_FIELDS):
         return "high"
+    if keys & EMPLOYMENT_STRUCTURE_FIELDS:
+        return "medium"
     if keys & WORK_IDENTITY_FIELDS:
         return "medium"
     return "low"
@@ -228,7 +296,100 @@ def _determine_risk_level(requested_field_keys: list[str]) -> str:
 
 def _requires_hr_review(requested_field_keys: list[str]) -> bool:
     keys = set(requested_field_keys)
-    return bool(keys & (IDENTITY_FIELDS | GOVERNMENT_ID_FIELDS | BANK_FIELDS | WORK_IDENTITY_FIELDS))
+    return bool(keys & (IDENTITY_FIELDS | GOVERNMENT_ID_FIELDS | BANK_FIELDS | WORK_IDENTITY_FIELDS | EMPLOYMENT_STRUCTURE_FIELDS))
+
+
+def _parse_email_list(value: Any) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, str):
+        return [_norm_text(part) for part in value.replace("\n", ",").split(",") if _norm_text(part)]
+    if isinstance(value, list):
+        return [_norm_text(part) for part in value if _norm_text(part)]
+    return []
+
+
+def _get_user_roles_upper(user_email: str) -> set[str]:
+    normalized = _norm_text(user_email)
+    if not normalized:
+        return set()
+    try:
+        return {
+            _norm_text(role).upper()
+            for role in frappe.get_roles(normalized)
+            if _norm_text(role)
+        }
+    except Exception:
+        return set()
+
+
+def _is_admin_user(user_email: str) -> bool:
+    return bool(_get_user_roles_upper(user_email) & ADMIN_ROLE_SET)
+
+
+def _session_can_impersonate_review_actor(review_actor_email: str) -> bool:
+    session_user = _norm_text(frappe.session.user)
+    if not session_user or session_user == "Guest":
+        return False
+    if session_user == review_actor_email:
+        return True
+    return _is_admin_user(session_user)
+
+
+def _request_allows_reviewer(req: Any, reviewer_email: str) -> bool:
+    normalized_reviewer = _norm_text(reviewer_email)
+    if not normalized_reviewer:
+        return False
+
+    allowed_reviewers = _parse_email_list(getattr(req, "approver_email", ""))
+    return (
+        not allowed_reviewers
+        or normalized_reviewer in allowed_reviewers
+        or _is_admin_user(normalized_reviewer)
+    )
+
+
+def _authorize_request_reviewer(req: Any, reviewer_email: str) -> dict[str, Any] | None:
+    normalized_reviewer = _norm_text(reviewer_email)
+    if not normalized_reviewer:
+        return {
+            "success": False,
+            "error": "Reviewer is required",
+            "code": "MISSING_REVIEWER",
+        }
+
+    if not _session_can_impersonate_review_actor(normalized_reviewer):
+        return {
+            "success": False,
+            "error": "Reviewer identity does not match the active session",
+            "code": "REVIEWER_MISMATCH",
+        }
+
+    request_employee = _norm_text(getattr(req, "employee", None) or req.get("employee"))
+    request_employee_user = (
+        _norm_text(frappe.db.get_value("Employee", request_employee, "user_id"))
+        if request_employee
+        else ""
+    )
+    if (
+        request_employee_user
+        and request_employee_user == normalized_reviewer
+        and not _is_admin_user(normalized_reviewer)
+    ):
+        return {
+            "success": False,
+            "error": "Employees cannot review their own submission",
+            "code": "FORBIDDEN",
+        }
+
+    if not _request_allows_reviewer(req, normalized_reviewer):
+        return {
+            "success": False,
+            "error": "Not permitted to review this request",
+            "code": "FORBIDDEN",
+        }
+
+    return None
 
 
 def _determine_proof_status(changes: dict[str, Any]) -> str:
@@ -387,6 +548,7 @@ def lookup_employee(token: str, biometric_id: str | None = None, employee: str |
         "department",
         "designation",
         "reports_to",
+        "employment_type",
         "cell_number",
         "personal_email",
         "current_address",
@@ -431,6 +593,7 @@ def lookup_employee(token: str, biometric_id: str | None = None, employee: str |
             "department": row.get("department"),
             "designation": row.get("designation"),
             "reports_to": row.get("reports_to"),
+            "employment_type": row.get("employment_type"),
             "cell_number": row.get("cell_number"),
             "personal_email": row.get("personal_email"),
             "current_address": row.get("current_address"),
@@ -528,7 +691,10 @@ def _build_enrichment_submission_meta(
     requested_changes: dict[str, Any],
     submitted_via: str | None = None,
     submission_reason: str | None = None,
+    requester_roles: Any = None,
 ) -> dict[str, Any]:
+    if requester_roles:
+        employee_row = {**employee_row, "requester_roles": requester_roles}
     requested_field_keys = _extract_requested_field_keys(requested_changes)
     policy = _classify_employee_policy(employee_row)
     snapshot = _get_employee_snapshot(employee_row, requested_field_keys)
@@ -618,6 +784,7 @@ def submit_enrichment_update(
     submitted_via: str | None = None,
     approver_email: str | None = None,
     submission_reason: str | None = None,
+    requester_roles: str | None = None,
 ) -> dict[str, Any]:
     """Create one grouped enrichment submission for profile updates."""
     if not employee:
@@ -639,7 +806,13 @@ def submit_enrichment_update(
         ["name", "employee_name", "branch", "designation"],
         as_dict=True,
     ) or {}
-    meta = _build_enrichment_submission_meta(employee_row, changes, submitted_via, submission_reason)
+    meta = _build_enrichment_submission_meta(
+        employee_row,
+        changes,
+        submitted_via,
+        submission_reason,
+        requester_roles,
+    )
 
     superseded_requests: list[str] = []
     open_requests = frappe.get_all(
@@ -876,6 +1049,7 @@ def approve_and_apply(
     approver_notes: str | None = None,
     is_hr_approver: bool | int | None = None,
     approved_fields: str | None = None,
+    acting_reviewer_email: str | None = None,
 ) -> dict[str, Any]:
     """
     Approve (or reject) and optionally apply an onboarding request.
@@ -895,10 +1069,13 @@ def approve_and_apply(
         return {"success": False, "error": "Request not found", "code": "NOT_FOUND"}
 
     req = frappe.get_doc(REQUEST_DOCTYPE, request_name)
+    acting_email = _norm_text(acting_reviewer_email or approver_email)
+    auth_error = _authorize_request_reviewer(req, acting_email)
+    if auth_error:
+        return auth_error
 
     if req.status not in ("Pending", "Escalated"):
         return {"success": False, "error": "Request not pending", "code": "NOT_PENDING"}
-
     req.approver_email = approver_email or ""
     req.approver_notes = approver_notes or ""
     req.approved_at = now_datetime()
@@ -908,21 +1085,21 @@ def approve_and_apply(
     if not isinstance(workflow, dict):
         workflow = {}
     claim_owner = _norm_text(workflow.get("claimed_by"))
-    if claim_owner and claim_owner != _norm_text(approver_email):
+    if claim_owner and claim_owner != acting_email:
         return {
             "success": False,
             "error": f"Request is currently claimed by {claim_owner}",
             "code": "CLAIM_CONFLICT",
         }
     if not claim_owner:
-        workflow["claimed_by"] = approver_email
+        workflow["claimed_by"] = acting_email
         workflow["claimed_at"] = str(now_datetime())
     meta["workflow"] = workflow
     _set_request_meta(req, meta)
 
     if decision == "reject":
         req.status = "Rejected"
-        _set_workflow_state(req, "Rejected", decided_by=approver_email, decided_at=str(now_datetime()))
+        _set_workflow_state(req, "Rejected", decided_by=acting_email, decided_at=str(now_datetime()))
         req.save(ignore_permissions=True)
         frappe.db.commit()
         return {"success": True, "data": {"status": req.status, "review_state": "Rejected"}}
@@ -930,7 +1107,7 @@ def approve_and_apply(
     if decision == "escalate":
         req.status = "Escalated"
         req.escalated_to_hr = 1
-        _set_workflow_state(req, "Pending Review", escalated_by=approver_email, escalated_at=str(now_datetime()))
+        _set_workflow_state(req, "Pending Review", escalated_by=acting_email, escalated_at=str(now_datetime()))
         req.save(ignore_permissions=True)
         frappe.db.commit()
         return {"success": True, "data": {"status": req.status, "review_state": "Pending Review"}}
@@ -1022,7 +1199,7 @@ def approve_and_apply(
                 review_state,
                 approved_fields=sorted(approved_field_set),
                 remaining_fields=remaining_fields,
-                decided_by=approver_email,
+                decided_by=acting_email,
                 decided_at=str(now_datetime()),
             )
             req.save(ignore_permissions=True)
@@ -1038,7 +1215,7 @@ def approve_and_apply(
             req.applied_at = now_datetime()
             req.applied_by = frappe.session.user
             req.approver_notes = (req.approver_notes or '') + f"\nEmployee created: {result['employee_id']}"
-            _set_workflow_state(req, "Applied", decided_by=approver_email, decided_at=str(now_datetime()))
+            _set_workflow_state(req, "Applied", decided_by=acting_email, decided_at=str(now_datetime()))
             req.save(ignore_permissions=True)
             frappe.db.commit()
 
@@ -1085,6 +1262,9 @@ def request_revision(
         return {"success": False, "error": "Request not found", "code": "NOT_FOUND"}
 
     req = frappe.get_doc(REQUEST_DOCTYPE, request_name)
+    auth_error = _authorize_request_reviewer(req, reviewer_email)
+    if auth_error:
+        return auth_error
 
     if req.status not in ("Pending", "Escalated"):
         return {"success": False, "error": "Request not pending", "code": "NOT_PENDING"}
@@ -1149,6 +1329,9 @@ def claim_request(request_name: str, reviewer_email: str, release: bool = False)
         return {"success": False, "error": "Request not found", "code": "NOT_FOUND"}
 
     req = frappe.get_doc(REQUEST_DOCTYPE, request_name)
+    auth_error = _authorize_request_reviewer(req, reviewer_email)
+    if auth_error:
+        return auth_error
     if req.status not in OPEN_REVIEW_STATUSES and req.status != "Approved":
         return {"success": False, "error": "Request is not open for review", "code": "NOT_OPEN"}
 


### PR DESCRIPTION
## Summary
- harden onboarding review authorization for grouped enrichment requests
- prevent employees from claiming or reviewing their own submissions
- preserve admin reviewer access and existing grouped request workflow

## Verification
- python -m py_compile hrms/api/onboarding.py
