### PR TITLE
fix: avoid labor-plan lock field collision

### DIFF
--- a/hrms/api/supervisor.py
+++ b/hrms/api/supervisor.py
@@ -723,7 +723,7 @@ def _apply_shifts(doc: Any, shifts: list[dict[str, Any]]):
 		row.ends_next_day = cint(normalized_shift.get("ends_next_day"))
 		row.notes = normalized_shift.get("notes")
 		row.shift_source = normalized_shift.get("shift_source") or "manual"
-		row.is_locked = cint(normalized_shift.get("is_locked"))
+		row.leave_locked = cint(normalized_shift.get("is_locked"))
 		resolved_shift_type = normalized_shift.get("storage_shift_type_name")
 		row.shift_type_name = _linked_shift_type_value(resolved_shift_type)
 		row.shift_type = _legacy_shift_type_value(normalized_shift.get("display_label"))
@@ -740,6 +740,19 @@ def _apply_shifts(doc: Any, shifts: list[dict[str, Any]]):
 
 	doc.total_hours = total_hours
 	return total_hours
+
+
+def _serialize_weekly_plan(doc: Any):
+	plan = doc.as_dict()
+	serialized_shifts = []
+	for row in plan.get("shifts") or []:
+		shift = row.as_dict() if hasattr(row, "as_dict") else dict(row)
+		shift["shift_source"] = shift.get("shift_source") or "manual"
+		shift["is_locked"] = cint(shift.get("leave_locked"))
+		shift.pop("leave_locked", None)
+		serialized_shifts.append(shift)
+	plan["shifts"] = serialized_shifts
+	return plan
 
 
 def _get_work_date(week_start_date: str, day_of_week: str):
@@ -1594,7 +1607,7 @@ def get_weekly_plan(store: str | None = None, week_start: str | None = None, sur
 
 	if plans:
 		doc = frappe.get_doc("BEI Weekly Labor Plan", plans[0].name)
-		return {"plan": doc.as_dict()}
+		return {"plan": _serialize_weekly_plan(doc)}
 	return {"plan": None}
 
 

--- a/hrms/hr/doctype/bei_planned_shift/bei_planned_shift.json
+++ b/hrms/hr/doctype/bei_planned_shift/bei_planned_shift.json
@@ -14,7 +14,7 @@
   "ends_next_day",
   "shift_type",
   "shift_source",
-  "is_locked",
+  "leave_locked",
   "hours",
   "notes"
  ],
@@ -93,10 +93,10 @@
   },
   {
    "default": "0",
-   "fieldname": "is_locked",
+   "fieldname": "leave_locked",
    "fieldtype": "Check",
    "hidden": 1,
-   "label": "Is Locked",
+   "label": "Leave Locked",
    "read_only": 1
   },
   {

--- a/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
+++ b/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
@@ -270,8 +270,33 @@ class TestS061LeaveAwareMerging(unittest.TestCase):
 		self.assertEqual(len(doc.shifts), 1)
 		self.assertEqual(doc.shifts[0].shift_type, "VL")
 		self.assertEqual(doc.shifts[0].shift_source, "approved_leave")
-		self.assertEqual(doc.shifts[0].is_locked, 1)
+		self.assertEqual(doc.shifts[0].leave_locked, 1)
 		self.assertEqual(doc.shifts[0].notes, "Approved vacation leave")
+
+	def test_serialize_weekly_plan_exposes_is_locked_alias(self):
+		class FakeRow(dict):
+			pass
+
+		class FakeDoc:
+			def as_dict(self):
+				return {
+					"name": "BEI-WLP-TEST",
+					"status": "Draft",
+					"shifts": [
+						FakeRow(
+							employee="EMP-001",
+							day_of_week="Monday",
+							shift_type="VL",
+							shift_source="approved_leave",
+							leave_locked=1,
+						)
+					],
+				}
+
+		serialized = supervisor._serialize_weekly_plan(FakeDoc())
+		self.assertEqual(serialized["shifts"][0]["shift_source"], "approved_leave")
+		self.assertEqual(serialized["shifts"][0]["is_locked"], 1)
+		self.assertNotIn("leave_locked", serialized["shifts"][0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rename the persisted lock field to leave_locked to avoid Frappe's reserved is_locked property
- alias leave_locked back to is_locked in weekly labor-plan API responses so the portal contract stays stable
- add regression coverage for persisted leave metadata serialization

## Why
PR #264 introduced a real live regression: creating a weekly labor plan started failing with AttributeError: property 'is_locked' of 'BEIPlannedShift' object has no setter. The save path needs a non-reserved persisted field name while still returning the expected API contract to the portal.

## Testing
- python -m ruff check hrms/api/supervisor.py hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
- python hrms/tests/test_s061_supervisor_labor_plan_leave_states.py