### PR TITLE
fix: harden procurement math for partial receipt flows

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -12,6 +12,7 @@ All endpoints use @frappe.whitelist() for external access.
 
 import json
 import re
+from typing import Any
 
 import frappe
 from hrms.utils.bei_config import get_company
@@ -664,7 +665,12 @@ def _augment_invoice_response(data):
 
 
 @frappe.whitelist()
-def get_purchase_orders(filters=None, page=1, page_size=20, search=None):
+def get_purchase_orders(
+    filters: dict[str, Any] | str | None = None,
+    page: int | str = 1,
+    page_size: int | str = 20,
+    search: str | None = None,
+) -> dict[str, Any]:
     """Get paginated list of POs."""
     conditions = []
     values = {}
@@ -704,12 +710,10 @@ def get_purchase_orders(filters=None, page=1, page_size=20, search=None):
     where_clause = " AND ".join(conditions) if conditions else "1=1"
     offset = (int(page) - 1) * int(page_size)
 
-    total = frappe.db.sql(
-        f"SELECT COUNT(*) FROM `tabBEI Purchase Order` WHERE {where_clause}",
-        values
-    )[0][0]
+    total_query = "SELECT COUNT(*) FROM `tabBEI Purchase Order` WHERE " + where_clause
+    total = frappe.db.sql(total_query, values)[0][0]
 
