### PR TITLE
fix: harden scm warehouse and commissary runtime paths

### DIFF
--- a/hrms/api/commissary_dashboard.py
+++ b/hrms/api/commissary_dashboard.py
@@ -6,6 +6,8 @@ Commissary Dashboard & Production Tracking APIs.
 Split from commissary.py (P0-11) for maintainability.
 """
 
+import time
+from contextlib import contextmanager
 import json
 from typing import Any
 
@@ -14,6 +16,55 @@ from frappe import _
 from frappe.utils import add_days, flt, today
 
 from hrms.api.commissary import get_commissary_company, get_commissary_warehouse
+from hrms.utils.scm_roles import SCM_COMMISSARY_ROLES, check_scm_permission
+
+
+def _enable_role_gated_write(doc: Any):
+	if getattr(doc, "flags", None) is None:
+		doc.flags = type("_CommissaryDashboardDocFlags", (), {})()
+	doc.flags.ignore_permissions = True
+	doc.flags.ignore_user_permissions = True
+	return doc
+
+
+@contextmanager
+def _run_as_system_user(user: str = "Administrator"):
+	session = getattr(frappe, "session", None)
+	if session is None:
+		session = getattr(getattr(frappe, "local", None), "session", None)
+	original_user = getattr(session, "user", None)
+	try:
+		if session and user:
+			session.user = user
+		yield
+	finally:
+		if session and original_user:
+			session.user = original_user
+
+
+def _rollback_savepoint(savepoint_name: str):
+	rollback = getattr(getattr(frappe, "db", None), "rollback", None)
+	if not callable(rollback):
+		return
+	try:
+		rollback(save_point=savepoint_name)
+	except TypeError:
+		rollback()
+
+
+def _release_savepoint(savepoint_name: str):
+	release = getattr(getattr(frappe, "db", None), "release_savepoint", None)
+	if callable(release):
+		release(savepoint_name)
+
+
+def _is_retryable_stock_entry_submit_error(exc: Exception) -> bool:
+	message = str(exc).lower()
+	return (
+		"lock wait timeout exceeded" in message
+		or "deadlock found" in message
+		or "try restarting transaction" in message
+	)
 
 # ============================================================
 # DASHBOARD / SUMMARY
@@ -282,6 +333,8 @@ def submit_production_output(
 	    batch_no: Optional batch reference (will auto-create if doesn't exist)
 	    remarks: Optional production notes
 	"""
+	check_scm_permission(SCM_COMMISSARY_ROLES, "record commissary production output")
+
 	if isinstance(items, str):
 		items = json.loads(items)
 
