### PR TITLE
fix: harden Sentry coverage for certified warehouse and commissary flows

### DIFF
--- a/hrms/api/commissary_dashboard.py
+++ b/hrms/api/commissary_dashboard.py
@@ -17,6 +17,7 @@ from frappe.utils import add_days, flt, today
 
 from hrms.api.commissary import get_commissary_company, get_commissary_warehouse
 from hrms.utils.scm_roles import SCM_COMMISSARY_ROLES, check_scm_permission
+from hrms.utils.sentry import set_backend_observability_context
 
 
 def _enable_role_gated_write(doc: Any):
@@ -65,7 +66,6 @@ def _is_retryable_stock_entry_submit_error(exc: Exception) -> bool:
 		or "deadlock found" in message
 		or "try restarting transaction" in message
 	)
-
 
 # ============================================================
 # DASHBOARD / SUMMARY
@@ -221,6 +221,14 @@ def get_production_items() -> dict[str, Any]:
 	Get finished goods that commissary produces.
 	Returns items with current stock levels.
 	"""
+	set_backend_observability_context(
+		module="commissary",
+		action="get_production_items",
+		route_action="get_production_items",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.commissary_dashboard.get_production_items",
+		phase="load",
+	)
 	commissary_warehouse = get_commissary_warehouse()
 
 	# P0-12: Batch query — get items + stock in one query (was N+1)
@@ -339,6 +347,18 @@ def submit_production_output(
 	if isinstance(items, str):
 		items = json.loads(items)
 
+	set_backend_observability_context(
+		module="commissary",
+		action="submit_production_output",
+		route_action="submit_production_output",
+		mutation_type="create",
+		endpoint_or_job="hrms.api.commissary_dashboard.submit_production_output",
+		phase="mutation",
+		extras={
+			"batch_no": batch_no,
+			"item_count": len(items) if isinstance(items, list) else None,
+		},
+	)
 	if not items:
 		frappe.throw(_("No items to record"))
 
@@ -505,6 +525,15 @@ def get_production_history(
 	"""
 	Get production history.
 	"""
+	set_backend_observability_context(
+		module="commissary",
+		action="get_production_history",
+		route_action="get_production_history",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.commissary_dashboard.get_production_history",
+		phase="load",
+		extras={"date_from": date_from, "date_to": date_to, "limit": limit},
+	)
 	commissary_warehouse = get_commissary_warehouse()
 
 	filters = {

--- a/hrms/api/commissary_dashboard.py
+++ b/hrms/api/commissary_dashboard.py
@@ -67,6 +67,7 @@ def _is_retryable_stock_entry_submit_error(exc: Exception) -> bool:
 		or "try restarting transaction" in message
 	)
 
+
 # ============================================================
 # DASHBOARD / SUMMARY
 # ============================================================

--- a/hrms/api/commissary_quality.py
+++ b/hrms/api/commissary_quality.py
@@ -23,6 +23,7 @@ from frappe.utils import add_days, flt, today
 
 from hrms.api.commissary import get_commissary_company, get_commissary_warehouse
 from hrms.utils.scm_roles import SCM_COMMISSARY_ROLES, check_scm_permission
+from hrms.utils.sentry import capture_backend_message, set_backend_observability_context
 
 
 def _enable_role_gated_write(doc: Any):
@@ -71,7 +72,6 @@ def _is_retryable_stock_entry_submit_error(exc: Exception) -> bool:
 		or "deadlock found" in message
 		or "try restarting transaction" in message
 	)
-
 
 # ============================================================
 # QUALITY INSPECTION
@@ -406,10 +406,28 @@ def log_wastage(
 	    remarks: Additional notes
 	"""
 	check_scm_permission(SCM_COMMISSARY_ROLES, "log commissary wastage")
