### PR TITLE
fix: search reports-to candidates by user alias

### DIFF
--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -125,11 +125,7 @@ def search_reports_to_candidates(
 			fields=["name", "full_name", "first_name", "last_name"],
 			limit_page_length=len(user_ids),
 		)
-		user_map = {
-			row.get("name"): row
-			for row in user_rows
-			if row.get("name")
-		}
+		user_map = {row.get("name"): row for row in user_rows if row.get("name")}
 
 	branch_norm = normalize_text(branch)
 	candidates = [row for row in rows if is_reports_to_candidate(row)]
@@ -186,10 +182,7 @@ def search_reports_to_candidates(
 		if len(results) >= limit:
 			break
 
-	return [
-		_build_reports_to_candidate_response(row, user_map.get(row.get("user_id")))
-		for row in results
-	]
+	return [_build_reports_to_candidate_response(row, user_map.get(row.get("user_id"))) for row in results]
 
 
 def _build_reports_to_candidate_response(employee_row: dict, user_row: dict | None = None) -> dict:

--- a/hrms/api/__init__.py
+++ b/hrms/api/__init__.py
@@ -7,7 +7,12 @@ from frappe.utils import add_days, date_diff, getdate, strip_html
 
 from erpnext.setup.doctype.employee.employee import get_holiday_list_for_employee
 
-from hrms.api.profile_policy import is_reports_to_candidate, normalize_text
+from hrms.api.profile_policy import (
+	is_reports_to_candidate,
+	matches_reports_to_query,
+	normalize_text,
+	resolve_reports_to_display_name,
+)
 
 SUPPORTED_FIELD_TYPES = [
 	"Link",
@@ -111,19 +116,29 @@ def search_reports_to_candidates(
 		limit_page_length=2000,
 	)
 
+	user_ids = sorted({row.get("user_id") for row in rows if row.get("user_id")})
+	user_map: dict[str, dict] = {}
+	if user_ids:
+		user_rows = frappe.get_all(
+			"User",
+			filters={"name": ["in", user_ids]},
+			fields=["name", "full_name", "first_name", "last_name"],
+			limit_page_length=len(user_ids),
+		)
+		user_map = {
+			row.get("name"): row
+			for row in user_rows
+			if row.get("name")
+		}
+
 	branch_norm = normalize_text(branch)
-	query_norm = normalize_text(query)
 	candidates = [row for row in rows if is_reports_to_candidate(row)]
 
-	if query_norm:
+	if query:
 		candidates = [
 			row
 			for row in candidates
-			if query_norm in normalize_text(row.get("employee_name"))
-			or query_norm in normalize_text(row.get("first_name"))
-			or query_norm in normalize_text(row.get("last_name"))
-			or query_norm in normalize_text(row.get("designation"))
-			or query_norm in normalize_text(row.get("user_id"))
+			if matches_reports_to_query(row, user_map.get(row.get("user_id")), query)
 		]
 
 	def _priority(row: dict) -> tuple[int, int, str]:
@@ -172,18 +187,32 @@ def search_reports_to_candidates(
 			break
 
 	return [
-		{
-			"name": row.get("name"),
-			"employee_id": row.get("name"),
-			"employee_name": row.get("employee_name"),
-			"designation": row.get("designation") or "",
-			"department": row.get("department") or "",
-			"branch": row.get("branch") or "",
-			"user_id": row.get("user_id") or "",
-			"image": row.get("image") or "",
-		}
+		_build_reports_to_candidate_response(row, user_map.get(row.get("user_id")))
 		for row in results
 	]
+
+
+def _build_reports_to_candidate_response(employee_row: dict, user_row: dict | None = None) -> dict:
+	employee_name = employee_row.get("employee_name") or ""
+	full_name = (user_row or {}).get("full_name") or ""
+	display_name = _resolve_reports_to_display_name(employee_name, full_name)
+
+	return {
+		"name": employee_row.get("name"),
+		"employee_id": employee_row.get("name"),
+		"employee_name": employee_name,
+		"display_name": display_name,
+		"full_name": full_name,
+		"designation": employee_row.get("designation") or "",
+		"department": employee_row.get("department") or "",
+		"branch": employee_row.get("branch") or "",
+		"user_id": employee_row.get("user_id") or "",
+		"image": employee_row.get("image") or "",
+	}
+
+
+def _resolve_reports_to_display_name(employee_name: str, full_name: str) -> str:
+	return resolve_reports_to_display_name(employee_name, full_name)
 
 
 # HR Settings

--- a/hrms/api/profile_policy.py
+++ b/hrms/api/profile_policy.py
@@ -121,3 +121,43 @@ def is_reports_to_candidate(employee_row: dict[str, Any]) -> bool:
 	if "EXECUTIVE" in department:
 		return True
 	return False
+
+
+def resolve_reports_to_display_name(employee_name: str | None, full_name: str | None) -> str:
+	employee_name = str(employee_name or "").strip()
+	full_name = str(full_name or "").strip()
+
+	if not full_name:
+		return employee_name
+	if not employee_name:
+		return full_name
+	if normalize_text(employee_name) == normalize_text(full_name):
+		return employee_name
+	if normalize_text(employee_name).endswith(" ADMIN"):
+		return full_name
+	return employee_name
+
+
+def matches_reports_to_query(
+	employee_row: dict[str, Any],
+	user_row: dict[str, Any] | None,
+	query: str | None,
+) -> bool:
+	query_norm = normalize_text(query)
+	if not query_norm:
+		return True
+
+	user_row = user_row or {}
+	return any(
+		query_norm in normalize_text(value)
+		for value in (
+			employee_row.get("employee_name"),
+			employee_row.get("first_name"),
+			employee_row.get("last_name"),
+			employee_row.get("designation"),
+			employee_row.get("user_id"),
+			user_row.get("full_name"),
+			user_row.get("first_name"),
+			user_row.get("last_name"),
+		)
+	)

--- a/hrms/tests/test_s048_contact_and_policy.py
+++ b/hrms/tests/test_s048_contact_and_policy.py
@@ -7,7 +7,12 @@ from hrms.api.contact_validation import (
 	validate_email_address,
 	validate_ph_mobile_number,
 )
-from hrms.api.profile_policy import classify_employee_policy, is_reports_to_candidate
+from hrms.api.profile_policy import (
+	classify_employee_policy,
+	is_reports_to_candidate,
+	matches_reports_to_query,
+	resolve_reports_to_display_name,
+)
 
 
 def test_contact_validation_normalizes_ph_numbers_and_rejects_bad_prefixes():
@@ -84,6 +89,37 @@ def test_reports_to_candidates_only_include_leadership_roles():
 			}
 		)
 		is False
+	)
+
+
+def test_reports_to_query_matches_linked_user_full_name():
+	employee_row = {
+		"name": "HR-EMP-00020",
+		"employee_name": "Sam Admin",
+		"first_name": "Sam",
+		"last_name": "Admin",
+		"designation": "Hr Manager",
+		"department": "Operations - BEI",
+		"branch": "ARANETA GATEWAY",
+		"user_id": "sam@bebang.ph",
+	}
+	user_row = {
+		"name": "sam@bebang.ph",
+		"full_name": "Sam Karazi",
+		"first_name": "Sam",
+		"last_name": "Karazi",
+	}
+
+	assert matches_reports_to_query(employee_row, user_row, "Karazi") is True
+	assert matches_reports_to_query(employee_row, user_row, "sam@bebang.ph") is True
+	assert matches_reports_to_query(employee_row, user_row, "Crew") is False
+
+
+def test_reports_to_display_name_prefers_user_full_name_for_admin_aliases():
+	assert resolve_reports_to_display_name("Sam Admin", "Sam Karazi") == "Sam Karazi"
+	assert (
+		resolve_reports_to_display_name("CARINGAL, RONALD H.", "Ronald Caringal")
+		== "CARINGAL, RONALD H."
 	)
 
 

--- a/hrms/tests/test_s048_contact_and_policy.py
+++ b/hrms/tests/test_s048_contact_and_policy.py
@@ -117,10 +117,7 @@ def test_reports_to_query_matches_linked_user_full_name():
 
 def test_reports_to_display_name_prefers_user_full_name_for_admin_aliases():
 	assert resolve_reports_to_display_name("Sam Admin", "Sam Karazi") == "Sam Karazi"
-	assert (
-		resolve_reports_to_display_name("CARINGAL, RONALD H.", "Ronald Caringal")
-		== "CARINGAL, RONALD H."
-	)
+	assert resolve_reports_to_display_name("CARINGAL, RONALD H.", "Ronald Caringal") == "CARINGAL, RONALD H."
 
 
 def test_enrichment_employee_row_fetches_requested_snapshot_fields(monkeypatch):


### PR DESCRIPTION
## Summary
- enrich reports-to candidates with linked User names
- search leadership candidates by linked user full name and email aliases
- return a controlled display-name fallback for admin placeholder employee names

## Verification
- python -m py_compile hrms/api/profile_policy.py hrms/api/__init__.py hrms/tests/test_s048_contact_and_policy.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_s048_contact_and_policy.py