@@ -289,16 +342,6 @@ def submit_production_output(
 		frappe.throw(_("No items to record"))
 
 	commissary_warehouse = get_commissary_warehouse()
-
-	se = frappe.new_doc("Stock Entry")
-	se.company = get_commissary_company()
-	se.posting_date = today()
-	se.posting_time = frappe.utils.nowtime()
-	se.to_warehouse = commissary_warehouse
-	se.remarks = _build_production_remarks(batch_no=batch_no, remarks=remarks)
-
-	# Try Manufacture type if BOM exists (auto-deducts raw materials)
-	# Fall back to Material Receipt if no BOM available
 	first_item_code = items[0]["item_code"] if items else None
 	bom = None
 	if first_item_code:
@@ -309,70 +352,99 @@ def submit_production_output(
 			as_dict=True,
 		)
 
-	if bom:
-		# Use Manufacture type - auto-deducts RM from BOM
-		se.stock_entry_type = "Manufacture"
-		se.from_bom = 1
-		se.bom_no = bom.name
-		se.fg_completed_qty = sum(flt(i["qty"]) for i in items)
-		se.from_warehouse = commissary_warehouse  # RM source
-		se.get_items()
+	se = None
+	for attempt in range(3):
+		savepoint_name = f"commissary_production_{attempt}"
+		savepoint = getattr(getattr(frappe, "db", None), "savepoint", None)
+		if callable(savepoint):
+			savepoint(savepoint_name)
 
-		# Only add FG if not already present from BOM
-		fg_already_present = any(
-			item.item_code == first_item_code and item.is_finished_item for item in se.items
-		)
-		item = frappe.get_doc("Item", first_item_code)
-		if not fg_already_present:
-			fg_row = se.append(
-				"items",
-				{
-					"item_code": first_item_code,
-					"item_name": item.item_name,
-					"description": item.description,
-					"qty": se.fg_completed_qty,
-					"uom": item.stock_uom,
-					"stock_uom": item.stock_uom,
-					"conversion_factor": 1,
-					"t_warehouse": commissary_warehouse,
-					"is_finished_item": 1,
-					"is_scrap_item": 0,
-				},
-			)
-		else:
-			# Get reference to the existing FG row for batch assignment below
-			fg_row = next(i for i in se.items if i.item_code == first_item_code and i.is_finished_item)
+		try:
+			se = frappe.new_doc("Stock Entry")
+			se.company = get_commissary_company()
+			se.posting_date = today()
+			se.posting_time = frappe.utils.nowtime()
+			se.to_warehouse = commissary_warehouse
+			se.remarks = _build_production_remarks(batch_no=batch_no, remarks=remarks)
 
-		# Override batch on FG if provided
-		if batch_no and batch_no.strip():
-			valid_batch = get_or_create_batch(batch_no, first_item_code)
-			if valid_batch:
-				fg_row.batch_no = valid_batch
-	else:
-		# Fallback: Material Receipt (no RM deduction)
-		se.stock_entry_type = "Material Receipt"
+			if bom:
+				# Use Manufacture type - auto-deducts RM from BOM
+				se.stock_entry_type = "Manufacture"
+				se.from_bom = 1
+				se.bom_no = bom.name
+				se.fg_completed_qty = sum(flt(i["qty"]) for i in items)
+				se.from_warehouse = commissary_warehouse  # RM source
+				se.get_items()
 
-		for item_data in items:
-			item = frappe.get_doc("Item", item_data["item_code"])
+				# Only add FG if not already present from BOM
+				fg_already_present = any(
+					item.item_code == first_item_code and item.is_finished_item for item in se.items
+				)
+				item = frappe.get_doc("Item", first_item_code)
+				if not fg_already_present:
+					fg_row = se.append(
+						"items",
+						{
+							"item_code": first_item_code,
+							"item_name": item.item_name,
+							"description": item.description,
+							"qty": se.fg_completed_qty,
+							"uom": item.stock_uom,
+							"stock_uom": item.stock_uom,
+							"conversion_factor": 1,
+							"t_warehouse": commissary_warehouse,
+							"is_finished_item": 1,
+							"is_scrap_item": 0,
+						},
+					)
+				else:
+					# Get reference to the existing FG row for batch assignment below
+					fg_row = next(
+						i for i in se.items if i.item_code == first_item_code and i.is_finished_item
+					)
 
-			item_row = {
-				"item_code": item_data["item_code"],
-				"item_name": item.item_name,
-				"description": item.description,
-				"qty": flt(item_data["qty"]),
-				"uom": item_data.get("uom") or item.stock_uom,
-				"stock_uom": item.stock_uom,
-				"conversion_factor": 1,
-				"t_warehouse": commissary_warehouse,
-			}
-			if batch_no and batch_no.strip():
-				valid_batch = get_or_create_batch(batch_no, item_data["item_code"])
-				if valid_batch:
-					item_row["batch_no"] = valid_batch
-			se.append("items", item_row)
+				# Override batch on FG if provided
+				if batch_no and batch_no.strip():
+					valid_batch = get_or_create_batch(batch_no, first_item_code)
+					if valid_batch:
+						fg_row.batch_no = valid_batch
+			else:
+				# Fallback: Material Receipt (no RM deduction)
+				se.stock_entry_type = "Material Receipt"
 
-	se.insert()
-	se.submit()
+				for item_data in items:
+					item = frappe.get_doc("Item", item_data["item_code"])
+
+					item_row = {
+						"item_code": item_data["item_code"],
+						"item_name": item.item_name,
+						"description": item.description,
+						"qty": flt(item_data["qty"]),
+						"uom": item_data.get("uom") or item.stock_uom,
+						"stock_uom": item.stock_uom,
+						"conversion_factor": 1,
+						"t_warehouse": commissary_warehouse,
+					}
+					if batch_no and batch_no.strip():
+						valid_batch = get_or_create_batch(batch_no, item_data["item_code"])
+						if valid_batch:
+							item_row["batch_no"] = valid_batch
+					se.append("items", item_row)
+
+			_enable_role_gated_write(se)
+			with _run_as_system_user():
+				se.insert(ignore_permissions=True)
+				se = frappe.get_doc("Stock Entry", se.name)
+				_enable_role_gated_write(se)
+				se.submit()
+
+			_release_savepoint(savepoint_name)
+			break
+		except Exception as exc:
+			_rollback_savepoint(savepoint_name)
+			if attempt == 2 or not _is_retryable_stock_entry_submit_error(exc):
+				raise
+			time.sleep(0.2 * (attempt + 1))
 
 	# G-051: FEFO warnings — check if older batches were skipped
 	fefo_warnings = _check_fefo_warnings(se, commissary_warehouse)

--- a/hrms/api/commissary_dashboard.py
+++ b/hrms/api/commissary_dashboard.py
@@ -6,9 +6,9 @@ Commissary Dashboard & Production Tracking APIs.
 Split from commissary.py (P0-11) for maintainability.
 """
 
+import json
 import time
 from contextlib import contextmanager
-import json
 from typing import Any
 
 import frappe
@@ -65,6 +65,7 @@ def _is_retryable_stock_entry_submit_error(exc: Exception) -> bool:
 		or "deadlock found" in message
 		or "try restarting transaction" in message
 	)
+
 
 # ============================================================
 # DASHBOARD / SUMMARY

--- a/hrms/api/commissary_quality.py
+++ b/hrms/api/commissary_quality.py
@@ -12,9 +12,9 @@ Contains all quality-related functionality:
   - QC Form Management (submit, list, detail, templates)
 """
 
+import json
 import time
 from contextlib import contextmanager
-import json
 from typing import Any
 
 import frappe
@@ -71,6 +71,7 @@ def _is_retryable_stock_entry_submit_error(exc: Exception) -> bool:
 		or "deadlock found" in message
 		or "try restarting transaction" in message
 	)
