### PR TITLE
fix: normalize duplicate trip insert errors

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -1583,14 +1583,36 @@ def preview_trip_stops(route_name: str, trip_date: str | None = None):
 def _duplicate_trip_response(route_name: str, trip_date: str, existing_trip: str):
 	return {
 		"success": False,
+		"code": "TRIP_ALREADY_EXISTS",
 		"error_code": "TRIP_ALREADY_EXISTS",
 		"trip": existing_trip,
+		"existing_trip": existing_trip,
+		"trip_name": existing_trip,
 		"route_name": route_name,
 		"trip_date": trip_date,
 		"message": _("A trip already exists for route '{0}' on {1}: {2}").format(
 			route_name, trip_date, existing_trip
 		),
 	}
+
+
+def _is_duplicate_trip_insert_error(exc: Exception) -> bool:
+	duplicate_types: list[type[Exception]] = []
+	for candidate in (
+		getattr(frappe, "DuplicateEntryError", None),
+		getattr(getattr(frappe, "exceptions", None), "DuplicateEntryError", None),
+	):
+		if isinstance(candidate, type) and issubclass(candidate, Exception):
+			duplicate_types.append(candidate)
+
+	if duplicate_types and isinstance(exc, tuple(duplicate_types)):
+		return True
+
+	if exc.__class__.__name__ == "DuplicateEntryError":
+		return True
+
+	message = str(exc).lower()
+	return "trip already exists" in message or ("duplicate" in message and "route" in message)
 
 
 @frappe.whitelist()
@@ -1716,13 +1738,15 @@ def create_trip_from_route(
 	_enable_role_gated_write(trip)
 	try:
 		trip.insert(ignore_permissions=True)
-	except frappe.DuplicateEntryError:
+	except Exception as exc:
+		if not _is_duplicate_trip_insert_error(exc):
+			raise
 		existing_trip = frappe.db.get_value(
 			"BEI Distribution Trip", {"route_name": route_name, "trip_date": trip_date}, "name"
 		)
 		if existing_trip:
 			return _duplicate_trip_response(route_name, trip_date, existing_trip)
-		raise
+		raise exc
 
 	return {
 		"success": True,

--- a/hrms/tests/test_trip_driver_estimated_minutes_s10.py
+++ b/hrms/tests/test_trip_driver_estimated_minutes_s10.py
@@ -73,7 +73,9 @@ def _install_fake_frappe_and_dependencies():
 	if "frappe.exceptions" not in sys.modules:
 		exceptions = types.ModuleType("frappe.exceptions")
 		exceptions.TimestampMismatchError = type("TimestampMismatchError", (Exception,), {})
+		exceptions.DuplicateEntryError = type("DuplicateEntryError", (Exception,), {})
 		sys.modules["frappe.exceptions"] = exceptions
+	frappe.exceptions = sys.modules["frappe.exceptions"]
 
 	if "hrms" not in sys.modules:
 		hrms_pkg = types.ModuleType("hrms")
@@ -378,6 +380,34 @@ class TestTripDriverEstimatedMinutesS10(unittest.TestCase):
 		self.assertEqual(result["error_code"], "TRIP_ALREADY_EXISTS")
 		self.assertEqual(result["trip"], "TRIP-EXISTING-0001")
 		self.assertIn("already exists", result["message"])
+
+	def test_create_trip_from_route_normalizes_frappe_exceptions_duplicate_error(self):
+		route = _Route()
+		trip = _TripDoc([])
+		duplicate_cls = dispatch.frappe.exceptions.DuplicateEntryError
+		trip.insert = MagicMock(side_effect=duplicate_cls("duplicate trip"))
+
+		def _get_value(doctype, filters=None, fieldname=None):
+			if doctype == "BEI Distribution Trip":
+				return "TRIP-EXISTING-0002"
+			return None
+
+		dispatch.frappe.get_doc = MagicMock(return_value=route)
+		dispatch.frappe.db.get_value = MagicMock(side_effect=_get_value)
+
+		with patch.object(dispatch, "_build_stop_preview", return_value=[]), patch.object(
+			dispatch, "_build_trip_doc", return_value=trip
+		):
+			result = dispatch.create_trip_from_route(
+				route_name="ROUTE-S10",
+				trip_date="2026-02-28",
+				selected_stops="[]",
+			)
+
+		self.assertFalse(result["success"])
+		self.assertEqual(result["code"], "TRIP_ALREADY_EXISTS")
+		self.assertEqual(result["error_code"], "TRIP_ALREADY_EXISTS")
+		self.assertEqual(result["existing_trip"], "TRIP-EXISTING-0002")
 
 	def test_enable_role_gated_write_sets_ignore_user_permissions(self):
 		doc = types.SimpleNamespace(flags=None)


### PR DESCRIPTION
## Summary
- normalize duplicate trip responses even when validation raises frappe.exceptions.DuplicateEntryError
- expose direct contract aliases for code/existing_trip/trip_name on duplicate-trip responses
- add regression coverage for the live duplicate exception class variant

## Testing
- python hrms/tests/test_trip_driver_estimated_minutes_s10.py