-
+	set_backend_observability_context(
+		module="commissary",
+		action="log_wastage",
+		route_action="log_wastage",
+		mutation_type="create",
+		endpoint_or_job="hrms.api.commissary_quality.log_wastage",
+		phase="mutation",
+		extras={"item_code": item_code, "qty": qty, "reason_code": reason_code, "batch_no": batch_no},
+	)
 	commissary_warehouse = get_commissary_warehouse()
 
 	if reason_code not in WASTAGE_REASONS:
+		capture_backend_message(
+			"Invalid wastage reason code",
+			module="commissary",
+			action="log_wastage",
+			route_action="log_wastage",
+			mutation_type="create",
+			endpoint_or_job="hrms.api.commissary_quality.log_wastage",
+			phase="mutation",
+			extras={"item_code": item_code, "qty": qty, "reason_code": reason_code, "batch_no": batch_no},
+		)
 		return {
 			"success": False,
 			"error": f"Invalid reason code. Valid codes: {', '.join(WASTAGE_REASONS.keys())}",
@@ -419,6 +437,16 @@ def log_wastage(
 	item = frappe.db.get_value("Item", item_code, ["item_name", "stock_uom", "valuation_rate"], as_dict=True)
 
 	if not item:
+		capture_backend_message(
+			f"Item {item_code} not found for wastage logging",
+			module="commissary",
+			action="log_wastage",
+			route_action="log_wastage",
+			mutation_type="create",
+			endpoint_or_job="hrms.api.commissary_quality.log_wastage",
+			phase="mutation",
+			extras={"item_code": item_code, "qty": qty, "reason_code": reason_code, "batch_no": batch_no},
+		)
 		return {"success": False, "error": f"Item {item_code} not found"}
 
 	se = None
@@ -495,6 +523,15 @@ def get_wastage_history(days: int | str = 30, item_code: str | None = None) -> d
 	    days: Days to look back (default 30)
 	    item_code: Filter by specific item (optional)
 	"""
+	set_backend_observability_context(
+		module="commissary",
+		action="get_wastage_history",
+		route_action="get_wastage_history",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.commissary_quality.get_wastage_history",
+		phase="load",
+		extras={"days": days, "item_code": item_code},
+	)
 	commissary_warehouse = get_commissary_warehouse()
 
 	# Build filters
@@ -564,6 +601,14 @@ def get_wastage_history(days: int | str = 30, item_code: str | None = None) -> d
 @frappe.whitelist()
 def get_wastage_reasons() -> dict[str, Any]:
 	"""Get available wastage reason codes and descriptions."""
+	set_backend_observability_context(
+		module="commissary",
+		action="get_wastage_reasons",
+		route_action="get_wastage_reasons",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.commissary_quality.get_wastage_reasons",
+		phase="load",
+	)
 	return {
 		"success": True,
 		"data": [{"code": code, "description": desc} for code, desc in WASTAGE_REASONS.items()],

--- a/hrms/api/commissary_quality.py
+++ b/hrms/api/commissary_quality.py
@@ -73,6 +73,7 @@ def _is_retryable_stock_entry_submit_error(exc: Exception) -> bool:
 		or "try restarting transaction" in message
 	)
 
+
 # ============================================================
 # QUALITY INSPECTION
 # ============================================================

--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -24,6 +24,7 @@ from hrms.utils.delivery_billing_policy import (
 # P0-10: Import centralized RBAC role sets
 from hrms.utils.scm_roles import SCM_ADMIN_ROLES, SCM_DISPATCH_ROLES, SCM_STORE_ROLES
 from hrms.utils.scm_roles import check_scm_permission as _check_scm_permission
+from hrms.utils.sentry import set_backend_observability_context
 from hrms.utils.supply_chain_contracts import (
 	buyer_entity_requires_billing_hold,
 	resolve_markup_percent,
@@ -1269,6 +1270,15 @@ def get_my_delivery(date: str | None = None):
 @frappe.whitelist()
 def get_routes(cargo_type: str | None = None, active_only: bool = True):
 	"""Get all route masters, optionally filtered."""
+	set_backend_observability_context(
+		module="warehouse",
+		action="get_routes",
+		route_action="get_routes",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.dispatch.get_routes",
+		phase="load",
+		extras={"cargo_type": cargo_type, "active_only": active_only},
+	)
 	_check_scm_permission(SCM_DISPATCH_ROLES, "view routes")
 
 	filters = {}
@@ -1309,6 +1319,15 @@ def get_routes(cargo_type: str | None = None, active_only: bool = True):
 @frappe.whitelist()
 def get_route_detail(route_name: str):
 	"""Get full route details including all stops."""
+	set_backend_observability_context(
+		module="warehouse",
+		action="get_route_detail",
+		route_action="get_route_detail",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.dispatch.get_route_detail",
+		phase="load",
+		extras={"route_name": route_name},
+	)
 	_check_scm_permission(SCM_DISPATCH_ROLES, "view route details")
 
 	route = frappe.get_doc("BEI Route", route_name)
@@ -1439,6 +1458,15 @@ def delete_route(route_name: str):
 @frappe.whitelist()
 def get_vehicles(status: str | None = None, owner_type: str | None = None):
 	"""List vehicles with optional filters."""
+	set_backend_observability_context(
+		module="warehouse",
+		action="get_vehicles",
+		route_action="get_vehicles",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.dispatch.get_vehicles",
+		phase="load",
+		extras={"status": status, "owner_type": owner_type},
+	)
 	_check_scm_permission(SCM_DISPATCH_ROLES, "view vehicles")
 
 	filters = {}
@@ -1569,6 +1597,16 @@ def _save_base64_attachment(
 @frappe.whitelist()
 def preview_trip_stops(route_name: str, trip_date: str | None = None):
 	"""Preview stops and pending store orders for a proposed trip."""
+	trip_date = trip_date or nowdate()
+	set_backend_observability_context(
+		module="warehouse",
+		action="preview_trip_stops",
+		route_action="preview_trip_stops",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.dispatch.preview_trip_stops",
+		phase="load",
+		extras={"route_name": route_name, "trip_date": trip_date},
+	)
 	_check_scm_permission(SCM_DISPATCH_ROLES, "preview trip stops")
 	route = frappe.get_doc("BEI Route", route_name)
 	trip_route_name = route.route_name or route_name
@@ -1576,7 +1614,6 @@ def preview_trip_stops(route_name: str, trip_date: str | None = None):
 	if not route.active:
 		frappe.throw(_("Route is not active"))
 
-	trip_date = trip_date or nowdate()
 	stops = _build_stop_preview(route, trip_date)
 	return {"route_name": route_name, "trip_date": trip_date, "stops": stops}
 
@@ -1632,6 +1669,22 @@ def create_trip_from_route(
 	3. Copies stops, links approved store orders
 	4. Returns trip name
 	"""
+	trip_date = trip_date or nowdate()
+	set_backend_observability_context(
+		module="warehouse",
+		action="create_trip_from_route",
+		route_action="create_trip_from_route",
+		mutation_type="create",
+		endpoint_or_job="hrms.api.dispatch.create_trip_from_route",
+		phase="mutation",
+		extras={
+			"route_name": route_name,
+			"trip_date": trip_date,
+			"vehicle": vehicle,
+			"driver": driver,
+			"selected_stops_provided": bool(selected_stops),
+		},
+	)
 	_check_scm_permission(SCM_DISPATCH_ROLES, "create trips from routes")
 
 	route = frappe.get_doc("BEI Route", route_name)
@@ -1639,8 +1692,6 @@ def create_trip_from_route(
 
 	if not route.active:
 		frappe.throw(_("Route is not active"))
-
-	trip_date = trip_date or nowdate()
 
 	# G-069: UX pre-check for duplicate trip (DB constraint is the real guard)
 	existing_trip = frappe.db.get_value(
@@ -1881,9 +1932,18 @@ def get_available_drivers(date: str | None = None):
 	Returns:
 	    {"drivers": [DriverStatus, ...]}
 	"""
+	trip_date = date or nowdate()
+	set_backend_observability_context(
+		module="warehouse",
+		action="get_available_drivers",
+		route_action="get_available_drivers",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.dispatch.get_available_drivers",
+		phase="load",
+		extras={"trip_date": trip_date},
+	)
 	_check_scm_permission(SCM_DISPATCH_ROLES, "view available drivers")
 
-	trip_date = date or nowdate()
 	phone_field = _get_employee_phone_field()
 	driver_fields = ["name", "employee_name", "designation", "status"]
 	if phone_field:

--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -1615,7 +1615,7 @@ def preview_trip_stops(route_name: str, trip_date: str | None = None):
 		frappe.throw(_("Route is not active"))
 
 	stops = _build_stop_preview(route, trip_date)
-	return {"route_name": route_name, "trip_date": trip_date, "stops": stops}
+	return {"route_name": trip_route_name, "trip_date": trip_date, "stops": stops}
 
 
 def _duplicate_trip_response(route_name: str, trip_date: str, existing_trip: str):

--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -24,6 +24,7 @@ from hrms.utils.scm_roles import (
 	SCM_RECEIVING_ROLES,
 	check_scm_permission,
 )
+from hrms.utils.sentry import set_backend_observability_context
 from hrms.utils.standard_buying_bridge import apply_standard_buying_context
 from hrms.utils.supply_chain_contracts import (
 	CANONICAL_COMMISSARY_OPERATION_WAREHOUSE,
@@ -899,6 +900,14 @@ def get_ready_for_dispatch():
 	Get approved Material Requests ready for dispatch.
 	Groups by destination store for trip planning.
 	"""
+	set_backend_observability_context(
+		module="warehouse",
+		action="get_ready_for_dispatch",
+		route_action="get_ready_for_dispatch",
+		mutation_type="load",
+		endpoint_or_job="hrms.api.warehouse.get_ready_for_dispatch",
+		phase="load",
+	)
 	mrs = frappe.get_all(
 		"Material Request",
 		filters={
@@ -972,6 +981,20 @@ def create_stock_transfer(
 	if isinstance(items, str):
 		items = json.loads(items)
 
+	set_backend_observability_context(
+		module="warehouse",
+		action="create_stock_transfer",
+		route_action="create_stock_transfer",
+		mutation_type="create",
+		endpoint_or_job="hrms.api.warehouse.create_stock_transfer",
+		phase="mutation",
+		extras={
+			"source_warehouse": source_warehouse,
+			"target_warehouse": target_warehouse,
+			"mr_name": mr_name,
+			"item_count": len(items) if isinstance(items, list) else None,
+		},
+	)
 	check_scm_permission(SCM_DISPATCH_ROLES, "dispatch warehouse stock transfers")
 
 	default_source_company = resolve_warehouse_company(source_warehouse) or get_company()

--- a/hrms/utils/sentry.py
+++ b/hrms/utils/sentry.py
@@ -18,18 +18,20 @@ import frappe
 
 # Test accounts whose errors should NOT be sent to Sentry.
 # These generate hundreds of expected validation errors during E2E testing.
-_TEST_USERS = frozenset({
-	"Administrator",
-	"test.area@bebang.ph",
-	"test.supervisor@bebang.ph",
-	"test.staff@bebang.ph",
-	"test.crew1@bebang.ph",
-	"test.hr@bebang.ph",
-	"test.projects@bebang.ph",
-	"test.projects.staff@bebang.ph",
-	"test.commissary@bebang.ph",
-	"test.warehouse@bebang.ph",
-})
+_TEST_USERS = frozenset(
+	{
+		"Administrator",
+		"test.area@bebang.ph",
+		"test.supervisor@bebang.ph",
+		"test.staff@bebang.ph",
+		"test.crew1@bebang.ph",
+		"test.hr@bebang.ph",
+		"test.projects@bebang.ph",
+		"test.projects.staff@bebang.ph",
+		"test.commissary@bebang.ph",
+		"test.warehouse@bebang.ph",
+	}
+)
 
 _sentry_initialized = False
 _log_error_patched = False
@@ -39,7 +41,9 @@ _handle_exception_patched = False
 def _is_test_user():
 	"""Return True if the current session user is a test/admin account."""
 	try:
-		user = getattr(frappe.session, "user", None) if hasattr(frappe, "session") and frappe.session else None
+		user = (
+			getattr(frappe.session, "user", None) if hasattr(frappe, "session") and frappe.session else None
+		)
 		return user in _TEST_USERS
 	except Exception:
 		return False
@@ -70,13 +74,13 @@ def _to_safe_tag_value(value: Any) -> str | None:
 
 def _sanitize_value(value: Any, depth: int = 0):
 	"""Best-effort sanitizer for Sentry context payloads."""
-	if value is None or isinstance(value, (str, int, float, bool)):
+	if value is None or isinstance(value, str | int | float | bool):
 		return value
 
 	if depth >= _MAX_DEPTH:
 		return "[truncated]"
 
-	if isinstance(value, (list, tuple, set)):
+	if isinstance(value, list | tuple | set):
 		return [_sanitize_value(item, depth + 1) for item in list(value)[:_MAX_ARRAY_ITEMS]]
 
 	if isinstance(value, dict):
@@ -272,11 +276,7 @@ def init_sentry():
 
 			sentry_sdk.init(
 				dsn=dsn,
-				environment=(
-					"development"
-					if getattr(frappe.conf, "developer_mode", 0)
-					else "production"
-				),
+				environment=("development" if getattr(frappe.conf, "developer_mode", 0) else "production"),
 				release=f"bei-hrms@{__version__}",
 				traces_sample_rate=0.1,
 				profiles_sample_rate=0.1,

--- a/hrms/utils/sentry.py
+++ b/hrms/utils/sentry.py
@@ -12,6 +12,7 @@ Hooks used (registered in hooks.py):
 import os
 import sys
 import threading
+from typing import Any
 
 import frappe
 
@@ -49,6 +50,196 @@ _patch_lock = threading.Lock()
 _exc_patch_lock = threading.Lock()
 _original_log_error = None
 _original_handle_exception = None
+_MAX_TAG_LENGTH = 200
+_MAX_ARRAY_ITEMS = 10
+_MAX_OBJECT_KEYS = 20
+_MAX_DEPTH = 3
+
+
+def _to_safe_tag_value(value: Any) -> str | None:
+	"""Return a bounded Sentry tag value or None when empty."""
+	if value is None:
+		return None
+
+	normalized = str(value).strip()
+	if not normalized:
+		return None
+
+	return normalized[:_MAX_TAG_LENGTH]
+
+
+def _sanitize_value(value: Any, depth: int = 0):
+	"""Best-effort sanitizer for Sentry context payloads."""
+	if value is None or isinstance(value, (str, int, float, bool)):
+		return value
+
+	if depth >= _MAX_DEPTH:
+		return "[truncated]"
+
+	if isinstance(value, (list, tuple, set)):
+		return [_sanitize_value(item, depth + 1) for item in list(value)[:_MAX_ARRAY_ITEMS]]
+
+	if isinstance(value, dict):
+		items = list(value.items())[:_MAX_OBJECT_KEYS]
+		return {str(key): _sanitize_value(entry, depth + 1) for key, entry in items}
+
+	if isinstance(value, Exception):
+		return {"type": type(value).__name__, "message": str(value)}
+
+	return str(value)
+
+
+def _sanitize_record(record: dict[str, Any] | None) -> dict[str, Any] | None:
+	"""Return a Sentry-safe dict or None when there is nothing to attach."""
+	if not record:
+		return None
+
+	sanitized = _sanitize_value(record)
+	return sanitized if isinstance(sanitized, dict) and sanitized else None
+
+
+def _set_sentry_user():
+	"""Attach the current Frappe user to the active Sentry scope."""
+	try:
+		import sentry_sdk
+
+		if hasattr(frappe, "session") and frappe.session and frappe.session.user:
+			sentry_sdk.set_user({"email": frappe.session.user, "id": frappe.session.user})
+	except Exception:
+		pass
+
+
+def _get_request_metadata() -> dict[str, str]:
+	"""Extract normalized request metadata from the current Frappe request."""
+	path = ""
+	method = ""
+	if hasattr(frappe, "request") and frappe.request:
+		path = frappe.request.path or ""
+		method = frappe.request.method or ""
+
+	cmd = ""
+	if frappe.form_dict:
+		cmd = frappe.form_dict.get("cmd", "") or ""
+
+	endpoint_or_job = cmd or path or "unknown"
+	route_action = cmd.rsplit(".", 1)[-1] if cmd else ""
+
+	return {
+		"route": path or "unknown",
+		"http_method": method or "unknown",
+		"frappe_cmd": cmd,
+		"endpoint_or_job": endpoint_or_job,
+		"route_action": route_action,
+	}
+
+
+def set_backend_observability_context(
+	*,
+	module: str | None = None,
+	action: str | None = None,
+	route: str | None = None,
+	route_action: str | None = None,
+	mutation_type: str | None = None,
+	endpoint_or_job: str | None = None,
+	phase: str | None = None,
+	surface: str = "frappe_whitelist",
+	extras: dict[str, Any] | None = None,
+):
+	"""Apply stable BEI tags/context to the current request scope."""
+	init_sentry()
+
+	if _is_test_user():
+		return
+
+	try:
+		import sentry_sdk
+
+		request_meta = _get_request_metadata()
+		_set_sentry_user()
+
+		tags = {
+			"module": module,
+			"route": route or request_meta["route"],
+			"action": action,
+			"route_action": route_action or request_meta["route_action"],
+			"mutation_type": mutation_type,
+			"endpoint_or_job": endpoint_or_job or request_meta["endpoint_or_job"],
+			"surface": surface,
+			"phase": phase,
+			"http_method": request_meta["http_method"],
+			"frappe_cmd": request_meta["frappe_cmd"],
+		}
+
+		for key, value in tags.items():
+			safe_value = _to_safe_tag_value(value)
+			if safe_value:
+				sentry_sdk.set_tag(key, safe_value)
+
+		context_payload = _sanitize_record(
+			{
+				"request_route": request_meta["route"],
+				"http_method": request_meta["http_method"],
+				"frappe_cmd": request_meta["frappe_cmd"],
+				"extras": extras or {},
+			}
+		)
+		if context_payload:
+			sentry_sdk.set_context("bei_backend_observability", context_payload)
+
+		sentry_sdk.add_breadcrumb(
+			category="bei.backend",
+			message=action or route_action or request_meta["route_action"] or "backend_event",
+			level="info",
+			data=_sanitize_record(
+				{
+					"module": module,
+					"route": route or request_meta["route"],
+					"endpoint_or_job": endpoint_or_job or request_meta["endpoint_or_job"],
+					"mutation_type": mutation_type,
+					"phase": phase,
+				}
+			),
+		)
+	except Exception:
+		pass
+
+
+def capture_backend_message(
+	message: str,
+	*,
+	level: str = "error",
+	module: str | None = None,
+	action: str | None = None,
+	route: str | None = None,
+	route_action: str | None = None,
+	mutation_type: str | None = None,
+	endpoint_or_job: str | None = None,
+	phase: str | None = None,
+	surface: str = "frappe_whitelist",
+	extras: dict[str, Any] | None = None,
+):
+	"""Capture handled backend failures without relying on an exception bubble."""
+	set_backend_observability_context(
+		module=module,
+		action=action,
+		route=route,
+		route_action=route_action,
+		mutation_type=mutation_type,
+		endpoint_or_job=endpoint_or_job,
+		phase=phase,
+		surface=surface,
+		extras=extras,
+	)
+
+	if _is_test_user():
+		return
+
+	try:
+		import sentry_sdk
+
+		sentry_sdk.capture_message(message, level=level)
+	except Exception:
+		pass
 
 
 def init_sentry():
@@ -130,14 +321,14 @@ def _patch_log_error():
 
 				title = kwargs.get("title", args[1] if len(args) > 1 else "Frappe Error")
 				message = kwargs.get("message", args[0] if args else "")
+				set_backend_observability_context(
+					action="frappe_log_error",
+					phase="log_error",
+					surface="frappe_log_error",
+					extras={"title": title, "message_preview": str(message)[:300]},
+				)
 
-				if hasattr(frappe, "session") and frappe.session and frappe.session.user:
-					sentry_sdk.set_user(
-						{
-							"email": frappe.session.user,
-							"id": frappe.session.user,
-						}
-					)
+				_set_sentry_user()
 
 				exc_info = sys.exc_info()
 				if exc_info[0] is not None:
@@ -191,34 +382,33 @@ def _patch_handle_exception():
 					import sentry_sdk
 
 					http_status = getattr(e, "http_status_code", 500)
+					request_meta = _get_request_metadata()
 
 					# Determine if this is a custom API endpoint (hrms.api.*)
 					# vs a Desk form submission. Errors from our API endpoints
 					# indicate real bugs (bad data, missing references, etc.)
 					# even if they're 4xx. Desk form validation (4xx) is expected.
-					endpoint = ""
-					if hasattr(frappe, "request") and frappe.request:
-						endpoint = frappe.request.path or ""
-					cmd = ""
-					if frappe.form_dict:
-						cmd = frappe.form_dict.get("cmd", "")
+					endpoint = request_meta["route"]
+					cmd = request_meta["frappe_cmd"]
 
 					is_custom_api = cmd.startswith("hrms.api.") or "hrms.api." in endpoint
 
 					if http_status < 500 and not is_custom_api:
 						return _original_handle_exception(e)
 
-					if hasattr(frappe, "session") and frappe.session and frappe.session.user:
-						sentry_sdk.set_user(
-							{
-								"email": frappe.session.user,
-								"id": frappe.session.user,
-							}
-						)
-
-					if hasattr(frappe, "request") and frappe.request:
-						sentry_sdk.set_tag("endpoint", frappe.request.path or "unknown")
-						sentry_sdk.set_tag("method", frappe.request.method or "unknown")
+					set_backend_observability_context(
+						action="handle_exception",
+						route=endpoint,
+						route_action=request_meta["route_action"] or None,
+						mutation_type="load" if request_meta["http_method"] == "GET" else "mutation",
+						endpoint_or_job=request_meta["endpoint_or_job"],
+						phase="backend_exception",
+						surface="frappe_request",
+						extras={
+							"http_status": http_status,
+							"exception_type": type(e).__name__,
+						},
+					)
 
 					# Tag API validation errors distinctly so they can be filtered
 					if is_custom_api and http_status < 500:


### PR DESCRIPTION
## Summary
- add backend observability context for certified warehouse and commissary endpoints
- harden handled and unhandled backend Sentry capture metadata
- prepare S080 shipping path for live observability verification

## Verification
- python -m py_compile hrms/utils/sentry.py hrms/api/dispatch.py hrms/api/warehouse.py hrms/api/commissary_dashboard.py hrms/api/commissary_quality.py
- ruff check hrms/utils/sentry.py hrms/api/dispatch.py hrms/api/warehouse.py hrms/api/commissary_dashboard.py hrms/api/commissary_quality.py