### PR TITLE
fix: simplify store order approval routing

### DIFF
--- a/hrms/api/ordering.py
+++ b/hrms/api/ordering.py
@@ -246,9 +246,8 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 		)
 
 	where_clause = " AND ".join(conditions)
-
-	orders = frappe.db.sql(
-		f"""
+	query = (
+		"""
 		SELECT
 			so.name,
 			so.store,
@@ -286,16 +285,18 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 		LEFT JOIN `tabWarehouse` wh ON wh.name = so.store
 		LEFT JOIN `tabWarehouse` wh_parent ON wh_parent.name = wh.parent_warehouse
 		LEFT JOIN `tabBEI Store Order Item` soi ON soi.parent = so.name
-		WHERE {where_clause}
+		WHERE """
+		+ where_clause
+		+ """
 		GROUP BY so.name
 		ORDER BY
 			CASE so.status WHEN 'Pending Approval' THEN 0 ELSE 1 END,
 			COALESCE(pending_queue.pending_since, so.creation) ASC,
 			so.store ASC
-		""",
-		params,
-		as_dict=True,
+		"""
 	)
+
+	orders = frappe.db.sql(query, params, as_dict=True)
 
 	return {
 		"orders": orders,

--- a/hrms/api/ordering.py
+++ b/hrms/api/ordering.py
@@ -223,16 +223,23 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 	filter_date = date or today()
 	current_user = frappe.session.user
 	current_roles = set(frappe.get_roles(current_user))
+	from hrms.api.store import _get_order_approval_fallback_user
 
 	conditions = ["so.order_date = %(date)s", "so.docstatus < 2"]
-	params = {"date": filter_date, "current_user": current_user}
+	fallback_approver = _get_order_approval_fallback_user()
+	params = {
+		"date": filter_date,
+		"current_user": current_user,
+		"fallback_user": fallback_approver or "",
+	}
 
 	if status:
 		conditions.append("so.status = %(status)s")
 		params["status"] = status
 
-	admin_viewer_roles = {"System Manager", "Administrator", "HR Manager", "Warehouse Manager"}
-	is_admin_viewer = bool(current_roles.intersection(admin_viewer_roles))
+	admin_viewer_roles = {"System Manager", "Administrator", "Warehouse Manager"}
+	is_fallback_viewer = bool(fallback_approver and current_user == fallback_approver)
+	is_admin_viewer = bool(current_roles.intersection(admin_viewer_roles)) or is_fallback_viewer
 	if not is_admin_viewer:
 		conditions.append(
 			"(so.status != 'Pending Approval' OR pending_queue.assigned_approver = %(current_user)s)"
@@ -256,10 +263,9 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 			pending_queue.assigned_approver AS current_approver,
 			pending_queue.pending_since AS pending_since,
 			CASE
-				WHEN so.is_emergency = 1
-					AND pending_queue.assigned_approver IS NOT NULL
-					AND pending_queue.assigned_approver != COALESCE(wh.custom_area_supervisor, wh_parent.custom_area_supervisor)
-					THEN 'Regional Manager Review'
+				WHEN %(fallback_user)s != ''
+					AND pending_queue.assigned_approver = %(fallback_user)s
+					THEN 'Fallback Approval Review'
 				ELSE 'Area Supervisor Review'
 			END AS approval_stage,
 			COUNT(soi.name) as items_count,

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -193,8 +193,7 @@ STORE_OPS_ALLOWED_ROLES = [
 	"Administrator",
 ]
 AREA_SUPERVISOR_ROLE = "Area Supervisor"
-REGIONAL_MANAGER_ROLE = "Regional Manager"
-REGIONAL_MANAGER_FALLBACK_EMAIL = "edlice@bebang.ph"
+ORDER_APPROVAL_FALLBACK_EMAIL = "edlice@bebang.ph"
 SYSTEM_APPROVER_ROLES = {"System Manager", "Administrator"}
 
 
@@ -469,13 +468,13 @@ def _doctype_has_field(doctype, fieldname):
 		return False
 
 
-def _get_regional_manager_fallback_user():
-	user = str(REGIONAL_MANAGER_FALLBACK_EMAIL or "").strip()
+def _get_order_approval_fallback_user():
+	user = str(ORDER_APPROVAL_FALLBACK_EMAIL or "").strip()
 	if not user:
 		return None
 	if not _is_enabled_user(user):
 		frappe.log_error(
-			f"Regional manager fallback user {user} is missing or disabled.",
+			f"Order approval fallback user {user} is missing or disabled.",
 			"Store Order Approver Fallback",
 		)
 		return None
@@ -483,9 +482,9 @@ def _get_regional_manager_fallback_user():
 		roles = set(frappe.get_roles(user))
 	except Exception:
 		roles = set()
-	if not roles.intersection({AREA_SUPERVISOR_ROLE, REGIONAL_MANAGER_ROLE, "System Manager"}):
+	if not roles.intersection({AREA_SUPERVISOR_ROLE, "Regional Manager"}.union(SYSTEM_APPROVER_ROLES)):
 		frappe.log_error(
-			f"Regional manager fallback user {user} has no approval role.",
+			f"Order approval fallback user {user} has no approval role.",
 			"Store Order Approver Fallback",
 		)
 		return None
@@ -497,9 +496,9 @@ def _resolve_review_approver_for_store(warehouse):
 	if area_supervisor:
 		return area_supervisor, "area_supervisor"
 
-	regional_manager = _get_regional_manager_fallback_user()
-	if regional_manager:
-		return regional_manager, "regional_manager_fallback"
+	fallback_approver = _get_order_approval_fallback_user()
+	if fallback_approver:
+		return fallback_approver, "fallback_approver"
 
 	return None, "unmapped"
 
@@ -510,17 +509,6 @@ def _is_system_approver(user_id):
 	except Exception:
 		roles = set()
 	return bool(roles.intersection(SYSTEM_APPROVER_ROLES))
-
-
-def _is_regional_manager_user(user_id):
-	user = str(user_id or "").strip()
-	if not user:
-		return False
-	try:
-		roles = set(frappe.get_roles(user))
-	except Exception:
-		roles = set()
-	return bool(roles.intersection({REGIONAL_MANAGER_ROLE, "System Manager", "HR Manager"}))
 
 
 def _create_order_notification_log(order_name, for_user, subject):
@@ -677,99 +665,11 @@ def _has_approved_stage_entry(order_name, approver):
 	)
 
 
-def _get_regional_manager_for_store(warehouse, area_supervisor=None):
-	field_candidates = [
-		"custom_regional_manager",
-		"custom_regional_supervisor",
-		"custom_regional_approver",
-	]
-
-	warehouse_chain = [warehouse]
-	parent = frappe.db.get_value("Warehouse", warehouse, "parent_warehouse")
-	if parent:
-		warehouse_chain.append(parent)
-
-	for wh in warehouse_chain:
-		for fieldname in field_candidates:
-			if not _doctype_has_field("Warehouse", fieldname):
-				continue
-			candidate = frappe.db.get_value("Warehouse", wh, fieldname)
-			if candidate and _is_enabled_user(candidate) and _is_regional_manager_user(candidate):
-				return candidate, f"warehouse.{fieldname}"
-
-	if area_supervisor:
-		area_employee = frappe.db.get_value(
-			"Employee",
-			{"user_id": area_supervisor, "status": "Active"},
-			["name", "reports_to"],
-			as_dict=True,
-		)
-		reports_to = area_employee.get("reports_to") if area_employee else None
-		if reports_to:
-			manager_user = frappe.db.get_value("Employee", reports_to, "user_id")
-			if manager_user and _is_enabled_user(manager_user) and _is_regional_manager_user(manager_user):
-				return manager_user, "employee.reports_to"
-
-	regional_manager = _get_regional_manager_fallback_user()
-	if regional_manager:
-		return regional_manager, "regional_manager_fallback"
-
-	return None, "unmapped"
-
-
-def _get_regional_manager_fallback_excluding(exclude_user):
-	candidate = _get_regional_manager_fallback_user()
-	if candidate and candidate != exclude_user:
-		return candidate, "regional_manager_fallback"
-	return None, "unmapped"
-
-
 def _resolve_order_approval_routing(warehouse, is_emergency, submitted_after_cutoff):
-	area_approver = _get_area_supervisor_for_store(warehouse)
-	regional_approver, regional_source = _get_regional_manager_for_store(
-		warehouse, area_supervisor=area_approver
-	)
-
-	if area_approver and regional_approver and regional_approver == area_approver:
-		fallback_regional, fallback_source = _get_regional_manager_fallback_excluding(
-			exclude_user=area_approver
-		)
-		if fallback_regional:
-			regional_approver = fallback_regional
-			regional_source = fallback_source
-
-	requires_regional_after_area = bool(
-		cint(is_emergency)
-		and submitted_after_cutoff
-		and area_approver
-		and regional_approver
-		and regional_approver != area_approver
-	)
-
-	if area_approver:
-		return {
-			"first_approver": area_approver,
-			"first_source": "area_supervisor",
-			"requires_regional_after_area": requires_regional_after_area,
-			"regional_approver": regional_approver,
-			"regional_source": regional_source,
-		}
-
-	if regional_approver:
-		return {
-			"first_approver": regional_approver,
-			"first_source": "regional_manager_fallback",
-			"requires_regional_after_area": False,
-			"regional_approver": regional_approver,
-			"regional_source": regional_source,
-		}
-
+	first_approver, first_source = _resolve_review_approver_for_store(warehouse)
 	return {
-		"first_approver": None,
-		"first_source": "unmapped",
-		"requires_regional_after_area": False,
-		"regional_approver": None,
-		"regional_source": "unmapped",
+		"first_approver": first_approver,
+		"first_source": first_source,
 	}
 
 
@@ -1805,23 +1705,19 @@ def submit_order(
 	)
 	first_approver = routing["first_approver"]
 	first_source = routing["first_source"]
-	requires_regional_after_area = bool(routing["requires_regional_after_area"])
-	regional_approver = routing["regional_approver"]
-	regional_source = routing["regional_source"]
 
 	requires_manual_approval = bool(
 		is_bulk_order
 		or edited_lines_count > 0
-		or requires_regional_after_area
 		or (is_emergency_flag and submitted_after_cutoff)
 	)
 	if requires_manual_approval and not first_approver:
 		frappe.throw(
 			_(
 				"Order requires Area Supervisor approval but no valid Area Supervisor mapping was found for {0}, "
-				"and Regional Manager fallback {1} is unavailable. Please update Warehouse.custom_area_supervisor "
+				"and fallback approver {1} is unavailable. Please update Warehouse.custom_area_supervisor "
 				"or provision fallback approver access before submitting."
-			).format(warehouse, REGIONAL_MANAGER_FALLBACK_EMAIL)
+			).format(warehouse, ORDER_APPROVAL_FALLBACK_EMAIL)
 		)
 
 	order.insert(ignore_permissions=True)
