### PR TITLE
fix: match duplicate trip lookup to trip route key

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -1571,6 +1571,7 @@ def preview_trip_stops(route_name: str, trip_date: str | None = None):
 	"""Preview stops and pending store orders for a proposed trip."""
 	_check_scm_permission(SCM_DISPATCH_ROLES, "preview trip stops")
 	route = frappe.get_doc("BEI Route", route_name)
+	trip_route_name = route.route_name or route_name
 
 	if not route.active:
 		frappe.throw(_("Route is not active"))
@@ -1634,6 +1635,7 @@ def create_trip_from_route(
 	_check_scm_permission(SCM_DISPATCH_ROLES, "create trips from routes")
 
 	route = frappe.get_doc("BEI Route", route_name)
+	trip_route_name = route.route_name or route_name
 
 	if not route.active:
 		frappe.throw(_("Route is not active"))
@@ -1642,10 +1644,10 @@ def create_trip_from_route(
 
 	# G-069: UX pre-check for duplicate trip (DB constraint is the real guard)
 	existing_trip = frappe.db.get_value(
-		"BEI Distribution Trip", {"route_name": route_name, "trip_date": trip_date}, "name"
+		"BEI Distribution Trip", {"route_name": trip_route_name, "trip_date": trip_date}, "name"
 	)
 	if existing_trip:
-		return _duplicate_trip_response(route_name, trip_date, existing_trip)
+		return _duplicate_trip_response(trip_route_name, trip_date, existing_trip)
 
 	# Resolve vehicle details
 	vehicle_plate = None
@@ -1742,10 +1744,10 @@ def create_trip_from_route(
 		if not _is_duplicate_trip_insert_error(exc):
 			raise
 		existing_trip = frappe.db.get_value(
-			"BEI Distribution Trip", {"route_name": route_name, "trip_date": trip_date}, "name"
+			"BEI Distribution Trip", {"route_name": trip_route_name, "trip_date": trip_date}, "name"
 		)
 		if existing_trip:
-			return _duplicate_trip_response(route_name, trip_date, existing_trip)
+			return _duplicate_trip_response(trip_route_name, trip_date, existing_trip)
 		raise exc
 
 	return {

--- a/hrms/tests/test_trip_driver_estimated_minutes_s10.py
+++ b/hrms/tests/test_trip_driver_estimated_minutes_s10.py
@@ -388,7 +388,10 @@ class TestTripDriverEstimatedMinutesS10(unittest.TestCase):
 		trip.insert = MagicMock(side_effect=duplicate_cls("duplicate trip"))
 
 		def _get_value(doctype, filters=None, fieldname=None):
-			if doctype == "BEI Distribution Trip":
+			if doctype == "BEI Distribution Trip" and filters == {
+				"route_name": route.route_name,
+				"trip_date": "2026-02-28",
+			}:
 				return "TRIP-EXISTING-0002"
 			return None
 
@@ -408,6 +411,7 @@ class TestTripDriverEstimatedMinutesS10(unittest.TestCase):
 		self.assertEqual(result["code"], "TRIP_ALREADY_EXISTS")
 		self.assertEqual(result["error_code"], "TRIP_ALREADY_EXISTS")
 		self.assertEqual(result["existing_trip"], "TRIP-EXISTING-0002")
+		self.assertEqual(result["route_name"], route.route_name)
 
 	def test_enable_role_gated_write_sets_ignore_user_permissions(self):
 		doc = types.SimpleNamespace(flags=None)


### PR DESCRIPTION
## Summary
- look up duplicate BEI Distribution Trip rows using the same route label stored on the trip doc
- keep duplicate-trip normalization aligned with live route wizard behavior
- tighten regression coverage so the duplicate lookup uses route.route_name rather than the route docname

## Testing
- python hrms/tests/test_trip_driver_estimated_minutes_s10.py