### PR TITLE
fix: normalize scm driver designation matching

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -1821,6 +1821,23 @@ def get_driver_list():
 # ============================================================================
 
 DRIVER_DESIGNATIONS = ["Driver", "Helper", "Relief Driver", "Delivery Driver", "Truck Driver"]
+_NORMALIZED_DRIVER_DESIGNATIONS = {
+	"driver",
+	"helper",
+	"relief driver",
+	"delivery driver",
+	"truck driver",
+	"executive driver",
+}
+
+
+def _normalize_driver_designation(value: str | None) -> str:
+	return " ".join(str(value or "").strip().lower().split())
+
+
+def _is_driver_designation(value: str | None) -> bool:
+	normalized = _normalize_driver_designation(value)
+	return normalized in _NORMALIZED_DRIVER_DESIGNATIONS or normalized.endswith(" driver")
 
 
 @frappe.whitelist()
@@ -1846,13 +1863,16 @@ def get_available_drivers(date: str | None = None):
 	if phone_field:
 		driver_fields.append(phone_field)
 
-	# All active employees with driver designations
+	# Designation labels are not normalized consistently in live data
+	# (for example DRIVER vs Driver vs Executive Driver), so filter in
+	# Python after loading active employees.
 	all_drivers = frappe.get_all(
 		"Employee",
-		filters={"status": "Active", "designation": ["in", DRIVER_DESIGNATIONS]},
+		filters={"status": "Active"},
 		fields=driver_fields,
 		order_by="employee_name",
 	)
+	all_drivers = [driver for driver in all_drivers if _is_driver_designation(driver.designation)]
 
 	# Build a map of employee -> trip for the date
 	trips_on_date = frappe.get_all(

--- a/hrms/tests/test_l1_blocker_contracts_s27.py
+++ b/hrms/tests/test_l1_blocker_contracts_s27.py
@@ -258,6 +258,47 @@ class TestL1BlockerContractsS27(unittest.TestCase):
 		self.assertEqual(result["drivers"][0]["cell_phone"], "09170000001")
 		self.assertEqual(result["drivers"][0]["status"], "Available")
 
+	def test_dispatch_matches_uppercase_and_extended_driver_designations(self):
+		_install_dispatch_deps()
+		dispatch = _load_module("dispatch_s27_uppercase_driver_under_test", "hrms/api/dispatch.py")
+
+		dispatch.frappe.db.has_column = lambda doctype, fieldname: False
+
+		def fake_get_all(doctype, filters=None, fields=None, order_by=None):
+			if doctype == "Employee":
+				return [
+					types.SimpleNamespace(
+						name="EMP-DRIVER",
+						employee_name="Upper Driver",
+						designation="DRIVER",
+						status="Active",
+					),
+					types.SimpleNamespace(
+						name="EMP-EXEC",
+						employee_name="Executive Driver",
+						designation="EXECUTIVE DRIVER",
+						status="Active",
+					),
+					types.SimpleNamespace(
+						name="EMP-OTHER",
+						employee_name="Other Employee",
+						designation="Warehouse Staff",
+						status="Active",
+					),
+				]
+			if doctype == "BEI Distribution Trip":
+				return []
+			return []
+
+		dispatch.frappe.get_all = fake_get_all
+
+		result = dispatch.get_available_drivers(date="2026-03-19")
+		self.assertEqual(result["summary"]["total"], 2)
+		self.assertCountEqual(
+			[driver["employee"] for driver in result["drivers"]],
+			["EMP-DRIVER", "EMP-EXEC"],
+		)
+
 	def test_store_closing_status_skips_missing_optional_columns(self):
 		_install_store_deps()
 		store = _load_module("store_s27_under_test", "hrms/api/store.py")


### PR DESCRIPTION
## Summary\n- normalize SCM driver designation matching so live values like DRIVER and EXECUTIVE DRIVER resolve\n- keep available driver lists populated for route and trip flows\n- add a unit guard for uppercase and extended driver designations\n\n## Verification\n- python hrms/tests/test_l1_blocker_contracts_s27.py\n- targeted dispatch cases via inline unittest runner