@@ -1843,11 +1739,7 @@ def submit_order(
 				assigned = _assign_order_for_approval(
 					order_name=order.name,
 					assigned_to=first_approver,
-					description=(
-						f"Store order {order.name} requires your approval."
-						if not requires_regional_after_area
-						else f"Store order {order.name} requires your Stage 1 approval before regional sign-off."
-					),
+					description=f"Store order {order.name} requires your approval.",
 				)
 				queue_status = "created" if assigned else "failed"
 				if not assigned:
@@ -1864,17 +1756,10 @@ def submit_order(
 			warning = "Order created but approval routing failed. Please notify your approver manually."
 			queue_status = "failed"
 
-	if requires_regional_after_area and regional_approver:
+	if first_source == "fallback_approver" and first_approver:
 		_append_order_comment(
 			order.name,
-			_(
-				"Emergency order submitted after cutoff {0}. Approval chain: Area Supervisor -> Regional Manager ({1})."
-			).format(cutoff_time, regional_approver),
-		)
-	elif first_source == "regional_manager_fallback" and first_approver:
-		_append_order_comment(
-			order.name,
-			_("Area Supervisor mapping missing; routed directly to Regional Manager ({0}).").format(
+			_("Area Supervisor mapping missing; routed directly to fallback approver ({0}).").format(
 				first_approver
 			),
 		)
@@ -1886,15 +1771,21 @@ def submit_order(
 		"requires_area_supervisor_review": bool(
 			requires_manual_approval and first_source == "area_supervisor"
 		),
-		"requires_regional_manager_review": bool(requires_regional_after_area),
+		"requires_regional_manager_review": False,
+		"requires_fallback_approval": bool(
+			requires_manual_approval and first_source == "fallback_approver"
+		),
 		"edited_lines_count": edited_lines_count,
 		"message": f"Order {order.name} submitted successfully",
 		"approval_queue_status": queue_status,
 		"approval_queue_name": queue_name,
 		"approval_approver_source": first_source if requires_manual_approval else "not_required",
 		"approval_assigned_approver": first_approver if requires_manual_approval else None,
-		"regional_approver": regional_approver,
-		"regional_approver_source": regional_source,
+		"fallback_approver": (
+			first_approver
+			if requires_manual_approval and first_source == "fallback_approver"
+			else None
+		),
 		"submitted_after_cutoff": bool(submitted_after_cutoff),
 		"is_emergency": bool(is_emergency_flag),
 		"cargo_category": normalized_cargo_category,
@@ -1960,9 +1851,9 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 @frappe.whitelist()
 def approve_order(order_name: str, approved_quantities: list | str | None = None) -> dict:
 	"""
-	Approve a store order with staged routing support.
-	- Regular/manual orders: single-step approval
-	- Emergency orders submitted after cutoff: Area Supervisor -> Regional Manager
+	Approve a store order.
+	Area Supervisors own the approval queue. The designated fallback approver may
+	intervene directly when an assigned approval is stuck.
 	"""
 	user = frappe.session.user
 	order = frappe.get_doc("BEI Store Order", order_name)
@@ -1975,20 +1866,23 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 	assigned_approver = active_entry.get("assigned_approver") if active_entry else None
 
 	is_system_user = _is_system_approver(user)
+	fallback_approver = _get_order_approval_fallback_user()
+	is_fallback_override = bool(
+		fallback_approver and user == fallback_approver and assigned_approver and assigned_approver != user
+	)
 	if assigned_approver:
-		if assigned_approver != user and not is_system_user:
+		if assigned_approver != user and not is_system_user and not is_fallback_override:
 			frappe.throw(
 				_("Order {0} is currently assigned to {1}.").format(order_name, assigned_approver),
 				frappe.PermissionError,
 			)
 	else:
 		user_roles = set(frappe.get_roles(user))
-		allowed_roles = {AREA_SUPERVISOR_ROLE, REGIONAL_MANAGER_ROLE}.union(SYSTEM_APPROVER_ROLES)
-		if not user_roles.intersection(allowed_roles):
+		allowed_roles = {AREA_SUPERVISOR_ROLE}.union(SYSTEM_APPROVER_ROLES)
+		is_fallback_user = bool(fallback_approver and user == fallback_approver)
+		if not user_roles.intersection(allowed_roles) and not is_fallback_user:
 			frappe.throw(
-				_(
-					"Only assigned approvers, Area Supervisors, Regional Managers, or System Managers can approve."
-				),
+				_("Only assigned approvers, Area Supervisors, fallback approvers, or System Managers can approve."),
 				frappe.PermissionError,
 			)
 
@@ -2013,41 +1907,14 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 		elif not flt(getattr(item, "qty_approved", 0)):
 			item.qty_approved = item.qty_requested
 
-	cutoff_hour, _cutoff_time = _get_order_cutoff()
-	order_created_dt = get_datetime(order.creation) if getattr(order, "creation", None) else now_datetime()
-	submitted_after_cutoff = order_created_dt.hour >= cutoff_hour
-	routing = _resolve_order_approval_routing(
-		warehouse=order.store,
-		is_emergency=order.is_emergency,
-		submitted_after_cutoff=submitted_after_cutoff,
-	)
 	area_approver = _get_area_supervisor_for_store(order.store)
-	regional_approver = routing.get("regional_approver")
-	requires_dual_stage = bool(routing.get("requires_regional_after_area"))
-
-	current_stage = "single_step"
-	if assigned_approver and assigned_approver == area_approver:
+	current_stage = "approved"
+	if fallback_approver and user == fallback_approver and user != area_approver:
+		current_stage = "fallback_approver"
+	elif assigned_approver and assigned_approver == area_approver:
 		current_stage = "area_supervisor"
-	elif assigned_approver and assigned_approver == regional_approver:
-		current_stage = "regional_manager"
-	elif requires_dual_stage:
-		if user == area_approver:
-			current_stage = "area_supervisor"
-		elif user == regional_approver:
-			current_stage = "regional_manager"
-
-	if requires_dual_stage and current_stage == "regional_manager":
-		if not _has_approved_stage_entry(order_name, area_approver):
-			frappe.throw(
-				_("Area Supervisor approval is required before Regional Manager final approval."),
-				frappe.PermissionError,
-			)
-
-	if requires_dual_stage and current_stage == "single_step" and not is_system_user:
-		frappe.throw(
-			_("Dual-stage approval is configured, but current approval stage could not be resolved."),
-			frappe.PermissionError,
-		)
+	elif is_system_user:
+		current_stage = "system_override"
 
 	if active_entry:
 		queue_doc = frappe.get_doc("BEI Approval Queue", active_entry["name"])
@@ -2057,74 +1924,13 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 		queue_doc.save(ignore_permissions=True)
 		_close_order_assignments(order_name, allocated_to=assigned_approver)
 
-	is_area_stage_approval = current_stage == "area_supervisor"
-	should_forward_to_regional = bool(
-		requires_dual_stage and is_area_stage_approval and regional_approver and regional_approver != user
-	)
-
-	if should_forward_to_regional:
-		order.status = "Pending Approval"
-		order.save(ignore_permissions=True)
-
-		queue_entry = None
-		try:
-			queue_entry = _create_approval_queue_entry(
-				order=order,
-				approver=regional_approver,
-				priority="Urgent",
-			)
-		except Exception:
-			frappe.log_error(
-				f"Failed to create regional approval queue for order {order_name}",
-				"Store Order Regional Queue Error",
-			)
-		assigned_ok = False
-		if queue_entry:
-			assigned_ok = _assign_order_for_approval(
-				order_name=order_name,
-				assigned_to=regional_approver,
-				description=(
-					f"Store order {order_name} completed Area Supervisor approval. "
-					"Regional Manager final approval required."
-				),
-			)
-			_append_order_comment(
-				order_name,
-				_(
-					"Area Supervisor approval completed by {0}. Routed to Regional Manager ({1}) for final sign-off."
-				).format(user, regional_approver),
-			)
-
-		_notify_store_ops(
-			event={
-				"family": "store_order_approved",
-				"source_system": "frappe",
-				"source_ref": order_name,
-				"severity": "high",
-				"owner": regional_approver or "Regional Manager",
-				"facts": {
-					"order_name": order_name,
-					"stage": "area_supervisor_forwarded",
-					"store": order.store,
-					"approved_by": user,
-					"regional_approver": regional_approver,
-					"dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
-				},
-			},
-			requested_space=get_chat_space(SPACE_OPS),
+	if is_fallback_override:
+		_append_order_comment(
+			order_name,
+			_("Fallback approval applied by {0}; original assigned approver was {1}.").format(
+				user, assigned_approver
+			),
 		)
-		return {
-			"success": True,
-			"status": order.status,
-			"stage": "area_supervisor",
-			"message": f"Area Supervisor approval captured. Routed to Regional Manager ({regional_approver}).",
-			"requires_regional_manager_review": True,
-			"approval_approver_source": "regional_manager",
-			"approval_assigned_approver": regional_approver,
-			"approval_queue_status": "created" if queue_entry and assigned_ok else "failed",
-			"material_request": None,
-			"dr_number": "",
-		}
 
 	order.status = "Approved"
 	order.approved_by = user
@@ -2161,22 +1967,24 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 				"stage": "approved",
 				"store": order.store,
 				"approved_by": user,
+				"approval_mode": "fallback_override" if is_fallback_override else "standard",
+				"assigned_approver": assigned_approver,
 				"material_request": mr_name,
 				"dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
 			},
 		},
 		requested_space=store_space or get_chat_space(SPACE_OPS),
 	)
-	final_stage = "regional_manager" if requires_dual_stage else current_stage
-
 	return {
 		"success": True,
 		"message": f"Order {order_name} approved",
 		"status": order.status,
-		"stage": final_stage,
+		"stage": current_stage,
 		"approval_queue_status": "completed",
 		"requires_regional_manager_review": False,
-		"approval_approver_source": final_stage,
+		"approval_approver_source": current_stage,
+		"approval_assigned_approver": None,
+		"fallback_override": bool(is_fallback_override),
 		"material_request": mr_name,
 		"dr_number": mr_name or "",
 	}

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -1707,9 +1707,7 @@ def submit_order(
 	first_source = routing["first_source"]
 
 	requires_manual_approval = bool(
-		is_bulk_order
-		or edited_lines_count > 0
-		or (is_emergency_flag and submitted_after_cutoff)
+		is_bulk_order or edited_lines_count > 0 or (is_emergency_flag and submitted_after_cutoff)
 	)
 	if requires_manual_approval and not first_approver:
 		frappe.throw(
@@ -1772,9 +1770,7 @@ def submit_order(
 			requires_manual_approval and first_source == "area_supervisor"
 		),
 		"requires_regional_manager_review": False,
-		"requires_fallback_approval": bool(
-			requires_manual_approval and first_source == "fallback_approver"
-		),
+		"requires_fallback_approval": bool(requires_manual_approval and first_source == "fallback_approver"),
 		"edited_lines_count": edited_lines_count,
 		"message": f"Order {order.name} submitted successfully",
 		"approval_queue_status": queue_status,
@@ -1782,9 +1778,7 @@ def submit_order(
 		"approval_approver_source": first_source if requires_manual_approval else "not_required",
 		"approval_assigned_approver": first_approver if requires_manual_approval else None,
 		"fallback_approver": (
-			first_approver
-			if requires_manual_approval and first_source == "fallback_approver"
-			else None
+			first_approver if requires_manual_approval and first_source == "fallback_approver" else None
 		),
 		"submitted_after_cutoff": bool(submitted_after_cutoff),
 		"is_emergency": bool(is_emergency_flag),
@@ -1882,7 +1876,9 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 		is_fallback_user = bool(fallback_approver and user == fallback_approver)
 		if not user_roles.intersection(allowed_roles) and not is_fallback_user:
 			frappe.throw(
-				_("Only assigned approvers, Area Supervisors, fallback approvers, or System Managers can approve."),
+				_(
+					"Only assigned approvers, Area Supervisors, fallback approvers, or System Managers can approve."
+				),
 				frappe.PermissionError,
 			)
 

--- a/hrms/tests/test_s19_area_supervisor_mapping.py
+++ b/hrms/tests/test_s19_area_supervisor_mapping.py
@@ -61,7 +61,7 @@ def _install_stubs():
 	role_map = {
 		"store.supervisor@bebang.ph": ["Store Supervisor"],
 		"area.supervisor@bebang.ph": ["Area Supervisor"],
-		"edlice@bebang.ph": ["Regional Manager"],
+		"edlice@bebang.ph": ["Area Supervisor"],
 		"test.area@bebang.ph": ["Area Supervisor"],
 	}
 	role_rows = [
@@ -105,6 +105,7 @@ def _install_stubs():
 	frappe.parse_json = lambda payload: payload
 	frappe.get_meta = lambda _doctype: types.SimpleNamespace(has_field=lambda _field: False)
 	frappe.get_roles = lambda user=None: role_map.get(user or "test.supervisor@bebang.ph", [])
+
 	def _get_all(doctype, **kwargs):
 		if doctype == "Employee":
 			return employees
@@ -148,6 +149,7 @@ def _install_stubs():
 	utils.now_datetime = lambda: "2026-03-02 10:00:00"
 	utils.flt = lambda value, precision=None: float(value or 0)
 	utils.cint = lambda value: int(float(value or 0))
+	utils.get_datetime = lambda value=None: value or "2026-03-02 10:00:00"
 	utils.getdate = lambda value=None: value or "2026-03-02"
 
 	sys.modules["frappe"] = frappe
@@ -162,6 +164,8 @@ def _install_stubs():
 	sys.modules["hrms.utils"] = utils_pkg
 
 	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.SPACE_OPS = "OPS"
+	bei_config.get_chat_space = lambda _space=None: "spaces/AAAAvDZdY-o"
 	bei_config.get_company = lambda: "Bebang Enterprise Inc."
 	sys.modules["hrms.utils.bei_config"] = bei_config
 
@@ -169,6 +173,21 @@ def _install_stubs():
 	scm_roles.SCM_APPROVAL_ROLES = []
 	scm_roles.check_scm_permission = lambda *args, **kwargs: None
 	sys.modules["hrms.utils.scm_roles"] = scm_roles
+
+	supply_chain_contracts = types.ModuleType("hrms.utils.supply_chain_contracts")
+	supply_chain_contracts.FINANCE_TREATMENT_INTERCOMPANY = "intercompany"
+	supply_chain_contracts.FINANCE_TREATMENT_SAME_COMPANY = "same_company"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_DISPOSAL = "store_disposal"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_ORDER = "store_order"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_RETURN = "store_return"
+	supply_chain_contracts.infer_finance_treatment = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_material_request_contract = lambda *args, **kwargs: {}
+	supply_chain_contracts.resolve_route_source_warehouse = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_store_buyer_entity = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_warehouse_company = lambda *args, **kwargs: "Bebang Enterprise Inc."
+	supply_chain_contracts.stamp_material_request_contract = lambda *args, **kwargs: None
+	supply_chain_contracts.stamp_stock_entry_contract = lambda *args, **kwargs: None
+	sys.modules["hrms.utils.supply_chain_contracts"] = supply_chain_contracts
 
 	return db, warehouse_rows
 
@@ -198,7 +217,6 @@ def test_invalid_store_supervisor_mapping_is_replaced_by_area_supervisor():
 def test_unmapped_store_returns_none_when_no_area_supervisor_can_be_inferred():
 	store_mod, _db, _rows = _load_store_module()
 
-	# Remove branch-linked area supervisor signals so inference cannot resolve.
 	store_mod.frappe.get_all = (
 		lambda doctype, **kwargs: [] if doctype in {"Employee", "Has Role", "User"} else []
 	)
@@ -207,10 +225,9 @@ def test_unmapped_store_returns_none_when_no_area_supervisor_can_be_inferred():
 	assert approver is None
 
 
-def test_unmapped_store_uses_regional_manager_fallback_when_area_supervisor_missing():
+def test_unmapped_store_uses_fallback_approver_when_area_supervisor_missing():
 	store_mod, _db, _rows = _load_store_module()
 
-	# Remove branch-linked employee and role signals; fallback should route to Regional Manager approver.
 	store_mod.frappe.get_all = (
 		lambda doctype, **kwargs: []
 		if doctype == "Employee"
@@ -228,10 +245,10 @@ def test_unmapped_store_uses_regional_manager_fallback_when_area_supervisor_miss
 		lambda user=None: {
 			"test.supervisor@bebang.ph": ["Store Supervisor"],
 			"test.area@bebang.ph": ["Area Supervisor"],
-			"edlice@bebang.ph": ["Regional Manager"],
+			"edlice@bebang.ph": ["Area Supervisor"],
 		}.get(user or "test.supervisor@bebang.ph", [])
 	)
 
 	approver, source = store_mod._resolve_review_approver_for_store("UNMAPPED - BEI")
 	assert approver == "edlice@bebang.ph"
-	assert source == "regional_manager_fallback"
+	assert source == "fallback_approver"

--- a/hrms/tests/test_s19_area_supervisor_mapping.py
+++ b/hrms/tests/test_s19_area_supervisor_mapping.py
@@ -217,8 +217,8 @@ def test_invalid_store_supervisor_mapping_is_replaced_by_area_supervisor():
 def test_unmapped_store_returns_none_when_no_area_supervisor_can_be_inferred():
 	store_mod, _db, _rows = _load_store_module()
 
-	store_mod.frappe.get_all = (
-		lambda doctype, **kwargs: [] if doctype in {"Employee", "Has Role", "User"} else []
+	store_mod.frappe.get_all = lambda doctype, **kwargs: (
+		[] if doctype in {"Employee", "Has Role", "User"} else []
 	)
 
 	approver = store_mod._get_area_supervisor_for_store("UNMAPPED - BEI")
@@ -228,8 +228,8 @@ def test_unmapped_store_returns_none_when_no_area_supervisor_can_be_inferred():
 def test_unmapped_store_uses_fallback_approver_when_area_supervisor_missing():
 	store_mod, _db, _rows = _load_store_module()
 
-	store_mod.frappe.get_all = (
-		lambda doctype, **kwargs: []
+	store_mod.frappe.get_all = lambda doctype, **kwargs: (
+		[]
 		if doctype == "Employee"
 		else (
 			[
@@ -241,13 +241,11 @@ def test_unmapped_store_uses_fallback_approver_when_area_supervisor_missing():
 			else []
 		)
 	)
-	store_mod.frappe.get_roles = (
-		lambda user=None: {
-			"test.supervisor@bebang.ph": ["Store Supervisor"],
-			"test.area@bebang.ph": ["Area Supervisor"],
-			"edlice@bebang.ph": ["Area Supervisor"],
-		}.get(user or "test.supervisor@bebang.ph", [])
-	)
+	store_mod.frappe.get_roles = lambda user=None: {
+		"test.supervisor@bebang.ph": ["Store Supervisor"],
+		"test.area@bebang.ph": ["Area Supervisor"],
+		"edlice@bebang.ph": ["Area Supervisor"],
+	}.get(user or "test.supervisor@bebang.ph", [])
 
 	approver, source = store_mod._resolve_review_approver_for_store("UNMAPPED - BEI")
 	assert approver == "edlice@bebang.ph"

--- a/hrms/tests/test_store_approval_notifications_s38.py
+++ b/hrms/tests/test_store_approval_notifications_s38.py
@@ -103,6 +103,7 @@ def _install_stubs():
 	scm_roles.check_scm_permission = lambda *args, **kwargs: None
 
 	supply_chain_contracts = types.ModuleType("hrms.utils.supply_chain_contracts")
+	supply_chain_contracts.FINANCE_TREATMENT_INTERCOMPANY = "intercompany"
 	supply_chain_contracts.FINANCE_TREATMENT_SAME_COMPANY = "same_company"
 	supply_chain_contracts.REQUEST_SOURCE_STORE_DISPOSAL = "store_disposal"
 	supply_chain_contracts.REQUEST_SOURCE_STORE_ORDER = "store_order"
@@ -163,11 +164,18 @@ class _FakeQueueDoc:
 		self._save_count += 1
 
 
-def test_area_stage_emits_forwarded_store_order_approved_event():
+@pytest.mark.parametrize(
+	("acting_user", "expected_stage", "expected_mode"),
+	[
+		("test.area@bebang.ph", "area_supervisor", "standard"),
+		("edlice@bebang.ph", "fallback_approver", "fallback_override"),
+	],
+)
+def test_store_order_approval_emits_approved_signal(acting_user, expected_stage, expected_mode):
 	store_mod = _load_store_module()
 	fake_order = _FakeOrder()
 	fake_queue_doc = _FakeQueueDoc("BEI-APQ-AREA-0001")
-	store_mod.frappe.session.user = "test.area@bebang.ph"
+	store_mod.frappe.session.user = acting_user
 	notifications = []
 
 	def fake_get_doc(doctype, name):
@@ -186,18 +194,10 @@ def test_area_stage_emits_forwarded_store_order_approved_event():
 		),
 		patch.object(store_mod, "_is_system_approver", return_value=False),
 		patch.object(store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"),
-		patch.object(
-			store_mod,
-			"_get_regional_manager_for_store",
-			return_value=("test.hr@bebang.ph", "employee.reports_to"),
-		),
-		patch.object(
-			store_mod, "_create_approval_queue_entry", return_value=SimpleNamespace(name="BEI-APQ-REG-0001")
-		),
-		patch.object(store_mod, "_assign_order_for_approval", return_value=True),
-		patch.object(store_mod, "_append_order_comment"),
+		patch.object(store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"),
 		patch.object(store_mod, "_close_order_assignments"),
-		patch.object(store_mod, "_create_mr_for_store_order") as create_mr,
+		patch.object(store_mod, "_append_order_comment"),
+		patch.object(store_mod, "_create_mr_for_store_order", return_value="MAT-MR-0001") as create_mr,
 	):
 		store_mod._notify_store_ops = lambda *args, **kwargs: notifications.append(kwargs)
 		result = store_mod.approve_order(
@@ -206,62 +206,13 @@ def test_area_stage_emits_forwarded_store_order_approved_event():
 		)
 
 	assert result["success"] is True
-	assert result["stage"] == "area_supervisor"
-	assert notifications
-	event = notifications[0]["event"]
-	assert event["family"] == "store_order_approved"
-	assert event["facts"]["stage"] == "area_supervisor_forwarded"
-	assert event["facts"]["regional_approver"] == "test.hr@bebang.ph"
-	assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"
-	assert not create_mr.called
-
-
-def test_final_stage_emits_store_order_approved_material_request_signal():
-	store_mod = _load_store_module()
-	fake_order = _FakeOrder()
-	fake_queue_doc = _FakeQueueDoc("BEI-APQ-REG-0001")
-	store_mod.frappe.session.user = "test.hr@bebang.ph"
-	notifications = []
-
-	def fake_get_doc(doctype, name):
-		if doctype == "BEI Store Order":
-			return fake_order
-		if doctype == "BEI Approval Queue":
-			return fake_queue_doc
-		raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
-
-	with (
-		patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc),
-		patch.object(
-			store_mod,
-			"_get_pending_approval_entries",
-			return_value=[{"name": "BEI-APQ-REG-0001", "assigned_approver": "test.hr@bebang.ph"}],
-		),
-		patch.object(store_mod, "_is_system_approver", return_value=False),
-		patch.object(store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"),
-		patch.object(
-			store_mod,
-			"_get_regional_manager_for_store",
-			return_value=("test.hr@bebang.ph", "employee.reports_to"),
-		),
-		patch.object(store_mod, "_has_approved_stage_entry", return_value=True),
-		patch.object(store_mod, "_close_order_assignments"),
-		patch.object(store_mod, "_create_mr_for_store_order", return_value="MAT-REQ-0001") as create_mr,
-		patch.object(store_mod.frappe.db, "get_value", return_value=None),
-	):
-		store_mod._notify_store_ops = lambda *args, **kwargs: notifications.append(kwargs)
-		result = store_mod.approve_order(
-			order_name=fake_order.name,
-			approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 3}],
-		)
-
-	assert result["success"] is True
-	assert result["stage"] == "regional_manager"
-	assert result["material_request"] == "MAT-REQ-0001"
+	assert result["stage"] == expected_stage
+	assert result["material_request"] == "MAT-MR-0001"
 	assert create_mr.call_count == 1
 	assert notifications
 	event = notifications[0]["event"]
 	assert event["family"] == "store_order_approved"
 	assert event["facts"]["stage"] == "approved"
-	assert event["facts"]["material_request"] == "MAT-REQ-0001"
+	assert event["facts"]["approval_mode"] == expected_mode
+	assert event["facts"]["material_request"] == "MAT-MR-0001"
 	assert notifications[0]["requested_space"] == "spaces/AAAAvDZdY-o"

--- a/hrms/tests/test_store_order_approval_flow.py
+++ b/hrms/tests/test_store_order_approval_flow.py
@@ -171,8 +171,9 @@ class _FakeQueueDoc:
 
 def test_resolve_routing_prefers_area_supervisor():
 	store_mod = _load_store_module()
-	with patch.object(store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"), patch.object(
-		store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"
+	with (
+		patch.object(store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"),
+		patch.object(store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"),
 	):
 		routing = store_mod._resolve_order_approval_routing(
 			warehouse="TEST-STORE - BEI",
@@ -186,8 +187,9 @@ def test_resolve_routing_prefers_area_supervisor():
 
 def test_resolve_routing_falls_back_when_area_is_unmapped():
 	store_mod = _load_store_module()
-	with patch.object(store_mod, "_get_area_supervisor_for_store", return_value=None), patch.object(
-		store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"
+	with (
+		patch.object(store_mod, "_get_area_supervisor_for_store", return_value=None),
+		patch.object(store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"),
 	):
 		routing = store_mod._resolve_order_approval_routing(
 			warehouse="TEST-STORE - BEI",
@@ -212,28 +214,26 @@ def test_approve_order_area_supervisor_finalizes_order():
 			return fake_queue_doc
 		raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
 
-	with patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc), patch.object(
-		store_mod,
-		"_get_pending_approval_entries",
-		return_value=[
-			{
-				"name": "BEI-APQ-AREA-0001",
-				"assigned_approver": "test.area@bebang.ph",
-			}
-		],
-	), patch.object(store_mod, "_is_system_approver", return_value=False), patch.object(
-		store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"
-	), patch.object(
-		store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"
-	), patch.object(
-		store_mod, "_notify_store_ops"
-	), patch.object(
-		store_mod, "_close_order_assignments"
-	), patch.object(
-		store_mod, "_append_order_comment"
-	) as append_comment, patch.object(
-		store_mod, "_create_mr_for_store_order", return_value="MAT-MR-0001"
-	) as create_mr:
+	with (
+		patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc),
+		patch.object(
+			store_mod,
+			"_get_pending_approval_entries",
+			return_value=[
+				{
+					"name": "BEI-APQ-AREA-0001",
+					"assigned_approver": "test.area@bebang.ph",
+				}
+			],
+		),
+		patch.object(store_mod, "_is_system_approver", return_value=False),
+		patch.object(store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"),
+		patch.object(store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"),
+		patch.object(store_mod, "_notify_store_ops"),
+		patch.object(store_mod, "_close_order_assignments"),
+		patch.object(store_mod, "_append_order_comment") as append_comment,
+		patch.object(store_mod, "_create_mr_for_store_order", return_value="MAT-MR-0001") as create_mr,
+	):
 		result = store_mod.approve_order(
 			order_name=fake_order.name,
 			approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],
@@ -265,28 +265,26 @@ def test_approve_order_fallback_override_finalizes_order():
 			return fake_queue_doc
 		raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
 
-	with patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc), patch.object(
-		store_mod,
-		"_get_pending_approval_entries",
-		return_value=[
-			{
-				"name": "BEI-APQ-AREA-0001",
-				"assigned_approver": "test.area@bebang.ph",
-			}
-		],
-	), patch.object(store_mod, "_is_system_approver", return_value=False), patch.object(
-		store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"
-	), patch.object(
-		store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"
-	), patch.object(
-		store_mod, "_notify_store_ops"
-	), patch.object(
-		store_mod, "_close_order_assignments"
-	), patch.object(
-		store_mod, "_append_order_comment"
-	) as append_comment, patch.object(
-		store_mod, "_create_mr_for_store_order", return_value="MAT-MR-0001"
-	) as create_mr:
+	with (
+		patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc),
+		patch.object(
+			store_mod,
+			"_get_pending_approval_entries",
+			return_value=[
+				{
+					"name": "BEI-APQ-AREA-0001",
+					"assigned_approver": "test.area@bebang.ph",
+				}
+			],
+		),
+		patch.object(store_mod, "_is_system_approver", return_value=False),
+		patch.object(store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"),
+		patch.object(store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"),
+		patch.object(store_mod, "_notify_store_ops"),
+		patch.object(store_mod, "_close_order_assignments"),
+		patch.object(store_mod, "_append_order_comment") as append_comment,
+		patch.object(store_mod, "_create_mr_for_store_order", return_value="MAT-MR-0001") as create_mr,
+	):
 		result = store_mod.approve_order(
 			order_name=fake_order.name,
 			approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],

--- a/hrms/tests/test_store_order_approval_flow.py
+++ b/hrms/tests/test_store_order_approval_flow.py
@@ -1,257 +1,304 @@
+import importlib.util
+import pathlib
+import sys
+import types
+from datetime import date, datetime
 from types import SimpleNamespace
 from unittest.mock import patch
 
-import frappe
-from frappe.tests.utils import FrappeTestCase
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
 
-from hrms.api import store
+
+def _install_stubs():
+	frappe = types.ModuleType("frappe")
+
+	class _DB:
+		@staticmethod
+		def exists(*args, **kwargs):
+			return None
+
+		@staticmethod
+		def get_value(*args, **kwargs):
+			return None
+
+		@staticmethod
+		def get_single_value(*args, **kwargs):
+			return None
+
+	def _flt(value, precision=None):
+		num = float(value or 0)
+		return round(num, precision) if precision is not None else num
+
+	def _cint(value):
+		return int(value or 0)
+
+	def _getdate(value=None):
+		if value in (None, ""):
+			return date(2026, 3, 13)
+		if isinstance(value, date):
+			return value
+		return datetime.strptime(str(value), "%Y-%m-%d").date()
+
+	def _get_datetime(value=None):
+		if value in (None, ""):
+			return datetime(2026, 3, 13, 10, 0, 0)
+		if isinstance(value, datetime):
+			return value
+		return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
+	def _throw(msg, *args, **kwargs):
+		raise RuntimeError(msg)
+
+	def _whitelist(fn=None, **kwargs):
+		if fn is None:
+			return lambda inner: inner
+		return fn
+
+	frappe.local = types.SimpleNamespace(
+		db=_DB(),
+		session=types.SimpleNamespace(user="test.area@bebang.ph"),
+	)
+	frappe.__dict__["db"] = frappe.local.db
+	frappe.__dict__["session"] = frappe.local.session
+	frappe.PermissionError = RuntimeError
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.get_roles = lambda *args, **kwargs: ["Store Supervisor"]
+	frappe.get_all = lambda *args, **kwargs: []
+	frappe.get_meta = lambda _doctype: types.SimpleNamespace(has_field=lambda _field: False)
+	frappe.new_doc = lambda doctype: None
+	frappe.get_doc = lambda *args, **kwargs: None
+	frappe.parse_json = lambda payload: payload
+	frappe.throw = _throw
+	frappe.whitelist = _whitelist
+	frappe._ = lambda msg: msg
+	frappe.utils = types.SimpleNamespace(cint=_cint, now=lambda: "2026-03-13 10:00:00")
+
+	utils = types.ModuleType("frappe.utils")
+	utils.nowdate = lambda: "2026-03-13"
+	utils.add_days = lambda _d, _n: "2026-03-14"
+	utils.now_datetime = lambda: datetime(2026, 3, 13, 10, 0, 0)
+	utils.flt = _flt
+	utils.cint = _cint
+	utils.getdate = _getdate
+	utils.get_datetime = _get_datetime
+
+	sys.modules["frappe"] = frappe
+	sys.modules["frappe.utils"] = utils
+
+	hrms_pkg = types.ModuleType("hrms")
+	hrms_pkg.__path__ = []
+	utils_pkg = types.ModuleType("hrms.utils")
+	utils_pkg.__path__ = []
+	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.SPACE_OPS = "OPS"
+	bei_config.get_chat_space = lambda _space: "spaces/AAAAvDZdY-o"
+	bei_config.get_company = lambda: "Bebang Enterprise Inc."
+
+	scm_roles = types.ModuleType("hrms.utils.scm_roles")
+	scm_roles.SCM_APPROVAL_ROLES = []
+	scm_roles.check_scm_permission = lambda *args, **kwargs: None
+
+	supply_chain_contracts = types.ModuleType("hrms.utils.supply_chain_contracts")
+	supply_chain_contracts.FINANCE_TREATMENT_INTERCOMPANY = "intercompany"
+	supply_chain_contracts.FINANCE_TREATMENT_SAME_COMPANY = "same_company"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_DISPOSAL = "store_disposal"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_ORDER = "store_order"
+	supply_chain_contracts.REQUEST_SOURCE_STORE_RETURN = "store_return"
+	supply_chain_contracts.infer_finance_treatment = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_material_request_contract = lambda *args, **kwargs: {}
+	supply_chain_contracts.resolve_route_source_warehouse = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_store_buyer_entity = lambda *args, **kwargs: None
+	supply_chain_contracts.resolve_warehouse_company = lambda *args, **kwargs: "Bebang Enterprise Inc."
+	supply_chain_contracts.stamp_material_request_contract = lambda *args, **kwargs: None
+	supply_chain_contracts.stamp_stock_entry_contract = lambda *args, **kwargs: None
+
+	sys.modules["hrms"] = hrms_pkg
+	sys.modules["hrms.utils"] = utils_pkg
+	sys.modules["hrms.utils.bei_config"] = bei_config
+	sys.modules["hrms.utils.scm_roles"] = scm_roles
+	sys.modules["hrms.utils.supply_chain_contracts"] = supply_chain_contracts
+
+
+def _load_store_module():
+	_install_stubs()
+	file_path = ROOT / "hrms" / "api" / "store.py"
+	spec = importlib.util.spec_from_file_location("store_order_approval_under_test", file_path)
+	module = importlib.util.module_from_spec(spec)
+	assert spec and spec.loader
+	spec.loader.exec_module(module)
+	return module
 
 
 class _FakeOrder:
-    def __init__(
-        self,
-        name="BEI-ORD-TEST-0001",
-        status="Pending Approval",
-        is_emergency=1,
-        store_name="TEST-STORE - BEI",
-        creation="2026-03-03 12:30:00",
-    ):
-        self.name = name
-        self.status = status
-        self.is_emergency = is_emergency
-        self.store = store_name
-        self.creation = creation
-        self.approved_by = None
-        self.approved_at = None
-        self.items = [
-            SimpleNamespace(item_code="ITEM-001", qty_requested=3, qty_approved=0),
-            SimpleNamespace(item_code="ITEM-002", qty_requested=5, qty_approved=0),
-        ]
-        self._save_count = 0
+	def __init__(
+		self,
+		name="BEI-ORD-TEST-0001",
+		status="Pending Approval",
+		is_emergency=1,
+		store_name="TEST-STORE - BEI",
+		creation="2026-03-03 12:30:00",
+	):
+		self.name = name
+		self.status = status
+		self.is_emergency = is_emergency
+		self.store = store_name
+		self.creation = creation
+		self.approved_by = None
+		self.approved_at = None
+		self.items = [
+			SimpleNamespace(item_code="ITEM-001", qty_requested=3, qty_approved=0),
+			SimpleNamespace(item_code="ITEM-002", qty_requested=5, qty_approved=0),
+		]
+		self._save_count = 0
 
-    def save(self, ignore_permissions=True):
-        self._save_count += 1
+	def save(self, ignore_permissions=True):
+		self._save_count += 1
 
 
 class _FakeQueueDoc:
-    def __init__(self, name):
-        self.name = name
-        self.status = "Pending"
-        self.approved_by = None
-        self.approved_at = None
-        self._save_count = 0
+	def __init__(self, name):
+		self.name = name
+		self.status = "Pending"
+		self.approved_by = None
+		self.approved_at = None
+		self._save_count = 0
 
-    def save(self, ignore_permissions=True):
-        self._save_count += 1
+	def save(self, ignore_permissions=True):
+		self._save_count += 1
 
 
-class TestStoreOrderApprovalFlow(FrappeTestCase):
-    def test_resolve_routing_requires_regional_after_area_when_emergency_after_cutoff(self):
-        with patch("hrms.api.store._get_area_supervisor_for_store", return_value="test.area@bebang.ph"), patch(
-            "hrms.api.store._get_regional_manager_for_store",
-            return_value=("test.regional@bebang.ph", "unit-test"),
-        ):
-            routing = store._resolve_order_approval_routing(
-                warehouse="TEST-STORE - BEI",
-                is_emergency=1,
-                submitted_after_cutoff=True,
-            )
+def test_resolve_routing_prefers_area_supervisor():
+	store_mod = _load_store_module()
+	with patch.object(store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"), patch.object(
+		store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"
+	):
+		routing = store_mod._resolve_order_approval_routing(
+			warehouse="TEST-STORE - BEI",
+			is_emergency=1,
+			submitted_after_cutoff=True,
+		)
 
-        self.assertEqual(routing["first_source"], "area_supervisor")
-        self.assertEqual(routing["first_approver"], "test.area@bebang.ph")
-        self.assertTrue(routing["requires_regional_after_area"])
-        self.assertEqual(routing["regional_approver"], "test.regional@bebang.ph")
+	assert routing["first_source"] == "area_supervisor"
+	assert routing["first_approver"] == "test.area@bebang.ph"
 
-    def test_resolve_routing_falls_back_to_regional_when_area_unmapped(self):
-        with patch("hrms.api.store._get_area_supervisor_for_store", return_value=None), patch(
-            "hrms.api.store._get_regional_manager_for_store",
-            return_value=("edlice@bebang.ph", "default_regional_manager"),
-        ):
-            routing = store._resolve_order_approval_routing(
-                warehouse="TEST-STORE - BEI",
-                is_emergency=1,
-                submitted_after_cutoff=True,
-            )
 
-        self.assertEqual(routing["first_source"], "regional_manager_fallback")
-        self.assertEqual(routing["first_approver"], "edlice@bebang.ph")
-        self.assertFalse(routing["requires_regional_after_area"])
+def test_resolve_routing_falls_back_when_area_is_unmapped():
+	store_mod = _load_store_module()
+	with patch.object(store_mod, "_get_area_supervisor_for_store", return_value=None), patch.object(
+		store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"
+	):
+		routing = store_mod._resolve_order_approval_routing(
+			warehouse="TEST-STORE - BEI",
+			is_emergency=1,
+			submitted_after_cutoff=True,
+		)
 
-    def test_resolve_routing_replaces_same_regional_with_distinct_fallback(self):
-        with patch("hrms.api.store._get_area_supervisor_for_store", return_value="test.area@bebang.ph"), patch(
-            "hrms.api.store._get_regional_manager_for_store",
-            return_value=("test.area@bebang.ph", "employee.reports_to"),
-        ), patch(
-            "hrms.api.store._get_regional_manager_fallback_excluding",
-            return_value=("edlice@bebang.ph", "regional_manager_fallback"),
-        ):
-            routing = store._resolve_order_approval_routing(
-                warehouse="TEST-STORE - BEI",
-                is_emergency=1,
-                submitted_after_cutoff=True,
-            )
+	assert routing["first_source"] == "fallback_approver"
+	assert routing["first_approver"] == "edlice@bebang.ph"
 
-        self.assertEqual(routing["first_source"], "area_supervisor")
-        self.assertEqual(routing["first_approver"], "test.area@bebang.ph")
-        self.assertEqual(routing["regional_approver"], "edlice@bebang.ph")
-        self.assertEqual(routing["regional_source"], "regional_manager_fallback")
-        self.assertTrue(routing["requires_regional_after_area"])
 
-    def test_approve_order_area_stage_forwards_to_regional(self):
-        fake_order = _FakeOrder()
-        fake_queue_doc = _FakeQueueDoc("BEI-APQ-AREA-0001")
-        frappe.session.user = "test.area@bebang.ph"
+def test_approve_order_area_supervisor_finalizes_order():
+	store_mod = _load_store_module()
+	fake_order = _FakeOrder()
+	fake_queue_doc = _FakeQueueDoc("BEI-APQ-AREA-0001")
+	store_mod.frappe.session.user = "test.area@bebang.ph"
 
-        def fake_get_doc(doctype, name):
-            if doctype == "BEI Store Order":
-                return fake_order
-            if doctype == "BEI Approval Queue":
-                return fake_queue_doc
-            raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
+	def fake_get_doc(doctype, name):
+		if doctype == "BEI Store Order":
+			return fake_order
+		if doctype == "BEI Approval Queue":
+			return fake_queue_doc
+		raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
 
-        with patch("frappe.get_doc", side_effect=fake_get_doc), patch(
-            "hrms.api.store._get_pending_approval_entries",
-            return_value=[
-                {
-                    "name": "BEI-APQ-AREA-0001",
-                    "assigned_approver": "test.area@bebang.ph",
-                }
-            ],
-        ), patch("hrms.api.store._is_system_approver", return_value=False), patch(
-            "hrms.api.store._get_area_supervisor_for_store",
-            return_value="test.area@bebang.ph",
-        ), patch(
-            "hrms.api.store._get_regional_manager_for_store",
-            return_value=("test.hr@bebang.ph", "employee.reports_to"),
-        ), patch(
-            "hrms.api.store._create_approval_queue_entry",
-            return_value=SimpleNamespace(name="BEI-APQ-REG-0001"),
-        ) as create_queue, patch("hrms.api.store._assign_order_for_approval", return_value=True) as assign_for_review, patch(
-            "hrms.api.store._append_order_comment"
-        ), patch(
-            "hrms.api.store._notify_store_ops"
-        ), patch(
-            "hrms.api.store._close_order_assignments"
-        ), patch(
-            "hrms.api.store._create_mr_for_store_order"
-        ) as create_mr:
-            result = store.approve_order(
-                order_name=fake_order.name,
-                approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],
-            )
+	with patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc), patch.object(
+		store_mod,
+		"_get_pending_approval_entries",
+		return_value=[
+			{
+				"name": "BEI-APQ-AREA-0001",
+				"assigned_approver": "test.area@bebang.ph",
+			}
+		],
+	), patch.object(store_mod, "_is_system_approver", return_value=False), patch.object(
+		store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"
+	), patch.object(
+		store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"
+	), patch.object(
+		store_mod, "_notify_store_ops"
+	), patch.object(
+		store_mod, "_close_order_assignments"
+	), patch.object(
+		store_mod, "_append_order_comment"
+	) as append_comment, patch.object(
+		store_mod, "_create_mr_for_store_order", return_value="MAT-MR-0001"
+	) as create_mr:
+		result = store_mod.approve_order(
+			order_name=fake_order.name,
+			approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],
+		)
 
-        self.assertTrue(result["success"])
-        self.assertEqual(result["stage"], "area_supervisor")
-        self.assertTrue(result["requires_regional_manager_review"])
-        self.assertEqual(result["approval_queue_status"], "created")
-        self.assertEqual(result["approval_assigned_approver"], "test.hr@bebang.ph")
-        self.assertEqual(fake_order.status, "Pending Approval")
-        self.assertEqual(fake_queue_doc.status, "Approved")
-        self.assertEqual(fake_queue_doc.approved_by, "test.area@bebang.ph")
-        self.assertEqual(create_queue.call_count, 1)
-        self.assertEqual(assign_for_review.call_count, 1)
-        self.assertEqual(assign_for_review.call_args.kwargs["assigned_to"], "test.hr@bebang.ph")
-        self.assertFalse(create_mr.called)
+	assert result["success"] is True
+	assert result["stage"] == "area_supervisor"
+	assert result["status"] == "Approved"
+	assert result["material_request"] == "MAT-MR-0001"
+	assert result["fallback_override"] is False
+	assert fake_order.status == "Approved"
+	assert fake_order.approved_by == "test.area@bebang.ph"
+	assert fake_queue_doc.status == "Approved"
+	assert fake_queue_doc.approved_by == "test.area@bebang.ph"
+	assert create_mr.call_count == 1
+	assert append_comment.called is False
 
-    def test_approve_order_area_stage_reports_failed_when_regional_assignment_fails(self):
-        fake_order = _FakeOrder()
-        fake_queue_doc = _FakeQueueDoc("BEI-APQ-AREA-0001")
-        frappe.session.user = "test.area@bebang.ph"
 
-        def fake_get_doc(doctype, name):
-            if doctype == "BEI Store Order":
-                return fake_order
-            if doctype == "BEI Approval Queue":
-                return fake_queue_doc
-            raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
+def test_approve_order_fallback_override_finalizes_order():
+	store_mod = _load_store_module()
+	fake_order = _FakeOrder()
+	fake_queue_doc = _FakeQueueDoc("BEI-APQ-AREA-0001")
+	store_mod.frappe.session.user = "edlice@bebang.ph"
 
-        with patch("frappe.get_doc", side_effect=fake_get_doc), patch(
-            "hrms.api.store._get_pending_approval_entries",
-            return_value=[
-                {
-                    "name": "BEI-APQ-AREA-0001",
-                    "assigned_approver": "test.area@bebang.ph",
-                }
-            ],
-        ), patch("hrms.api.store._is_system_approver", return_value=False), patch(
-            "hrms.api.store._get_area_supervisor_for_store",
-            return_value="test.area@bebang.ph",
-        ), patch(
-            "hrms.api.store._get_regional_manager_for_store",
-            return_value=("test.hr@bebang.ph", "employee.reports_to"),
-        ), patch(
-            "hrms.api.store._create_approval_queue_entry",
-            return_value=SimpleNamespace(name="BEI-APQ-REG-0001"),
-        ), patch(
-            "hrms.api.store._assign_order_for_approval",
-            return_value=False,
-        ), patch(
-            "hrms.api.store._append_order_comment"
-        ), patch(
-            "hrms.api.store._notify_store_ops"
-        ), patch(
-            "hrms.api.store._close_order_assignments"
-        ), patch(
-            "hrms.api.store._create_mr_for_store_order"
-        ) as create_mr:
-            result = store.approve_order(
-                order_name=fake_order.name,
-                approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],
-            )
+	def fake_get_doc(doctype, name):
+		if doctype == "BEI Store Order":
+			return fake_order
+		if doctype == "BEI Approval Queue":
+			return fake_queue_doc
+		raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
 
-        self.assertTrue(result["success"])
-        self.assertEqual(result["stage"], "area_supervisor")
-        self.assertEqual(result["approval_queue_status"], "failed")
-        self.assertEqual(fake_order.status, "Pending Approval")
-        self.assertFalse(create_mr.called)
+	with patch.object(store_mod.frappe, "get_doc", side_effect=fake_get_doc), patch.object(
+		store_mod,
+		"_get_pending_approval_entries",
+		return_value=[
+			{
+				"name": "BEI-APQ-AREA-0001",
+				"assigned_approver": "test.area@bebang.ph",
+			}
+		],
+	), patch.object(store_mod, "_is_system_approver", return_value=False), patch.object(
+		store_mod, "_get_area_supervisor_for_store", return_value="test.area@bebang.ph"
+	), patch.object(
+		store_mod, "_get_order_approval_fallback_user", return_value="edlice@bebang.ph"
+	), patch.object(
+		store_mod, "_notify_store_ops"
+	), patch.object(
+		store_mod, "_close_order_assignments"
+	), patch.object(
+		store_mod, "_append_order_comment"
+	) as append_comment, patch.object(
+		store_mod, "_create_mr_for_store_order", return_value="MAT-MR-0001"
+	) as create_mr:
+		result = store_mod.approve_order(
+			order_name=fake_order.name,
+			approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 2}],
+		)
 
-    def test_approve_order_regional_stage_finalizes(self):
-        fake_order = _FakeOrder()
-        fake_queue_doc = _FakeQueueDoc("BEI-APQ-REG-0001")
-        frappe.session.user = "test.hr@bebang.ph"
-
-        def fake_get_doc(doctype, name):
-            if doctype == "BEI Store Order":
-                return fake_order
-            if doctype == "BEI Approval Queue":
-                return fake_queue_doc
-            raise AssertionError(f"Unexpected get_doc call: {doctype} / {name}")
-
-        with patch("frappe.get_doc", side_effect=fake_get_doc), patch(
-            "hrms.api.store._get_pending_approval_entries",
-            return_value=[
-                {
-                    "name": "BEI-APQ-REG-0001",
-                    "assigned_approver": "test.hr@bebang.ph",
-                }
-            ],
-        ), patch("hrms.api.store._is_system_approver", return_value=False), patch(
-            "hrms.api.store._get_area_supervisor_for_store",
-            return_value="test.area@bebang.ph",
-        ), patch(
-            "hrms.api.store._get_regional_manager_for_store",
-            return_value=("test.hr@bebang.ph", "employee.reports_to"),
-        ), patch(
-            "hrms.api.store._notify_store_ops"
-        ), patch(
-            "hrms.api.store._close_order_assignments"
-        ), patch(
-            "hrms.api.store._create_mr_for_store_order",
-            return_value="MAT-REQ-0001",
-        ) as create_mr, patch(
-            "hrms.api.store._create_approval_queue_entry"
-        ) as create_queue:
-            result = store.approve_order(
-                order_name=fake_order.name,
-                approved_quantities=[{"item_code": "ITEM-001", "qty_approved": 3}],
-            )
-
-        self.assertTrue(result["success"])
-        self.assertEqual(result["stage"], "regional_manager")
-        self.assertEqual(result["status"], "Approved")
-        self.assertEqual(result["material_request"], "MAT-REQ-0001")
-        self.assertEqual(fake_order.status, "Approved")
-        self.assertEqual(fake_order.approved_by, "test.hr@bebang.ph")
-        self.assertEqual(fake_queue_doc.status, "Approved")
-        self.assertEqual(create_mr.call_count, 1)
-        self.assertFalse(create_queue.called)
+	assert result["success"] is True
+	assert result["stage"] == "fallback_approver"
+	assert result["status"] == "Approved"
+	assert result["fallback_override"] is True
+	assert fake_order.status == "Approved"
+	assert fake_order.approved_by == "edlice@bebang.ph"
+	assert fake_queue_doc.status == "Approved"
+	assert fake_queue_doc.approved_by == "edlice@bebang.ph"
+	assert create_mr.call_count == 1
+	assert append_comment.call_count == 1

--- a/hrms/utils/scm_roles.py
+++ b/hrms/utils/scm_roles.py
@@ -42,17 +42,15 @@ SCM_PICKING_ROLES = {"Warehouse Manager", "Warehouse Staff", "Logistics Coordina
 ORDERING_STORE_ROLES = {"Store Staff", "Store Supervisor", "Store OIC", "System Manager"}
 ORDERING_WAREHOUSE_ROLES = {
 	"Area Supervisor",
-	"Regional Manager",
-	"HR Manager",
 	"Warehouse Manager",
 	"System Manager",
+	"Administrator",
 }
 ORDERING_APPROVAL_ROLES = {
 	"Area Supervisor",
-	"Regional Manager",
-	"HR Manager",
 	"Warehouse Manager",
 	"System Manager",
+	"Administrator",
 }
 
 # Billing (billing.py)


### PR DESCRIPTION
## Summary
- remove the second-stage regional/HR approval path for store orders
- keep area supervisors as the primary approvers and Edlice as the explicit fallback approver
- update focused approval tests to cover final approval and fallback override behavior

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms\\tests\\test_store_order_approval_flow.py hrms\\tests\\test_store_approval_notifications_s38.py hrms\\tests\\test_s19_area_supervisor_mapping.py