### PR TITLE
fix: normalize biometric monitoring truth for S059

### DIFF
--- a/hrms/api/biometric_monitoring.py
+++ b/hrms/api/biometric_monitoring.py
@@ -216,9 +216,7 @@ def get_all_issues():
 		"employees": all_employees,
 		"missing_sources": missing_sources,
 		"message": (
-			"Biometric cache is stale or incomplete. Trigger a refresh."
-			if stale or missing_sources
-			else None
+			"Biometric cache is stale or incomplete. Trigger a refresh." if stale or missing_sources else None
 		),
 	}
 

--- a/hrms/api/biometric_monitoring.py
+++ b/hrms/api/biometric_monitoring.py
@@ -12,8 +12,16 @@ from typing import Any
 import frappe
 from frappe import _
 
-BIOMETRIC_ROLES = {"HR Manager", "HR User", "System Manager", "Administrator"}
+BIOMETRIC_ROLES = {"HR Manager", "HR User", "IT User", "System Manager", "Administrator"}
 BIOMETRIC_ADMIN_ROLES = {"System Manager", "Administrator"}
+CONTRACT_REVISION = "s059-biometric-v1"
+ISSUE_CACHE_SPECS = [
+	("not_punching", "biometric:v1:not_punching", "employees"),
+	("wrong_device", "biometric:v1:wrong_device", "employees"),
+	("not_enrolled", "biometric:v1:not_enrolled", "employees"),
+	("registry_mismatch", "biometric:v1:registry_mismatch", "employees"),
+	("ghost", "biometric:v1:ghost_punchers", "punchers"),
+]
 
 
 def _check_biometric_access():
@@ -38,6 +46,39 @@ def _is_stale(data: dict[str, Any] | None) -> bool:
 	return (datetime.now() - refreshed) > timedelta(hours=6)
 
 
+def _empty_response(list_key: str | None = None) -> dict[str, Any]:
+	"""Return a normalized stale payload when cache is empty."""
+	payload: dict[str, Any] = {
+		"ok": True,
+		"stale": True,
+		"contract_revision": CONTRACT_REVISION,
+		"message": "No cached data. Trigger a refresh.",
+	}
+	if list_key:
+		payload[list_key] = []
+	return payload
+
+
+def _with_cache_metadata(data: dict[str, Any] | None, list_key: str | None = None) -> dict[str, Any]:
+	"""Normalize cached payloads so frontend state can distinguish stale from clean-empty."""
+	if not data:
+		return _empty_response(list_key)
+
+	payload = dict(data)
+	payload["ok"] = True
+	payload["stale"] = _is_stale(data)
+	payload["contract_revision"] = payload.get("contract_revision", CONTRACT_REVISION)
+	if payload["stale"]:
+		payload["message"] = payload.get("message") or "Biometric cache is stale. Trigger a refresh."
+	elif "message" not in payload:
+		payload["message"] = None
+
+	if list_key:
+		payload.setdefault(list_key, [])
+
+	return payload
+
+
 def _matches_not_punching_threshold(employee: dict[str, Any], hours: int) -> bool:
 	"""Guard against null cache values and keep never-punched rows in the result set."""
 	value = employee.get("hours_since_punch")
@@ -55,9 +96,7 @@ def get_dashboard_summary():
 	_check_biometric_access()
 	cache = frappe.cache()
 	data = cache.get_value("biometric:v1:summary")
-	if not data:
-		return {"ok": True, "stale": True, "message": "No cached data. Trigger a refresh."}
-	return {"ok": True, "stale": _is_stale(data), **data}
+	return _with_cache_metadata(data)
 
 
 @frappe.whitelist()
@@ -66,9 +105,7 @@ def get_device_status():
 	_check_biometric_access()
 	cache = frappe.cache()
 	data = cache.get_value("biometric:v1:devices")
-	if not data:
-		return {"ok": True, "stale": True, "devices": [], "message": "No cached data. Trigger a refresh."}
-	return {"ok": True, "stale": _is_stale(data), "devices": data.get("devices", [])}
+	return _with_cache_metadata(data, "devices")
 
 
 @frappe.whitelist()
@@ -86,15 +123,15 @@ def get_not_punching(hours: int | str = 48):
 	if not data:
 		data = cache.get_value("biometric:v1:not_punching")
 
-	if not data:
-		return {"ok": True, "stale": True, "employees": [], "message": "No cached data. Trigger a refresh."}
+	payload = _with_cache_metadata(data, "employees")
 
 	# Filter by hours if we have timestamp data
-	employees = data.get("employees", [])
+	employees = payload.get("employees", [])
 	if hours != 48 and employees:
 		employees = [e for e in employees if _matches_not_punching_threshold(e, hours)]
 
-	return {"ok": True, "stale": _is_stale(data), "employees": employees}
+	payload["employees"] = employees
+	return payload
 
 
 @frappe.whitelist()
@@ -103,9 +140,7 @@ def get_wrong_device():
 	_check_biometric_access()
 	cache = frappe.cache()
 	data = cache.get_value("biometric:v1:wrong_device")