-    pos = frappe.db.sql(f"""
+    po_query = """
         SELECT
             name, po_no, po_date, status, supplier, supplier_name,
             subtotal, vat_amount, grand_total,
@@ -718,10 +722,13 @@ def get_purchase_orders(filters=None, page=1, page_size=20, search=None):
             requires_dual_approval, mae_approval, butch_approval,
             delivery_date
         FROM `tabBEI Purchase Order`
-        WHERE {where_clause}
+        WHERE """
+    po_query += where_clause
+    po_query += """
         ORDER BY po_date DESC
         LIMIT %(page_size)s OFFSET %(offset)s
-    """, {**values, "page_size": int(page_size), "offset": offset}, as_dict=True)
+    """
+    pos = frappe.db.sql(po_query, {**values, "page_size": int(page_size), "offset": offset}, as_dict=True)
 
     if _clean_optional_filter(applied_filters.get("item_code")):
         for row in pos:
@@ -740,7 +747,7 @@ def get_purchase_orders(filters=None, page=1, page_size=20, search=None):
 
 
 @frappe.whitelist()
-def get_purchase_order(name):
+def get_purchase_order(name: str) -> dict[str, Any]:
     """Get single PO with items."""
     po = frappe.get_doc("BEI Purchase Order", name)
     data = po.as_dict()
@@ -760,7 +767,7 @@ def get_purchase_order(name):
 
 
 @frappe.whitelist()
-def get_purchase_order_items(name):
+def get_purchase_order_items(name: str) -> list[dict[str, Any]]:
     """Get items for a specific PO."""
     return frappe.db.sql("""
         SELECT name, item_code, item_name, description, qty, unit_cost, unit_cost as rate,
@@ -785,7 +792,7 @@ def get_goods_receipt_items(name):
 
 
 @frappe.whitelist()
-def create_purchase_order(data=None):
+def create_purchase_order(data: dict[str, Any] | str | None = None) -> dict[str, Any]:
     """Create new PO.
 
     AUDIT CONTROL 2.8: Supplier master data quality checks
@@ -923,7 +930,12 @@ def get_pending_po_approvals():
 # =============================================================================
 
 @frappe.whitelist()
-def get_goods_receipts(filters=None, page=1, page_size=20, search=None):
+def get_goods_receipts(
+    filters: dict[str, Any] | str | None = None,
+    page: int | str = 1,
+    page_size: int | str = 20,
+    search: str | None = None,
+) -> dict[str, Any]:
     """Get paginated list of GRs."""
     conditions = []
     values = {}
@@ -953,22 +965,23 @@ def get_goods_receipts(filters=None, page=1, page_size=20, search=None):
     where_clause = " AND ".join(conditions) if conditions else "1=1"
     offset = (int(page) - 1) * int(page_size)
 
-    total = frappe.db.sql(
-        f"SELECT COUNT(*) FROM `tabBEI Goods Receipt` WHERE {where_clause}",
-        values
-    )[0][0]
+    total_query = "SELECT COUNT(*) FROM `tabBEI Goods Receipt` WHERE " + where_clause
+    total = frappe.db.sql(total_query, values)[0][0]
 
-    grs = frappe.db.sql(f"""
+    gr_query = """
         SELECT
             name, gr_no, gr_no as gr_number, receipt_date, status,
             purchase_order, purchase_order as po_number,
             supplier, supplier_name,
             total_ordered_qty, total_received_qty, total_amount
         FROM `tabBEI Goods Receipt`
-        WHERE {where_clause}
+        WHERE """
+    gr_query += where_clause
+    gr_query += """
         ORDER BY receipt_date DESC
         LIMIT %(page_size)s OFFSET %(offset)s
-    """, {**values, "page_size": int(page_size), "offset": offset}, as_dict=True)
+    """
+    grs = frappe.db.sql(gr_query, {**values, "page_size": int(page_size), "offset": offset}, as_dict=True)
 
     return {
         "data": grs,
@@ -980,7 +993,7 @@ def get_goods_receipts(filters=None, page=1, page_size=20, search=None):
 
 
 @frappe.whitelist()
-def get_goods_receipt(name):
+def get_goods_receipt(name: str) -> dict[str, Any]:
     """Get single GR with items."""
     gr = frappe.get_doc("BEI Goods Receipt", name)
     data = gr.as_dict()
@@ -1018,7 +1031,7 @@ def get_invoices_for_po(name):
 
 
 @frappe.whitelist()
-def create_goods_receipt(data=None):
+def create_goods_receipt(data: dict[str, Any] | str | None = None) -> dict[str, Any]:
     """Create new GR.
 
     AUDIT CONTROL 2.4: Block GR creation for >₱500K POs without complete approval
@@ -1094,7 +1107,12 @@ def submit_goods_receipt(name):
 
 
 @frappe.whitelist()
-def complete_gr_inspection(name, passed=True, result=None, notes=None):
+def complete_gr_inspection(
+    name: str,
+    passed: bool = True,
+    result: str | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
     """Complete quality inspection on GR."""
     if result is not None:
         passed = result == "pass"
@@ -1103,7 +1121,7 @@ def complete_gr_inspection(name, passed=True, result=None, notes=None):
 
 
 @frappe.whitelist()
-def get_pending_gr_for_po(purchase_order):
+def get_pending_gr_for_po(purchase_order: str) -> dict[str, Any]:
     """Get receivable items for a PO."""
     po = frappe.get_doc("BEI Purchase Order", purchase_order)
 
@@ -1132,7 +1150,12 @@ def get_pending_gr_for_po(purchase_order):
 # =============================================================================
 
 @frappe.whitelist()
-def get_invoices(filters=None, page=1, page_size=20, search=None):
+def get_invoices(
+    filters: dict[str, Any] | str | None = None,
+    page: int | str = 1,
+    page_size: int | str = 20,
+    search: str | None = None,
+) -> dict[str, Any]:
     """Get paginated list of invoices."""
     conditions = []
     values = {}
@@ -1167,22 +1190,23 @@ def get_invoices(filters=None, page=1, page_size=20, search=None):
     where_clause = " AND ".join(conditions) if conditions else "1=1"
     offset = (int(page) - 1) * int(page_size)
 
-    total = frappe.db.sql(
-        f"SELECT COUNT(*) FROM `tabBEI Invoice` WHERE {where_clause}",
-        values
-    )[0][0]
+    total_query = "SELECT COUNT(*) FROM `tabBEI Invoice` WHERE " + where_clause
+    total = frappe.db.sql(total_query, values)[0][0]
 
-    invoices = frappe.db.sql(f"""
+    invoice_query = """
         SELECT
             name, invoice_no, invoice_no as invoice_number, supplier_invoice_no, invoice_date, due_date,
             status, supplier, supplier_name, purchase_order, purchase_order as po_number,
             subtotal, vat_amount, subtotal as net_total, vat_amount as tax_amount,
             grand_total, balance_due, payment_status, match_status
         FROM `tabBEI Invoice`
-        WHERE {where_clause}
+        WHERE """
+    invoice_query += where_clause
+    invoice_query += """
         ORDER BY due_date ASC
         LIMIT %(page_size)s OFFSET %(offset)s
-    """, {**values, "page_size": int(page_size), "offset": offset}, as_dict=True)
+    """
+    invoices = frappe.db.sql(invoice_query, {**values, "page_size": int(page_size), "offset": offset}, as_dict=True)
 
     return {
         "data": invoices,
@@ -1194,14 +1218,14 @@ def get_invoices(filters=None, page=1, page_size=20, search=None):
 
 
 @frappe.whitelist()
-def get_invoice(name):
+def get_invoice(name: str) -> dict[str, Any]:
     """Get single invoice with full details."""
     invoice = frappe.get_doc("BEI Invoice", name)
     return _augment_invoice_response(invoice.as_dict())
 
 
 @frappe.whitelist()
-def get_invoice_items(name):
+def get_invoice_items(name: str) -> list[dict[str, Any]]:
     """Return the line items that support an invoice's 3-way match math.
 
     BEI Invoice itself does not persist a child table, so the UI should inspect
@@ -1256,7 +1280,7 @@ def get_invoice_items(name):
 
 
 @frappe.whitelist()
-def create_invoice(data):
+def create_invoice(data: dict[str, Any] | str) -> dict[str, Any]:
     """Create new invoice.
 
     AUDIT CONTROL 2.1: Require Goods Receipt before Invoice (Three-Way Matching)
@@ -1340,14 +1364,14 @@ def verify_invoice_match(name):
 
 
 @frappe.whitelist()
-def approve_invoice_variance(name, notes=None):
+def approve_invoice_variance(name: str, notes: str | None = None) -> dict[str, Any]:
     """Approve invoice despite variance."""
     invoice = frappe.get_doc("BEI Invoice", name)
     return invoice.approve_variance(notes)
 
 
 @frappe.whitelist()
-def reject_invoice_variance(name, reason):
+def reject_invoice_variance(name: str, reason: str) -> dict[str, Any]:
     """Reject invoice due to variance."""
     invoice = frappe.get_doc("BEI Invoice", name)
     return invoice.reject_variance(reason)
@@ -1358,7 +1382,12 @@ def reject_invoice_variance(name, reason):
 # =============================================================================
 
 @frappe.whitelist()
-def get_payment_requests(filters=None, page=1, page_size=20, search=None):
+def get_payment_requests(
+    filters: dict[str, Any] | str | None = None,
+    page: int | str = 1,
+    page_size: int | str = 20,
+    search: str | None = None,
+) -> dict[str, Any]:
     """Get paginated list of payment requests."""
     conditions = []
     values = {}
@@ -1396,12 +1425,10 @@ def get_payment_requests(filters=None, page=1, page_size=20, search=None):
     where_clause = " AND ".join(conditions) if conditions else "1=1"
     offset = (int(page) - 1) * int(page_size)
 
-    total = frappe.db.sql(
-        f"SELECT COUNT(*) FROM `tabBEI Payment Request` pr WHERE {where_clause}",
-        values
-    )[0][0]
+    total_query = "SELECT COUNT(*) FROM `tabBEI Payment Request` pr WHERE " + where_clause
+    total = frappe.db.sql(total_query, values)[0][0]
 
-    requests = frappe.db.sql(f"""
+    request_query = """
         SELECT
             pr.name, pr.payment_request_no, pr.payment_request_no as request_number, pr.request_date, pr.status,
             COALESCE(pr.supplier, inv.supplier) as supplier,
@@ -1410,10 +1437,17 @@ def get_payment_requests(filters=None, page=1, page_size=20, search=None):
             pr.ceo_required, pr.payment_date
         FROM `tabBEI Payment Request` pr
         LEFT JOIN `tabBEI Invoice` inv ON pr.invoice = inv.name
-        WHERE {where_clause}
+        WHERE """
+    request_query += where_clause
+    request_query += """
         ORDER BY pr.request_date DESC
         LIMIT %(page_size)s OFFSET %(offset)s
-    """, {**values, "page_size": int(page_size), "offset": offset}, as_dict=True)
+    """
+    requests = frappe.db.sql(
+        request_query,
+        {**values, "page_size": int(page_size), "offset": offset},
+        as_dict=True,
+    )
 
     if _clean_optional_filter(applied_filters.get("item_code")):
         for row in requests:
@@ -1432,7 +1466,7 @@ def get_payment_requests(filters=None, page=1, page_size=20, search=None):
 
 
 @frappe.whitelist()
-def get_payment_request(name):
+def get_payment_request(name: str) -> dict[str, Any]:
     """Get single payment request with approval status."""
     request = frappe.get_doc("BEI Payment Request", name)
     data = request.as_dict()
@@ -1443,7 +1477,7 @@ def get_payment_request(name):
 
 
 @frappe.whitelist()
-def create_payment_request(data):
+def create_payment_request(data: dict[str, Any] | str) -> dict[str, Any]:
     """Create new payment request.
 
     AUDIT CONTROL 2.1: Require Goods Receipt before Payment (Three-Way Matching)

--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -1017,9 +1017,9 @@ def get_goods_receipts_for_po(name):
 
 
 @frappe.whitelist()
-def get_invoices_for_po(name):
-    """Get invoices linked to a specific PO."""
-    return frappe.db.sql("""
+def get_invoices_for_po(name: str) -> list[dict[str, Any]]:
+	"""Get invoices linked to a specific PO."""
+	return frappe.db.sql("""
         SELECT name, invoice_no, invoice_no as invoice_number, invoice_date, due_date, status,
             supplier, supplier_name, purchase_order, purchase_order as po_number,
             subtotal, vat_amount, subtotal as net_total, vat_amount as tax_amount,

--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -16,6 +16,7 @@ import re
 import frappe
 from hrms.utils.bei_config import get_company
 from hrms.utils.delivery_billing_policy import CPO_APPROVER_EMAIL, CFO_APPROVER_EMAIL, append_approval_audit_log
+from hrms.utils.procurement_math import calculate_goods_receipt_gross_total
 from frappe import _
 from frappe.utils import flt, cint, getdate, nowdate, add_days, get_first_day, get_last_day
 
@@ -556,6 +557,112 @@ def build_payment_request_operational_filters(filters=None):
     return clauses, values
 
 
+def _normalize_purchase_order_payload(data):
+    """Compute authoritative PO totals from line items and document-level adjustments."""
+    normalized = dict(data or {})
+    normalized_items = []
+    subtotal = 0.0
+    vat_total = 0.0
+
+    for raw_item in normalized.get("items") or []:
+        item = dict(raw_item or {})
+
+        if "rate" in item and "unit_cost" not in item:
+            item["unit_cost"] = item.pop("rate")
+
+        if item.get("uom") and not frappe.db.exists("UOM", item["uom"]):
+            item.pop("uom")
+
+        qty = flt(item.get("qty"), 2)
+        unit_cost = flt(item.get("unit_cost"), 2)
+        vat_rate = flt(item.get("vat_rate") if item.get("vat_rate") is not None else 12, 2)
+
+        line_subtotal = flt(qty * unit_cost, 2)
+        line_vat = flt(line_subtotal * vat_rate / 100, 2)
+
+        item["qty"] = qty
+        item["unit_cost"] = unit_cost
+        item["vat_rate"] = vat_rate
+        item["vat_amount"] = line_vat
+        item["amount"] = flt(line_subtotal + line_vat, 2)
+
+        subtotal += line_subtotal
+        vat_total += line_vat
+        normalized_items.append(item)
+
+    discount_amount = flt(normalized.get("discount_amount"), 2)
+    delivery_fee = flt(normalized.get("delivery_fee"), 2)
+    grand_total = flt(subtotal + vat_total - discount_amount + delivery_fee, 2)
+
+    normalized["items"] = normalized_items
+    normalized["subtotal"] = flt(subtotal, 2)
+    normalized["vat_amount"] = flt(vat_total, 2)
+    normalized["discount_amount"] = discount_amount
+    normalized["delivery_fee"] = delivery_fee
+    normalized["grand_total"] = grand_total
+    normalized["requires_dual_approval"] = 1 if grand_total > 500000 else 0
+
+    return normalized
+
+
+def _normalize_invoice_payload(data):
+    """Compute authoritative invoice subtotal/VAT totals from submitted line hints."""
+    normalized = dict(data or {})
+    raw_items = normalized.pop("items", None) or []
+
+    subtotal = normalized.get("subtotal", normalized.get("net_total"))
+    vat_amount = normalized.get("vat_amount", normalized.get("tax_amount"))
+
+    if raw_items:
+        subtotal = 0.0
+        vat_amount = 0.0
+
+        for raw_item in raw_items:
+            item = dict(raw_item or {})
+            qty = flt(item.get("qty"), 2)
+            rate = flt(item.get("rate") or item.get("unit_cost"), 2)
+            line_subtotal = flt(qty * rate, 2)
+
+            if item.get("vat_rate") not in (None, ""):
+                line_vat = flt(line_subtotal * flt(item.get("vat_rate"), 2) / 100, 2)
+            elif item.get("vat_amount") not in (None, ""):
+                line_vat = flt(item.get("vat_amount"), 2)
+            elif item.get("amount") not in (None, ""):
+                line_vat = max(flt(item.get("amount"), 2) - line_subtotal, 0)
+            else:
+                line_vat = 0.0
+
+            subtotal += line_subtotal
+            vat_amount += flt(line_vat, 2)
+
+    normalized["subtotal"] = flt(subtotal, 2)
+    normalized["vat_amount"] = flt(vat_amount, 2)
+    normalized["withholding_tax"] = flt(normalized.get("withholding_tax"), 2)
+    normalized["grand_total"] = flt(
+        normalized["subtotal"] + normalized["vat_amount"] - normalized["withholding_tax"], 2
+    )
+    normalized.pop("net_total", None)
+    normalized.pop("tax_amount", None)
+
+    return normalized
+
+
+def _augment_purchase_order_response(data):
+    """Expose legacy aliases while keeping canonical VAT fields available."""
+    data["net_total"] = flt(data.get("subtotal"), 2)
+    data["tax_amount"] = flt(data.get("vat_amount"), 2)
+    return data
+
+
+def _augment_invoice_response(data):
+    """Expose stable aliases expected by the portal detail/list contracts."""
+    data["invoice_number"] = data.get("invoice_no")
+    data["po_number"] = data.get("purchase_order")
+    data["net_total"] = flt(data.get("subtotal"), 2)
+    data["tax_amount"] = flt(data.get("vat_amount"), 2)
+    return data
+
+
 @frappe.whitelist()
 def get_purchase_orders(filters=None, page=1, page_size=20, search=None):
     """Get paginated list of POs."""
@@ -605,7 +712,10 @@ def get_purchase_orders(filters=None, page=1, page_size=20, search=None):
     pos = frappe.db.sql(f"""
         SELECT
             name, po_no, po_date, status, supplier, supplier_name,
-            grand_total, requires_dual_approval, mae_approval, butch_approval,
+            subtotal, vat_amount, grand_total,
+            discount_amount, delivery_fee,
+            subtotal as net_total, vat_amount as tax_amount,
+            requires_dual_approval, mae_approval, butch_approval,
             delivery_date
         FROM `tabBEI Purchase Order`
         WHERE {where_clause}
@@ -638,22 +748,23 @@ def get_purchase_order(name):
     # Ensure items are always present (even if child table was added after PO creation)
     if not data.get("items"):
         items = frappe.db.sql("""
-            SELECT name, item_code, item_name, description, qty, rate, amount, uom
+            SELECT name, item_code, item_name, description, qty,
+                   unit_cost, unit_cost as rate, vat_rate, vat_amount, amount, uom, received_qty
             FROM `tabBEI PO Item`
             WHERE parent = %s
             ORDER BY idx
         """, (name,), as_dict=True)
         data["items"] = items
 
-    return data
+    return _augment_purchase_order_response(data)
 
 
 @frappe.whitelist()
 def get_purchase_order_items(name):
     """Get items for a specific PO."""
     return frappe.db.sql("""
-        SELECT name, item_code, item_name, description, qty, unit_cost, unit_cost as rate, amount, uom,
-               received_qty
+        SELECT name, item_code, item_name, description, qty, unit_cost, unit_cost as rate,
+               vat_rate, vat_amount, amount, uom, received_qty
         FROM `tabBEI PO Item`
         WHERE parent = %s
         ORDER BY idx
@@ -685,6 +796,7 @@ def create_purchase_order(data=None):
         frappe.throw(_("Missing required parameter: data"), frappe.ValidationError)
     if isinstance(data, str):
         data = frappe.parse_json(data)
+    data = _normalize_purchase_order_payload(data)
 
     warnings = []
     supplier_name = data.get("supplier")
@@ -729,15 +841,6 @@ def create_purchase_order(data=None):
                     supplier.supplier_name, ", ".join(missing_docs)
                 )
             )
-
-    # Map 'rate' to 'unit_cost' in items if needed (frontend sends 'rate')
-    if "items" in data:
-        for item in data["items"]:
-            if "rate" in item and "unit_cost" not in item:
-                item["unit_cost"] = item.pop("rate")
-            # Strip invalid UOM to avoid LinkValidationError
-            if item.get("uom") and not frappe.db.exists("UOM", item["uom"]):
-                item.pop("uom")
 
     po = frappe.get_doc({
         "doctype": "BEI Purchase Order",
@@ -904,8 +1007,9 @@ def get_goods_receipts_for_po(name):
 def get_invoices_for_po(name):
     """Get invoices linked to a specific PO."""
     return frappe.db.sql("""
-        SELECT name, invoice_no, invoice_date, due_date, status,
-            supplier, supplier_name, purchase_order,
+        SELECT name, invoice_no, invoice_no as invoice_number, invoice_date, due_date, status,
+            supplier, supplier_name, purchase_order, purchase_order as po_number,
+            subtotal, vat_amount, subtotal as net_total, vat_amount as tax_amount,
             grand_total, balance_due, payment_status, match_status
         FROM `tabBEI Invoice`
         WHERE purchase_order = %s
@@ -1070,9 +1174,10 @@ def get_invoices(filters=None, page=1, page_size=20, search=None):
 
     invoices = frappe.db.sql(f"""
         SELECT
-            name, invoice_no, supplier_invoice_no, invoice_date, due_date,
-            status, supplier, supplier_name, purchase_order, grand_total,
-            balance_due, payment_status, match_status
+            name, invoice_no, invoice_no as invoice_number, supplier_invoice_no, invoice_date, due_date,
+            status, supplier, supplier_name, purchase_order, purchase_order as po_number,
+            subtotal, vat_amount, subtotal as net_total, vat_amount as tax_amount,
+            grand_total, balance_due, payment_status, match_status
         FROM `tabBEI Invoice`
         WHERE {where_clause}
         ORDER BY due_date ASC
@@ -1092,7 +1197,62 @@ def get_invoices(filters=None, page=1, page_size=20, search=None):
 def get_invoice(name):
     """Get single invoice with full details."""
     invoice = frappe.get_doc("BEI Invoice", name)
-    return invoice.as_dict()
+    return _augment_invoice_response(invoice.as_dict())
+
+
+@frappe.whitelist()
+def get_invoice_items(name):
+    """Return the line items that support an invoice's 3-way match math.
+
+    BEI Invoice itself does not persist a child table, so the UI should inspect
+    the linked Goods Receipt first, then fall back to the PO items when the
+    invoice is still in pre-verification drafting.
+    """
+    invoice = frappe.get_doc("BEI Invoice", name)
+
+    if invoice.goods_receipt:
+        return frappe.db.sql(
+            """
+            SELECT
+                name,
+                item_code,
+                item_name,
+                description,
+                accepted_qty AS qty,
+                unit_cost AS rate,
+                amount,
+                uom
+            FROM `tabBEI GR Item`
+            WHERE parent = %s
+            ORDER BY idx
+            """,
+            (invoice.goods_receipt,),
+            as_dict=True,
+        )
+
+    if invoice.purchase_order:
+        return frappe.db.sql(
+            """
+            SELECT
+                name,
+                item_code,
+                item_name,
+                description,
+                qty,
+                unit_cost AS rate,
+                amount,
+                uom,
+                vat_rate,
+                vat_amount
+            FROM `tabBEI PO Item`
+            WHERE parent = %s
+            ORDER BY idx
+            """,
+            (invoice.purchase_order,),
+            as_dict=True,
+        )
+
+    return []
 
 
 @frappe.whitelist()
@@ -1105,6 +1265,7 @@ def create_invoice(data):
     """
     if isinstance(data, str):
         data = frappe.parse_json(data)
+    data = _normalize_invoice_payload(data)
 
     purchase_order = data.get("purchase_order")
     if purchase_order:
@@ -1242,10 +1403,10 @@ def get_payment_requests(filters=None, page=1, page_size=20, search=None):
 
     requests = frappe.db.sql(f"""
         SELECT
-            pr.name, pr.payment_request_no, pr.request_date, pr.status,
+            pr.name, pr.payment_request_no, pr.payment_request_no as request_number, pr.request_date, pr.status,
             COALESCE(pr.supplier, inv.supplier) as supplier,
             COALESCE(pr.supplier_name, inv.supplier_name) as supplier_name,
-            pr.payment_amount, pr.payment_mode, pr.invoice,
+            pr.payment_amount, pr.payment_mode, pr.payment_mode as payment_method, pr.invoice,
             pr.ceo_required, pr.payment_date
         FROM `tabBEI Payment Request` pr
         LEFT JOIN `tabBEI Invoice` inv ON pr.invoice = inv.name
@@ -1275,6 +1436,8 @@ def get_payment_request(name):
     """Get single payment request with approval status."""
     request = frappe.get_doc("BEI Payment Request", name)
     data = request.as_dict()
+    data["request_number"] = data.get("payment_request_no")
+    data["payment_method"] = data.get("payment_mode")
     data["approval_status"] = request.get_approval_status()
     return data
 
@@ -1365,21 +1528,39 @@ def create_payment_request(data):
                     data["is_advance_payment"] = 1
             else:
                 # AUDIT CONTROL 2.3: Payment limited to received value
-                # (only applies when GR exists — exception-approved payments skip this)
-                received_value = frappe.db.sql("""
-                    SELECT COALESCE(SUM(gri.received_qty * gri.unit_cost), 0)
-                    FROM `tabBEI GR Item` gri
-                    JOIN `tabBEI Goods Receipt` gr ON gri.parent = gr.name
-                    WHERE gr.purchase_order = %s
-                    AND gr.status IN ('Submitted', 'Approved', 'Inspected', 'Accepted')
-                """, (purchase_order,))[0][0] or 0
-
                 payment_amount = flt(data.get("payment_amount") or invoice.balance_due)
-                if payment_amount > received_value:
+                invoice_payable = flt(invoice.balance_due or invoice.grand_total)
+                received_value = invoice_payable
+
+                if invoice.goods_receipt:
+                    po_items = frappe.db.sql(
+                        """
+                        SELECT item_code, qty, unit_cost, vat_rate, vat_amount
+                        FROM `tabBEI PO Item`
+                        WHERE parent = %s
+                        ORDER BY idx
+                        """,
+                        (purchase_order,),
+                        as_dict=True,
+                    )
+                    gr_items = frappe.db.sql(
+                        """
+                        SELECT item_code, accepted_qty, received_qty, rejected_qty, unit_cost
+                        FROM `tabBEI GR Item`
+                        WHERE parent = %s
+                        ORDER BY idx
+                        """,
+                        (invoice.goods_receipt,),
+                        as_dict=True,
+                    )
+                    received_value = calculate_goods_receipt_gross_total(gr_items, po_items)
+
+                payable_cap = min(invoice_payable, received_value)
+                if payment_amount > payable_cap:
                     frappe.throw(
-                        _("Payment amount (₱{0:,.2f}) exceeds received value (₱{1:,.2f}). "
-                          "You can only pay for goods actually received.").format(
-                            payment_amount, received_value
+                        _("Payment amount (₱{0:,.2f}) exceeds the payable received value (₱{1:,.2f}). "
+                          "You can only pay for goods actually accepted and invoiced.").format(
+                            payment_amount, payable_cap
                         ),
                         title=_("Partial Delivery Control")
                     )

--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -176,7 +176,7 @@ class BEIInvoice(Document):
 			return {"success": False, "message": _("3-way match failed")}
 
 	@frappe.whitelist()
-	def approve_variance(self, notes=None):
+	def approve_variance(self, notes: str | None = None):
 		"""Approve invoice despite variance."""
 		if self.status != "Variance Pending Approval":
 			frappe.throw(_("Invoice is not pending variance approval"))
@@ -201,7 +201,7 @@ class BEIInvoice(Document):
 		return {"success": True, "message": _("Variance approved - Invoice verified") + pi_message}
 
 	@frappe.whitelist()
-	def reject_variance(self, reason):
+	def reject_variance(self, reason: str):
 		"""Reject invoice due to variance."""
 		if self.status != "Variance Pending Approval":
 			frappe.throw(_("Invoice is not pending variance approval"))
@@ -473,7 +473,12 @@ class BEIInvoice(Document):
 			frappe.throw(_("Failed to submit Purchase Invoice: {0}").format(str(e)))
 
 	@frappe.whitelist()
-	def record_payment(self, amount, payment_date=None, reference=None):
+	def record_payment(
+		self,
+		amount: float | int | str,
+		payment_date: str | None = None,
+		reference: str | None = None,
+	):
 		"""Record a payment against this invoice."""
 		amount = flt(amount, 2)
 
@@ -503,3 +508,4 @@ class BEIInvoice(Document):
 	def on_cancel(self):
 		"""Handle invoice cancellation."""
 		self.status = "Cancelled"
+		self.db_set("status", self.status, update_modified=False)

--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -4,526 +4,502 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import flt, now_datetime, getdate, add_days
+from frappe.utils import add_days, flt, getdate, now_datetime
+
 from hrms.utils.bei_config import get_company
 from hrms.utils.procurement_math import calculate_goods_receipt_gross_total
 from hrms.utils.standard_buying_bridge import apply_standard_buying_context
 
 
 class BEIInvoice(Document):
-    def validate(self):
-        self.set_invoice_no()
-        self.validate_goods_receipt()
-        self.calculate_totals()
-        self.load_reference_amounts()
-        self.perform_three_way_match()
+	def validate(self):
+		self.set_invoice_no()
+		self.validate_goods_receipt()
+		self.calculate_totals()
+		self.load_reference_amounts()
+		self.perform_three_way_match()
 
-    def validate_goods_receipt(self):
-        """Require goods_receipt unless an approved match exception exists for this PO."""
-        if self.goods_receipt:
-            return
+	def validate_goods_receipt(self):
+		"""Require goods_receipt unless an approved match exception exists for this PO."""
+		if self.goods_receipt:
+			return
 
-        if not self.purchase_order:
-            frappe.throw(_("Either Goods Receipt or Purchase Order is required"))
-            return
+		if not self.purchase_order:
+			frappe.throw(_("Either Goods Receipt or Purchase Order is required"))
+			return
 
-        approved_exception = frappe.db.exists("BEI Match Exception", {
-            "purchase_order": self.purchase_order,
-            "status": "Approved",
-        })
-        if not approved_exception:
-            frappe.throw(
-                _("Goods Receipt is required unless a match exception is approved. "
-                  "Request an exception via the procurement flow.")
-            )
+		approved_exception = frappe.db.exists(
+			"BEI Match Exception",
+			{
+				"purchase_order": self.purchase_order,
+				"status": "Approved",
+			},
+		)
+		if not approved_exception:
+			frappe.throw(
+				_(
+					"Goods Receipt is required unless a match exception is approved. "
+					"Request an exception via the procurement flow."
+				)
+			)
 
-    def set_invoice_no(self):
-        """Set invoice number from name if not already set."""
-        if not self.invoice_no and self.name:
-            self.invoice_no = self.name
+	def set_invoice_no(self):
+		"""Set invoice number from name if not already set."""
+		if not self.invoice_no and self.name:
+			self.invoice_no = self.name
 
-    def after_insert(self):
-        self.invoice_no = self.name
-        self.db_set("invoice_no", self.name, update_modified=False)
+	def after_insert(self):
+		self.invoice_no = self.name
+		self.db_set("invoice_no", self.name, update_modified=False)
 
-    def calculate_totals(self):
-        """Calculate grand total and balance."""
-        self.grand_total = (
-            flt(self.subtotal, 2)
-            + flt(self.vat_amount, 2)
-            - flt(self.withholding_tax, 2)
-        )
-        self.balance_due = flt(self.grand_total, 2) - flt(self.amount_paid, 2)
+	def calculate_totals(self):
+		"""Calculate grand total and balance."""
+		self.grand_total = flt(self.subtotal, 2) + flt(self.vat_amount, 2) - flt(self.withholding_tax, 2)
+		self.balance_due = flt(self.grand_total, 2) - flt(self.amount_paid, 2)
 
-        # Update payment status
-        if flt(self.amount_paid, 2) >= flt(self.grand_total, 2):
-            self.payment_status = "Paid"
-        elif flt(self.amount_paid, 2) > 0:
-            self.payment_status = "Partially Paid"
-        else:
-            self.payment_status = "Unpaid"
+		# Update payment status
+		if flt(self.amount_paid, 2) >= flt(self.grand_total, 2):
+			self.payment_status = "Paid"
+		elif flt(self.amount_paid, 2) > 0:
+			self.payment_status = "Partially Paid"
+		else:
+			self.payment_status = "Unpaid"
 
-    def load_reference_amounts(self):
-        """Load PO and GR amounts for 3-way match."""
-        if self.purchase_order:
-            self.po_amount = flt(
-                frappe.db.get_value("BEI Purchase Order", self.purchase_order, "grand_total")
-            )
+	def load_reference_amounts(self):
+		"""Load PO and GR amounts for 3-way match."""
+		if self.purchase_order:
+			self.po_amount = flt(
+				frappe.db.get_value("BEI Purchase Order", self.purchase_order, "grand_total")
+			)
 
-        if self.goods_receipt:
-            po_items = frappe.db.sql(
-                """
+		if self.goods_receipt:
+			po_items = frappe.db.sql(
+				"""
                 SELECT item_code, qty, unit_cost, vat_rate, vat_amount
                 FROM `tabBEI PO Item`
                 WHERE parent = %s
                 ORDER BY idx
                 """,
-                (self.purchase_order,),
-                as_dict=True,
-            )
-            gr_items = frappe.db.sql(
-                """
+				(self.purchase_order,),
+				as_dict=True,
+			)
+			gr_items = frappe.db.sql(
+				"""
                 SELECT item_code, accepted_qty, received_qty, rejected_qty, unit_cost
                 FROM `tabBEI GR Item`
                 WHERE parent = %s
                 ORDER BY idx
                 """,
-                (self.goods_receipt,),
-                as_dict=True,
-            )
-            receipt_slice_total = calculate_goods_receipt_gross_total(gr_items, po_items)
-            self.gr_amount = receipt_slice_total
-            if self.purchase_order:
-                self.po_amount = receipt_slice_total
-
-    def perform_three_way_match(self):
-        """Perform 3-way match between PO, GR, and Invoice."""
-        if not self.purchase_order or not self.goods_receipt:
-            self.match_status = "Pending"
-            return
-
-        # Preserve approved variance status - don't recalculate after approval
-        if self.match_status == "Approved with Variance":
-            return
-
-        # Calculate variances
-        self.po_gr_variance = flt(self.po_amount, 2) - flt(self.gr_amount, 2)
-        self.gr_inv_variance = flt(self.gr_amount, 2) - flt(self.grand_total, 2)
-
-        # Check if within tolerance
-        tolerance = flt(self.variance_tolerance, 2) or 1000  # Default PHP 1000
-
-        po_gr_ok = abs(flt(self.po_gr_variance, 2)) <= tolerance
-        gr_inv_ok = abs(flt(self.gr_inv_variance, 2)) <= tolerance
-
-        if po_gr_ok and gr_inv_ok:
-            self.match_status = "Matched"
-        else:
-            self.match_status = "Variance Detected"
-
-    @frappe.whitelist()
-    def submit_for_verification(self):
-        """Submit invoice for 3-way match verification."""
-        if self.status != "Draft":
-            frappe.throw(_("Only Draft invoices can be submitted"))
-
-        if not self.invoice_attachment:
-            frappe.throw(_("Please attach the supplier invoice"))
-
-        self.status = "Pending 3-Way Match"
-        self.save()
-
-        return {"success": True, "message": _("Invoice submitted for 3-way match")}
-
-    @frappe.whitelist()
-    def verify_match(self):
-        """Verify the 3-way match."""
-        if self.status != "Pending 3-Way Match":
-            frappe.throw(_("Invoice is not pending 3-way match"))
-
-        if self.match_status == "Matched":
-            self.status = "Verified"
-            self.verified_by = frappe.session.user
-            self.verified_date = now_datetime()
-            self.save()
-
-            # Create Frappe Purchase Invoice (best-effort - don't block verification)
-            pi_message = ""
-            try:
-                self.create_frappe_purchase_invoice()
-                pi_message = " Frappe Purchase Invoice created."
-            except Exception as e:
-                frappe.log_error(title="PI Creation Failed", message=str(e))
-                pi_message = f" Note: Frappe PI creation deferred ({str(e)[:100]})"
-
-            return {"success": True, "message": _("Invoice verified - 3-way match passed") + pi_message}
-
-        elif self.match_status == "Variance Detected":
-            self.status = "Variance Pending Approval"
-            self.save()
-            return {
-                "success": False,
-                "message": _("Variance detected - requires approval"),
-                "po_gr_variance": self.po_gr_variance,
-                "gr_inv_variance": self.gr_inv_variance
-            }
-
-        else:
-            self.status = "Match Failed"
-            self.save()
-            return {"success": False, "message": _("3-way match failed")}
-
-    @frappe.whitelist()
-    def approve_variance(self, notes=None):
-        """Approve invoice despite variance."""
-        if self.status != "Variance Pending Approval":
-            frappe.throw(_("Invoice is not pending variance approval"))
-
-        self.match_status = "Approved with Variance"
-        self.variance_approved_by = frappe.session.user
-        self.variance_notes = notes
-        self.status = "Verified"
-        self.verified_by = frappe.session.user
-        self.verified_date = now_datetime()
-        self.save()
-
-        # Create Frappe Purchase Invoice (best-effort - don't block variance approval)
-        pi_message = ""
-        try:
-            self.create_frappe_purchase_invoice()
-            pi_message = " Frappe Purchase Invoice created."
-        except Exception as e:
-            frappe.log_error(title="PI Creation Failed", message=str(e))
-            pi_message = f" Note: Frappe PI creation deferred ({str(e)[:100]})"
-
-        return {"success": True, "message": _("Variance approved - Invoice verified") + pi_message}
-
-    @frappe.whitelist()
-    def reject_variance(self, reason):
-        """Reject invoice due to variance."""
-        if self.status != "Variance Pending Approval":
-            frappe.throw(_("Invoice is not pending variance approval"))
-
-        if not reason:
-            frappe.throw(_("Please provide a rejection reason"))
-
-        self.variance_notes = reason
-        self.status = "Match Failed"
-        self.save()
-
-        return {"success": True, "message": _("Invoice rejected due to variance")}
-
-    def create_frappe_purchase_invoice(self):
-        """
-        Create corresponding Frappe Purchase Invoice.
-
-        PREREQUISITES:
-        - BEI Invoice must be Verified (3-way match passed or variance approved)
-        - BEI PO must have Frappe PO linked
-        - BEI GR must have Frappe Purchase Receipt linked
-
-        FIELD MAPPING:
-        - invoice_date -> posting_date
-        - due_date -> due_date
-        - supplier_invoice_no -> bill_no
-        - items from GR (accepted quantities)
-        - withholding_tax -> taxes (EWT)
-        - Links to Frappe PO and PR for proper AP posting
-
-        GL ENTRIES (created automatically by Frappe):
-        - Dr: Expense/Stock Account (per item)
-        - Cr: Accounts Payable
-
-        Returns: Frappe Purchase Invoice name or None
-        """
-        if self.frappe_purchase_invoice:
-            frappe.msgprint(
-                _("Already linked to Frappe Purchase Invoice: {0}").format(
-                    self.frappe_purchase_invoice
-                ),
-                indicator="blue"
-            )
-            return self.frappe_purchase_invoice
-
-        # Validate status - must be verified
-        if self.status not in ["Verified", "Partially Paid", "Paid"]:
-            frappe.throw(
-                _("Cannot create Purchase Invoice - 3-way match not verified. "
-                  "Current status: {0}").format(self.status)
-            )
-
-        # Validate match status
-        if self.match_status not in ["Matched", "Approved with Variance"]:
-            frappe.throw(
-                _("Cannot create Purchase Invoice - Match status: {0}").format(
-                    self.match_status
-                )
-            )
-
-        # Get Frappe Supplier
-        bei_supplier = frappe.get_doc("BEI Supplier", self.supplier)
-        frappe_supplier = bei_supplier.get_or_create_frappe_supplier()
-
-        if not frappe_supplier:
-            frappe.throw(
-                _("Could not get or create Frappe Supplier for {0}").format(
-                    self.supplier
-                )
-            )
-
-        # Get linked documents
-        bei_po = frappe.get_doc("BEI Purchase Order", self.purchase_order)
-        bei_gr = frappe.get_doc("BEI Goods Receipt", self.goods_receipt)
-
-        # Ensure Frappe PO exists
-        if not bei_po.frappe_po:
-            if bei_po.status == "Approved":
-                bei_po.create_frappe_purchase_order()
-            else:
-                frappe.throw(
-                    _("No Frappe PO linked. Please ensure BEI PO is approved first.")
-                )
-
-        frappe_po = bei_po.frappe_po
-
-        # Ensure Frappe PR exists
-        if not bei_gr.frappe_purchase_receipt:
-            if bei_gr.status in ["Accepted", "Partially Accepted"]:
-                bei_gr.create_frappe_purchase_receipt()
-            else:
-                frappe.throw(
-                    _("No Frappe Purchase Receipt linked. "
-                      "Please ensure GR is accepted first.")
-                )
-
-        frappe_pr = bei_gr.frappe_purchase_receipt
-
-        # Prepare invoice items from GR (actual received quantities)
-        pi_items = []
-        for gr_item in bei_gr.items:
-            accepted_qty = flt(gr_item.accepted_qty, 2)
-
-            if accepted_qty <= 0:
-                continue
-
-            # Find corresponding PO and PR items
-            po_item = self._find_po_item(frappe_po, gr_item.item_code)
-            pr_item = self._find_pr_item(frappe_pr, gr_item.item_code)
-
-            pi_items.append({
-                "item_code": gr_item.item_code,
-                "item_name": gr_item.item_name,
-                "description": gr_item.description or gr_item.item_name,
-                "qty": accepted_qty,
-                "stock_uom": gr_item.uom or "Nos",
-                "uom": gr_item.uom or "Nos",
-                "conversion_factor": 1,
-                "rate": flt(gr_item.unit_cost, 2),
-                "expense_account": self._get_expense_account(gr_item),
-                "purchase_order": frappe_po,
-                "po_detail": po_item,
-                "purchase_receipt": frappe_pr,
-                "pr_detail": pr_item,
-                "bei_invoice_item": gr_item.name,  # Reference
-            })
-
-        if not pi_items:
-            frappe.throw(_("No valid items to create Purchase Invoice"))
-
-        # Create Frappe Purchase Invoice
-        pi = frappe.get_doc({
-            "doctype": "Purchase Invoice",
-            "supplier": frappe_supplier,
-            "posting_date": self.invoice_date,
-            "due_date": self.due_date,
-            "bill_no": self.supplier_invoice_no,
-            "bill_date": self.invoice_date,
-            "company": get_company(),
-            "currency": "PHP",
-            "buying_price_list": "Standard Buying",
-            "update_stock": 0,  # Stock already updated via PR
-            "is_return": 0,
-            "bei_invoice": self.name,  # Reference back
-            "payment_terms_template": self.payment_terms,
-            "items": pi_items
-        })
-        apply_standard_buying_context(
-            pi,
-            store_label=bei_gr.warehouse or bei_po.ship_to,
-        )
-
-        # Add withholding tax (EWT) if applicable
-        if flt(self.withholding_tax, 2) > 0:
-            self._add_withholding_tax(pi)
-
-        try:
-            pi.insert(ignore_permissions=True)
-            # Don't submit yet - may need review
-            # pi.submit()
-
-            self.frappe_purchase_invoice = pi.name
-            self.db_set("frappe_purchase_invoice", pi.name, update_modified=False)
-
-            frappe.msgprint(
-                _("Created Frappe Purchase Invoice (Draft): {0}. "
-                  "Review and submit manually.").format(pi.name),
-                indicator="green"
-            )
-
-            return pi.name
-
-        except Exception as e:
-            frappe.log_error(
-                f"Failed to create Frappe PI for BEI Invoice {self.name}: {e}",
-                "BEI Invoice Integration Error"
-            )
-            frappe.throw(
-                _("Failed to create Frappe Purchase Invoice: {0}").format(str(e))
-            )
-
-    def _find_po_item(self, frappe_po_name, item_code):
-        """Find Purchase Order Item for linking."""
-        return frappe.db.get_value(
-            "Purchase Order Item",
-            {"parent": frappe_po_name, "item_code": item_code},
-            "name"
-        )
-
-    def _find_pr_item(self, frappe_pr_name, item_code):
-        """Find Purchase Receipt Item for linking."""
-        return frappe.db.get_value(
-            "Purchase Receipt Item",
-            {"parent": frappe_pr_name, "item_code": item_code},
-            "name"
-        )
-
-    def _get_expense_account(self, item):
-        """
-        Get appropriate expense account for invoice item.
-
-        Account mapping based on item group:
-        - Raw Materials: 5110 - Cost of Raw Materials
-        - Finished Goods: 5100 - Cost of Goods Sold
-        - Packaging: 5120 - Packaging Expenses
-        - Consumables: 6200 - Operating Supplies
-        - Fixed Assets: 1500 - Fixed Assets
-
-        Returns: Account name
-        """
-        # Get item group
-        item_group = frappe.db.get_value("Item", item.item_code, "item_group")
-
-        # Account mapping (BEI COA)
-        account_map = {
-            "Raw Material": "5110 - Cost of Raw Materials - BEI",
-            "Finished Goods": "5100 - Cost of Goods Sold - BEI",
-            "Packaging Material": "5120 - Packaging Expenses - BEI",
-            "Consumable": "6200 - Operating Supplies - BEI",
-            "Fixed Asset": "1500 - Fixed Assets - BEI",
-            "Products": "5100 - Cost of Goods Sold - BEI",  # Default
-        }
-
-        # Return mapped account or default
-        account = account_map.get(item_group, "5100 - Cost of Goods Sold - BEI")
-
-        # Verify account exists, fallback to default expense account
-        if not frappe.db.exists("Account", account):
-            default_expense = frappe.db.get_value(
-                "Company",
-                get_company(),
-                "default_expense_account"
-            )
-            return default_expense or "5100 - Cost of Goods Sold - BEI"
-
-        return account
-
-    def _add_withholding_tax(self, pi):
-        """
-        Add withholding tax (EWT) to Purchase Invoice.
-
-        Philippine EWT rates:
-        - 1% for goods
-        - 2% for services
-        - 5% for professional fees
-
-        This method adds a negative tax entry for EWT.
-        """
-        ewt_account = "2150 - Withholding Tax Payable - BEI"
-
-        # Verify EWT account exists
-        if not frappe.db.exists("Account", ewt_account):
-            # Try to find any withholding account
-            ewt_account = frappe.db.get_value(
-                "Account",
-                {"account_name": ["like", "%Withholding%"], "company": get_company()},
-                "name"
-            )
-
-        if ewt_account:
-            pi.append("taxes", {
-                "charge_type": "Actual",
-                "account_head": ewt_account,
-                "description": "Expanded Withholding Tax (EWT)",
-                "tax_amount": -flt(self.withholding_tax, 2),  # Negative to reduce payable
-                "category": "Total",
-                "add_deduct_tax": "Deduct"
-            })
-
-    @frappe.whitelist()
-    def submit_frappe_invoice(self):
-        """Submit the linked Frappe Purchase Invoice."""
-        if not self.frappe_purchase_invoice:
-            frappe.throw(_("No Frappe Purchase Invoice linked"))
-
-        pi = frappe.get_doc("Purchase Invoice", self.frappe_purchase_invoice)
-
-        if pi.docstatus == 1:
-            frappe.msgprint(
-                _("Frappe Purchase Invoice already submitted"),
-                indicator="blue"
-            )
-            return
-
-        try:
-            pi.submit()
-            frappe.msgprint(
-                _("Submitted Frappe Purchase Invoice: {0}").format(pi.name),
-                indicator="green"
-            )
-            return pi.name
-        except Exception as e:
-            frappe.throw(
-                _("Failed to submit Purchase Invoice: {0}").format(str(e))
-            )
-
-    @frappe.whitelist()
-    def record_payment(self, amount, payment_date=None, reference=None):
-        """Record a payment against this invoice."""
-        amount = flt(amount, 2)
-
-        if amount <= 0:
-            frappe.throw(_("Payment amount must be greater than zero"))
-
-        if amount > self.balance_due:
-            frappe.throw(_("Payment amount cannot exceed balance due"))
-
-        self.amount_paid = flt(self.amount_paid, 2) + amount
-        self.last_payment_date = payment_date or getdate()
-        self.calculate_totals()
-
-        if self.payment_status == "Paid":
-            self.status = "Paid"
-        else:
-            self.status = "Partially Paid"
-
-        self.save()
-
-        return {
-            "success": True,
-            "message": _("Payment of {0} recorded").format(amount),
-            "balance_due": self.balance_due
-        }
-
-    def on_cancel(self):
-        """Handle invoice cancellation."""
-        self.status = "Cancelled"
+				(self.goods_receipt,),
+				as_dict=True,
+			)
+			receipt_slice_total = calculate_goods_receipt_gross_total(gr_items, po_items)
+			self.gr_amount = receipt_slice_total
+			if self.purchase_order:
+				self.po_amount = receipt_slice_total
+
+	def perform_three_way_match(self):
+		"""Perform 3-way match between PO, GR, and Invoice."""
+		if not self.purchase_order or not self.goods_receipt:
+			self.match_status = "Pending"
+			return
+
+		# Preserve approved variance status - don't recalculate after approval
+		if self.match_status == "Approved with Variance":
+			return
+
+		# Calculate variances
+		self.po_gr_variance = flt(self.po_amount, 2) - flt(self.gr_amount, 2)
+		self.gr_inv_variance = flt(self.gr_amount, 2) - flt(self.grand_total, 2)
+
+		# Check if within tolerance
+		tolerance = flt(self.variance_tolerance, 2) or 1000  # Default PHP 1000
+
+		po_gr_ok = abs(flt(self.po_gr_variance, 2)) <= tolerance
+		gr_inv_ok = abs(flt(self.gr_inv_variance, 2)) <= tolerance
+
+		if po_gr_ok and gr_inv_ok:
+			self.match_status = "Matched"
+		else:
+			self.match_status = "Variance Detected"
+
+	@frappe.whitelist()
+	def submit_for_verification(self):
+		"""Submit invoice for 3-way match verification."""
+		if self.status != "Draft":
+			frappe.throw(_("Only Draft invoices can be submitted"))
+
+		if not self.invoice_attachment:
+			frappe.throw(_("Please attach the supplier invoice"))
+
+		self.status = "Pending 3-Way Match"
+		self.save()
+
+		return {"success": True, "message": _("Invoice submitted for 3-way match")}
+
+	@frappe.whitelist()
+	def verify_match(self):
+		"""Verify the 3-way match."""
+		if self.status != "Pending 3-Way Match":
+			frappe.throw(_("Invoice is not pending 3-way match"))
+
+		if self.match_status == "Matched":
+			self.status = "Verified"
+			self.verified_by = frappe.session.user
+			self.verified_date = now_datetime()
+			self.save()
+
+			# Create Frappe Purchase Invoice (best-effort - don't block verification)
+			pi_message = ""
+			try:
+				self.create_frappe_purchase_invoice()
+				pi_message = " Frappe Purchase Invoice created."
+			except Exception as e:
+				frappe.log_error(title="PI Creation Failed", message=str(e))
+				pi_message = f" Note: Frappe PI creation deferred ({str(e)[:100]})"
+
+			return {"success": True, "message": _("Invoice verified - 3-way match passed") + pi_message}
+
+		elif self.match_status == "Variance Detected":
+			self.status = "Variance Pending Approval"
+			self.save()
+			return {
+				"success": False,
+				"message": _("Variance detected - requires approval"),
+				"po_gr_variance": self.po_gr_variance,
+				"gr_inv_variance": self.gr_inv_variance,
+			}
+
+		else:
+			self.status = "Match Failed"
+			self.save()
+			return {"success": False, "message": _("3-way match failed")}
+
+	@frappe.whitelist()
+	def approve_variance(self, notes=None):
+		"""Approve invoice despite variance."""
+		if self.status != "Variance Pending Approval":
+			frappe.throw(_("Invoice is not pending variance approval"))
+
+		self.match_status = "Approved with Variance"
+		self.variance_approved_by = frappe.session.user
+		self.variance_notes = notes
+		self.status = "Verified"
+		self.verified_by = frappe.session.user
+		self.verified_date = now_datetime()
+		self.save()
+
+		# Create Frappe Purchase Invoice (best-effort - don't block variance approval)
+		pi_message = ""
+		try:
+			self.create_frappe_purchase_invoice()
+			pi_message = " Frappe Purchase Invoice created."
+		except Exception as e:
+			frappe.log_error(title="PI Creation Failed", message=str(e))
+			pi_message = f" Note: Frappe PI creation deferred ({str(e)[:100]})"
+
+		return {"success": True, "message": _("Variance approved - Invoice verified") + pi_message}
+
+	@frappe.whitelist()
+	def reject_variance(self, reason):
+		"""Reject invoice due to variance."""
+		if self.status != "Variance Pending Approval":
+			frappe.throw(_("Invoice is not pending variance approval"))
+
+		if not reason:
+			frappe.throw(_("Please provide a rejection reason"))
+
+		self.variance_notes = reason
+		self.status = "Match Failed"
+		self.save()
+
+		return {"success": True, "message": _("Invoice rejected due to variance")}
+
+	def create_frappe_purchase_invoice(self):
+		"""
+		Create corresponding Frappe Purchase Invoice.
+
+		PREREQUISITES:
+		- BEI Invoice must be Verified (3-way match passed or variance approved)
+		- BEI PO must have Frappe PO linked
+		- BEI GR must have Frappe Purchase Receipt linked
+
+		FIELD MAPPING:
+		- invoice_date -> posting_date
+		- due_date -> due_date
+		- supplier_invoice_no -> bill_no
+		- items from GR (accepted quantities)
+		- withholding_tax -> taxes (EWT)
+		- Links to Frappe PO and PR for proper AP posting
+
+		GL ENTRIES (created automatically by Frappe):
+		- Dr: Expense/Stock Account (per item)
+		- Cr: Accounts Payable
+
+		Returns: Frappe Purchase Invoice name or None
+		"""
+		if self.frappe_purchase_invoice:
+			frappe.msgprint(
+				_("Already linked to Frappe Purchase Invoice: {0}").format(self.frappe_purchase_invoice),
+				indicator="blue",
+			)
+			return self.frappe_purchase_invoice
+
+		# Validate status - must be verified
+		if self.status not in ["Verified", "Partially Paid", "Paid"]:
+			frappe.throw(
+				_("Cannot create Purchase Invoice - 3-way match not verified. " "Current status: {0}").format(
+					self.status
+				)
+			)
+
+		# Validate match status
+		if self.match_status not in ["Matched", "Approved with Variance"]:
+			frappe.throw(_("Cannot create Purchase Invoice - Match status: {0}").format(self.match_status))
+
+		# Get Frappe Supplier
+		bei_supplier = frappe.get_doc("BEI Supplier", self.supplier)
+		frappe_supplier = bei_supplier.get_or_create_frappe_supplier()
+
+		if not frappe_supplier:
+			frappe.throw(_("Could not get or create Frappe Supplier for {0}").format(self.supplier))
+
+		# Get linked documents
+		bei_po = frappe.get_doc("BEI Purchase Order", self.purchase_order)
+		bei_gr = frappe.get_doc("BEI Goods Receipt", self.goods_receipt)
+
+		# Ensure Frappe PO exists
+		if not bei_po.frappe_po:
+			if bei_po.status == "Approved":
+				bei_po.create_frappe_purchase_order()
+			else:
+				frappe.throw(_("No Frappe PO linked. Please ensure BEI PO is approved first."))
+
+		frappe_po = bei_po.frappe_po
+
+		# Ensure Frappe PR exists
+		if not bei_gr.frappe_purchase_receipt:
+			if bei_gr.status in ["Accepted", "Partially Accepted"]:
+				bei_gr.create_frappe_purchase_receipt()
+			else:
+				frappe.throw(_("No Frappe Purchase Receipt linked. " "Please ensure GR is accepted first."))
+
+		frappe_pr = bei_gr.frappe_purchase_receipt
+
+		# Prepare invoice items from GR (actual received quantities)
+		pi_items = []
+		for gr_item in bei_gr.items:
+			accepted_qty = flt(gr_item.accepted_qty, 2)
+
+			if accepted_qty <= 0:
+				continue
+
+			# Find corresponding PO and PR items
+			po_item = self._find_po_item(frappe_po, gr_item.item_code)
+			pr_item = self._find_pr_item(frappe_pr, gr_item.item_code)
+
+			pi_items.append(
+				{
+					"item_code": gr_item.item_code,
+					"item_name": gr_item.item_name,
+					"description": gr_item.description or gr_item.item_name,
+					"qty": accepted_qty,
+					"stock_uom": gr_item.uom or "Nos",
+					"uom": gr_item.uom or "Nos",
+					"conversion_factor": 1,
+					"rate": flt(gr_item.unit_cost, 2),
+					"expense_account": self._get_expense_account(gr_item),
+					"purchase_order": frappe_po,
+					"po_detail": po_item,
+					"purchase_receipt": frappe_pr,
+					"pr_detail": pr_item,
+					"bei_invoice_item": gr_item.name,  # Reference
+				}
+			)
+
+		if not pi_items:
+			frappe.throw(_("No valid items to create Purchase Invoice"))
+
+		# Create Frappe Purchase Invoice
+		pi = frappe.get_doc(
+			{
+				"doctype": "Purchase Invoice",
+				"supplier": frappe_supplier,
+				"posting_date": self.invoice_date,
+				"due_date": self.due_date,
+				"bill_no": self.supplier_invoice_no,
+				"bill_date": self.invoice_date,
+				"company": get_company(),
+				"currency": "PHP",
+				"buying_price_list": "Standard Buying",
+				"update_stock": 0,  # Stock already updated via PR
+				"is_return": 0,
+				"bei_invoice": self.name,  # Reference back
+				"payment_terms_template": self.payment_terms,
+				"items": pi_items,
+			}
+		)
+		apply_standard_buying_context(
+			pi,
+			store_label=bei_gr.warehouse or bei_po.ship_to,
+		)
+
+		# Add withholding tax (EWT) if applicable
+		if flt(self.withholding_tax, 2) > 0:
+			self._add_withholding_tax(pi)
+
+		try:
+			pi.insert(ignore_permissions=True)
+			# Don't submit yet - may need review
+			# pi.submit()
+
+			self.frappe_purchase_invoice = pi.name
+			self.db_set("frappe_purchase_invoice", pi.name, update_modified=False)
+
+			frappe.msgprint(
+				_("Created Frappe Purchase Invoice (Draft): {0}. " "Review and submit manually.").format(
+					pi.name
+				),
+				indicator="green",
+			)
+
+			return pi.name
+
+		except Exception as e:
+			frappe.log_error(
+				f"Failed to create Frappe PI for BEI Invoice {self.name}: {e}",
+				"BEI Invoice Integration Error",
+			)
+			frappe.throw(_("Failed to create Frappe Purchase Invoice: {0}").format(str(e)))
+
+	def _find_po_item(self, frappe_po_name, item_code):
+		"""Find Purchase Order Item for linking."""
+		return frappe.db.get_value(
+			"Purchase Order Item", {"parent": frappe_po_name, "item_code": item_code}, "name"
+		)
+
+	def _find_pr_item(self, frappe_pr_name, item_code):
+		"""Find Purchase Receipt Item for linking."""
+		return frappe.db.get_value(
+			"Purchase Receipt Item", {"parent": frappe_pr_name, "item_code": item_code}, "name"
+		)
+
+	def _get_expense_account(self, item):
+		"""
+		Get appropriate expense account for invoice item.
+
+		Account mapping based on item group:
+		- Raw Materials: 5110 - Cost of Raw Materials
+		- Finished Goods: 5100 - Cost of Goods Sold
+		- Packaging: 5120 - Packaging Expenses
+		- Consumables: 6200 - Operating Supplies
+		- Fixed Assets: 1500 - Fixed Assets
+
+		Returns: Account name
+		"""
+		# Get item group
+		item_group = frappe.db.get_value("Item", item.item_code, "item_group")
+
+		# Account mapping (BEI COA)
+		account_map = {
+			"Raw Material": "5110 - Cost of Raw Materials - BEI",
+			"Finished Goods": "5100 - Cost of Goods Sold - BEI",
+			"Packaging Material": "5120 - Packaging Expenses - BEI",
+			"Consumable": "6200 - Operating Supplies - BEI",
+			"Fixed Asset": "1500 - Fixed Assets - BEI",
+			"Products": "5100 - Cost of Goods Sold - BEI",  # Default
+		}
+
+		# Return mapped account or default
+		account = account_map.get(item_group, "5100 - Cost of Goods Sold - BEI")
+
+		# Verify account exists, fallback to default expense account
+		if not frappe.db.exists("Account", account):
+			default_expense = frappe.db.get_value("Company", get_company(), "default_expense_account")
+			return default_expense or "5100 - Cost of Goods Sold - BEI"
+
+		return account
+
+	def _add_withholding_tax(self, pi):
+		"""
+		Add withholding tax (EWT) to Purchase Invoice.
+
+		Philippine EWT rates:
+		- 1% for goods
+		- 2% for services
+		- 5% for professional fees
+
+		This method adds a negative tax entry for EWT.
+		"""
+		ewt_account = "2150 - Withholding Tax Payable - BEI"
+
+		# Verify EWT account exists
+		if not frappe.db.exists("Account", ewt_account):
+			# Try to find any withholding account
+			ewt_account = frappe.db.get_value(
+				"Account", {"account_name": ["like", "%Withholding%"], "company": get_company()}, "name"
+			)
+
+		if ewt_account:
+			pi.append(
+				"taxes",
+				{
+					"charge_type": "Actual",
+					"account_head": ewt_account,
+					"description": "Expanded Withholding Tax (EWT)",
+					"tax_amount": -flt(self.withholding_tax, 2),  # Negative to reduce payable
+					"category": "Total",
+					"add_deduct_tax": "Deduct",
+				},
+			)
+
+	@frappe.whitelist()
+	def submit_frappe_invoice(self):
+		"""Submit the linked Frappe Purchase Invoice."""
+		if not self.frappe_purchase_invoice:
+			frappe.throw(_("No Frappe Purchase Invoice linked"))
+
+		pi = frappe.get_doc("Purchase Invoice", self.frappe_purchase_invoice)
+
+		if pi.docstatus == 1:
+			frappe.msgprint(_("Frappe Purchase Invoice already submitted"), indicator="blue")
+			return
+
+		try:
+			pi.submit()
+			frappe.msgprint(_("Submitted Frappe Purchase Invoice: {0}").format(pi.name), indicator="green")
+			return pi.name
+		except Exception as e:
+			frappe.throw(_("Failed to submit Purchase Invoice: {0}").format(str(e)))
+
+	@frappe.whitelist()
+	def record_payment(self, amount, payment_date=None, reference=None):
+		"""Record a payment against this invoice."""
+		amount = flt(amount, 2)
+
+		if amount <= 0:
+			frappe.throw(_("Payment amount must be greater than zero"))
+
+		if amount > self.balance_due:
+			frappe.throw(_("Payment amount cannot exceed balance due"))
+
+		self.amount_paid = flt(self.amount_paid, 2) + amount
+		self.last_payment_date = payment_date or getdate()
+		self.calculate_totals()
+
+		if self.payment_status == "Paid":
+			self.status = "Paid"
+		else:
+			self.status = "Partially Paid"
+
+		self.save()
+
+		return {
+			"success": True,
+			"message": _("Payment of {0} recorded").format(amount),
+			"balance_due": self.balance_due,
+		}
+
+	def on_cancel(self):
+		"""Handle invoice cancellation."""
+		self.status = "Cancelled"

--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -6,6 +6,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import flt, now_datetime, getdate, add_days
 from hrms.utils.bei_config import get_company
+from hrms.utils.procurement_math import calculate_goods_receipt_gross_total
 from hrms.utils.standard_buying_bridge import apply_standard_buying_context
 
 
@@ -65,14 +66,35 @@ class BEIInvoice(Document):
     def load_reference_amounts(self):
         """Load PO and GR amounts for 3-way match."""
         if self.purchase_order:
-            self.po_amount = flt(frappe.db.get_value(
-                "BEI Purchase Order", self.purchase_order, "grand_total"
-            ))
+            self.po_amount = flt(
+                frappe.db.get_value("BEI Purchase Order", self.purchase_order, "grand_total")
+            )
 
         if self.goods_receipt:
-            self.gr_amount = flt(frappe.db.get_value(
-                "BEI Goods Receipt", self.goods_receipt, "total_amount"
-            ))
+            po_items = frappe.db.sql(
+                """
+                SELECT item_code, qty, unit_cost, vat_rate, vat_amount
+                FROM `tabBEI PO Item`
+                WHERE parent = %s
+                ORDER BY idx
+                """,
+                (self.purchase_order,),
+                as_dict=True,
+            )
+            gr_items = frappe.db.sql(
+                """
+                SELECT item_code, accepted_qty, received_qty, rejected_qty, unit_cost
+                FROM `tabBEI GR Item`
+                WHERE parent = %s
+                ORDER BY idx
+                """,
+                (self.goods_receipt,),
+                as_dict=True,
+            )
+            receipt_slice_total = calculate_goods_receipt_gross_total(gr_items, po_items)
+            self.gr_amount = receipt_slice_total
+            if self.purchase_order:
+                self.po_amount = receipt_slice_total
 
     def perform_three_way_match(self):
         """Perform 3-way match between PO, GR, and Invoice."""

--- a/hrms/tests/test_procurement_math_contract_s062.py
+++ b/hrms/tests/test_procurement_math_contract_s062.py
@@ -46,7 +46,7 @@ def _install_fake_frappe():
 	frappe.throw = _throw
 	frappe.ValidationError = ValidationError
 	frappe.PermissionError = PermissionError
-	frappe.session = types.SimpleNamespace(user="Administrator")
+	frappe.__dict__["session"] = types.SimpleNamespace(user="Administrator")
 	frappe.parse_json = lambda value: json.loads(value) if isinstance(value, str) else value
 	frappe.has_permission = lambda *args, **kwargs: True
 	frappe.get_roles = lambda user=None: ["System Manager"]
@@ -54,7 +54,7 @@ def _install_fake_frappe():
 	frappe.msgprint = lambda *args, **kwargs: None
 	frappe.get_doc = lambda *args, **kwargs: None
 	frappe.get_all = lambda *args, **kwargs: []
-	frappe.db = types.SimpleNamespace(
+	frappe.__dict__["db"] = types.SimpleNamespace(
 		exists=lambda *args, **kwargs: None,
 		get_value=lambda *args, **kwargs: None,
 		set_value=lambda *args, **kwargs: None,
@@ -114,7 +114,7 @@ class _InsertedDoc:
 
 class TestProcurementMathContractS062(unittest.TestCase):
 	def setUp(self):
-		procurement.frappe.session = types.SimpleNamespace(user="Administrator")
+		procurement.frappe.__dict__["session"] = types.SimpleNamespace(user="Administrator")
 		procurement.frappe.db.exists = MagicMock(return_value=True)
 		procurement.frappe.db.get_value = MagicMock(return_value=None)
 		procurement.frappe.db.sql = MagicMock(return_value=[])

--- a/hrms/tests/test_procurement_math_contract_s062.py
+++ b/hrms/tests/test_procurement_math_contract_s062.py
@@ -8,94 +8,94 @@ from unittest.mock import MagicMock
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+	sys.path.insert(0, str(ROOT))
 
 
 def _install_fake_frappe():
-    if "frappe" in sys.modules:
-        return
+	if "frappe" in sys.modules:
+		return
 
-    frappe = types.ModuleType("frappe")
-    utils = types.ModuleType("frappe.utils")
+	frappe = types.ModuleType("frappe")
+	utils = types.ModuleType("frappe.utils")
 
-    class ValidationError(Exception):
-        pass
+	class ValidationError(Exception):
+		pass
 
-    class PermissionError(Exception):
-        pass
+	class PermissionError(Exception):
+		pass
 
-    def whitelist(*args, **kwargs):
-        def decorator(fn):
-            return fn
+	def whitelist(*args, **kwargs):
+		def decorator(fn):
+			return fn
 
-        return decorator
+		return decorator
 
-    def _throw(message, exc=None, title=None):
-        if isinstance(exc, type) and issubclass(exc, Exception):
-            raise exc(message)
-        raise Exception(message)
+	def _throw(message, exc=None, title=None):
+		if isinstance(exc, type) and issubclass(exc, Exception):
+			raise exc(message)
+		raise Exception(message)
 
-    def _flt(value, precision=None):
-        num = float(value or 0)
-        if precision is not None:
-            return round(num, int(precision))
-        return num
+	def _flt(value, precision=None):
+		num = float(value or 0)
+		if precision is not None:
+			return round(num, int(precision))
+		return num
 
-    frappe.whitelist = whitelist
-    frappe._ = lambda text: text
-    frappe.throw = _throw
-    frappe.ValidationError = ValidationError
-    frappe.PermissionError = PermissionError
-    frappe.session = types.SimpleNamespace(user="Administrator")
-    frappe.parse_json = lambda value: json.loads(value) if isinstance(value, str) else value
-    frappe.has_permission = lambda *args, **kwargs: True
-    frappe.get_roles = lambda user=None: ["System Manager"]
-    frappe.log_error = lambda *args, **kwargs: None
-    frappe.msgprint = lambda *args, **kwargs: None
-    frappe.get_doc = lambda *args, **kwargs: None
-    frappe.get_all = lambda *args, **kwargs: []
-    frappe.db = types.SimpleNamespace(
-        exists=lambda *args, **kwargs: None,
-        get_value=lambda *args, **kwargs: None,
-        set_value=lambda *args, **kwargs: None,
-        sql=lambda *args, **kwargs: [],
-    )
+	frappe.whitelist = whitelist
+	frappe._ = lambda text: text
+	frappe.throw = _throw
+	frappe.ValidationError = ValidationError
+	frappe.PermissionError = PermissionError
+	frappe.session = types.SimpleNamespace(user="Administrator")
+	frappe.parse_json = lambda value: json.loads(value) if isinstance(value, str) else value
+	frappe.has_permission = lambda *args, **kwargs: True
+	frappe.get_roles = lambda user=None: ["System Manager"]
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.msgprint = lambda *args, **kwargs: None
+	frappe.get_doc = lambda *args, **kwargs: None
+	frappe.get_all = lambda *args, **kwargs: []
+	frappe.db = types.SimpleNamespace(
+		exists=lambda *args, **kwargs: None,
+		get_value=lambda *args, **kwargs: None,
+		set_value=lambda *args, **kwargs: None,
+		sql=lambda *args, **kwargs: [],
+	)
 
-    utils.flt = _flt
-    utils.cint = lambda value: int(float(value or 0))
-    utils.getdate = lambda value=None: value or "2026-03-18"
-    utils.nowdate = lambda: "2026-03-18"
-    utils.add_days = lambda date_obj, days: date_obj
-    utils.date_diff = lambda end_date, start_date: 0
-    utils.get_first_day = lambda date_obj: date_obj
-    utils.get_last_day = lambda date_obj: date_obj
+	utils.flt = _flt
+	utils.cint = lambda value: int(float(value or 0))
+	utils.getdate = lambda value=None: value or "2026-03-18"
+	utils.nowdate = lambda: "2026-03-18"
+	utils.add_days = lambda date_obj, days: date_obj
+	utils.date_diff = lambda end_date, start_date: 0
+	utils.get_first_day = lambda date_obj: date_obj
+	utils.get_last_day = lambda date_obj: date_obj
 
-    sys.modules["frappe"] = frappe
-    sys.modules["frappe.utils"] = utils
+	sys.modules["frappe"] = frappe
+	sys.modules["frappe.utils"] = utils
 
 
 def _install_stub_dependencies():
-    hrms_api = types.ModuleType("hrms.api")
+	hrms_api = types.ModuleType("hrms.api")
 
-    bei_config = types.ModuleType("hrms.utils.bei_config")
-    bei_config.get_company = lambda: "Bebang Enterprises Inc."
+	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.get_company = lambda: "Bebang Enterprises Inc."
 
-    delivery_policy = types.ModuleType("hrms.utils.delivery_billing_policy")
-    delivery_policy.CPO_APPROVER_EMAIL = "mae@bebang.ph"
-    delivery_policy.CFO_APPROVER_EMAIL = "butch@bebang.ph"
-    delivery_policy.append_approval_audit_log = lambda *args, **kwargs: None
+	delivery_policy = types.ModuleType("hrms.utils.delivery_billing_policy")
+	delivery_policy.CPO_APPROVER_EMAIL = "mae@bebang.ph"
+	delivery_policy.CFO_APPROVER_EMAIL = "butch@bebang.ph"
+	delivery_policy.append_approval_audit_log = lambda *args, **kwargs: None
 
-    sys.modules["hrms.api"] = hrms_api
-    sys.modules["hrms.utils.bei_config"] = bei_config
-    sys.modules["hrms.utils.delivery_billing_policy"] = delivery_policy
+	sys.modules["hrms.api"] = hrms_api
+	sys.modules["hrms.utils.bei_config"] = bei_config
+	sys.modules["hrms.utils.delivery_billing_policy"] = delivery_policy
 
 
 _install_fake_frappe()
 _install_stub_dependencies()
 
 procurement_spec = importlib.util.spec_from_file_location(
-    "procurement_under_test_s062",
-    ROOT / "hrms" / "api" / "procurement.py",
+	"procurement_under_test_s062",
+	ROOT / "hrms" / "api" / "procurement.py",
 )
 procurement = importlib.util.module_from_spec(procurement_spec)
 assert procurement_spec and procurement_spec.loader
@@ -103,194 +103,192 @@ procurement_spec.loader.exec_module(procurement)
 
 
 class _InsertedDoc:
-    def __init__(self, name):
-        self.name = name
-        self.insert_calls = 0
+	def __init__(self, name):
+		self.name = name
+		self.insert_calls = 0
 
-    def insert(self, ignore_permissions=False):
-        self.insert_calls += 1
-        return self
+	def insert(self, ignore_permissions=False):
+		self.insert_calls += 1
+		return self
 
 
 class TestProcurementMathContractS062(unittest.TestCase):
-    def setUp(self):
-        procurement.frappe.session = types.SimpleNamespace(user="Administrator")
-        procurement.frappe.db.exists = MagicMock(return_value=True)
-        procurement.frappe.db.get_value = MagicMock(return_value=None)
-        procurement.frappe.db.sql = MagicMock(return_value=[])
-        procurement.frappe.get_doc = MagicMock()
+	def setUp(self):
+		procurement.frappe.session = types.SimpleNamespace(user="Administrator")
+		procurement.frappe.db.exists = MagicMock(return_value=True)
+		procurement.frappe.db.get_value = MagicMock(return_value=None)
+		procurement.frappe.db.sql = MagicMock(return_value=[])
+		procurement.frappe.get_doc = MagicMock()
 
-    def test_normalize_purchase_order_payload_recalculates_all_line_and_document_totals(self):
-        payload = procurement._normalize_purchase_order_payload(
-            {
-                "discount_amount": 5000,
-                "delivery_fee": 1500,
-                "grand_total": 100,
-                "items": [
-                    {"item_code": "RM018", "qty": 2000, "rate": 137, "vat_rate": 0, "uom": "Kg"},
-                    {"item_code": "CM34", "qty": 5000, "rate": 4.55, "vat_rate": 12, "uom": "Pc"},
-                ],
-            }
-        )
+	def test_normalize_purchase_order_payload_recalculates_all_line_and_document_totals(self):
+		payload = procurement._normalize_purchase_order_payload(
+			{
+				"discount_amount": 5000,
+				"delivery_fee": 1500,
+				"grand_total": 100,
+				"items": [
+					{"item_code": "RM018", "qty": 2000, "rate": 137, "vat_rate": 0, "uom": "Kg"},
+					{"item_code": "CM34", "qty": 5000, "rate": 4.55, "vat_rate": 12, "uom": "Pc"},
+				],
+			}
+		)
 
-        self.assertEqual(payload["subtotal"], 296750.0)
-        self.assertEqual(payload["vat_amount"], 2730.0)
-        self.assertEqual(payload["grand_total"], 295980.0)
-        self.assertEqual(payload["requires_dual_approval"], 0)
-        self.assertEqual(payload["items"][0]["unit_cost"], 137.0)
-        self.assertEqual(payload["items"][0]["amount"], 274000.0)
-        self.assertEqual(payload["items"][1]["amount"], 25480.0)
+		self.assertEqual(payload["subtotal"], 296750.0)
+		self.assertEqual(payload["vat_amount"], 2730.0)
+		self.assertEqual(payload["grand_total"], 295980.0)
+		self.assertEqual(payload["requires_dual_approval"], 0)
+		self.assertEqual(payload["items"][0]["unit_cost"], 137.0)
+		self.assertEqual(payload["items"][0]["amount"], 274000.0)
+		self.assertEqual(payload["items"][1]["amount"], 25480.0)
 
-    def test_create_purchase_order_uses_recalculated_grand_total_for_tin_threshold(self):
-        supplier = types.SimpleNamespace(
-            supplier_name="Marivic's Ube",
-            tin=None,
-            bir_2307="FILE-001",
-            business_permit="FILE-002",
-        )
+	def test_create_purchase_order_uses_recalculated_grand_total_for_tin_threshold(self):
+		supplier = types.SimpleNamespace(
+			supplier_name="Marivic's Ube",
+			tin=None,
+			bir_2307="FILE-001",
+			business_permit="FILE-002",
+		)
 
-        def _get_doc(*args, **kwargs):
-            if args and args[0] == "BEI Supplier":
-                return supplier
-            raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
+		def _get_doc(*args, **kwargs):
+			if args and args[0] == "BEI Supplier":
+				return supplier
+			raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
 
-        procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
-        procurement.frappe.db.sql = MagicMock(return_value=[(0,)])
+		procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
+		procurement.frappe.db.sql = MagicMock(return_value=[(0,)])
 
-        with self.assertRaises(Exception) as exc:
-            procurement.create_purchase_order(
-                {
-                    "supplier": "MU9",
-                    "grand_total": 1,
-                    "items": [
-                        {"item_code": "FG012", "qty": 3000, "rate": 138, "vat_rate": 0, "uom": "Pack"}
-                    ],
-                }
-            )
+		with self.assertRaises(Exception) as exc:
+			procurement.create_purchase_order(
+				{
+					"supplier": "MU9",
+					"grand_total": 1,
+					"items": [{"item_code": "FG012", "qty": 3000, "rate": 138, "vat_rate": 0, "uom": "Pack"}],
+				}
+			)
 
-        self.assertIn("TIN registration", str(exc.exception))
+		self.assertIn("TIN registration", str(exc.exception))
 
-    def test_create_invoice_recalculates_totals_from_items_and_drops_ui_only_payload(self):
-        inserted_doc = _InsertedDoc("INV-2026-00001")
-        captured_payload = {}
+	def test_create_invoice_recalculates_totals_from_items_and_drops_ui_only_payload(self):
+		inserted_doc = _InsertedDoc("INV-2026-00001")
+		captured_payload = {}
 
-        def _get_doc(*args, **kwargs):
-            if args and isinstance(args[0], dict):
-                captured_payload.update(args[0])
-                return inserted_doc
-            raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
+		def _get_doc(*args, **kwargs):
+			if args and isinstance(args[0], dict):
+				captured_payload.update(args[0])
+				return inserted_doc
+			raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
 
-        procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
+		procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
 
-        result = procurement.create_invoice(
-            {
-                "supplier": "MU9",
-                "supplier_name": "Marivic's Ube",
-                "supplier_invoice_no": "SI-001",
-                "invoice_date": "2026-03-18",
-                "due_date": "2026-04-17",
-                "items": [
-                    {"item_code": "CM34", "qty": 5000, "rate": 4.55, "vat_rate": 12},
-                    {"item_code": "FG012", "qty": 1200, "rate": 135, "vat_rate": 0},
-                ],
-                "subtotal": 1,
-                "vat_amount": 1,
-            }
-        )
+		result = procurement.create_invoice(
+			{
+				"supplier": "MU9",
+				"supplier_name": "Marivic's Ube",
+				"supplier_invoice_no": "SI-001",
+				"invoice_date": "2026-03-18",
+				"due_date": "2026-04-17",
+				"items": [
+					{"item_code": "CM34", "qty": 5000, "rate": 4.55, "vat_rate": 12},
+					{"item_code": "FG012", "qty": 1200, "rate": 135, "vat_rate": 0},
+				],
+				"subtotal": 1,
+				"vat_amount": 1,
+			}
+		)
 
-        self.assertTrue(result["success"])
-        self.assertEqual(result["name"], "INV-2026-00001")
-        self.assertEqual(inserted_doc.insert_calls, 1)
-        self.assertEqual(captured_payload["subtotal"], 184750.0)
-        self.assertEqual(captured_payload["vat_amount"], 2730.0)
-        self.assertEqual(captured_payload["grand_total"], 187480.0)
-        self.assertNotIn("items", captured_payload)
+		self.assertTrue(result["success"])
+		self.assertEqual(result["name"], "INV-2026-00001")
+		self.assertEqual(inserted_doc.insert_calls, 1)
+		self.assertEqual(captured_payload["subtotal"], 184750.0)
+		self.assertEqual(captured_payload["vat_amount"], 2730.0)
+		self.assertEqual(captured_payload["grand_total"], 187480.0)
+		self.assertNotIn("items", captured_payload)
 
-    def test_create_payment_request_allows_vatable_partial_receipt_up_to_gross_invoice_amount(self):
-        invoice = types.SimpleNamespace(
-            purchase_order="PO-2026-00001",
-            goods_receipt="GR-2026-00001",
-            balance_due=142.10,
-            grand_total=142.10,
-            invoice_date="2026-03-18",
-        )
-        po = types.SimpleNamespace(grand_total=289.288, po_no="PO-2026-00001")
-        inserted_doc = _InsertedDoc("PAY-2026-00001")
-        captured_payload = {}
+	def test_create_payment_request_allows_vatable_partial_receipt_up_to_gross_invoice_amount(self):
+		invoice = types.SimpleNamespace(
+			purchase_order="PO-2026-00001",
+			goods_receipt="GR-2026-00001",
+			balance_due=142.10,
+			grand_total=142.10,
+			invoice_date="2026-03-18",
+		)
+		po = types.SimpleNamespace(grand_total=289.288, po_no="PO-2026-00001")
+		inserted_doc = _InsertedDoc("PAY-2026-00001")
+		captured_payload = {}
 
-        def _sql(query, params=None, as_dict=False):
-            if "SUM(advance_outstanding)" in query:
-                return [(0,)]
-            if "FROM `tabBEI PO Item`" in query:
-                return [
-                    {
-                        "item_code": "RM018",
-                        "qty": 2,
-                        "unit_cost": 137,
-                        "vat_rate": 0,
-                        "vat_amount": 0,
-                    },
-                    {
-                        "item_code": "CM34",
-                        "qty": 3,
-                        "unit_cost": 4.55,
-                        "vat_rate": 12,
-                        "vat_amount": 1.638,
-                    },
-                ]
-            if "FROM `tabBEI GR Item`" in query:
-                return [
-                    {
-                        "item_code": "RM018",
-                        "accepted_qty": 1,
-                        "received_qty": 1,
-                        "rejected_qty": 0,
-                        "unit_cost": 137,
-                    },
-                    {
-                        "item_code": "CM34",
-                        "accepted_qty": 1,
-                        "received_qty": 1,
-                        "rejected_qty": 0,
-                        "unit_cost": 4.55,
-                    },
-                ]
-            raise AssertionError(f"Unexpected SQL query: {query}")
+		def _sql(query, params=None, as_dict=False):
+			if "SUM(advance_outstanding)" in query:
+				return [(0,)]
+			if "FROM `tabBEI PO Item`" in query:
+				return [
+					{
+						"item_code": "RM018",
+						"qty": 2,
+						"unit_cost": 137,
+						"vat_rate": 0,
+						"vat_amount": 0,
+					},
+					{
+						"item_code": "CM34",
+						"qty": 3,
+						"unit_cost": 4.55,
+						"vat_rate": 12,
+						"vat_amount": 1.638,
+					},
+				]
+			if "FROM `tabBEI GR Item`" in query:
+				return [
+					{
+						"item_code": "RM018",
+						"accepted_qty": 1,
+						"received_qty": 1,
+						"rejected_qty": 0,
+						"unit_cost": 137,
+					},
+					{
+						"item_code": "CM34",
+						"accepted_qty": 1,
+						"received_qty": 1,
+						"rejected_qty": 0,
+						"unit_cost": 4.55,
+					},
+				]
+			raise AssertionError(f"Unexpected SQL query: {query}")
 
-        def _get_value(doctype, filters=None, fieldname=None, as_dict=False):
-            if doctype == "BEI Invoice" and fieldname == "purchase_order":
-                return "PO-2026-00001"
-            return None
+		def _get_value(doctype, filters=None, fieldname=None, as_dict=False):
+			if doctype == "BEI Invoice" and fieldname == "purchase_order":
+				return "PO-2026-00001"
+			return None
 
-        def _get_doc(*args, **kwargs):
-            if args and args[0] == "BEI Invoice":
-                return invoice
-            if args and args[0] == "BEI Purchase Order":
-                return po
-            if args and isinstance(args[0], dict):
-                captured_payload.update(args[0])
-                return inserted_doc
-            raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
+		def _get_doc(*args, **kwargs):
+			if args and args[0] == "BEI Invoice":
+				return invoice
+			if args and args[0] == "BEI Purchase Order":
+				return po
+			if args and isinstance(args[0], dict):
+				captured_payload.update(args[0])
+				return inserted_doc
+			raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
 
-        procurement.frappe.db.get_value = MagicMock(side_effect=_get_value)
-        procurement.frappe.db.exists = MagicMock(return_value=True)
-        procurement.frappe.db.sql = MagicMock(side_effect=_sql)
-        procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
+		procurement.frappe.db.get_value = MagicMock(side_effect=_get_value)
+		procurement.frappe.db.exists = MagicMock(return_value=True)
+		procurement.frappe.db.sql = MagicMock(side_effect=_sql)
+		procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
 
-        result = procurement.create_payment_request(
-            {
-                "invoice": "INV-2026-00001",
-                "payment_amount": 142.10,
-                "payment_mode": "Bank Transfer",
-            }
-        )
+		result = procurement.create_payment_request(
+			{
+				"invoice": "INV-2026-00001",
+				"payment_amount": 142.10,
+				"payment_mode": "Bank Transfer",
+			}
+		)
 
-        self.assertTrue(result["success"])
-        self.assertEqual(result["name"], "PAY-2026-00001")
-        self.assertEqual(inserted_doc.insert_calls, 1)
-        self.assertEqual(captured_payload["invoice"], "INV-2026-00001")
-        self.assertEqual(captured_payload["payment_amount"], 142.10)
+		self.assertTrue(result["success"])
+		self.assertEqual(result["name"], "PAY-2026-00001")
+		self.assertEqual(inserted_doc.insert_calls, 1)
+		self.assertEqual(captured_payload["invoice"], "INV-2026-00001")
+		self.assertEqual(captured_payload["payment_amount"], 142.10)
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_procurement_math_contract_s062.py
+++ b/hrms/tests/test_procurement_math_contract_s062.py
@@ -1,0 +1,296 @@
+import importlib.util
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_frappe():
+    if "frappe" in sys.modules:
+        return
+
+    frappe = types.ModuleType("frappe")
+    utils = types.ModuleType("frappe.utils")
+
+    class ValidationError(Exception):
+        pass
+
+    class PermissionError(Exception):
+        pass
+
+    def whitelist(*args, **kwargs):
+        def decorator(fn):
+            return fn
+
+        return decorator
+
+    def _throw(message, exc=None, title=None):
+        if isinstance(exc, type) and issubclass(exc, Exception):
+            raise exc(message)
+        raise Exception(message)
+
+    def _flt(value, precision=None):
+        num = float(value or 0)
+        if precision is not None:
+            return round(num, int(precision))
+        return num
+
+    frappe.whitelist = whitelist
+    frappe._ = lambda text: text
+    frappe.throw = _throw
+    frappe.ValidationError = ValidationError
+    frappe.PermissionError = PermissionError
+    frappe.session = types.SimpleNamespace(user="Administrator")
+    frappe.parse_json = lambda value: json.loads(value) if isinstance(value, str) else value
+    frappe.has_permission = lambda *args, **kwargs: True
+    frappe.get_roles = lambda user=None: ["System Manager"]
+    frappe.log_error = lambda *args, **kwargs: None
+    frappe.msgprint = lambda *args, **kwargs: None
+    frappe.get_doc = lambda *args, **kwargs: None
+    frappe.get_all = lambda *args, **kwargs: []
+    frappe.db = types.SimpleNamespace(
+        exists=lambda *args, **kwargs: None,
+        get_value=lambda *args, **kwargs: None,
+        set_value=lambda *args, **kwargs: None,
+        sql=lambda *args, **kwargs: [],
+    )
+
+    utils.flt = _flt
+    utils.cint = lambda value: int(float(value or 0))
+    utils.getdate = lambda value=None: value or "2026-03-18"
+    utils.nowdate = lambda: "2026-03-18"
+    utils.add_days = lambda date_obj, days: date_obj
+    utils.date_diff = lambda end_date, start_date: 0
+    utils.get_first_day = lambda date_obj: date_obj
+    utils.get_last_day = lambda date_obj: date_obj
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = utils
+
+
+def _install_stub_dependencies():
+    hrms_api = types.ModuleType("hrms.api")
+
+    bei_config = types.ModuleType("hrms.utils.bei_config")
+    bei_config.get_company = lambda: "Bebang Enterprises Inc."
+
+    delivery_policy = types.ModuleType("hrms.utils.delivery_billing_policy")
+    delivery_policy.CPO_APPROVER_EMAIL = "mae@bebang.ph"
+    delivery_policy.CFO_APPROVER_EMAIL = "butch@bebang.ph"
+    delivery_policy.append_approval_audit_log = lambda *args, **kwargs: None
+
+    sys.modules["hrms.api"] = hrms_api
+    sys.modules["hrms.utils.bei_config"] = bei_config
+    sys.modules["hrms.utils.delivery_billing_policy"] = delivery_policy
+
+
+_install_fake_frappe()
+_install_stub_dependencies()
+
+procurement_spec = importlib.util.spec_from_file_location(
+    "procurement_under_test_s062",
+    ROOT / "hrms" / "api" / "procurement.py",
+)
+procurement = importlib.util.module_from_spec(procurement_spec)
+assert procurement_spec and procurement_spec.loader
+procurement_spec.loader.exec_module(procurement)
+
+
+class _InsertedDoc:
+    def __init__(self, name):
+        self.name = name
+        self.insert_calls = 0
+
+    def insert(self, ignore_permissions=False):
+        self.insert_calls += 1
+        return self
+
+
+class TestProcurementMathContractS062(unittest.TestCase):
+    def setUp(self):
+        procurement.frappe.session = types.SimpleNamespace(user="Administrator")
+        procurement.frappe.db.exists = MagicMock(return_value=True)
+        procurement.frappe.db.get_value = MagicMock(return_value=None)
+        procurement.frappe.db.sql = MagicMock(return_value=[])
+        procurement.frappe.get_doc = MagicMock()
+
+    def test_normalize_purchase_order_payload_recalculates_all_line_and_document_totals(self):
+        payload = procurement._normalize_purchase_order_payload(
+            {
+                "discount_amount": 5000,
+                "delivery_fee": 1500,
+                "grand_total": 100,
+                "items": [
+                    {"item_code": "RM018", "qty": 2000, "rate": 137, "vat_rate": 0, "uom": "Kg"},
+                    {"item_code": "CM34", "qty": 5000, "rate": 4.55, "vat_rate": 12, "uom": "Pc"},
+                ],
+            }
+        )
+
+        self.assertEqual(payload["subtotal"], 296750.0)
+        self.assertEqual(payload["vat_amount"], 2730.0)
+        self.assertEqual(payload["grand_total"], 295980.0)
+        self.assertEqual(payload["requires_dual_approval"], 0)
+        self.assertEqual(payload["items"][0]["unit_cost"], 137.0)
+        self.assertEqual(payload["items"][0]["amount"], 274000.0)
+        self.assertEqual(payload["items"][1]["amount"], 25480.0)
+
+    def test_create_purchase_order_uses_recalculated_grand_total_for_tin_threshold(self):
+        supplier = types.SimpleNamespace(
+            supplier_name="Marivic's Ube",
+            tin=None,
+            bir_2307="FILE-001",
+            business_permit="FILE-002",
+        )
+
+        def _get_doc(*args, **kwargs):
+            if args and args[0] == "BEI Supplier":
+                return supplier
+            raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
+
+        procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
+        procurement.frappe.db.sql = MagicMock(return_value=[(0,)])
+
+        with self.assertRaises(Exception) as exc:
+            procurement.create_purchase_order(
+                {
+                    "supplier": "MU9",
+                    "grand_total": 1,
+                    "items": [
+                        {"item_code": "FG012", "qty": 3000, "rate": 138, "vat_rate": 0, "uom": "Pack"}
+                    ],
+                }
+            )
+
+        self.assertIn("TIN registration", str(exc.exception))
+
+    def test_create_invoice_recalculates_totals_from_items_and_drops_ui_only_payload(self):
+        inserted_doc = _InsertedDoc("INV-2026-00001")
+        captured_payload = {}
+
+        def _get_doc(*args, **kwargs):
+            if args and isinstance(args[0], dict):
+                captured_payload.update(args[0])
+                return inserted_doc
+            raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
+
+        procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
+
+        result = procurement.create_invoice(
+            {
+                "supplier": "MU9",
+                "supplier_name": "Marivic's Ube",
+                "supplier_invoice_no": "SI-001",
+                "invoice_date": "2026-03-18",
+                "due_date": "2026-04-17",
+                "items": [
+                    {"item_code": "CM34", "qty": 5000, "rate": 4.55, "vat_rate": 12},
+                    {"item_code": "FG012", "qty": 1200, "rate": 135, "vat_rate": 0},
+                ],
+                "subtotal": 1,
+                "vat_amount": 1,
+            }
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["name"], "INV-2026-00001")
+        self.assertEqual(inserted_doc.insert_calls, 1)
+        self.assertEqual(captured_payload["subtotal"], 184750.0)
+        self.assertEqual(captured_payload["vat_amount"], 2730.0)
+        self.assertEqual(captured_payload["grand_total"], 187480.0)
+        self.assertNotIn("items", captured_payload)
+
+    def test_create_payment_request_allows_vatable_partial_receipt_up_to_gross_invoice_amount(self):
+        invoice = types.SimpleNamespace(
+            purchase_order="PO-2026-00001",
+            goods_receipt="GR-2026-00001",
+            balance_due=142.10,
+            grand_total=142.10,
+            invoice_date="2026-03-18",
+        )
+        po = types.SimpleNamespace(grand_total=289.288, po_no="PO-2026-00001")
+        inserted_doc = _InsertedDoc("PAY-2026-00001")
+        captured_payload = {}
+
+        def _sql(query, params=None, as_dict=False):
+            if "SUM(advance_outstanding)" in query:
+                return [(0,)]
+            if "FROM `tabBEI PO Item`" in query:
+                return [
+                    {
+                        "item_code": "RM018",
+                        "qty": 2,
+                        "unit_cost": 137,
+                        "vat_rate": 0,
+                        "vat_amount": 0,
+                    },
+                    {
+                        "item_code": "CM34",
+                        "qty": 3,
+                        "unit_cost": 4.55,
+                        "vat_rate": 12,
+                        "vat_amount": 1.638,
+                    },
+                ]
+            if "FROM `tabBEI GR Item`" in query:
+                return [
+                    {
+                        "item_code": "RM018",
+                        "accepted_qty": 1,
+                        "received_qty": 1,
+                        "rejected_qty": 0,
+                        "unit_cost": 137,
+                    },
+                    {
+                        "item_code": "CM34",
+                        "accepted_qty": 1,
+                        "received_qty": 1,
+                        "rejected_qty": 0,
+                        "unit_cost": 4.55,
+                    },
+                ]
+            raise AssertionError(f"Unexpected SQL query: {query}")
+
+        def _get_value(doctype, filters=None, fieldname=None, as_dict=False):
+            if doctype == "BEI Invoice" and fieldname == "purchase_order":
+                return "PO-2026-00001"
+            return None
+
+        def _get_doc(*args, **kwargs):
+            if args and args[0] == "BEI Invoice":
+                return invoice
+            if args and args[0] == "BEI Purchase Order":
+                return po
+            if args and isinstance(args[0], dict):
+                captured_payload.update(args[0])
+                return inserted_doc
+            raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
+
+        procurement.frappe.db.get_value = MagicMock(side_effect=_get_value)
+        procurement.frappe.db.exists = MagicMock(return_value=True)
+        procurement.frappe.db.sql = MagicMock(side_effect=_sql)
+        procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
+
+        result = procurement.create_payment_request(
+            {
+                "invoice": "INV-2026-00001",
+                "payment_amount": 142.10,
+                "payment_mode": "Bank Transfer",
+            }
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["name"], "PAY-2026-00001")
+        self.assertEqual(inserted_doc.insert_calls, 1)
+        self.assertEqual(captured_payload["invoice"], "INV-2026-00001")
+        self.assertEqual(captured_payload["payment_amount"], 142.10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hrms/utils/procurement_math.py
+++ b/hrms/utils/procurement_math.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Iterable
+
+from frappe.utils import flt
+
+
+def _accepted_qty(item: dict[str, Any]) -> float:
+    if item.get("accepted_qty") is not None:
+        return flt(item.get("accepted_qty"), 6)
+    if item.get("received_qty") is not None:
+        return flt(item.get("received_qty"), 6) - flt(item.get("rejected_qty"), 6)
+    return flt(item.get("qty"), 6)
+
+
+def _line_vat_rate(po_item: dict[str, Any]) -> float:
+    explicit_rate = flt(po_item.get("vat_rate"), 6)
+    if explicit_rate > 0:
+        return explicit_rate
+
+    base_qty = flt(po_item.get("qty"), 6)
+    base_rate = flt(po_item.get("unit_cost") or po_item.get("rate"), 6)
+    base_amount = base_qty * base_rate
+    vat_amount = flt(po_item.get("vat_amount"), 6)
+
+    if base_amount <= 0 or vat_amount <= 0:
+        return 0
+
+    return vat_amount / base_amount * 100
+
+
+def _po_item_key(po_item: dict[str, Any]) -> tuple[str, float]:
+    return (
+        str(po_item.get("item_code") or ""),
+        round(flt(po_item.get("unit_cost") or po_item.get("rate"), 6), 6),
+    )
+
+
+def _gr_item_key(gr_item: dict[str, Any]) -> tuple[str, float]:
+    return (
+        str(gr_item.get("item_code") or ""),
+        round(flt(gr_item.get("unit_cost") or gr_item.get("rate"), 6), 6),
+    )
+
+
+def _build_po_index(
+    po_items: Iterable[dict[str, Any]]
+) -> tuple[dict[tuple[str, float], list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
+    index: dict[tuple[str, float], list[dict[str, Any]]] = defaultdict(list)
+    fallback_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    for po_item in po_items:
+        index[_po_item_key(po_item)].append(po_item)
+        fallback_index[str(po_item.get("item_code") or "")].append(po_item)
+
+    return index, fallback_index
+
+
+def _match_po_item(
+    po_index: dict[tuple[str, float], list[dict[str, Any]]],
+    fallback_index: dict[str, list[dict[str, Any]]],
+    gr_item: dict[str, Any],
+) -> dict[str, Any]:
+    exact_key = _gr_item_key(gr_item)
+    if po_index.get(exact_key):
+        return po_index[exact_key][0]
+
+    candidates = fallback_index.get(str(gr_item.get("item_code") or ""), [])
+    return candidates[0] if candidates else {}
+
+
+def calculate_goods_receipt_gross_total(
+    gr_items: Iterable[dict[str, Any]],
+    po_items: Iterable[dict[str, Any]],
+) -> float:
+    po_index, fallback_index = _build_po_index(po_items)
+    total = 0.0
+
+    for gr_item in gr_items:
+        qty = _accepted_qty(gr_item)
+        unit_cost = flt(gr_item.get("unit_cost") or gr_item.get("rate"), 6)
+        net_amount = qty * unit_cost
+
+        po_item = _match_po_item(po_index, fallback_index, gr_item)
+        vat_rate = _line_vat_rate(po_item)
+        vat_amount = net_amount * vat_rate / 100
+        total += net_amount + vat_amount
+
+    return flt(total, 2)

--- a/hrms/utils/procurement_math.py
+++ b/hrms/utils/procurement_math.py
@@ -1,90 +1,91 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from frappe.utils import flt
 
 
 def _accepted_qty(item: dict[str, Any]) -> float:
-    if item.get("accepted_qty") is not None:
-        return flt(item.get("accepted_qty"), 6)
-    if item.get("received_qty") is not None:
-        return flt(item.get("received_qty"), 6) - flt(item.get("rejected_qty"), 6)
-    return flt(item.get("qty"), 6)
+	if item.get("accepted_qty") is not None:
+		return flt(item.get("accepted_qty"), 6)
+	if item.get("received_qty") is not None:
+		return flt(item.get("received_qty"), 6) - flt(item.get("rejected_qty"), 6)
+	return flt(item.get("qty"), 6)
 
 
 def _line_vat_rate(po_item: dict[str, Any]) -> float:
-    explicit_rate = flt(po_item.get("vat_rate"), 6)
-    if explicit_rate > 0:
-        return explicit_rate
+	explicit_rate = flt(po_item.get("vat_rate"), 6)
+	if explicit_rate > 0:
+		return explicit_rate
 
-    base_qty = flt(po_item.get("qty"), 6)
-    base_rate = flt(po_item.get("unit_cost") or po_item.get("rate"), 6)
-    base_amount = base_qty * base_rate
-    vat_amount = flt(po_item.get("vat_amount"), 6)
+	base_qty = flt(po_item.get("qty"), 6)
+	base_rate = flt(po_item.get("unit_cost") or po_item.get("rate"), 6)
+	base_amount = base_qty * base_rate
+	vat_amount = flt(po_item.get("vat_amount"), 6)
 
-    if base_amount <= 0 or vat_amount <= 0:
-        return 0
+	if base_amount <= 0 or vat_amount <= 0:
+		return 0
 
-    return vat_amount / base_amount * 100
+	return vat_amount / base_amount * 100
 
 
 def _po_item_key(po_item: dict[str, Any]) -> tuple[str, float]:
-    return (
-        str(po_item.get("item_code") or ""),
-        round(flt(po_item.get("unit_cost") or po_item.get("rate"), 6), 6),
-    )
+	return (
+		str(po_item.get("item_code") or ""),
+		round(flt(po_item.get("unit_cost") or po_item.get("rate"), 6), 6),
+	)
 
 
 def _gr_item_key(gr_item: dict[str, Any]) -> tuple[str, float]:
-    return (
-        str(gr_item.get("item_code") or ""),
-        round(flt(gr_item.get("unit_cost") or gr_item.get("rate"), 6), 6),
-    )
+	return (
+		str(gr_item.get("item_code") or ""),
+		round(flt(gr_item.get("unit_cost") or gr_item.get("rate"), 6), 6),
+	)
 
 
 def _build_po_index(
-    po_items: Iterable[dict[str, Any]]
+	po_items: Iterable[dict[str, Any]],
 ) -> tuple[dict[tuple[str, float], list[dict[str, Any]]], dict[str, list[dict[str, Any]]]]:
-    index: dict[tuple[str, float], list[dict[str, Any]]] = defaultdict(list)
-    fallback_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
+	index: dict[tuple[str, float], list[dict[str, Any]]] = defaultdict(list)
+	fallback_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
 
-    for po_item in po_items:
-        index[_po_item_key(po_item)].append(po_item)
-        fallback_index[str(po_item.get("item_code") or "")].append(po_item)
+	for po_item in po_items:
+		index[_po_item_key(po_item)].append(po_item)
+		fallback_index[str(po_item.get("item_code") or "")].append(po_item)
 
-    return index, fallback_index
+	return index, fallback_index
 
 
 def _match_po_item(
-    po_index: dict[tuple[str, float], list[dict[str, Any]]],
-    fallback_index: dict[str, list[dict[str, Any]]],
-    gr_item: dict[str, Any],
+	po_index: dict[tuple[str, float], list[dict[str, Any]]],
+	fallback_index: dict[str, list[dict[str, Any]]],
+	gr_item: dict[str, Any],
 ) -> dict[str, Any]:
-    exact_key = _gr_item_key(gr_item)
-    if po_index.get(exact_key):
-        return po_index[exact_key][0]
+	exact_key = _gr_item_key(gr_item)
+	if po_index.get(exact_key):
+		return po_index[exact_key][0]
 
-    candidates = fallback_index.get(str(gr_item.get("item_code") or ""), [])
-    return candidates[0] if candidates else {}
+	candidates = fallback_index.get(str(gr_item.get("item_code") or ""), [])
+	return candidates[0] if candidates else {}
 
 
 def calculate_goods_receipt_gross_total(
-    gr_items: Iterable[dict[str, Any]],
-    po_items: Iterable[dict[str, Any]],
+	gr_items: Iterable[dict[str, Any]],
+	po_items: Iterable[dict[str, Any]],
 ) -> float:
-    po_index, fallback_index = _build_po_index(po_items)
-    total = 0.0
+	po_index, fallback_index = _build_po_index(po_items)
+	total = 0.0
 
-    for gr_item in gr_items:
-        qty = _accepted_qty(gr_item)
-        unit_cost = flt(gr_item.get("unit_cost") or gr_item.get("rate"), 6)
-        net_amount = qty * unit_cost
+	for gr_item in gr_items:
+		qty = _accepted_qty(gr_item)
+		unit_cost = flt(gr_item.get("unit_cost") or gr_item.get("rate"), 6)
+		net_amount = qty * unit_cost
 
-        po_item = _match_po_item(po_index, fallback_index, gr_item)
-        vat_rate = _line_vat_rate(po_item)
-        vat_amount = net_amount * vat_rate / 100
-        total += net_amount + vat_amount
+		po_item = _match_po_item(po_index, fallback_index, gr_item)
+		vat_rate = _line_vat_rate(po_item)
+		vat_amount = net_amount * vat_rate / 100
+		total += net_amount + vat_amount
 
-    return flt(total, 2)
+	return flt(total, 2)


### PR DESCRIPTION
## Summary\n- recalculate authoritative PO totals from line items and adjustments\n- preserve VAT/gross math through partial GR, invoice matching, and payment-request caps\n- add backend contract coverage for procurement math regression cases\n\n## Verification\n- python hrms/tests/test_procurement_math_contract_s062.py\n- python -m py_compile hrms/api/procurement.py hrms/hr/doctype/bei_invoice/bei_invoice.py hrms/utils/procurement_math.py hrms/tests/test_procurement_math_contract_s062.py