### PR TITLE
fix: auto-submit pi before payment entry

### DIFF
--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -1,6 +1,10 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+from __future__ import annotations
+
+from datetime import date, datetime
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -476,7 +480,7 @@ class BEIInvoice(Document):
 	def record_payment(
 		self,
 		amount: float | int | str,
-		payment_date: str | None = None,
+		payment_date: str | date | datetime | None = None,
 		reference: str | None = None,
 	):
 		"""Record a payment against this invoice."""
@@ -489,7 +493,7 @@ class BEIInvoice(Document):
 			frappe.throw(_("Payment amount cannot exceed balance due"))
 
 		self.amount_paid = flt(self.amount_paid, 2) + amount
-		self.last_payment_date = payment_date or getdate()
+		self.last_payment_date = getdate(payment_date) if payment_date else getdate()
 		self.calculate_totals()
 
 		if self.payment_status == "Paid":

--- a/hrms/hr/doctype/bei_payment_request/bei_payment_request.py
+++ b/hrms/hr/doctype/bei_payment_request/bei_payment_request.py
@@ -342,6 +342,10 @@ class BEIPaymentRequest(Document):
 
 		# Check PI is submitted
 		pi_doc = frappe.get_doc("Purchase Invoice", frappe_pi)
+		if pi_doc.docstatus == 0 and bei_invoice.status in ["Verified", "Partially Paid", "Paid"]:
+			bei_invoice.submit_frappe_invoice()
+			pi_doc = frappe.get_doc("Purchase Invoice", frappe_pi)
+
 		if pi_doc.docstatus != 1:
 			frappe.throw(
 				_("Frappe Purchase Invoice {0} is not submitted. " "Please submit it first.").format(

--- a/hrms/tests/test_procurement_math_contract_s062.py
+++ b/hrms/tests/test_procurement_math_contract_s062.py
@@ -132,6 +132,14 @@ bei_invoice = importlib.util.module_from_spec(invoice_spec)
 assert invoice_spec and invoice_spec.loader
 invoice_spec.loader.exec_module(bei_invoice)
 
+payment_request_spec = importlib.util.spec_from_file_location(
+	"bei_payment_request_under_test_s062",
+	ROOT / "hrms" / "hr" / "doctype" / "bei_payment_request" / "bei_payment_request.py",
+)
+bei_payment_request = importlib.util.module_from_spec(payment_request_spec)
+assert payment_request_spec and payment_request_spec.loader
+payment_request_spec.loader.exec_module(bei_payment_request)
+
 
 class _InsertedDoc:
 	def __init__(self, name):
@@ -363,6 +371,85 @@ class TestProcurementMathContractS062(unittest.TestCase):
 		self.assertEqual(doc.amount_paid, 50)
 		self.assertEqual(doc.last_payment_date, date(2026, 3, 18))
 		self.assertEqual(doc.status, "Partially Paid")
+
+	def test_payment_request_auto_submits_linked_frappe_pi_before_creating_payment_entry(self):
+		bei_invoice_doc = types.SimpleNamespace(
+			status="Verified",
+			frappe_purchase_invoice="PINV-0001",
+			submit_calls=0,
+		)
+		supplier_doc = types.SimpleNamespace(
+			supplier_name="Marivic's Ube",
+			get_or_create_frappe_supplier=lambda: "SUP-MARIVIC",
+		)
+		pi_doc = types.SimpleNamespace(
+			docstatus=0,
+			credit_to="2101000 - ACCOUNTS PAYABLE - TRADE - BEI",
+			grand_total=142.10,
+			outstanding_amount=142.10,
+		)
+
+		def _submit_frappe_invoice():
+			bei_invoice_doc.submit_calls += 1
+			pi_doc.docstatus = 1
+
+		bei_invoice_doc.submit_frappe_invoice = _submit_frappe_invoice
+
+		class _PaymentEntry:
+			def __init__(self):
+				self.name = "PE-0001"
+				self.references = []
+				self.insert_calls = 0
+				self.submit_calls = 0
+
+			def append(self, fieldname, payload):
+				if fieldname == "references":
+					self.references.append(payload)
+
+			def insert(self, ignore_permissions=False):
+				self.insert_calls += 1
+				return self
+
+			def submit(self):
+				self.submit_calls += 1
+
+		payment_entry = _PaymentEntry()
+
+		def _get_doc(*args, **kwargs):
+			if args and args[0] == "BEI Invoice":
+				return bei_invoice_doc
+			if args and args[0] == "Purchase Invoice":
+				return pi_doc
+			if args and args[0] == "BEI Supplier":
+				return supplier_doc
+			if args and isinstance(args[0], dict):
+				return payment_entry
+			raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
+
+		bei_payment_request.frappe.get_doc = MagicMock(side_effect=_get_doc)
+
+		doc = types.SimpleNamespace(
+			status="Approved",
+			invoice="INV-0001",
+			supplier="S062SUP",
+			payment_mode="Bank Transfer",
+			payment_amount=142.10,
+			payment_date="2026-03-18",
+			transaction_reference="TXN-0001",
+			check_number="",
+			name="PAY-0001",
+			_get_payment_accounts=lambda: ("1100 - Cash and Bank - BEI", "Wire Transfer"),
+			db_set=lambda *args, **kwargs: None,
+		)
+		doc.get = lambda fieldname, default=None: getattr(doc, fieldname, default)
+
+		result = bei_payment_request.BEIPaymentRequest.create_frappe_payment_entry(doc)
+
+		self.assertEqual(result, "PE-0001")
+		self.assertEqual(bei_invoice_doc.submit_calls, 1)
+		self.assertEqual(payment_entry.insert_calls, 1)
+		self.assertEqual(payment_entry.submit_calls, 1)
+		self.assertEqual(payment_entry.references[0]["reference_name"], "PINV-0001")
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_procurement_math_contract_s062.py
+++ b/hrms/tests/test_procurement_math_contract_s062.py
@@ -1,8 +1,10 @@
 import importlib.util
+import inspect
 import json
 import sys
 import types
 import unittest
+from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -121,6 +123,14 @@ purchase_order_spec = importlib.util.spec_from_file_location(
 bei_purchase_order = importlib.util.module_from_spec(purchase_order_spec)
 assert purchase_order_spec and purchase_order_spec.loader
 purchase_order_spec.loader.exec_module(bei_purchase_order)
+
+invoice_spec = importlib.util.spec_from_file_location(
+	"bei_invoice_under_test_s062",
+	ROOT / "hrms" / "hr" / "doctype" / "bei_invoice" / "bei_invoice.py",
+)
+bei_invoice = importlib.util.module_from_spec(invoice_spec)
+assert invoice_spec and invoice_spec.loader
+invoice_spec.loader.exec_module(bei_invoice)
 
 
 class _InsertedDoc:
@@ -326,6 +336,33 @@ class TestProcurementMathContractS062(unittest.TestCase):
 		self.assertEqual(doc.subtotal, 13.65)
 		self.assertEqual(doc.vat_amount, 1.64)
 		self.assertEqual(doc.grand_total, 15.29)
+
+	def test_invoice_record_payment_annotation_accepts_date_inputs(self):
+		annotation = (
+			inspect.signature(bei_invoice.BEIInvoice.record_payment).parameters["payment_date"].annotation
+		)
+		self.assertIn("date", str(annotation))
+
+		doc = types.SimpleNamespace(
+			amount_paid=0,
+			balance_due=100,
+			payment_status="Unpaid",
+			status="Verified",
+			last_payment_date=None,
+		)
+		doc.calculate_totals = lambda: setattr(doc, "payment_status", "Partially Paid")
+		doc.save = lambda: None
+
+		result = bei_invoice.BEIInvoice.record_payment(
+			doc,
+			amount=50,
+			payment_date=date(2026, 3, 18),
+		)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(doc.amount_paid, 50)
+		self.assertEqual(doc.last_payment_date, date(2026, 3, 18))
+		self.assertEqual(doc.status, "Partially Paid")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- auto-submit the linked Frappe Purchase Invoice when a verified BEI invoice reaches payment-entry creation with the PI still in draft
- keep payment-entry creation on the happy path for verified procure-to-pay flows instead of degrading to a manual warning
- add a contract test that proves a draft PI is auto-submitted before Payment Entry creation

## Verification
- python hrms/tests/test_procurement_math_contract_s062.py
- pre-commit run --files hrms/hr/doctype/bei_payment_request/bei_payment_request.py hrms/tests/test_procurement_math_contract_s062.py