### PR TITLE
fix: backfill invoice supplier context

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -69,6 +69,31 @@ def _populate_payment_request_invoice_context(data: dict[str, Any], invoice: Any
         data["rfp_type"] = "Vendor Invoice"
 
 
+def _populate_invoice_context(
+    data: dict[str, Any],
+    purchase_order: Any | None = None,
+    goods_receipt: Any | None = None,
+) -> None:
+    """Backfill invoice party context from linked procurement documents."""
+    if not data.get("purchase_order") and getattr(goods_receipt, "purchase_order", None):
+        data["purchase_order"] = goods_receipt.purchase_order
+
+    if not data.get("supplier"):
+        supplier = getattr(purchase_order, "supplier", None) or getattr(goods_receipt, "supplier", None)
+        if supplier:
+            data["supplier"] = supplier
+
+    if not data.get("supplier_name"):
+        supplier_name = (
+            getattr(purchase_order, "supplier_name", None)
+            or getattr(goods_receipt, "supplier_name", None)
+        )
+        if not supplier_name and data.get("supplier"):
+            supplier_name = frappe.db.get_value("BEI Supplier", data["supplier"], "supplier_name")
+        if supplier_name:
+            data["supplier_name"] = supplier_name
+
+
 def _require_roles(allowed_roles: set[str], message: str) -> None:
     """Enforce role-based access for sensitive procurement actions."""
     user = frappe.session.user or "Guest"
@@ -1348,6 +1373,15 @@ def create_invoice(data: dict[str, Any] | str) -> dict[str, Any]:
     data = _normalize_invoice_payload(data)
 
     purchase_order = data.get("purchase_order")
+    goods_receipt = data.get("goods_receipt")
+    po = None
+    gr_doc = None
+
+    if goods_receipt:
+        gr_doc = frappe.get_doc("BEI Goods Receipt", goods_receipt)
+        _populate_invoice_context(data, goods_receipt=gr_doc)
+        purchase_order = data.get("purchase_order") or purchase_order
+
     if purchase_order:
         # AUDIT CONTROL 2.1: Check GR exists for this PO
         # Note: GR status can be "Accepted" after the receive+inspect workflow
@@ -1376,6 +1410,7 @@ def create_invoice(data: dict[str, Any] | str) -> dict[str, Any]:
 
         # AUDIT CONTROL 2.2: Invoice date >= PO date
         po = frappe.get_doc("BEI Purchase Order", purchase_order)
+        _populate_invoice_context(data, purchase_order=po, goods_receipt=gr_doc)
         invoice_date = getdate(data.get("invoice_date") or nowdate())
         po_date = getdate(po.po_date)
         if invoice_date < po_date:

--- a/hrms/tests/test_procurement_sprint02.py
+++ b/hrms/tests/test_procurement_sprint02.py
@@ -168,6 +168,19 @@ class _FormDoc:
 		return self
 
 
+class _InsertedDoc:
+	def __init__(self, payload, name="INV-TEST-0001"):
+		self.payload = dict(payload)
+		self.name = name
+		self.insert_calls = 0
+		for key, value in self.payload.items():
+			setattr(self, key, value)
+
+	def insert(self, ignore_permissions=False):
+		self.insert_calls += 1
+		return self
+
+
 class TestProcurementSprint02(unittest.TestCase):
 	def setUp(self):
 		procurement.frappe.session = types.SimpleNamespace(user="Administrator")
@@ -582,6 +595,104 @@ class TestProcurementSprint02(unittest.TestCase):
 
 		self.assertTrue(result["success"])
 		self.assertEqual(inserted_payload["received_by"], "HR-EMP-0001")
+
+	def test_create_invoice_backfills_supplier_context_from_purchase_order(self):
+		gr_doc = types.SimpleNamespace(
+			name="GR-TEST-0001",
+			purchase_order="PO-TEST-0001",
+		)
+		po_doc = types.SimpleNamespace(
+			name="PO-TEST-0001",
+			po_date="2026-02-28",
+			grand_total=1200,
+			mae_approval=1,
+			butch_approval=1,
+			supplier="SUP-001",
+			supplier_name="Supplier A",
+		)
+		captured = {}
+
+		def _get_doc(arg, *args, **kwargs):
+			if isinstance(arg, str) and arg == "BEI Goods Receipt":
+				return gr_doc
+			if isinstance(arg, str) and arg == "BEI Purchase Order":
+				return po_doc
+			if isinstance(arg, dict):
+				doc = _InsertedDoc(arg)
+				captured["invoice"] = doc
+				return doc
+			raise AssertionError(f"Unexpected get_doc call: {arg!r}")
+
+		procurement.frappe.db.exists = MagicMock(return_value="GR-TEST-0001")
+		procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
+
+		result = procurement.create_invoice(
+			{
+				"purchase_order": "PO-TEST-0001",
+				"goods_receipt": "GR-TEST-0001",
+				"supplier_invoice_no": "SI-0001",
+				"invoice_date": "2026-03-01",
+				"due_date": "2026-03-31",
+				"subtotal": 1000,
+				"vat_amount": 200,
+				"invoice_attachment": "/files/test.png",
+			}
+		)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(captured["invoice"].supplier, "SUP-001")
+		self.assertEqual(captured["invoice"].supplier_name, "Supplier A")
+		self.assertEqual(captured["invoice"].insert_calls, 1)
+
+	def test_create_invoice_backfills_purchase_order_and_supplier_from_goods_receipt(self):
+		gr_doc = types.SimpleNamespace(
+			name="GR-TEST-0001",
+			purchase_order="PO-TEST-0002",
+			supplier="SUP-002",
+			supplier_name="Supplier B",
+		)
+		po_doc = types.SimpleNamespace(
+			name="PO-TEST-0002",
+			po_date="2026-02-28",
+			grand_total=850,
+			mae_approval=1,
+			butch_approval=1,
+			supplier="SUP-002",
+			supplier_name="Supplier B",
+		)
+		captured = {}
+
+		def _get_doc(arg, *args, **kwargs):
+			if isinstance(arg, str) and arg == "BEI Goods Receipt":
+				return gr_doc
+			if isinstance(arg, str) and arg == "BEI Purchase Order":
+				return po_doc
+			if isinstance(arg, dict):
+				doc = _InsertedDoc(arg, name="INV-TEST-0002")
+				captured["invoice"] = doc
+				return doc
+			raise AssertionError(f"Unexpected get_doc call: {arg!r}")
+
+		procurement.frappe.db.exists = MagicMock(return_value="GR-TEST-0001")
+		procurement.frappe.get_doc = MagicMock(side_effect=_get_doc)
+
+		result = procurement.create_invoice(
+			{
+				"goods_receipt": "GR-TEST-0001",
+				"supplier_invoice_no": "SI-0002",
+				"invoice_date": "2026-03-01",
+				"due_date": "2026-03-31",
+				"subtotal": 850,
+				"vat_amount": 0,
+				"invoice_attachment": "/files/test.png",
+			}
+		)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(captured["invoice"].purchase_order, "PO-TEST-0002")
+		self.assertEqual(captured["invoice"].supplier, "SUP-002")
+		self.assertEqual(captured["invoice"].supplier_name, "Supplier B")
+		self.assertEqual(captured["invoice"].insert_calls, 1)
 
 	def test_bei_purchase_order_doctype_is_submittable(self):
 		doctype_path = (


### PR DESCRIPTION
## Summary
- backfill invoice supplier and supplier_name from the linked PO or GR before insert
- infer purchase_order from Goods Receipt when the UI sends only the GR link
- add procurement regression tests for invoice context backfill

## Verification
- python hrms\tests\test_procurement_sprint02.py
- live Playwright regression after the portal due-date fix exposed mandatory supplier failure in production invoice creation