### PR TITLE
fix: harden labor plan row serialization

### DIFF
--- a/hrms/api/supervisor.py
+++ b/hrms/api/supervisor.py
@@ -746,7 +746,8 @@ def _serialize_weekly_plan(doc: Any):
 	plan = doc.as_dict()
 	serialized_shifts = []
 	for row in plan.get("shifts") or []:
-		shift = row.as_dict() if hasattr(row, "as_dict") else dict(row)
+		row_as_dict = getattr(row, "as_dict", None)
+		shift = row_as_dict() if callable(row_as_dict) else dict(row)
 		shift["shift_source"] = shift.get("shift_source") or "manual"
 		shift["is_locked"] = cint(shift.get("leave_locked"))
 		shift.pop("leave_locked", None)

--- a/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
+++ b/hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
@@ -298,6 +298,18 @@ class TestS061LeaveAwareMerging(unittest.TestCase):
 		self.assertEqual(serialized["shifts"][0]["is_locked"], 1)
 		self.assertNotIn("leave_locked", serialized["shifts"][0])
 
+	def test_serialize_weekly_plan_handles_rows_with_noncallable_as_dict(self):
+		row = {"employee": "EMP-001", "shift_source": None, "leave_locked": 0}
+		row["as_dict"] = None
+
+		class FakeDoc:
+			def as_dict(self):
+				return {"name": "BEI-WLP-TEST", "status": "Draft", "shifts": [row]}
+
+		serialized = supervisor._serialize_weekly_plan(FakeDoc())
+		self.assertEqual(serialized["shifts"][0]["shift_source"], "manual")
+		self.assertEqual(serialized["shifts"][0]["is_locked"], 0)
+
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Summary
- guard the weekly-plan serializer against non-callable s_dict row values
- add regression coverage for dict-like shift rows returned from doc.as_dict()

## Why
After the lock-field hotfix, live get_weekly_plan still failed because the serializer assumed every row with an s_dict attribute had a callable method. In production, the row payload can expose s_dict: null, which caused TypeError: 'NoneType' object is not callable and broke labor-plan fetch after save.

## Testing
- python -m ruff check hrms/api/supervisor.py hrms/tests/test_s061_supervisor_labor_plan_leave_states.py
- python hrms/tests/test_s061_supervisor_labor_plan_leave_states.py