### PR TITLE
fix: normalize 3pl vehicle onboarding

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -106,6 +106,40 @@ def _infer_vehicle_type(vehicle_label: str | None) -> str:
 	return "Truck"
 
 
+def _normalize_vehicle_type(vehicle_type: str | None, vehicle_label: str | None = None) -> str:
+	"""Map portal shorthand into the valid BEI Vehicle master options."""
+	text = (vehicle_type or "").strip().lower()
+	if not text:
+		return _infer_vehicle_type(vehicle_label)
+	if text in {"reefer", "reefer truck"}:
+		return "Reefer Truck"
+	if text == "reefer van":
+		return "Reefer Van"
+	if text in {"non-reefer", "truck"}:
+		return "Truck"
+	if text in {"motorcycle", "motorbike", "bike"}:
+		return "Motorcycle"
+	if text == "l300":
+		return "L300"
+	if text == "van":
+		return "Van"
+	return vehicle_type
+
+
+def _resolve_threepl_partner_link(threepl_partner: str | None) -> str:
+	"""Resolve either a Supplier name or supplier_name into a valid Supplier link."""
+	partner = (threepl_partner or "").strip()
+	if not partner:
+		return ""
+	exact_name = frappe.db.get_value("Supplier", partner, "name")
+	if exact_name:
+		return str(exact_name)
+	match_by_supplier_name = frappe.db.get_value("Supplier", {"supplier_name": partner}, "name")
+	if match_by_supplier_name:
+		return str(match_by_supplier_name)
+	return partner
+
+
 def _resolve_or_create_departure_vehicle(
 	vehicle_label: str | None,
 	vehicle_plate: str | None,
@@ -152,10 +186,10 @@ def _resolve_or_create_departure_vehicle(
 		vehicle_doc = frappe.new_doc("BEI Vehicle")
 		vehicle_doc.naming_series = "BEI-VEH-.####"
 		vehicle_doc.vehicle_plate = vehicle_plate
-		vehicle_doc.vehicle_type = vehicle_type or _infer_vehicle_type(vehicle_label)
+		vehicle_doc.vehicle_type = _normalize_vehicle_type(vehicle_type, vehicle_label)
 		vehicle_doc.owner_type = "3PL"
 		if _has_column("BEI Vehicle", "threepl_partner") and threepl_partner:
-			vehicle_doc.threepl_partner = threepl_partner
+			vehicle_doc.threepl_partner = _resolve_threepl_partner_link(threepl_partner)
 		vehicle_doc.status = "Available"
 		if hasattr(vehicle_doc, "notes"):
 			vehicle_doc.notes = vehicle_label or vehicle_plate
@@ -1541,10 +1575,10 @@ def create_vehicle(
 	vehicle_doc = frappe.new_doc("BEI Vehicle")
 	vehicle_doc.naming_series = "BEI-VEH-.####"
 	vehicle_doc.vehicle_plate = vehicle_plate
-	vehicle_doc.vehicle_type = vehicle_type or _infer_vehicle_type(notes or vehicle_plate)
+	vehicle_doc.vehicle_type = _normalize_vehicle_type(vehicle_type, notes or vehicle_plate)
 	vehicle_doc.owner_type = owner_type or "3PL"
 	if _has_column("BEI Vehicle", "threepl_partner") and threepl_partner:
-		vehicle_doc.threepl_partner = threepl_partner
+		vehicle_doc.threepl_partner = _resolve_threepl_partner_link(threepl_partner)
 	vehicle_doc.status = "Available"
 	if hasattr(vehicle_doc, "notes") and notes:
 		vehicle_doc.notes = notes

--- a/hrms/tests/test_dispatch_vehicle_contract_s07.py
+++ b/hrms/tests/test_dispatch_vehicle_contract_s07.py
@@ -190,6 +190,59 @@ class TestDispatchVehicleContractS07(unittest.TestCase):
 		self.assertIn("resolution_notes", result["required_fields"])
 		self.assertIn("System Error", result["resolution_types"])
 
+	@patch.object(dispatch, "_check_scm_permission")
+	@patch.object(dispatch, "_has_column", return_value=True)
+	def test_create_vehicle_normalizes_portal_contract_inputs(self, _mock_has_column, _mock_perm):
+		insert_calls = []
+		comment_calls = []
+		vehicle_doc = types.SimpleNamespace(
+			name="BEI-VEH-0009",
+			doctype="BEI Vehicle",
+			vehicle_plate="ABC 1234",
+			vehicle_type="",
+			owner_type="",
+			threepl_partner="",
+			status="",
+			notes="",
+		)
+
+		def _insert(**kwargs):
+			insert_calls.append(kwargs)
+
+		def _add_comment(_comment_type, text=None):
+			comment_calls.append(text)
+
+		vehicle_doc.insert = _insert
+		vehicle_doc.add_comment = _add_comment
+
+		def _fake_get_value(doctype, filters=None, fieldname=None, as_dict=False):
+			if doctype == "BEI Vehicle":
+				return None
+			if doctype == "Supplier" and filters == "RCS Logistics":
+				return None
+			if doctype == "Supplier" and filters == {"supplier_name": "RCS Logistics"}:
+				return "SUP-RCS"
+			return None
+
+		with (
+			patch.object(dispatch.frappe.db, "get_value", side_effect=_fake_get_value),
+			patch.object(dispatch.frappe, "new_doc", return_value=vehicle_doc),
+		):
+			result = dispatch.create_vehicle(
+				vehicle_plate="ABC 1234",
+				vehicle_type="Non-Reefer",
+				owner_type="3PL",
+				threepl_partner="RCS Logistics",
+				notes="Portal onboarding",
+			)
+
+		self.assertTrue(result["success"])
+		self.assertTrue(result["created"])
+		self.assertEqual(vehicle_doc.vehicle_type, "Truck")
+		self.assertEqual(vehicle_doc.threepl_partner, "SUP-RCS")
+		self.assertEqual(insert_calls, [{"ignore_permissions": True}])
+		self.assertTrue(any("Vehicle onboarded by" in str(text) for text in comment_calls))
+
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
## Summary
- normalize portal shorthand vehicle types into valid BEI Vehicle master values
- resolve 3PL partner inputs to Supplier links by name or supplier_name
- cover the contract with a focused dispatch test

## Verification
- python hrms\\tests\\test_dispatch_vehicle_contract_s07.py
- python hrms\\tests\\test_dispatch_pre_delivery.py