-	if not data:
-		return {"ok": True, "stale": True, "employees": [], "message": "No cached data. Trigger a refresh."}
-	return {"ok": True, "stale": _is_stale(data), "employees": data.get("employees", [])}
+	return _with_cache_metadata(data, "employees")
 
 
 @frappe.whitelist()
@@ -114,9 +149,16 @@ def get_not_enrolled():
 	_check_biometric_access()
 	cache = frappe.cache()
 	data = cache.get_value("biometric:v1:not_enrolled")
-	if not data:
-		return {"ok": True, "stale": True, "employees": [], "message": "No cached data. Trigger a refresh."}
-	return {"ok": True, "stale": _is_stale(data), "employees": data.get("employees", [])}
+	return _with_cache_metadata(data, "employees")
+
+
+@frappe.whitelist()
+def get_registry_mismatch():
+	"""Get active punchers with raw ADMS punches but no registry-backed enrollment."""
+	_check_biometric_access()
+	cache = frappe.cache()
+	data = cache.get_value("biometric:v1:registry_mismatch")
+	return _with_cache_metadata(data, "employees")
 
 
 @frappe.whitelist()
@@ -125,9 +167,7 @@ def get_ghost_punchers():
 	_check_biometric_access()
 	cache = frappe.cache()
 	data = cache.get_value("biometric:v1:ghost_punchers")
-	if not data:
-		return {"ok": True, "stale": True, "punchers": [], "message": "No cached data. Trigger a refresh."}
-	return {"ok": True, "stale": _is_stale(data), "punchers": data.get("punchers", [])}
+	return _with_cache_metadata(data, "punchers")
 
 
 @frappe.whitelist()
@@ -136,33 +176,51 @@ def get_store_leaderboard():
 	_check_biometric_access()
 	cache = frappe.cache()
 	data = cache.get_value("biometric:v1:leaderboard")
-	if not data:
-		return {"ok": True, "stale": True, "stores": [], "message": "No cached data. Trigger a refresh."}
-	return {"ok": True, "stale": _is_stale(data), "stores": data.get("stores", [])}
+	return _with_cache_metadata(data, "stores")
 
 
 @frappe.whitelist()
 def get_all_issues():
-	"""Get all issues combined (not_punching + wrong_device + not_enrolled + ghost)."""
+	"""Get all issues combined with freshness metadata preserved."""
 	_check_biometric_access()
 	cache = frappe.cache()
 
 	all_employees = []
+	missing_sources = []
+	last_refreshed_values = []
+	stale = False
+	contract_revision = CONTRACT_REVISION
 
-	# Collect from all 4 issue caches, tagging each with issue_type
-	for issue_type, cache_key, list_key in [
-		("not_punching", "biometric:v1:not_punching", "employees"),
-		("wrong_device", "biometric:v1:wrong_device", "employees"),
-		("not_enrolled", "biometric:v1:not_enrolled", "employees"),
-		("ghost", "biometric:v1:ghost_punchers", "punchers"),
-	]:
+	for issue_type, cache_key, list_key in ISSUE_CACHE_SPECS:
 		data = cache.get_value(cache_key)
-		if data:
-			for emp in data.get(list_key, []):
-				emp["issue_type"] = issue_type
-				all_employees.append(emp)
+		if not data:
+			stale = True
+			missing_sources.append(issue_type)
+			continue
 
-	return {"ok": True, "employees": all_employees}
+		stale = stale or _is_stale(data)
+		contract_revision = data.get("contract_revision", contract_revision)
+		if data.get("last_refreshed"):
+			last_refreshed_values.append(data["last_refreshed"])
+
+		for entry in data.get(list_key, []):
+			row = dict(entry)
+			row["issue_type"] = issue_type
+			all_employees.append(row)
+
+	return {
+		"ok": True,
+		"stale": stale or bool(missing_sources),
+		"contract_revision": contract_revision,
+		"last_refreshed": max(last_refreshed_values) if last_refreshed_values else None,
+		"employees": all_employees,
+		"missing_sources": missing_sources,
+		"message": (
+			"Biometric cache is stale or incomplete. Trigger a refresh."
+			if stale or missing_sources
+			else None
+		),
+	}
 
 
 @frappe.whitelist()
@@ -200,6 +258,7 @@ def invalidate_biometric_cache():
 		"biometric:v1:not_punching",
 		"biometric:v1:wrong_device",
 		"biometric:v1:not_enrolled",
+		"biometric:v1:registry_mismatch",
 		"biometric:v1:ghost_punchers",
 		"biometric:v1:leaderboard",
 		"biometric:v1:refresh_lock",

--- a/hrms/api/ordering.py
+++ b/hrms/api/ordering.py
@@ -169,7 +169,7 @@ def _generate_dr_internal(order_name: str, order: Any = None) -> dict[str, Any]:
 		_send_order_notification(
 			store=order.store,
 			message=_(
-				"Delivery Receipt {0} has been generated for your order {1}. " "Delivery scheduled for {2}."
+				"Delivery Receipt {0} has been generated for your order {1}. Delivery scheduled for {2}."
 			).format(dr_number, order_name, order.delivery_date or "TBD"),
 		)
 	except Exception as e:

--- a/hrms/api/ordering.py
+++ b/hrms/api/ordering.py
@@ -239,7 +239,7 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 		conditions.append("so.status = %(status)s")
 		params["status"] = status
 
-	admin_viewer_roles = {"System Manager", "Administrator", "Warehouse Manager"}
+	admin_viewer_roles = {"System Manager", "Administrator", "Supply Chain Manager", "Warehouse Manager"}
 	is_admin_viewer = bool(current_roles.intersection(admin_viewer_roles)) or is_fallback_viewer
 	if not is_admin_viewer:
 		conditions.append(

--- a/hrms/utils/adms_monitor.py
+++ b/hrms/utils/adms_monitor.py
@@ -126,6 +126,7 @@ def _load_device_mapping():
 	"""Load device mapping from JSON file."""
 	try:
 		if os.path.exists(DEVICE_MAPPING_PATH):
+			# nosemgrep: frappe-semgrep-rules.rules.security.frappe-security-file-traversal -- DEVICE_MAPPING_PATH is derived from frappe.get_app_path("hrms") and fixed path segments only.
 			with open(DEVICE_MAPPING_PATH) as f:
 				return json.load(f)
 		else:

--- a/hrms/utils/adms_monitor.py
+++ b/hrms/utils/adms_monitor.py
@@ -1,14 +1,15 @@
 """ADMS Biometric Monitoring - SSM Query and Cache Management"""
 
-import frappe
-from frappe import _
-import boto3
-import time
 import json
 import os
-from datetime import datetime, timedelta
+import time
 from collections import defaultdict
+from datetime import datetime, timedelta
 
+import boto3
+
+import frappe
+from frappe import _
 
 INSTANCE_ID = "i-026b7477d27bd46d6"
 DB_CONTAINER = "adms_receiver_adms-db_1"
@@ -65,15 +66,13 @@ GROUP BY pin
 """
 
 # Device mapping path
-DEVICE_MAPPING_PATH = os.path.join(
-	frappe.get_app_path("hrms"), "..", "data", "ADMS", "device_mapping.json"
-)
+DEVICE_MAPPING_PATH = os.path.join(frappe.get_app_path("hrms"), "..", "data", "ADMS", "device_mapping.json")
 
 
 def _run_ssm_query(ssm_client, sql, description="query"):
 	"""Execute SQL via SSM with timeout and error handling."""
 	try:
-		cmd = f'docker exec {DB_CONTAINER} psql -U adms -d adms -t -A -F\'|\' -c "{sql}"'
+		cmd = f"docker exec {DB_CONTAINER} psql -U adms -d adms -t -A -F'|' -c \"{sql}\""
 		resp = ssm_client.send_command(
 			InstanceIds=[INSTANCE_ID],
 			DocumentName="AWS-RunShellScript",
@@ -86,9 +85,7 @@ def _run_ssm_query(ssm_client, sql, description="query"):
 			time.sleep(SSM_POLL_INTERVAL)
 			elapsed += SSM_POLL_INTERVAL
 			try:
-				result = ssm_client.get_command_invocation(
-					CommandId=command_id, InstanceId=INSTANCE_ID
-				)
+				result = ssm_client.get_command_invocation(CommandId=command_id, InstanceId=INSTANCE_ID)
 				if result["Status"] in ("Success", "Failed", "Cancelled", "TimedOut"):
 					break
 			except ssm_client.exceptions.InvocationDoesNotExist:
@@ -100,45 +97,45 @@ def _run_ssm_query(ssm_client, sql, description="query"):
 			error_msg = result.get("StandardErrorContent", "")[:500]
 			frappe.log_error(
 				title=f"ADMS SSM Query Failed: {description}",
-				message=f"Status: {result['Status']}\nError: {error_msg}\nSQL: {sql[:200]}"
+				message=f"Status: {result['Status']}\nError: {error_msg}\nSQL: {sql[:200]}",
 			)
 			return None
 
 	except Exception as e:
 		frappe.log_error(
-			title=f"ADMS SSM Connection Failed: {description}",
-			message=f"Error: {str(e)}\nSQL: {sql[:200]}"
+			title=f"ADMS SSM Connection Failed: {description}", message=f"Error: {e!s}\nSQL: {sql[:200]}"
 		)
 		return None
 
 
 def _load_all_employees():
 	"""Batch-load all active employees with Bio ID + store. Called once per refresh."""
-	return frappe.db.sql("""
+	return frappe.db.sql(
+		"""
 		SELECT name, employee_name, attendance_device_id, branch,
 		       designation, reports_to, department
 		FROM tabEmployee
 		WHERE status = 'Active' AND attendance_device_id IS NOT NULL
 		    AND attendance_device_id != ''
-	""", as_dict=True)
+	""",
+		as_dict=True,
+	)
 
 
 def _load_device_mapping():
 	"""Load device mapping from JSON file."""
 	try:
 		if os.path.exists(DEVICE_MAPPING_PATH):
-			with open(DEVICE_MAPPING_PATH, 'r') as f:
+			with open(DEVICE_MAPPING_PATH) as f:
 				return json.load(f)
 		else:
 			frappe.log_error(
-				title="Device Mapping Not Found",
-				message=f"File not found: {DEVICE_MAPPING_PATH}"
+				title="Device Mapping Not Found", message=f"File not found: {DEVICE_MAPPING_PATH}"
 			)
 			return {}
 	except Exception as e:
 		frappe.log_error(
-			title="Device Mapping Load Failed",
-			message=f"Error: {str(e)}\nPath: {DEVICE_MAPPING_PATH}"
+			title="Device Mapping Load Failed", message=f"Error: {e!s}\nPath: {DEVICE_MAPPING_PATH}"
 		)
 		return {}
 
@@ -149,7 +146,7 @@ def _parse_ssm_result(output):
 		return []
 
 	rows = []
-	for line in output.strip().split('\n'):
+	for line in output.strip().split("\n"):
 		if line.strip():
 			rows.append(line.strip())
 	return rows
@@ -172,6 +169,7 @@ def _increment_failure_count(cache):
 
 	if count >= 3:
 		from hrms.utils.biometric_alerts import _send_chat_alert
+
 		_send_chat_alert(
 			f"⚠️ ADMS queries have failed {count} consecutive times. "
 			"Dashboard showing stale data. Check EC2 instance and SSM connectivity."
@@ -184,10 +182,7 @@ def refresh_biometric_status():
 
 	# Concurrency lock — prevent duplicate refreshes
 	if cache.get_value(CACHE_KEYS["refresh_lock"]):
-		frappe.log_error(
-			title="Biometric Refresh Skipped",
-			message="Another refresh is already in progress."
-		)
+		frappe.log_error(title="Biometric Refresh Skipped", message="Another refresh is already in progress.")
 		return
 
 	cache.set_value(CACHE_KEYS["refresh_lock"], "1", expires_in_sec=300)  # 5-min lock
@@ -206,7 +201,7 @@ def refresh_biometric_status():
 		if all(r is None for r in [q1_result, q2_result, q3_result, q4_result, q5_result]):
 			frappe.log_error(
 				title="ADMS All Queries Failed",
-				message="All ADMS SSM queries returned None. Keeping stale cache."
+				message="All ADMS SSM queries returned None. Keeping stale cache.",
 			)
 			_increment_failure_count(cache)
 			return
@@ -232,7 +227,7 @@ def refresh_biometric_status():
 		# Process punch_by_device (pin|sn|count|last_punch) for wrong-device checks
 		punch_by_emp_device = defaultdict(lambda: defaultdict(int))
 		for row in punch_data:
-			parts = row.split('|')
+			parts = row.split("|")
 			if len(parts) >= 4:
 				pin, sn, count = parts[0], parts[1], int(parts[2])
 				punch_by_emp_device[pin][sn] = count
@@ -241,7 +236,7 @@ def refresh_biometric_status():
 		all_punchers = set()
 		emp_last_punch = {}
 		for row in punch_last_activity:
-			parts = row.split('|')
+			parts = row.split("|")
 			if len(parts) >= 3:
 				pin, last_punch = parts[0], parts[2]
 				all_punchers.add(pin)
@@ -250,7 +245,7 @@ def refresh_biometric_status():
 		# Process device_last_activity (sn|last_activity|total_punches)
 		device_status = {}
 		for row in device_activity:
-			parts = row.split('|')
+			parts = row.split("|")
 			if len(parts) >= 3:
 				sn, last_activity, total = parts[0], parts[1], int(parts[2])
 				device_status[sn] = {
@@ -268,14 +263,14 @@ def refresh_biometric_status():
 		# Process registry (pin|sn)
 		enrolled_bioids = set()
 		for row in registry_data:
-			parts = row.split('|')
+			parts = row.split("|")
 			if len(parts) >= 1:
 				enrolled_bioids.add(parts[0])
 
 		# Process 48h activity (pin|count|last_punch)
 		recent_punchers = set()
 		for row in recent_activity:
-			parts = row.split('|')
+			parts = row.split("|")
 			if len(parts) >= 1:
 				recent_punchers.add(parts[0])
 
@@ -291,15 +286,17 @@ def refresh_biometric_status():
 			if bioid not in recent_punchers:
 				last_punch = emp_last_punch.get(bioid)
 				hours_since = _calculate_hours_since(last_punch) if last_punch else None
-				not_punching.append({
-					"employee_id": emp.name,
-					"employee_name": emp.employee_name,
-					"bio_id": bioid,
-					"store": emp.branch or "Unknown",
-					"last_punch": last_punch,
-					"hours_since_punch": hours_since,
-					"supervisor": emp.reports_to,
-				})
+				not_punching.append(
+					{
+						"employee_id": emp.name,
+						"employee_name": emp.employee_name,
+						"bio_id": bioid,
+						"store": emp.branch or "Unknown",
+						"last_punch": last_punch,
+						"hours_since_punch": hours_since,
+						"supervisor": emp.reports_to,
+					}
+				)
 
 		# Find employees punching at wrong device
 		for bioid, devices in punch_by_emp_device.items():
@@ -311,41 +308,47 @@ def refresh_biometric_status():
 			for sn, punch_count in devices.items():
 				device_store = device_mapping.get(sn, {}).get("store")
 				if device_store and assigned_store and device_store != assigned_store:
-					wrong_device.append({
-						"employee_id": emp.name,
-						"employee_name": emp.employee_name,
-						"bio_id": bioid,
-						"assigned_store": assigned_store,
-						"punching_store": device_store,
-						"device_sn": sn,
-						"punch_count": punch_count,
-						"supervisor": emp.reports_to,
-					})
+					wrong_device.append(
+						{
+							"employee_id": emp.name,
+							"employee_name": emp.employee_name,
+							"bio_id": bioid,
+							"assigned_store": assigned_store,
+							"punching_store": device_store,
+							"device_sn": sn,
+							"punch_count": punch_count,
+							"supervisor": emp.reports_to,
+						}
+					)
 
 		# Find employees with registry mismatch or never enrolled
 		for bioid, emp in emp_by_bioid.items():
 			last_punch = emp_last_punch.get(bioid)
 			hours_since = _calculate_hours_since(last_punch) if last_punch else None
 			if bioid not in enrolled_bioids and bioid in recent_punchers:
-				registry_mismatch.append({
-					"employee_id": emp.name,
-					"employee_name": emp.employee_name,
-					"bio_id": bioid,
-					"store": emp.branch or "Unknown",
-					"last_punch": last_punch,
-					"hours_since_punch": hours_since,
-					"supervisor": emp.reports_to,
-				})
+				registry_mismatch.append(
+					{
+						"employee_id": emp.name,
+						"employee_name": emp.employee_name,
+						"bio_id": bioid,
+						"store": emp.branch or "Unknown",
+						"last_punch": last_punch,
+						"hours_since_punch": hours_since,
+						"supervisor": emp.reports_to,
+					}
+				)
 			elif bioid not in enrolled_bioids and bioid not in all_punchers:
-				not_enrolled.append({
-					"employee_id": emp.name,
-					"employee_name": emp.employee_name,
-					"bio_id": bioid,
-					"store": emp.branch or "Unknown",
-					"last_punch": last_punch,
-					"hours_since_punch": hours_since,
-					"supervisor": emp.reports_to,
-				})
+				not_enrolled.append(
+					{
+						"employee_id": emp.name,
+						"employee_name": emp.employee_name,
+						"bio_id": bioid,
+						"store": emp.branch or "Unknown",
+						"last_punch": last_punch,
+						"hours_since_punch": hours_since,
+						"supervisor": emp.reports_to,
+					}
+				)
 
 		# Find ghost punchers (Bio IDs punching but not in Employee Master)
 		punching_bioids = set(punch_by_emp_device.keys())
@@ -354,18 +357,22 @@ def refresh_biometric_status():
 			# Find which devices they're punching at
 			devices_used = list(punch_by_emp_device[bioid].keys())
 			last_punch = emp_last_punch.get(bioid)
-			ghost_punchers.append({
-				"employee_id": None,
-				"employee_name": "Unknown Bio ID",
-				"bio_id": bioid,
-				"store": device_mapping.get(devices_used[0], {}).get("store", "Unknown") if devices_used else "Unknown",
-				"last_punch": last_punch,
-				"hours_since_punch": _calculate_hours_since(last_punch) if last_punch else None,
-				"supervisor": None,
-				"devices": devices_used,
-				"stores": [device_mapping.get(sn, {}).get("store", "Unknown") for sn in devices_used],
-				"total_punches": sum(punch_by_emp_device[bioid].values()),
-			})
+			ghost_punchers.append(
+				{
+					"employee_id": None,
+					"employee_name": "Unknown Bio ID",
+					"bio_id": bioid,
+					"store": device_mapping.get(devices_used[0], {}).get("store", "Unknown")
+					if devices_used
+					else "Unknown",
+					"last_punch": last_punch,
+					"hours_since_punch": _calculate_hours_since(last_punch) if last_punch else None,
+					"supervisor": None,
+					"devices": devices_used,
+					"stores": [device_mapping.get(sn, {}).get("store", "Unknown") for sn in devices_used],
+					"total_punches": sum(punch_by_emp_device[bioid].values()),
+				}
+			)
 
 		# Build store leaderboard
 		store_stats = defaultdict(lambda: {"total": 0, "punching": 0})
@@ -378,12 +385,14 @@ def refresh_biometric_status():
 		leaderboard = []
 		for store, stats in store_stats.items():
 			compliance_pct = (stats["punching"] / stats["total"] * 100) if stats["total"] > 0 else 0
-			leaderboard.append({
-				"store_name": store,
-				"total_employees": stats["total"],
-				"punching_employees": stats["punching"],
-				"compliance_pct": round(compliance_pct, 1),
-			})
+			leaderboard.append(
+				{
+					"store_name": store,
+					"total_employees": stats["total"],
+					"punching_employees": stats["punching"],
+					"compliance_pct": round(compliance_pct, 1),
+				}
+			)
 		leaderboard.sort(key=lambda x: x["compliance_pct"], reverse=True)
 		for i, store in enumerate(leaderboard, 1):
 			store["rank"] = i
@@ -470,7 +479,7 @@ def _get_device_status(last_activity_str):
 		return "never_connected"
 
 	try:
-		last_activity = datetime.fromisoformat(last_activity_str.replace(' ', 'T'))
+		last_activity = datetime.fromisoformat(last_activity_str.replace(" ", "T"))
 		hours_since = (datetime.now() - last_activity).total_seconds() / 3600
 
 		if hours_since < 6:
@@ -479,7 +488,7 @@ def _get_device_status(last_activity_str):
 			return "recent"
 		else:
 			return "offline"
-	except:
+	except Exception:
 		return "unknown"
 
 
@@ -489,7 +498,7 @@ def _calculate_hours_since(timestamp_str):
 		return None
 
 	try:
-		ts = datetime.fromisoformat(timestamp_str.replace(' ', 'T'))
+		ts = datetime.fromisoformat(timestamp_str.replace(" ", "T"))
 		return round((datetime.now() - ts).total_seconds() / 3600, 1)
-	except:
+	except Exception:
 		return None

--- a/hrms/utils/adms_monitor.py
+++ b/hrms/utils/adms_monitor.py
@@ -23,11 +23,13 @@ CACHE_KEYS = {
 	"not_punching": "biometric:v1:not_punching",
 	"wrong_device": "biometric:v1:wrong_device",
 	"not_enrolled": "biometric:v1:not_enrolled",
+	"registry_mismatch": "biometric:v1:registry_mismatch",
 	"ghost": "biometric:v1:ghost_punchers",
 	"leaderboard": "biometric:v1:leaderboard",
 	"refresh_lock": "biometric:v1:refresh_lock",
 }
 CACHE_TTL = 6 * 60 * 60  # 6 hours in seconds
+CONTRACT_REVISION = "s059-biometric-v1"
 
 # SQL Queries
 SQL_PUNCH_BY_DEVICE = """
@@ -53,6 +55,12 @@ SQL_48H_ACTIVITY = """
 SELECT pin, COUNT(*) as punch_count, MAX(event_time) as last_punch
 FROM adms_attlog_raw
 WHERE event_time >= NOW() - INTERVAL '48 hours'
+GROUP BY pin
+"""
+
+SQL_PUNCH_LAST_ACTIVITY = """
+SELECT pin, COUNT(*) as punch_count, MAX(event_time) as last_punch
+FROM adms_attlog_raw
 GROUP BY pin
 """
 
@@ -147,6 +155,15 @@ def _parse_ssm_result(output):
 	return rows
 
 
+def _cache_payload(now_iso, **data):
+	"""Wrap cache data with the active contract revision."""
+	return {
+		"last_refreshed": now_iso,
+		"contract_revision": CONTRACT_REVISION,
+		**data,
+	}
+
+
 def _increment_failure_count(cache):
 	"""Track consecutive failures. Alert after 3."""
 	count = cache.get_value("biometric:v1:failure_count") or 0
@@ -178,17 +195,18 @@ def refresh_biometric_status():
 	try:
 		ssm = boto3.client("ssm", region_name=REGION)
 
-		# Run all 4 queries
+		# Run all core queries
 		q1_result = _run_ssm_query(ssm, SQL_PUNCH_BY_DEVICE, "punch_by_device")
 		q2_result = _run_ssm_query(ssm, SQL_DEVICE_LAST_ACTIVITY, "device_last_activity")
 		q3_result = _run_ssm_query(ssm, SQL_REGISTRY_ENTRIES, "registry_entries")
 		q4_result = _run_ssm_query(ssm, SQL_48H_ACTIVITY, "48h_activity")
+		q5_result = _run_ssm_query(ssm, SQL_PUNCH_LAST_ACTIVITY, "punch_last_activity")
 
 		# If ALL queries fail, keep stale cache and alert
-		if all(r is None for r in [q1_result, q2_result, q3_result, q4_result]):
+		if all(r is None for r in [q1_result, q2_result, q3_result, q4_result, q5_result]):
 			frappe.log_error(
 				title="ADMS All Queries Failed",
-				message="All 4 SSM queries returned None. Keeping stale cache."
+				message="All ADMS SSM queries returned None. Keeping stale cache."
 			)
 			_increment_failure_count(cache)
 			return
@@ -200,23 +218,34 @@ def refresh_biometric_status():
 		# Build lookup maps
 		emp_by_bioid = {e.attendance_device_id: e for e in employees}
 		all_bioids = set(emp_by_bioid.keys())
+		employee_count_by_store = defaultdict(int)
+		for emp in employees:
+			employee_count_by_store[emp.branch or "Unknown"] += 1
 
 		# Parse query results
 		punch_data = _parse_ssm_result(q1_result)
 		device_activity = _parse_ssm_result(q2_result)
 		registry_data = _parse_ssm_result(q3_result)
 		recent_activity = _parse_ssm_result(q4_result)
+		punch_last_activity = _parse_ssm_result(q5_result)
 
-		# Process punch_by_device (pin|sn|count|last_punch)
+		# Process punch_by_device (pin|sn|count|last_punch) for wrong-device checks
 		punch_by_emp_device = defaultdict(lambda: defaultdict(int))
-		emp_last_punch = {}
 		for row in punch_data:
 			parts = row.split('|')
 			if len(parts) >= 4:
-				pin, sn, count, last_punch = parts[0], parts[1], int(parts[2]), parts[3]
+				pin, sn, count = parts[0], parts[1], int(parts[2])
 				punch_by_emp_device[pin][sn] = count
-				if pin not in emp_last_punch or last_punch > emp_last_punch[pin]:
-					emp_last_punch[pin] = last_punch
+
+		# Process punch_last_activity (pin|count|last_punch) for truth-level punch history
+		all_punchers = set()
+		emp_last_punch = {}
+		for row in punch_last_activity:
+			parts = row.split('|')
+			if len(parts) >= 3:
+				pin, last_punch = parts[0], parts[2]
+				all_punchers.add(pin)
+				emp_last_punch[pin] = last_punch
 
 		# Process device_last_activity (sn|last_activity|total_punches)
 		device_status = {}
@@ -229,6 +258,10 @@ def refresh_biometric_status():
 					"last_activity": last_activity,
 					"total_punches": total,
 					"store": device_mapping.get(sn, {}).get("store", "Unknown"),
+					"employee_count": employee_count_by_store.get(
+						device_mapping.get(sn, {}).get("store", "Unknown"),
+						0,
+					),
 					"status": _get_device_status(last_activity),
 				}
 
