### PR TITLE
fix: backfill payment request supplier context

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -44,6 +44,31 @@ def _sanitize_doc_data(data):
     return {k: v for k, v in data.items() if k not in _BLOCKED_FIELDS}
 
 
+def _populate_payment_request_invoice_context(data: dict[str, Any], invoice: Any) -> None:
+    """Backfill canonical vendor-invoice fields from the linked invoice."""
+    if not data.get("supplier") and getattr(invoice, "supplier", None):
+        data["supplier"] = invoice.supplier
+
+    if not data.get("supplier_name"):
+        supplier_name = getattr(invoice, "supplier_name", None)
+        if not supplier_name and data.get("supplier"):
+            supplier_name = frappe.db.get_value("BEI Supplier", data["supplier"], "supplier_name")
+        if supplier_name:
+            data["supplier_name"] = supplier_name
+
+    if not data.get("purchase_order") and getattr(invoice, "purchase_order", None):
+        data["purchase_order"] = invoice.purchase_order
+
+    if not data.get("goods_receipt") and getattr(invoice, "goods_receipt", None):
+        data["goods_receipt"] = invoice.goods_receipt
+
+    if not data.get("payment_amount"):
+        data["payment_amount"] = flt(invoice.balance_due or invoice.grand_total, 2)
+
+    if not data.get("rfp_type"):
+        data["rfp_type"] = "Vendor Invoice"
+
+
 def _require_roles(allowed_roles: set[str], message: str) -> None:
     """Enforce role-based access for sensitive procurement actions."""
     user = frappe.session.user or "Guest"
@@ -1528,6 +1553,7 @@ def create_payment_request(data: dict[str, Any] | str) -> dict[str, Any]:
     invoice_name = data.get("invoice")
     if invoice_name:
         invoice = frappe.get_doc("BEI Invoice", invoice_name)
+        _populate_payment_request_invoice_context(data, invoice)
         purchase_order = invoice.purchase_order
 
         if purchase_order:

--- a/hrms/hr/doctype/bei_payment_request/bei_payment_request.py
+++ b/hrms/hr/doctype/bei_payment_request/bei_payment_request.py
@@ -53,10 +53,38 @@ class BEIPaymentRequest(Document):
 	"""
 
 	def validate(self):
+		self.populate_invoice_context()
 		self.set_payment_request_no()
 		self.check_ceo_requirement()
 		self.load_supplier_bank_info()
 		self.auto_assign_gl_account()
+
+	def populate_invoice_context(self):
+		"""Backfill canonical vendor-invoice fields from the linked invoice."""
+		if not self.invoice:
+			return
+
+		invoice = frappe.get_doc("BEI Invoice", self.invoice)
+
+		if not self.supplier and invoice.supplier:
+			self.supplier = invoice.supplier
+
+		if not self.supplier_name:
+			self.supplier_name = invoice.supplier_name or (
+				frappe.db.get_value("BEI Supplier", self.supplier, "supplier_name") if self.supplier else None
+			)
+
+		if not self.purchase_order and invoice.purchase_order:
+			self.purchase_order = invoice.purchase_order
+
+		if not self.goods_receipt and invoice.goods_receipt:
+			self.goods_receipt = invoice.goods_receipt
+
+		if not self.payment_amount:
+			self.payment_amount = flt(invoice.balance_due or invoice.grand_total, 2)
+
+		if not self.rfp_type:
+			self.rfp_type = "Vendor Invoice"
 
 	def set_payment_request_no(self):
 		"""Set payment request number from name if not already set."""
@@ -276,9 +304,14 @@ class BEIPaymentRequest(Document):
 		invoice = frappe.get_doc("BEI Invoice", self.invoice)
 		invoice.record_payment(amount=self.payment_amount, payment_date=self.payment_date)
 
+		supplier_id = self.supplier or invoice.supplier
+		if supplier_id and not self.supplier:
+			self.supplier = supplier_id
+			self.db_set("supplier", supplier_id, update_modified=False)
+
 		# Update supplier payment metrics
-		if self.supplier:
-			supplier = frappe.get_doc("BEI Supplier", self.supplier)
+		if supplier_id:
+			supplier = frappe.get_doc("BEI Supplier", supplier_id)
 			supplier.update_metrics()
 			supplier.save()
 
@@ -354,7 +387,15 @@ class BEIPaymentRequest(Document):
 			)
 
 		# Get Frappe Supplier
-		bei_supplier = frappe.get_doc("BEI Supplier", self.supplier)
+		supplier_id = self.supplier or bei_invoice.supplier
+		if not supplier_id:
+			frappe.throw(_("No BEI Supplier linked to Payment Request {0}.").format(self.name))
+
+		if not self.supplier:
+			self.supplier = supplier_id
+			self.db_set("supplier", supplier_id, update_modified=False)
+
+		bei_supplier = frappe.get_doc("BEI Supplier", supplier_id)
 		frappe_supplier = bei_supplier.get_or_create_frappe_supplier()
 
 		# Determine accounts and mode of payment

--- a/hrms/tests/test_procurement_math_contract_s062.py
+++ b/hrms/tests/test_procurement_math_contract_s062.py
@@ -245,6 +245,8 @@ class TestProcurementMathContractS062(unittest.TestCase):
 
 	def test_create_payment_request_allows_vatable_partial_receipt_up_to_gross_invoice_amount(self):
 		invoice = types.SimpleNamespace(
+			supplier="MU9",
+			supplier_name="Marivic's Ube",
 			purchase_order="PO-2026-00001",
 			goods_receipt="GR-2026-00001",
 			balance_due=142.10,
@@ -326,7 +328,12 @@ class TestProcurementMathContractS062(unittest.TestCase):
 		self.assertEqual(result["name"], "PAY-2026-00001")
 		self.assertEqual(inserted_doc.insert_calls, 1)
 		self.assertEqual(captured_payload["invoice"], "INV-2026-00001")
+		self.assertEqual(captured_payload["supplier"], "MU9")
+		self.assertEqual(captured_payload["supplier_name"], "Marivic's Ube")
+		self.assertEqual(captured_payload["purchase_order"], "PO-2026-00001")
+		self.assertEqual(captured_payload["goods_receipt"], "GR-2026-00001")
 		self.assertEqual(captured_payload["payment_amount"], 142.10)
+		self.assertEqual(captured_payload["rfp_type"], "Vendor Invoice")
 
 	def test_purchase_order_doctype_rounds_vat_and_grand_total_to_centavos(self):
 		doc = types.SimpleNamespace(
@@ -375,6 +382,7 @@ class TestProcurementMathContractS062(unittest.TestCase):
 	def test_payment_request_auto_submits_linked_frappe_pi_before_creating_payment_entry(self):
 		bei_invoice_doc = types.SimpleNamespace(
 			status="Verified",
+			supplier="S062SUP",
 			frappe_purchase_invoice="PINV-0001",
 			submit_calls=0,
 		)
@@ -450,6 +458,108 @@ class TestProcurementMathContractS062(unittest.TestCase):
 		self.assertEqual(payment_entry.insert_calls, 1)
 		self.assertEqual(payment_entry.submit_calls, 1)
 		self.assertEqual(payment_entry.references[0]["reference_name"], "PINV-0001")
+
+	def test_payment_request_populates_missing_invoice_context_during_validate(self):
+		invoice_doc = types.SimpleNamespace(
+			supplier="MU9",
+			supplier_name="Marivic's Ube",
+			purchase_order="PO-2026-00001",
+			goods_receipt="GR-2026-00001",
+			balance_due=142.10,
+			grand_total=142.10,
+		)
+		bei_payment_request.frappe.get_doc = MagicMock(return_value=invoice_doc)
+		bei_payment_request.frappe.db.get_value = MagicMock(return_value="Marivic's Ube")
+
+		doc = types.SimpleNamespace(
+			invoice="INV-2026-00001",
+			supplier="",
+			supplier_name="",
+			purchase_order="",
+			goods_receipt="",
+			payment_amount=0,
+			rfp_type="",
+		)
+
+		bei_payment_request.BEIPaymentRequest.populate_invoice_context(doc)
+
+		self.assertEqual(doc.supplier, "MU9")
+		self.assertEqual(doc.supplier_name, "Marivic's Ube")
+		self.assertEqual(doc.purchase_order, "PO-2026-00001")
+		self.assertEqual(doc.goods_receipt, "GR-2026-00001")
+		self.assertEqual(doc.payment_amount, 142.10)
+		self.assertEqual(doc.rfp_type, "Vendor Invoice")
+
+	def test_payment_request_falls_back_to_invoice_supplier_when_legacy_row_is_blank(self):
+		bei_invoice_doc = types.SimpleNamespace(
+			status="Verified",
+			supplier="S062SUP",
+			frappe_purchase_invoice="PINV-0001",
+			submit_calls=0,
+		)
+		supplier_doc = types.SimpleNamespace(
+			supplier_name="Marivic's Ube",
+			get_or_create_frappe_supplier=lambda: "SUP-MARIVIC",
+		)
+		pi_doc = types.SimpleNamespace(
+			docstatus=1,
+			credit_to="2101000 - ACCOUNTS PAYABLE - TRADE - BEI",
+			grand_total=142.10,
+			outstanding_amount=142.10,
+		)
+
+		class _PaymentEntry:
+			def __init__(self):
+				self.name = "PE-0002"
+				self.references = []
+
+			def append(self, fieldname, payload):
+				if fieldname == "references":
+					self.references.append(payload)
+
+			def insert(self, ignore_permissions=False):
+				return self
+
+			def submit(self):
+				return None
+
+		payment_entry = _PaymentEntry()
+		db_set_calls = []
+
+		def _get_doc(*args, **kwargs):
+			if args and args[0] == "BEI Invoice":
+				return bei_invoice_doc
+			if args and args[0] == "Purchase Invoice":
+				return pi_doc
+			if args and args[0] == "BEI Supplier":
+				self.assertEqual(args[1], "S062SUP")
+				return supplier_doc
+			if args and isinstance(args[0], dict):
+				return payment_entry
+			raise AssertionError(f"Unexpected get_doc call: {args} {kwargs}")
+
+		bei_payment_request.frappe.get_doc = MagicMock(side_effect=_get_doc)
+
+		doc = types.SimpleNamespace(
+			status="Approved",
+			invoice="INV-0001",
+			supplier="",
+			payment_mode="Bank Transfer",
+			payment_amount=142.10,
+			payment_date="2026-03-18",
+			transaction_reference="TXN-0002",
+			check_number="",
+			name="PAY-0002",
+			_get_payment_accounts=lambda: ("1100 - Cash and Bank - BEI", "Wire Transfer"),
+			db_set=lambda *args, **kwargs: db_set_calls.append((args, kwargs)),
+		)
+		doc.get = lambda fieldname, default=None: getattr(doc, fieldname, default)
+
+		result = bei_payment_request.BEIPaymentRequest.create_frappe_payment_entry(doc)
+
+		self.assertEqual(result, "PE-0002")
+		self.assertEqual(doc.supplier, "S062SUP")
+		self.assertTrue(db_set_calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- backfill supplier and linked invoice context when creating vendor-invoice payment requests\n- self-heal missing supplier context on BEI Payment Request validation and payment-entry creation\n- extend S062 procurement math contract coverage for invoice-linked payment requests\n\n## Testing\n- python hrms/tests/test_procurement_math_contract_s062.py\n- pre-commit run --files hrms/api/procurement.py hrms/hr/doctype/bei_payment_request/bei_payment_request.py hrms/tests/test_procurement_math_contract_s062.py