### PR TITLE
fix: honor approved leave overlays in labor plan

### DIFF
--- a/hrms/api/supervisor.py
+++ b/hrms/api/supervisor.py
@@ -543,7 +543,7 @@ def _get_approved_leave_overrides(
 		"Leave Application",
 		filters={
 			"employee": ["in", employee_names],
-			"docstatus": 1,
+			"docstatus": ["!=", 2],
 			"status": "Approved",
 			"from_date": ["<=", week_end],
 			"to_date": [">=", str(week_start_date)],

--- a/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
+++ b/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
@@ -2,6 +2,7 @@ import importlib.util
 import sys
 import types
 import unittest
+from datetime import date, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
@@ -189,6 +190,43 @@ class TestS061LeaveAwareMerging(unittest.TestCase):
 				)
 
 		self.assertIn("Approved leave is required", str(exc.exception))
+
+	def test_approved_leave_overrides_include_status_approved_rows_even_if_not_submitted(self):
+		def fake_get_all(*args, **kwargs):
+			filters = kwargs.get("filters") or {}
+			if filters.get("docstatus") == 1:
+				return []
+			return [
+				{
+					"name": "HR-LAP-0001",
+					"employee": "EMP-001",
+					"employee_name": "Pat",
+					"leave_type": "Vacation Leave",
+					"from_date": "2026-03-16",
+					"to_date": "2026-03-16",
+					"description": "Approved but still draft-docstatus contract",
+				}
+			]
+
+		with (
+			patch.object(supervisor, "getdate", side_effect=lambda value: date.fromisoformat(str(value))),
+			patch.object(
+				supervisor,
+				"add_days",
+				side_effect=lambda value, days: (date.fromisoformat(str(value)) + timedelta(days=days)).isoformat(),
+			),
+			patch.object(supervisor.frappe, "get_all", side_effect=fake_get_all),
+		):
+			overrides = supervisor._get_approved_leave_overrides(
+				{"warehouse": "W1", "warehouse_name": "W1"},
+				"2026-03-16",
+				employees=[{"name": "EMP-001", "employee_name": "Pat"}],
+			)
+
+		self.assertEqual(len(overrides), 1)
+		self.assertEqual(overrides[0]["shift_label"], "VL")
+		self.assertEqual(overrides[0]["leave_application"], "HR-LAP-0001")
+		self.assertEqual(overrides[0]["shift_source"], "approved_leave")
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
+++ b/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
@@ -213,7 +213,9 @@ class TestS061LeaveAwareMerging(unittest.TestCase):
 			patch.object(
 				supervisor,
 				"add_days",
-				side_effect=lambda value, days: (date.fromisoformat(str(value)) + timedelta(days=days)).isoformat(),
+				side_effect=lambda value, days: (
+					date.fromisoformat(str(value)) + timedelta(days=days)
+				).isoformat(),
 			),
 			patch.object(supervisor.frappe, "get_all", side_effect=fake_get_all),
 		):


### PR DESCRIPTION
## Summary
- treat approved leave as a valid overlay source even when the approval flow leaves the record at docstatus 0
- keep canceled leave excluded from labor-plan overlays
- add an S061 regression test for the approved-status/draft-docstatus contract

## Validation
- python -m ruff check hrms/api/supervisor.py hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
- python hrms/tests/test_s061_supervisor_labor_plan_leave_states.py