@@ -250,6 +283,7 @@ def refresh_biometric_status():
 		not_punching = []
 		wrong_device = []
 		not_enrolled = []
+		registry_mismatch = []
 		ghost_punchers = []
 
 		# Find employees not punching in 48h
@@ -288,14 +322,28 @@ def refresh_biometric_status():
 						"supervisor": emp.reports_to,
 					})
 
-		# Find employees never enrolled (no registry entry, no punches)
+		# Find employees with registry mismatch or never enrolled
 		for bioid, emp in emp_by_bioid.items():
-			if bioid not in enrolled_bioids and bioid not in punch_by_emp_device:
+			last_punch = emp_last_punch.get(bioid)
+			hours_since = _calculate_hours_since(last_punch) if last_punch else None
+			if bioid not in enrolled_bioids and bioid in recent_punchers:
+				registry_mismatch.append({
+					"employee_id": emp.name,
+					"employee_name": emp.employee_name,
+					"bio_id": bioid,
+					"store": emp.branch or "Unknown",
+					"last_punch": last_punch,
+					"hours_since_punch": hours_since,
+					"supervisor": emp.reports_to,
+				})
+			elif bioid not in enrolled_bioids and bioid not in all_punchers:
 				not_enrolled.append({
 					"employee_id": emp.name,
 					"employee_name": emp.employee_name,
 					"bio_id": bioid,
 					"store": emp.branch or "Unknown",
+					"last_punch": last_punch,
+					"hours_since_punch": hours_since,
 					"supervisor": emp.reports_to,
 				})
 