+
 
 # ============================================================
 # QUALITY INSPECTION

--- a/hrms/api/commissary_quality.py
+++ b/hrms/api/commissary_quality.py
@@ -12,6 +12,8 @@ Contains all quality-related functionality:
   - QC Form Management (submit, list, detail, templates)
 """
 
+import time
+from contextlib import contextmanager
 import json
 from typing import Any
 
@@ -19,8 +21,56 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, flt, today
 
-from hrms.api.commissary import get_commissary_warehouse
-from hrms.utils.bei_config import get_company
+from hrms.api.commissary import get_commissary_company, get_commissary_warehouse
+from hrms.utils.scm_roles import SCM_COMMISSARY_ROLES, check_scm_permission
+
+
+def _enable_role_gated_write(doc: Any):
+	if getattr(doc, "flags", None) is None:
+		doc.flags = type("_CommissaryQualityDocFlags", (), {})()
+	doc.flags.ignore_permissions = True
+	doc.flags.ignore_user_permissions = True
+	return doc
+
+
+@contextmanager
+def _run_as_system_user(user: str = "Administrator"):
+	session = getattr(frappe, "session", None)
+	if session is None:
+		session = getattr(getattr(frappe, "local", None), "session", None)
+	original_user = getattr(session, "user", None)
+	try:
+		if session and user:
+			session.user = user
+		yield
+	finally:
+		if session and original_user:
+			session.user = original_user
+
+
+def _rollback_savepoint(savepoint_name: str):
+	rollback = getattr(getattr(frappe, "db", None), "rollback", None)
+	if not callable(rollback):
+		return
+	try:
+		rollback(save_point=savepoint_name)
+	except TypeError:
+		rollback()
+
+
+def _release_savepoint(savepoint_name: str):
+	release = getattr(getattr(frappe, "db", None), "release_savepoint", None)
+	if callable(release):
+		release(savepoint_name)
+
+
+def _is_retryable_stock_entry_submit_error(exc: Exception) -> bool:
+	message = str(exc).lower()
+	return (
+		"lock wait timeout exceeded" in message
+		or "deadlock found" in message
+		or "try restarting transaction" in message
+	)
 
 # ============================================================
 # QUALITY INSPECTION
@@ -354,6 +404,8 @@ def log_wastage(
 	    batch_no: Batch number (optional)
 	    remarks: Additional notes
 	"""
+	check_scm_permission(SCM_COMMISSARY_ROLES, "log commissary wastage")
+
 	commissary_warehouse = get_commissary_warehouse()
 
 	if reason_code not in WASTAGE_REASONS:
@@ -368,33 +420,54 @@ def log_wastage(
 	if not item:
 		return {"success": False, "error": f"Item {item_code} not found"}
 
-	# Create Stock Entry for Material Issue (Wastage)
-	se = frappe.new_doc("Stock Entry")
-	se.stock_entry_type = "Material Issue"
-	se.company = get_company()
-	se.purpose = "Material Issue"
+	se = None
+	for attempt in range(3):
+		savepoint_name = f"commissary_wastage_{attempt}"
+		savepoint = getattr(getattr(frappe, "db", None), "savepoint", None)
+		if callable(savepoint):
+			savepoint(savepoint_name)
 
-	# Build remarks with reason
-	full_remarks = f"WASTAGE: {WASTAGE_REASONS[reason_code]}"
-	if remarks:
-		full_remarks += f" - {remarks}"
-	se.remarks = full_remarks
+		try:
+			# Create Stock Entry for Material Issue (Wastage)
+			se = frappe.new_doc("Stock Entry")
+			se.stock_entry_type = "Material Issue"
+			se.company = get_commissary_company()
+			se.purpose = "Material Issue"
 
-	se.append(
-		"items",
-		{
-			"item_code": item_code,
-			"item_name": item.item_name,
-			"s_warehouse": commissary_warehouse,
-			"qty": flt(qty),
-			"uom": item.stock_uom,
-			"stock_uom": item.stock_uom,
-			"batch_no": batch_no,
-		},
-	)
+			# Build remarks with reason
+			full_remarks = f"WASTAGE: {WASTAGE_REASONS[reason_code]}"
+			if remarks:
+				full_remarks += f" - {remarks}"
+			se.remarks = full_remarks
 
-	se.insert()
-	se.submit()
+			row = {
+				"item_code": item_code,
+				"item_name": item.item_name,
+				"s_warehouse": commissary_warehouse,
+				"qty": flt(qty),
+				"uom": item.stock_uom,
+				"stock_uom": item.stock_uom,
+				"batch_no": batch_no,
+				"valuation_rate": flt(item.valuation_rate or 0),
+			}
+			if flt(item.valuation_rate or 0) <= 0:
+				row["allow_zero_valuation_rate"] = 1
+			se.append("items", row)
+
+			_enable_role_gated_write(se)
+			with _run_as_system_user():
+				se.insert(ignore_permissions=True)
+				se = frappe.get_doc("Stock Entry", se.name)
+				_enable_role_gated_write(se)
+				se.submit()
+
+			_release_savepoint(savepoint_name)
+			break
+		except Exception as exc:
+			_rollback_savepoint(savepoint_name)
+			if attempt == 2 or not _is_retryable_stock_entry_submit_error(exc):
+				raise
+			time.sleep(0.2 * (attempt + 1))
 
 	# Calculate wastage value
 	wastage_value = flt(qty) * flt(item.valuation_rate or 0)

--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -1580,6 +1580,19 @@ def preview_trip_stops(route_name: str, trip_date: str | None = None):
 	return {"route_name": route_name, "trip_date": trip_date, "stops": stops}
 
 
+def _duplicate_trip_response(route_name: str, trip_date: str, existing_trip: str):
+	return {
+		"success": False,
+		"error_code": "TRIP_ALREADY_EXISTS",
+		"trip": existing_trip,
+		"route_name": route_name,
+		"trip_date": trip_date,
+		"message": _("A trip already exists for route '{0}' on {1}: {2}").format(
+			route_name, trip_date, existing_trip
+		),
+	}
+
+
 @frappe.whitelist()
 def create_trip_from_route(
 	route_name: str,
@@ -1610,11 +1623,7 @@ def create_trip_from_route(
 		"BEI Distribution Trip", {"route_name": route_name, "trip_date": trip_date}, "name"
 	)
 	if existing_trip:
-		frappe.throw(
-			_("A trip already exists for route '{0}' on {1}: {2}").format(
-				route_name, trip_date, existing_trip
-			)
-		)
+		return _duplicate_trip_response(route_name, trip_date, existing_trip)
 
 	# Resolve vehicle details
 	vehicle_plate = None
@@ -1705,7 +1714,15 @@ def create_trip_from_route(
 			trip.stops[idx].store_order = stop_data["store_order"]
 
 	_enable_role_gated_write(trip)
-	trip.insert(ignore_permissions=True)
+	try:
+		trip.insert(ignore_permissions=True)
+	except frappe.DuplicateEntryError:
+		existing_trip = frappe.db.get_value(
+			"BEI Distribution Trip", {"route_name": route_name, "trip_date": trip_date}, "name"
+		)
+		if existing_trip:
+			return _duplicate_trip_response(route_name, trip_date, existing_trip)
+		raise
 
 	return {
 		"success": True,

--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -159,8 +159,7 @@ def _resolve_stock_entry_item_valuation(item_code: str, warehouse: str | None):
 	zero-valuation movement so dispatch does not die on a generic 417/validation error.
 	"""
 	bin_rate = flt(
-		frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse}, "valuation_rate")
-		or 0
+		frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse}, "valuation_rate") or 0
 	)
 	if bin_rate > 0:
 		return bin_rate, False

--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -151,6 +151,35 @@ def _clear_legacy_serial_batch_fields_after_auto_bundle(stock_entry: Any) -> Non
 			item.serial_no = None
 
 
+def _resolve_stock_entry_item_valuation(item_code: str, warehouse: str | None):
+	"""Return a stable valuation context for outbound stock rows.
+
+	Material Issue movements can fail at submit time when the source stock has no
+	valuation rate yet. When that happens, explicitly mark the row as an allowed
+	zero-valuation movement so dispatch does not die on a generic 417/validation error.
+	"""
+	bin_rate = flt(
+		frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse}, "valuation_rate")
+		or 0
+	)
+	if bin_rate > 0:
+		return bin_rate, False
+
+	item_rates = frappe.db.get_value(
+		"Item",
+		item_code,
+		["valuation_rate", "standard_rate", "last_purchase_rate"],
+		as_dict=True,
+	) or {"valuation_rate": 0, "standard_rate": 0, "last_purchase_rate": 0}
+	resolved_rate = flt(
+		item_rates.get("valuation_rate")
+		or item_rates.get("standard_rate")
+		or item_rates.get("last_purchase_rate")
+		or 0
+	)
+	return resolved_rate, resolved_rate <= 0
+
+
 @frappe.whitelist()
 def get_pending_purchase_orders(item_code=None, warehouse=None):
 	"""
@@ -1032,6 +1061,9 @@ def create_stock_transfer(
 		# Get item details
 		item = frappe.get_doc("Item", item_data["item_code"])
 		valid_uom = _resolve_valid_item_uom(item, item_data.get("uom"))
+		valuation_rate, allow_zero_valuation_rate = _resolve_stock_entry_item_valuation(
+			item_data["item_code"], source_warehouse
+		)
 
 		# ERPNext v15 auto-creates outward serial/batch bundles for Material Issue.
 		# Supplying legacy batch fields in that path causes duplicate-bundle validation,
@@ -1064,6 +1096,10 @@ def create_stock_transfer(
 			"material_request": mr_name if mr_item_ref else None,
 			"material_request_item": mr_item_ref,
 		}
+		if is_intercompany:
+			row["valuation_rate"] = valuation_rate
+			if allow_zero_valuation_rate:
+				row["allow_zero_valuation_rate"] = 1
 		if batch_no:
 			row["batch_no"] = batch_no
 		if not is_intercompany:

--- a/hrms/tests/test_commissary_dashboard_summary.py
+++ b/hrms/tests/test_commissary_dashboard_summary.py
@@ -12,6 +12,8 @@ class _FakeFrappe(types.ModuleType):
 	def __getattr__(self, name):
 		if name == "db":
 			return self.local.db
+		if name == "session":
+			return self.local.session
 		raise AttributeError(name)
 
 
@@ -24,7 +26,14 @@ def _install_fake_modules():
 	fake_frappe = _FakeFrappe("frappe")
 	fake_frappe._dict = lambda data: types.SimpleNamespace(**data)
 	fake_frappe.local = types.SimpleNamespace(
-		db=types.SimpleNamespace(sql=lambda *args, **kwargs: [], count=lambda *args, **kwargs: 0)
+		session=types.SimpleNamespace(user="test.commissary@bebang.ph"),
+		db=types.SimpleNamespace(
+			sql=lambda *args, **kwargs: [],
+			count=lambda *args, **kwargs: 0,
+			savepoint=lambda *args, **kwargs: None,
+			release_savepoint=lambda *args, **kwargs: None,
+			rollback=lambda *args, **kwargs: None,
+		),
 	)
 	fake_frappe.get_all = lambda *args, **kwargs: []
 	fake_frappe.whitelist = _whitelist
@@ -48,6 +57,11 @@ def _install_fake_modules():
 	fake_commissary.get_commissary_warehouse = lambda: "Shaw BLVD - BKI"
 	fake_commissary.get_commissary_company = lambda: "Bebang Kitchen Inc."
 	sys.modules["hrms.api.commissary"] = fake_commissary
+
+	fake_scm_roles = types.ModuleType("hrms.utils.scm_roles")
+	fake_scm_roles.SCM_COMMISSARY_ROLES = {"Commissary Supervisor", "Warehouse User"}
+	fake_scm_roles.check_scm_permission = lambda roles, action="": None
+	sys.modules["hrms.utils.scm_roles"] = fake_scm_roles
 
 	fake_bei_config = types.ModuleType("hrms.utils.bei_config")
 	fake_bei_config.get_company = lambda: "Bebang Kitchen Inc."
@@ -124,6 +138,7 @@ class TestCommissaryDashboardSummary(unittest.TestCase):
 
 		class _FakeStockEntry:
 			def __init__(self):
+				self.doctype = "Stock Entry"
 				self.company = None
 				self.stock_entry_type = None
 				self.posting_date = None
@@ -139,9 +154,10 @@ class TestCommissaryDashboardSummary(unittest.TestCase):
 				defaults = {"batch_no": None, "s_warehouse": None, "t_warehouse": None}
 				defaults.update(row)
 				self.items.append(types.SimpleNamespace(**defaults))
+				return self.items[-1]
 
-			def insert(self):
-				self.insert_called = True
+			def insert(self, ignore_permissions=False):
+				self.insert_called = ignore_permissions
 				return self
 
 			def submit(self):
@@ -153,6 +169,13 @@ class TestCommissaryDashboardSummary(unittest.TestCase):
 			doc = _FakeStockEntry()
 			created["doc"] = doc
 			return doc
+
+		def fake_get_doc(doctype, name=None):
+			if doctype == "Stock Entry":
+				return created["doc"]
+			return types.SimpleNamespace(
+				item_name="BANANA CINNAMON", description="Finished good", stock_uom="KG"
+			)
 
 		with (
 			patch.object(commissary_dashboard, "get_commissary_warehouse", return_value="Shaw BLVD - BKI"),
@@ -167,9 +190,7 @@ class TestCommissaryDashboardSummary(unittest.TestCase):
 			patch.object(
 				commissary_dashboard.frappe,
 				"get_doc",
-				return_value=types.SimpleNamespace(
-					item_name="BANANA CINNAMON", description="Finished good", stock_uom="KG"
-				),
+				side_effect=fake_get_doc,
 				create=True,
 			),
 		):
@@ -184,6 +205,8 @@ class TestCommissaryDashboardSummary(unittest.TestCase):
 		self.assertEqual(doc.stock_entry_type, "Material Receipt")
 		self.assertTrue(doc.insert_called)
 		self.assertTrue(doc.submit_called)
+		self.assertTrue(doc.flags.ignore_permissions)
+		self.assertTrue(doc.flags.ignore_user_permissions)
 		self.assertEqual(result["data"]["name"], "MAT-STE-UNIT-0001")
 
 

--- a/hrms/tests/test_s37_commissary_quality_contract.py
+++ b/hrms/tests/test_s37_commissary_quality_contract.py
@@ -244,7 +244,9 @@ class TestS37CommissaryQualityContract(unittest.TestCase):
 			if doctype == "Quality Inspection Template" and name == "Commissary FG QC":
 				return types.SimpleNamespace(
 					item_quality_inspection_parameter=[
-						types.SimpleNamespace(specification="Visual Appearance", value="No defects, correct color"),
+						types.SimpleNamespace(
+							specification="Visual Appearance", value="No defects, correct color"
+						),
 						types.SimpleNamespace(specification="Temperature", value="-18°C to 4°C range"),
 					]
 				)

--- a/hrms/tests/test_s37_commissary_quality_contract.py
+++ b/hrms/tests/test_s37_commissary_quality_contract.py
@@ -49,6 +49,32 @@ class _FakeQualityInspection:
 		return self
 
 
+class _FakeStockEntry:
+	def __init__(self):
+		self.doctype = "Stock Entry"
+		self.name = "MAT-STE-WASTE-0001"
+		self.company = None
+		self.stock_entry_type = None
+		self.purpose = None
+		self.remarks = None
+		self.flags = None
+		self.items = []
+		self.insert_called = False
+		self.submit_called = False
+
+	def append(self, table, row):
+		self.items.append(types.SimpleNamespace(**row))
+		return self.items[-1]
+
+	def insert(self, ignore_permissions=False):
+		self.insert_called = ignore_permissions
+		return self
+
+	def submit(self):
+		self.submit_called = True
+		return self
+
+
 _DOCS_CREATED: list[_FakeQualityInspection] = []
 
 
@@ -80,7 +106,7 @@ def _install_fake_modules():
 		)
 
 		def _new_doc(doctype):
-			doc = _FakeQualityInspection()
+			doc = _FakeQualityInspection() if doctype == "Quality Inspection" else _FakeStockEntry()
 			_DOCS_CREATED.append(doc)
 			return doc
 
@@ -112,11 +138,13 @@ def _install_fake_modules():
 
 	commissary_mod = types.ModuleType("hrms.api.commissary")
 	commissary_mod.get_commissary_warehouse = lambda: "Shaw BLVD - BKI"
+	commissary_mod.get_commissary_company = lambda: "Bebang Kitchen Inc."
 	sys.modules["hrms.api.commissary"] = commissary_mod
 
-	bei_config_mod = types.ModuleType("hrms.utils.bei_config")
-	bei_config_mod.get_company = lambda: "Bebang Kitchen Inc."
-	sys.modules["hrms.utils.bei_config"] = bei_config_mod
+	scm_roles_mod = types.ModuleType("hrms.utils.scm_roles")
+	scm_roles_mod.SCM_COMMISSARY_ROLES = {"Commissary Supervisor", "Warehouse User"}
+	scm_roles_mod.check_scm_permission = lambda roles, action="": None
+	sys.modules["hrms.utils.scm_roles"] = scm_roles_mod
 
 
 _install_fake_modules()
@@ -251,6 +279,45 @@ class TestS37CommissaryQualityContract(unittest.TestCase):
 		self.assertEqual(created.readings[1].manual_inspection, 1)
 		self.assertEqual(created.readings[1].reading_1, "-18°C to 4°C range")
 		self.assertEqual(created.readings[1].status, "Accepted")
+
+	def test_log_wastage_uses_commissary_company_and_role_gated_submit(self):
+		_DOCS_CREATED.clear()
+		original_get_value = commissary_quality.frappe.db.get_value
+		original_get_doc = commissary_quality.frappe.get_doc
+
+		def fake_get_value(doctype, filters, fieldname=None, as_dict=False):
+			if doctype == "Item":
+				return types.SimpleNamespace(item_name="TAPIOCA", stock_uom="KG", valuation_rate=0)
+			return original_get_value(doctype, filters, fieldname, as_dict)
+
+		def fake_get_doc(doctype, name=None):
+			if doctype == "Stock Entry":
+				return _DOCS_CREATED[-1]
+			return original_get_doc(doctype, name)
+
+		commissary_quality.frappe.db.get_value = fake_get_value
+		commissary_quality.frappe.get_doc = fake_get_doc
+		try:
+			result = commissary_quality.log_wastage(
+				item_code="FG009",
+				qty=2,
+				reason_code="expired",
+				remarks="S078 wastage hardening",
+			)
+		finally:
+			commissary_quality.frappe.db.get_value = original_get_value
+			commissary_quality.frappe.get_doc = original_get_doc
+
+		self.assertTrue(result["success"])
+		created = _DOCS_CREATED[-1]
+		self.assertEqual(created.company, "Bebang Kitchen Inc.")
+		self.assertEqual(created.stock_entry_type, "Material Issue")
+		self.assertTrue(created.insert_called)
+		self.assertTrue(created.submit_called)
+		self.assertTrue(created.flags.ignore_permissions)
+		self.assertTrue(created.flags.ignore_user_permissions)
+		self.assertEqual(created.items[0].allow_zero_valuation_rate, 1)
+		self.assertEqual(created.items[0].valuation_rate, 0)
 
 
 if __name__ == "__main__":

--- a/hrms/tests/test_s37_warehouse_role_gated_writes.py
+++ b/hrms/tests/test_s37_warehouse_role_gated_writes.py
@@ -418,6 +418,40 @@ class TestS37WarehouseRoleGatedWrites(unittest.TestCase):
 		self.assertEqual(created.items[0].uom, "KG")
 		self.assertEqual(created.items[0].stock_uom, "KG")
 
+	def test_create_stock_transfer_allows_zero_valuation_for_intercompany_material_issue(self):
+		original_get_value = warehouse.frappe.db.get_value
+
+		def _get_value(doctype, filters=None, fieldname=None, as_dict=False):
+			if doctype == "Bin":
+				return 0
+			if doctype == "Item" and filters == "FG002-A" and as_dict:
+				return {"valuation_rate": 0, "standard_rate": 0, "last_purchase_rate": 0}
+			return original_get_value(doctype, filters, fieldname, as_dict)
+
+		warehouse.frappe.db.get_value = _get_value
+		try:
+			result = warehouse.create_stock_transfer(
+				source_warehouse="Shaw BLVD - BKI",
+				target_warehouse="TEST-STORE-BGC - BEI",
+				items=[
+					{
+						"item_code": "FG002-A",
+						"qty": 1,
+						"uom": "KG",
+					}
+				],
+				mr_name=_MR_DOC.name,
+				remarks="S078 zero valuation dispatch hardening",
+			)
+		finally:
+			warehouse.frappe.db.get_value = original_get_value
+
+		self.assertTrue(result["success"])
+		created = _DOCS_CREATED[0]
+		self.assertEqual(created.stock_entry_type, "Material Issue")
+		self.assertEqual(created.items[0].valuation_rate, 0)
+		self.assertEqual(created.items[0].allow_zero_valuation_rate, 1)
+
 	def test_create_stock_transfer_omits_legacy_batch_field_for_intercompany_material_issue(self):
 		original_get_doc = warehouse.frappe.get_doc
 

--- a/hrms/tests/test_trip_driver_estimated_minutes_s10.py
+++ b/hrms/tests/test_trip_driver_estimated_minutes_s10.py
@@ -357,6 +357,28 @@ class TestTripDriverEstimatedMinutesS10(unittest.TestCase):
 		self.assertTrue(result["success"])
 		set_in_transit.assert_not_called()
 
+	def test_create_trip_from_route_returns_structured_duplicate_response(self):
+		route = _Route()
+
+		def _get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Distribution Trip":
+				return "TRIP-EXISTING-0001"
+			return None
+
+		dispatch.frappe.get_doc = MagicMock(return_value=route)
+		dispatch.frappe.db.get_value = MagicMock(side_effect=_get_value)
+
+		result = dispatch.create_trip_from_route(
+			route_name="ROUTE-S10",
+			trip_date="2026-02-28",
+			selected_stops="[]",
+		)
+
+		self.assertFalse(result["success"])
+		self.assertEqual(result["error_code"], "TRIP_ALREADY_EXISTS")
+		self.assertEqual(result["trip"], "TRIP-EXISTING-0001")
+		self.assertIn("already exists", result["message"])
+
 	def test_enable_role_gated_write_sets_ignore_user_permissions(self):
 		doc = types.SimpleNamespace(flags=None)
 		dispatch._enable_role_gated_write(doc)

--- a/hrms/utils/scm_roles.py
+++ b/hrms/utils/scm_roles.py
@@ -120,6 +120,17 @@ SCM_RECEIVING_ROLES = {
 	"System Manager",
 }
 
+# Commissary production / QA mutations
+SCM_COMMISSARY_ROLES = {
+	"Commissary Supervisor",
+	"Warehouse Manager",
+	"Warehouse User",
+	"Supply Chain Manager",
+	"HR Manager",
+	"System Manager",
+	"Administrator",
+}
+
 
 # ============================================================
 # Shared Permission Check


### PR DESCRIPTION
## Summary
- harden warehouse dispatch valuation handling and duplicate trip creation responses
- harden commissary production and wastage mutations with role-gated writes and retryable submit handling
- add focused backend regression tests for the SCM defect paths

## Validation
- python hrms\\tests\\test_s37_warehouse_role_gated_writes.py
- python hrms\\tests\\test_trip_driver_estimated_minutes_s10.py
- python hrms\\tests\\test_commissary_dashboard_summary.py
- python hrms\\tests\\test_s37_commissary_quality_contract.py