### PR TITLE
fix: persist approved leave metadata on labor plans

### DIFF
--- a/hrms/api/supervisor.py
+++ b/hrms/api/supervisor.py
@@ -722,6 +722,8 @@ def _apply_shifts(doc: Any, shifts: list[dict[str, Any]]):
 		row.is_off = cint(normalized_shift.get("is_off"))
 		row.ends_next_day = cint(normalized_shift.get("ends_next_day"))
 		row.notes = normalized_shift.get("notes")
+		row.shift_source = normalized_shift.get("shift_source") or "manual"
+		row.is_locked = cint(normalized_shift.get("is_locked"))
 		resolved_shift_type = normalized_shift.get("storage_shift_type_name")
 		row.shift_type_name = _linked_shift_type_value(resolved_shift_type)
 		row.shift_type = _legacy_shift_type_value(normalized_shift.get("display_label"))

--- a/hrms/hr/doctype/bei_planned_shift/bei_planned_shift.json
+++ b/hrms/hr/doctype/bei_planned_shift/bei_planned_shift.json
@@ -13,6 +13,8 @@
   "shift_end",
   "ends_next_day",
   "shift_type",
+  "shift_source",
+  "is_locked",
   "hours",
   "notes"
  ],
@@ -79,6 +81,23 @@
    "in_list_view": 1,
    "label": "Shift Type",
    "options": "Opening\nMid\nClosing\nOff\nDay Off\nVL\nSL\nCommissary - Dawn\nCommissary - Morning\nCommissary - Afternoon\nCommissary - Night"
+  },
+  {
+   "default": "manual",
+   "fieldname": "shift_source",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Shift Source",
+   "options": "manual\napproved_leave",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_locked",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is Locked",
+   "read_only": 1
   },
   {
    "fieldname": "hours",

--- a/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
+++ b/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
@@ -230,6 +230,49 @@ class TestS061LeaveAwareMerging(unittest.TestCase):
 		self.assertEqual(overrides[0]["leave_application"], "HR-LAP-0001")
 		self.assertEqual(overrides[0]["shift_source"], "approved_leave")
 
+	def test_apply_shifts_persists_leave_metadata_on_plan_rows(self):
+		class FakeRow:
+			pass
+
+		class FakeDoc:
+			def __init__(self):
+				self.shifts = []
+				self.total_hours = 0
+
+			def append(self, fieldname, value):
+				self.asserted_fieldname = fieldname
+				row = FakeRow()
+				self.shifts.append(row)
+				return row
+
+		doc = FakeDoc()
+
+		supervisor._apply_shifts(
+			doc,
+			[
+				{
+					"employee": "EMP-001",
+					"employee_name": "Pat",
+					"day_of_week": "Monday",
+					"shift_type_name": "Off",
+					"shift_type": "VL",
+					"shift_label": "VL",
+					"storage_shift_type_name": "Off",
+					"is_off": 1,
+					"shift_source": "approved_leave",
+					"is_locked": 1,
+					"notes": "Approved vacation leave",
+				}
+			],
+		)
+
+		self.assertEqual(doc.asserted_fieldname, "shifts")
+		self.assertEqual(len(doc.shifts), 1)
+		self.assertEqual(doc.shifts[0].shift_type, "VL")
+		self.assertEqual(doc.shifts[0].shift_source, "approved_leave")
+		self.assertEqual(doc.shifts[0].is_locked, 1)
+		self.assertEqual(doc.shifts[0].notes, "Approved vacation leave")
+
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Summary
- persist shift_source and is_locked on weekly labor plan rows
- add hidden schema fields to BEI Planned Shift so saved/published plans retain leave-lock metadata
- add regression coverage for persisted leave metadata on plan rows

## Why
S061 live L3 still failed after the leave overlay fetch fix because the saved/published labor plan kept the VL/SL label but dropped the underlying leave metadata. That broke the certification proof that approved leave stays locked through save and publish.

## Testing
- python -m ruff check hrms/api/supervisor.py hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
- python hrms/tests/test_s061_supervisor_labor_plan_leave_states.py