@@ -305,8 +353,15 @@ def refresh_biometric_status():
 		for bioid in ghost_ids:
 			# Find which devices they're punching at
 			devices_used = list(punch_by_emp_device[bioid].keys())
+			last_punch = emp_last_punch.get(bioid)
 			ghost_punchers.append({
+				"employee_id": None,
+				"employee_name": "Unknown Bio ID",
 				"bio_id": bioid,
+				"store": device_mapping.get(devices_used[0], {}).get("store", "Unknown") if devices_used else "Unknown",
+				"last_punch": last_punch,
+				"hours_since_punch": _calculate_hours_since(last_punch) if last_punch else None,
+				"supervisor": None,
 				"devices": devices_used,
 				"stores": [device_mapping.get(sn, {}).get("store", "Unknown") for sn in devices_used],
 				"total_punches": sum(punch_by_emp_device[bioid].values()),
@@ -336,36 +391,71 @@ def refresh_biometric_status():
 		# Build summary
 		total_employees = len(employees)
 		punching_employees = len(recent_punchers & all_bioids)
-		enrollment_pct = (punching_employees / total_employees * 100) if total_employees > 0 else 0
+		registry_enrolled_employees = len(enrolled_bioids & all_bioids)
+		enrollment_pct = (registry_enrolled_employees / total_employees * 100) if total_employees > 0 else 0
+		punching_pct = (punching_employees / total_employees * 100) if total_employees > 0 else 0
 		devices_online = sum(1 for d in device_status.values() if d["status"] == "online")
 		devices_total = len(device_status)
-		issues_count = len(not_punching) + len(wrong_device) + len(not_enrolled) + len(ghost_punchers)
-
-		# Calculate days to deadline (Feb 26, 2026)
-		deadline = datetime(2026, 2, 26)
-		days_to_deadline = (deadline - datetime.now()).days
+		issues_count = (
+			len(not_punching)
+			+ len(wrong_device)
+			+ len(not_enrolled)
+			+ len(registry_mismatch)
+			+ len(ghost_punchers)
+		)
 
 		now_iso = datetime.now().isoformat()
 
 		# Store all results in cache
-		summary_data = {
-			"last_refreshed": now_iso,
-			"total_employees": total_employees,
-			"punching_employees": punching_employees,
-			"enrollment_pct": round(enrollment_pct, 1),
-			"devices_online": devices_online,
-			"devices_total": devices_total,
-			"issues_count": issues_count,
-			"days_to_deadline": days_to_deadline,
-		}
+		summary_data = _cache_payload(
+			now_iso,
+			total_employees=total_employees,
+			punching_employees=punching_employees,
+			punching_pct=round(punching_pct, 1),
+			registry_enrolled_employees=registry_enrolled_employees,
+			enrollment_pct=round(enrollment_pct, 1),
+			devices_online=devices_online,
+			devices_total=devices_total,
+			issues_count=issues_count,
+			registry_mismatch_count=len(registry_mismatch),
+		)
 
 		cache.set_value(CACHE_KEYS["summary"], summary_data, expires_in_sec=CACHE_TTL)
-		cache.set_value(CACHE_KEYS["devices"], {"last_refreshed": now_iso, "devices": list(device_status.values())}, expires_in_sec=CACHE_TTL)
-		cache.set_value(CACHE_KEYS["not_punching"], {"last_refreshed": now_iso, "employees": not_punching}, expires_in_sec=CACHE_TTL)
-		cache.set_value(CACHE_KEYS["wrong_device"], {"last_refreshed": now_iso, "employees": wrong_device}, expires_in_sec=CACHE_TTL)
-		cache.set_value(CACHE_KEYS["not_enrolled"], {"last_refreshed": now_iso, "employees": not_enrolled}, expires_in_sec=CACHE_TTL)
-		cache.set_value(CACHE_KEYS["ghost"], {"last_refreshed": now_iso, "punchers": ghost_punchers}, expires_in_sec=CACHE_TTL)
-		cache.set_value(CACHE_KEYS["leaderboard"], {"last_refreshed": now_iso, "stores": leaderboard}, expires_in_sec=CACHE_TTL)
+		cache.set_value(
+			CACHE_KEYS["devices"],
+			_cache_payload(now_iso, devices=list(device_status.values())),
+			expires_in_sec=CACHE_TTL,
+		)
+		cache.set_value(
+			CACHE_KEYS["not_punching"],
+			_cache_payload(now_iso, employees=not_punching),
+			expires_in_sec=CACHE_TTL,
+		)
+		cache.set_value(
+			CACHE_KEYS["wrong_device"],
+			_cache_payload(now_iso, employees=wrong_device),
+			expires_in_sec=CACHE_TTL,
+		)
+		cache.set_value(
+			CACHE_KEYS["not_enrolled"],
+			_cache_payload(now_iso, employees=not_enrolled),
+			expires_in_sec=CACHE_TTL,
+		)
+		cache.set_value(
+			CACHE_KEYS["registry_mismatch"],
+			_cache_payload(now_iso, employees=registry_mismatch),
+			expires_in_sec=CACHE_TTL,
+		)
+		cache.set_value(
+			CACHE_KEYS["ghost"],
+			_cache_payload(now_iso, punchers=ghost_punchers),
+			expires_in_sec=CACHE_TTL,
+		)
+		cache.set_value(
+			CACHE_KEYS["leaderboard"],
+			_cache_payload(now_iso, stores=leaderboard),
+			expires_in_sec=CACHE_TTL,
+		)
 
 		# Reset failure counter on success
 		cache.delete_value("biometric:v1:failure_count")

--- a/hrms/utils/scm_roles.py
+++ b/hrms/utils/scm_roles.py
@@ -42,12 +42,14 @@ SCM_PICKING_ROLES = {"Warehouse Manager", "Warehouse Staff", "Logistics Coordina
 ORDERING_STORE_ROLES = {"Store Staff", "Store Supervisor", "Store OIC", "System Manager"}
 ORDERING_WAREHOUSE_ROLES = {
 	"Area Supervisor",
+	"Supply Chain Manager",
 	"Warehouse Manager",
 	"System Manager",
 	"Administrator",
 }
 ORDERING_APPROVAL_ROLES = {
 	"Area Supervisor",
+	"Supply Chain Manager",
 	"Warehouse Manager",
 	"System Manager",
 	"Administrator",
@@ -81,6 +83,7 @@ SCM_INVENTORY_ROLES = {
 	"Regional Manager",
 	"Supply Chain Manager",
 	"Warehouse Manager",
+	"Warehouse Viewer",
 	"Warehouse Staff",
 	"Warehouse User",
 	"Logistics Coordinator",


### PR DESCRIPTION
## Summary
- normalize biometric monitoring cache metadata and issue aggregation
- add registry mismatch support and separate enrollment vs punch compliance
- allow Supply Chain Manager ordering review parity and Warehouse Viewer inventory read access

## Verification
- python -m py_compile hrms/api/biometric_monitoring.py hrms/utils/adms_monitor.py hrms/utils/scm_roles.py hrms/api/ordering.py
