### PR TITLE
fix: include enrichment snapshot fields

### DIFF
--- a/hrms/api/onboarding.py
+++ b/hrms/api/onboarding.py
@@ -568,6 +568,27 @@ def _build_enrichment_submission_meta(
 	}
 
 
+def _get_enrichment_employee_row(employee: str, requested_field_keys: list[str]) -> dict[str, Any]:
+	base_fields = ["name", "employee_name", "branch", "department", "designation"]
+	snapshot_fields = [
+		employee_field
+		for employee_field in {
+			INPUT_TO_EMPLOYEE_FIELD_MAP.get(field_key, field_key) for field_key in requested_field_keys
+		}
+		if employee_field
+	]
+	employee_fields = list(dict.fromkeys([*base_fields, *snapshot_fields]))
+	return (
+		frappe.db.get_value(
+			"Employee",
+			employee,
+			employee_fields,
+			as_dict=True,
+		)
+		or {}
+	)
+
+
 def _get_requested_field_keys_from_request(doc_or_row: Any) -> list[str]:
 	meta = _get_request_meta(doc_or_row)
 	workflow = meta.get("workflow")
@@ -658,15 +679,7 @@ def submit_enrichment_update(
 	if not requested_field_keys and not (isinstance(attachments, dict) and attachments):
 		return {"success": False, "error": "No changes to submit", "code": "NO_CHANGES"}
 
-	employee_row = (
-		frappe.db.get_value(
-			"Employee",
-			employee,
-			["name", "employee_name", "branch", "department", "designation"],
-			as_dict=True,
-		)
-		or {}
-	)
+	employee_row = _get_enrichment_employee_row(employee, requested_field_keys)
 	meta = _build_enrichment_submission_meta(employee_row, changes, submitted_via, submission_reason)
 
 	superseded_requests: list[str] = []

--- a/hrms/tests/test_s048_contact_and_policy.py
+++ b/hrms/tests/test_s048_contact_and_policy.py
@@ -1,3 +1,7 @@
+import importlib
+import sys
+import types
+
 from hrms.api.contact_validation import (
 	normalize_ph_mobile_draft_value,
 	validate_email_address,
@@ -81,3 +85,54 @@ def test_reports_to_candidates_only_include_leadership_roles():
 		)
 		is False
 	)
+
+
+def test_enrichment_employee_row_fetches_requested_snapshot_fields(monkeypatch):
+	import frappe.utils
+
+	captured = {}
+	utils_data = types.ModuleType("frappe.utils.data")
+	utils_data.add_to_date = lambda *args, **kwargs: None
+
+	def fake_get_value(doctype, name, fields, as_dict=False):
+		captured["doctype"] = doctype
+		captured["name"] = name
+		captured["fields"] = list(fields)
+		captured["as_dict"] = as_dict
+		return {
+			"name": name,
+			"employee_name": "Test Crew",
+			"branch": "TEST-STORE-BGC",
+			"department": "Operations",
+			"designation": "Store Staff",
+			"custom_nickname": "Crew Nick",
+			"current_address": "123 Test Street",
+			"reports_to": "TEST-AREA-001",
+		}
+
+	monkeypatch.setattr(frappe.utils, "today", lambda: "2026-03-16", raising=False)
+	monkeypatch.setattr("frappe.db.get_value", fake_get_value)
+	monkeypatch.setitem(sys.modules, "frappe.utils.data", utils_data)
+	onboarding = importlib.import_module("hrms.api.onboarding")
+
+	row = onboarding._get_enrichment_employee_row(
+		"TEST-CREW-001",
+		["custom_nickname", "current_address", "reports_to"],
+	)
+
+	assert captured["doctype"] == "Employee"
+	assert captured["name"] == "TEST-CREW-001"
+	assert captured["as_dict"] is True
+	assert set(captured["fields"]) == {
+		"name",
+		"employee_name",
+		"branch",
+		"department",
+		"designation",
+		"custom_nickname",
+		"current_address",
+		"reports_to",
+	}
+	assert row["custom_nickname"] == "Crew Nick"
+	assert row["current_address"] == "123 Test Street"
+	assert row["reports_to"] == "TEST-AREA-001"


### PR DESCRIPTION
## Summary
- fetch requested employee fields before building enrichment request snapshots
- prevent false stale-request escalations during grouped profile approval
- add a regression test for the enrichment snapshot field fetch

## Testing
- python -m py_compile hrms/api/onboarding.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_s048_contact_and_policy.py
