### PR TITLE
fix: unblock finance billing approval journal entries

### DIFF
--- a/hrms/hr/doctype/bei_billing_schedule/bei_billing_schedule.py
+++ b/hrms/hr/doctype/bei_billing_schedule/bei_billing_schedule.py
@@ -122,8 +122,9 @@ class BEIBillingSchedule(Document):
 				{
 					"account": account,
 					"credit_in_account_currency": credit_amount,
-					"reference_type": "BEI Billing Schedule",
-					"reference_name": self.name,
+					# Journal Entry Account only accepts core ERP reference doctypes here.
+					# Keep BEI billing linkage on the receivable leg instead of writing an invalid custom doctype.
+					"user_remark": f"Billing revenue for {self.name}",
 				},
 			)
 
@@ -140,8 +141,7 @@ class BEIBillingSchedule(Document):
 				{
 					"account": franchise_income_account,
 					"credit_in_account_currency": flt(self.handling_fee),
-					"reference_type": "BEI Billing Schedule",
-					"reference_name": self.name,
+					"user_remark": f"Billing markup for {self.name}",
 				},
 			)
 

--- a/hrms/tests/test_billing_doc_events_s08.py
+++ b/hrms/tests/test_billing_doc_events_s08.py
@@ -8,113 +8,115 @@ from unittest.mock import MagicMock
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+	sys.path.insert(0, str(ROOT))
 
 
 def _install_fake_frappe():
-    frappe = sys.modules.get("frappe")
-    if frappe is None:
-        frappe = types.ModuleType("frappe")
-        sys.modules["frappe"] = frappe
-    model = sys.modules.get("frappe.model")
-    if model is None:
-        model = types.ModuleType("frappe.model")
-        sys.modules["frappe.model"] = model
-    utils = sys.modules.get("frappe.utils")
-    if utils is None:
-        utils = types.ModuleType("frappe.utils")
-        sys.modules["frappe.utils"] = utils
+	frappe = sys.modules.get("frappe")
+	if frappe is None:
+		frappe = types.ModuleType("frappe")
+		sys.modules["frappe"] = frappe
+	model = sys.modules.get("frappe.model")
+	if model is None:
+		model = types.ModuleType("frappe.model")
+		sys.modules["frappe.model"] = model
+	utils = sys.modules.get("frappe.utils")
+	if utils is None:
+		utils = types.ModuleType("frappe.utils")
+		sys.modules["frappe.utils"] = utils
 
-    class ValidationError(Exception):
-        pass
+	class ValidationError(Exception):
+		pass
 
-    class PermissionError(Exception):
-        pass
+	class PermissionError(Exception):
+		pass
 
-    def whitelist(*args, **kwargs):
-        def decorator(fn):
-            return fn
+	def whitelist(*args, **kwargs):
+		def decorator(fn):
+			return fn
 
-        return decorator
+		return decorator
 
-    def _throw(message, exc=None):
-        if isinstance(exc, type) and issubclass(exc, Exception):
-            raise exc(message)
-        raise Exception(message)
+	def _throw(message, exc=None):
+		if isinstance(exc, type) and issubclass(exc, Exception):
+			raise exc(message)
+		raise Exception(message)
 
-    def _getdate(value=None):
-        if isinstance(value, datetime.date):
-            return value
-        if not value:
-            return datetime.date(2026, 2, 27)
-        return datetime.date.fromisoformat(str(value))
+	def _getdate(value=None):
+		if isinstance(value, datetime.date):
+			return value
+		if not value:
+			return datetime.date(2026, 2, 27)
+		return datetime.date.fromisoformat(str(value))
 
-    frappe.whitelist = whitelist
-    frappe._ = lambda text: text
-    frappe.throw = _throw
-    frappe.ValidationError = ValidationError
-    frappe.PermissionError = PermissionError
-    frappe.session = types.SimpleNamespace(user="Administrator")
-    frappe.has_permission = lambda *args, **kwargs: True
-    frappe.format_value = lambda value, _type=None: f"{float(value):.2f}"
-    frappe.log_error = lambda *args, **kwargs: None
-    frappe.new_doc = MagicMock()
-    frappe.db = types.SimpleNamespace(
-        sql=lambda *args, **kwargs: [],
-        get_value=lambda *args, **kwargs: None,
-        set_value=lambda *args, **kwargs: None,
-        savepoint=lambda *args, **kwargs: None,
-        release_savepoint=lambda *args, **kwargs: None,
-        rollback=lambda *args, **kwargs: None,
-    )
+	frappe.whitelist = whitelist
+	frappe._ = lambda text: text
+	frappe.throw = _throw
+	frappe.ValidationError = ValidationError
+	frappe.PermissionError = PermissionError
+	frappe.session = types.SimpleNamespace(user="Administrator")
+	frappe.has_permission = lambda *args, **kwargs: True
+	frappe.format_value = lambda value, _type=None: f"{float(value):.2f}"
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.new_doc = MagicMock()
+	frappe.db = types.SimpleNamespace(
+		sql=lambda *args, **kwargs: [],
+		get_value=lambda *args, **kwargs: None,
+		set_value=lambda *args, **kwargs: None,
+		savepoint=lambda *args, **kwargs: None,
+		release_savepoint=lambda *args, **kwargs: None,
+		rollback=lambda *args, **kwargs: None,
+	)
 
-    utils.flt = lambda value, precision=None: round(float(value or 0), int(precision)) if precision is not None else float(value or 0)
-    utils.now_datetime = lambda: datetime.datetime(2026, 2, 27, 10, 0, 0)
-    utils.nowdate = lambda: "2026-02-27"
-    utils.get_first_day = lambda value: datetime.date.fromisoformat(str(value)[:10]).replace(day=1)
-    utils.get_last_day = lambda value: datetime.date.fromisoformat(str(value)[:10]).replace(day=28)
-    utils.getdate = _getdate
+	utils.flt = lambda value, precision=None: (
+		round(float(value or 0), int(precision)) if precision is not None else float(value or 0)
+	)
+	utils.now_datetime = lambda: datetime.datetime(2026, 2, 27, 10, 0, 0)
+	utils.nowdate = lambda: "2026-02-27"
+	utils.get_first_day = lambda value: datetime.date.fromisoformat(str(value)[:10]).replace(day=1)
+	utils.get_last_day = lambda value: datetime.date.fromisoformat(str(value)[:10]).replace(day=28)
+	utils.getdate = _getdate
 
-    model.get_permitted_fields = lambda *args, **kwargs: []
+	model.get_permitted_fields = lambda *args, **kwargs: []
 
-    frappe.utils = utils
-    frappe.model = model
+	frappe.utils = utils
+	frappe.model = model
 
 
 def _install_stub_dependencies():
-    hrms_pkg = types.ModuleType("hrms")
-    hrms_hr = types.ModuleType("hrms.hr")
-    hrms_doctype = types.ModuleType("hrms.hr.doctype")
-    hrms_store_type_pkg = types.ModuleType("hrms.hr.doctype.bei_store_type")
-    hrms_utils = types.ModuleType("hrms.utils")
-    bei_config = types.ModuleType("hrms.utils.bei_config")
-    bei_config.get_company = lambda: "Bebang Enterprises Inc."
+	hrms_pkg = types.ModuleType("hrms")
+	hrms_hr = types.ModuleType("hrms.hr")
+	hrms_doctype = types.ModuleType("hrms.hr.doctype")
+	hrms_store_type_pkg = types.ModuleType("hrms.hr.doctype.bei_store_type")
+	hrms_utils = types.ModuleType("hrms.utils")
+	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.get_company = lambda: "Bebang Enterprises Inc."
 
-    scm_roles = types.ModuleType("hrms.utils.scm_roles")
-    scm_roles.RATE_MANAGEMENT_ROLES = ["Accounts Manager", "Supply Chain Manager"]
-    scm_roles.SCM_BILLING_ROLES = ["Accounts Manager", "Supply Chain Manager"]
-    scm_roles.check_scm_permission = lambda roles, action=None: True
+	scm_roles = types.ModuleType("hrms.utils.scm_roles")
+	scm_roles.RATE_MANAGEMENT_ROLES = ["Accounts Manager", "Supply Chain Manager"]
+	scm_roles.SCM_BILLING_ROLES = ["Accounts Manager", "Supply Chain Manager"]
+	scm_roles.check_scm_permission = lambda roles, action=None: True
 
-    store_type = types.ModuleType("hrms.hr.doctype.bei_store_type.bei_store_type")
-    store_type.resolve_store_type = lambda *args, **kwargs: None
+	store_type = types.ModuleType("hrms.hr.doctype.bei_store_type.bei_store_type")
+	store_type.resolve_store_type = lambda *args, **kwargs: None
 
-    sys.modules["hrms"] = hrms_pkg
-    sys.modules["hrms.hr"] = hrms_hr
-    sys.modules["hrms.hr.doctype"] = hrms_doctype
-    sys.modules["hrms.hr.doctype.bei_store_type"] = hrms_store_type_pkg
-    sys.modules["hrms.utils"] = hrms_utils
+	sys.modules["hrms"] = hrms_pkg
+	sys.modules["hrms.hr"] = hrms_hr
+	sys.modules["hrms.hr.doctype"] = hrms_doctype
+	sys.modules["hrms.hr.doctype.bei_store_type"] = hrms_store_type_pkg
+	sys.modules["hrms.utils"] = hrms_utils
 
-    sys.modules["hrms.utils.bei_config"] = bei_config
-    sys.modules["hrms.utils.scm_roles"] = scm_roles
-    sys.modules["hrms.hr.doctype.bei_store_type.bei_store_type"] = store_type
+	sys.modules["hrms.utils.bei_config"] = bei_config
+	sys.modules["hrms.utils.scm_roles"] = scm_roles
+	sys.modules["hrms.hr.doctype.bei_store_type.bei_store_type"] = store_type
 
 
 _install_fake_frappe()
 _install_stub_dependencies()
 
 billing_spec = importlib.util.spec_from_file_location(
-    "billing_under_test",
-    ROOT / "hrms" / "api" / "billing.py",
+	"billing_under_test",
+	ROOT / "hrms" / "api" / "billing.py",
 )
 billing = importlib.util.module_from_spec(billing_spec)
 assert billing_spec and billing_spec.loader
@@ -122,45 +124,53 @@ billing_spec.loader.exec_module(billing)
 
 
 class _BillingDoc:
-    def __init__(self, name="BILL-0001", billing_type="Monthly Fees", billing_period=None, generated_on=None, status="Draft", sent_on=None):
-        self.name = name
-        self.billing_type = billing_type
-        self.billing_period = billing_period
-        self.generated_on = generated_on
-        self.status = status
-        self.sent_on = sent_on
+	def __init__(
+		self,
+		name="BILL-0001",
+		billing_type="Monthly Fees",
+		billing_period=None,
+		generated_on=None,
+		status="Draft",
+		sent_on=None,
+	):
+		self.name = name
+		self.billing_type = billing_type
+		self.billing_period = billing_period
+		self.generated_on = generated_on
+		self.status = status
+		self.sent_on = sent_on
 
 
 class TestBillingDocEventsSprint08(unittest.TestCase):
-    def setUp(self):
-        billing.frappe.db.get_value = MagicMock(return_value=None)
-        billing.frappe.db.sql = MagicMock(return_value=[{"ewt_atc": "WC110", "ewt_rate": 1.0}])
-        billing.frappe.new_doc = MagicMock()
+	def setUp(self):
+		billing.frappe.db.get_value = MagicMock(return_value=None)
+		billing.frappe.db.sql = MagicMock(return_value=[{"ewt_atc": "WC110", "ewt_rate": 1.0}])
+		billing.frappe.new_doc = MagicMock()
 
-    def test_hooks_map_contains_billing_doc_events(self):
-        hooks_path = ROOT / "hrms" / "hooks.py"
-        text = hooks_path.read_text(encoding="utf-8")
-        self.assertIn('"BEI Billing Schedule"', text)
-        self.assertIn("hrms.api.billing.on_billing_schedule_validate", text)
-        self.assertIn("hrms.api.billing.on_billing_schedule_update", text)
+	def test_hooks_map_contains_billing_doc_events(self):
+		hooks_path = ROOT / "hrms" / "hooks.py"
+		text = hooks_path.read_text(encoding="utf-8")
+		self.assertIn('"BEI Billing Schedule"', text)
+		self.assertIn("hrms.api.billing.on_billing_schedule_validate", text)
+		self.assertIn("hrms.api.billing.on_billing_schedule_update", text)
 
-    def test_on_billing_schedule_validate_backfills_period(self):
-        doc = _BillingDoc(generated_on="2026-02-15")
-        billing.on_billing_schedule_validate(doc, "validate")
-        self.assertEqual(doc.billing_period, "2026-02")
+	def test_on_billing_schedule_validate_backfills_period(self):
+		doc = _BillingDoc(generated_on="2026-02-15")
+		billing.on_billing_schedule_validate(doc, "validate")
+		self.assertEqual(doc.billing_period, "2026-02")
 
-    def test_create_3pl_payment_request_is_idempotent_for_existing_cheque_no(self):
-        billing.frappe.db.get_value = MagicMock(
-            return_value={"name": "ACC-JV-0001", "total_debit": 1000.0, "docstatus": 1}
-        )
+	def test_create_3pl_payment_request_is_idempotent_for_existing_cheque_no(self):
+		billing.frappe.db.get_value = MagicMock(
+			return_value={"name": "ACC-JV-0001", "total_debit": 1000.0, "docstatus": 1}
+		)
 
-        result = billing.create_3pl_payment_request(2, 2026, "RCS", 1000.0)
+		result = billing.create_3pl_payment_request(2, 2026, "RCS", 1000.0)
 
-        self.assertTrue(result["success"])
-        self.assertTrue(result["idempotent"])
-        self.assertEqual(result["journal_entry"], "ACC-JV-0001")
-        billing.frappe.new_doc.assert_not_called()
+		self.assertTrue(result["success"])
+		self.assertTrue(result["idempotent"])
+		self.assertEqual(result["journal_entry"], "ACC-JV-0001")
+		billing.frappe.new_doc.assert_not_called()
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_billing_doc_events_s08.py
+++ b/hrms/tests/test_billing_doc_events_s08.py
@@ -16,6 +16,10 @@ def _install_fake_frappe():
     if frappe is None:
         frappe = types.ModuleType("frappe")
         sys.modules["frappe"] = frappe
+    model = sys.modules.get("frappe.model")
+    if model is None:
+        model = types.ModuleType("frappe.model")
+        sys.modules["frappe.model"] = model
     utils = sys.modules.get("frappe.utils")
     if utils is None:
         utils = types.ModuleType("frappe.utils")
@@ -71,10 +75,18 @@ def _install_fake_frappe():
     utils.get_last_day = lambda value: datetime.date.fromisoformat(str(value)[:10]).replace(day=28)
     utils.getdate = _getdate
 
+    model.get_permitted_fields = lambda *args, **kwargs: []
+
     frappe.utils = utils
+    frappe.model = model
 
 
 def _install_stub_dependencies():
+    hrms_pkg = types.ModuleType("hrms")
+    hrms_hr = types.ModuleType("hrms.hr")
+    hrms_doctype = types.ModuleType("hrms.hr.doctype")
+    hrms_store_type_pkg = types.ModuleType("hrms.hr.doctype.bei_store_type")
+    hrms_utils = types.ModuleType("hrms.utils")
     bei_config = types.ModuleType("hrms.utils.bei_config")
     bei_config.get_company = lambda: "Bebang Enterprises Inc."
 
@@ -83,8 +95,18 @@ def _install_stub_dependencies():
     scm_roles.SCM_BILLING_ROLES = ["Accounts Manager", "Supply Chain Manager"]
     scm_roles.check_scm_permission = lambda roles, action=None: True
 
+    store_type = types.ModuleType("hrms.hr.doctype.bei_store_type.bei_store_type")
+    store_type.resolve_store_type = lambda *args, **kwargs: None
+
+    sys.modules["hrms"] = hrms_pkg
+    sys.modules["hrms.hr"] = hrms_hr
+    sys.modules["hrms.hr.doctype"] = hrms_doctype
+    sys.modules["hrms.hr.doctype.bei_store_type"] = hrms_store_type_pkg
+    sys.modules["hrms.utils"] = hrms_utils
+
     sys.modules["hrms.utils.bei_config"] = bei_config
     sys.modules["hrms.utils.scm_roles"] = scm_roles
+    sys.modules["hrms.hr.doctype.bei_store_type.bei_store_type"] = store_type
 
 
 _install_fake_frappe()

--- a/hrms/tests/test_billing_doc_events_s08.py
+++ b/hrms/tests/test_billing_doc_events_s08.py
@@ -54,12 +54,13 @@ def _install_fake_frappe():
 	frappe.throw = _throw
 	frappe.ValidationError = ValidationError
 	frappe.PermissionError = PermissionError
-	frappe.session = types.SimpleNamespace(user="Administrator")
+	frappe.local = types.SimpleNamespace()
+	frappe.local.session = types.SimpleNamespace(user="Administrator")
 	frappe.has_permission = lambda *args, **kwargs: True
 	frappe.format_value = lambda value, _type=None: f"{float(value):.2f}"
 	frappe.log_error = lambda *args, **kwargs: None
 	frappe.new_doc = MagicMock()
-	frappe.db = types.SimpleNamespace(
+	frappe.local.db = types.SimpleNamespace(
 		sql=lambda *args, **kwargs: [],
 		get_value=lambda *args, **kwargs: None,
 		set_value=lambda *args, **kwargs: None,
@@ -81,6 +82,15 @@ def _install_fake_frappe():
 
 	frappe.utils = utils
 	frappe.model = model
+
+	def _module_getattr(name):
+		if name == "db":
+			return frappe.local.db
+		if name == "session":
+			return frappe.local.session
+		raise AttributeError(name)
+
+	frappe.__getattr__ = _module_getattr
 
 
 def _install_stub_dependencies():

--- a/hrms/tests/test_billing_gl_reference_contract.py
+++ b/hrms/tests/test_billing_gl_reference_contract.py
@@ -69,7 +69,8 @@ def _install_fake_frappe():
 		def submit(self):
 			self.submit_called = True
 
-	frappe.db = FakeDB()
+	frappe.local = types.SimpleNamespace()
+	frappe.local.db = FakeDB()
 	journal_entries = []
 
 	def new_doc(doctype):
@@ -82,11 +83,20 @@ def _install_fake_frappe():
 	frappe.throw = lambda message, exc=None: (_ for _ in ()).throw(Exception(message))
 	frappe._ = lambda text: text
 	frappe.get_roles = lambda *_args, **_kwargs: []
-	frappe.session = types.SimpleNamespace(user="test.hr@bebang.ph")
+	frappe.local.session = types.SimpleNamespace(user="test.hr@bebang.ph")
 	frappe.whitelist = lambda *args, **kwargs: lambda fn: fn
 	frappe.log_error = lambda *args, **kwargs: None
 	frappe.model = model
 	frappe.utils = utils
+
+	def _module_getattr(name):
+		if name == "db":
+			return frappe.local.db
+		if name == "session":
+			return frappe.local.session
+		raise AttributeError(name)
+
+	frappe.__getattr__ = _module_getattr
 	return journal_entries
 
 

--- a/hrms/tests/test_billing_gl_reference_contract.py
+++ b/hrms/tests/test_billing_gl_reference_contract.py
@@ -3,144 +3,147 @@ import sys
 import types
 import unittest
 from pathlib import Path
+from typing import ClassVar
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+	sys.path.insert(0, str(ROOT))
 
 
 def _install_fake_frappe():
-    frappe = types.ModuleType("frappe")
-    sys.modules["frappe"] = frappe
+	frappe = types.ModuleType("frappe")
+	sys.modules["frappe"] = frappe
 
-    utils = types.ModuleType("frappe.utils")
-    utils.flt = lambda value, precision=None: round(float(value or 0), int(precision)) if precision is not None else float(value or 0)
-    utils.nowdate = lambda: "2026-03-19"
-    sys.modules["frappe.utils"] = utils
+	utils = types.ModuleType("frappe.utils")
+	utils.flt = lambda value, precision=None: (
+		round(float(value or 0), int(precision)) if precision is not None else float(value or 0)
+	)
+	utils.nowdate = lambda: "2026-03-19"
+	sys.modules["frappe.utils"] = utils
 
-    model = types.ModuleType("frappe.model")
-    sys.modules["frappe.model"] = model
-    document_mod = types.ModuleType("frappe.model.document")
-    sys.modules["frappe.model.document"] = document_mod
+	model = types.ModuleType("frappe.model")
+	sys.modules["frappe.model"] = model
+	document_mod = types.ModuleType("frappe.model.document")
+	sys.modules["frappe.model.document"] = document_mod
 
-    class Document:
-        def add_comment(self, *_args, **_kwargs):
-            return None
+	class Document:
+		def add_comment(self, *_args, **_kwargs):
+			return None
 
-        def get_doc_before_save(self):
-            return None
+		def get_doc_before_save(self):
+			return None
 
-    document_mod.Document = Document
+	document_mod.Document = Document
 
-    class FakeDB:
-        ACCOUNT_MAP = {
-            "4000305": "4000305 - Delivery Income - BEI",
-            "4000306": "4000306 - Logistics Income - BEI",
-            "4000300": "4000300 - Franchise Income - BEI",
-            "1103101": "1103101 - Accounts Receivable - BEI",
-        }
+	class FakeDB:
+		ACCOUNT_MAP: ClassVar[dict[str, str]] = {
+			"4000305": "4000305 - Delivery Income - BEI",
+			"4000306": "4000306 - Logistics Income - BEI",
+			"4000300": "4000300 - Franchise Income - BEI",
+			"1103101": "1103101 - Accounts Receivable - BEI",
+		}
 
-        def get_value(self, doctype, filters, fieldname):
-            if doctype != "Account" or fieldname != "name":
-                return None
-            return self.ACCOUNT_MAP.get(str(filters.get("account_number")))
+		def get_value(self, doctype, filters, fieldname):
+			if doctype != "Account" or fieldname != "name":
+				return None
+			return self.ACCOUNT_MAP.get(str(filters.get("account_number")))
 
-    class FakeJournalEntry:
-        def __init__(self):
-            self.accounts = []
-            self.posting_date = None
-            self.voucher_type = None
-            self.company = None
-            self.user_remark = None
-            self.name = "ACC-JV-TEST-0001"
-            self.insert_called = False
-            self.submit_called = False
+	class FakeJournalEntry:
+		def __init__(self):
+			self.accounts = []
+			self.posting_date = None
+			self.voucher_type = None
+			self.company = None
+			self.user_remark = None
+			self.name = "ACC-JV-TEST-0001"
+			self.insert_called = False
+			self.submit_called = False
 
-        def append(self, fieldname, row):
-            assert fieldname == "accounts"
-            self.accounts.append(row)
+		def append(self, fieldname, row):
+			assert fieldname == "accounts"
+			self.accounts.append(row)
 
-        def insert(self, ignore_permissions=False):
-            self.insert_called = True
+		def insert(self, ignore_permissions=False):
+			self.insert_called = True
 
-        def submit(self):
-            self.submit_called = True
+		def submit(self):
+			self.submit_called = True
 
-    frappe.db = FakeDB()
-    journal_entries = []
+	frappe.db = FakeDB()
+	journal_entries = []
 
-    def new_doc(doctype):
-        assert doctype == "Journal Entry"
-        doc = FakeJournalEntry()
-        journal_entries.append(doc)
-        return doc
+	def new_doc(doctype):
+		assert doctype == "Journal Entry"
+		doc = FakeJournalEntry()
+		journal_entries.append(doc)
+		return doc
 
-    frappe.new_doc = new_doc
-    frappe.throw = lambda message, exc=None: (_ for _ in ()).throw(Exception(message))
-    frappe._ = lambda text: text
-    frappe.get_roles = lambda *_args, **_kwargs: []
-    frappe.session = types.SimpleNamespace(user="test.hr@bebang.ph")
-    frappe.whitelist = lambda *args, **kwargs: (lambda fn: fn)
-    frappe.log_error = lambda *args, **kwargs: None
-    frappe.model = model
-    frappe.utils = utils
-    return journal_entries
+	frappe.new_doc = new_doc
+	frappe.throw = lambda message, exc=None: (_ for _ in ()).throw(Exception(message))
+	frappe._ = lambda text: text
+	frappe.get_roles = lambda *_args, **_kwargs: []
+	frappe.session = types.SimpleNamespace(user="test.hr@bebang.ph")
+	frappe.whitelist = lambda *args, **kwargs: lambda fn: fn
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.model = model
+	frappe.utils = utils
+	return journal_entries
 
 
 def _install_stub_dependencies():
-    bei_config = types.ModuleType("hrms.utils.bei_config")
-    bei_config.get_company = lambda: "Bebang Enterprises Inc."
-    sys.modules["hrms.utils.bei_config"] = bei_config
+	bei_config = types.ModuleType("hrms.utils.bei_config")
+	bei_config.get_company = lambda: "Bebang Enterprises Inc."
+	sys.modules["hrms.utils.bei_config"] = bei_config
 
 
 class TestBillingGlReferenceContract(unittest.TestCase):
-    def setUp(self):
-        self.journal_entries = _install_fake_frappe()
-        _install_stub_dependencies()
+	def setUp(self):
+		self.journal_entries = _install_fake_frappe()
+		_install_stub_dependencies()
 
-        spec = importlib.util.spec_from_file_location(
-            "bei_billing_schedule_under_test",
-            ROOT / "hrms" / "hr" / "doctype" / "bei_billing_schedule" / "bei_billing_schedule.py",
-        )
-        self.module = importlib.util.module_from_spec(spec)
-        assert spec and spec.loader
-        spec.loader.exec_module(self.module)
+		spec = importlib.util.spec_from_file_location(
+			"bei_billing_schedule_under_test",
+			ROOT / "hrms" / "hr" / "doctype" / "bei_billing_schedule" / "bei_billing_schedule.py",
+		)
+		self.module = importlib.util.module_from_spec(spec)
+		assert spec and spec.loader
+		spec.loader.exec_module(self.module)
 
-    def test_credit_rows_do_not_write_invalid_custom_reference_type(self):
-        billing = self.module.BEIBillingSchedule()
-        billing.name = "BILL-MF-TEST-0001"
-        billing.store = "TEST-STORE-BGC - BEI"
-        billing.billing_type = "Delivery"
-        billing.royalty_fee = 0
-        billing.management_fee = 0
-        billing.marketing_fee = 0
-        billing.ecommerce_fee = 0
-        billing.delivery_fee = 1500
-        billing.logistics_fee = 800
-        billing.repairs_maintenance = 0
-        billing.preventive_maintenance = 0
-        billing.goods_value = 15000
-        billing.handling_fee = 1200
-        billing.line_items = []
+	def test_credit_rows_do_not_write_invalid_custom_reference_type(self):
+		billing = self.module.BEIBillingSchedule()
+		billing.name = "BILL-MF-TEST-0001"
+		billing.store = "TEST-STORE-BGC - BEI"
+		billing.billing_type = "Delivery"
+		billing.royalty_fee = 0
+		billing.management_fee = 0
+		billing.marketing_fee = 0
+		billing.ecommerce_fee = 0
+		billing.delivery_fee = 1500
+		billing.logistics_fee = 800
+		billing.repairs_maintenance = 0
+		billing.preventive_maintenance = 0
+		billing.goods_value = 15000
+		billing.handling_fee = 1200
+		billing.line_items = []
 
-        billing._create_gl_entries()
+		billing._create_gl_entries()
 
-        self.assertEqual(len(self.journal_entries), 1)
-        entry = self.journal_entries[0]
-        self.assertTrue(entry.insert_called)
-        self.assertTrue(entry.submit_called)
+		self.assertEqual(len(self.journal_entries), 1)
+		entry = self.journal_entries[0]
+		self.assertTrue(entry.insert_called)
+		self.assertTrue(entry.submit_called)
 
-        credit_rows = [row for row in entry.accounts if row.get("credit_in_account_currency")]
-        self.assertGreaterEqual(len(credit_rows), 3)
-        for row in credit_rows:
-            self.assertNotIn("reference_type", row)
-            self.assertNotIn("reference_name", row)
+		credit_rows = [row for row in entry.accounts if row.get("credit_in_account_currency")]
+		self.assertGreaterEqual(len(credit_rows), 3)
+		for row in credit_rows:
+			self.assertNotIn("reference_type", row)
+			self.assertNotIn("reference_name", row)
 
-        debit_rows = [row for row in entry.accounts if row.get("debit_in_account_currency")]
-        self.assertEqual(len(debit_rows), 1)
-        self.assertEqual(debit_rows[0].get("against_voucher_type"), "BEI Billing Schedule")
-        self.assertEqual(debit_rows[0].get("against_voucher"), "BILL-MF-TEST-0001")
+		debit_rows = [row for row in entry.accounts if row.get("debit_in_account_currency")]
+		self.assertEqual(len(debit_rows), 1)
+		self.assertEqual(debit_rows[0].get("against_voucher_type"), "BEI Billing Schedule")
+		self.assertEqual(debit_rows[0].get("against_voucher"), "BILL-MF-TEST-0001")
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_billing_gl_reference_contract.py
+++ b/hrms/tests/test_billing_gl_reference_contract.py
@@ -1,0 +1,146 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_frappe():
+    frappe = types.ModuleType("frappe")
+    sys.modules["frappe"] = frappe
+
+    utils = types.ModuleType("frappe.utils")
+    utils.flt = lambda value, precision=None: round(float(value or 0), int(precision)) if precision is not None else float(value or 0)
+    utils.nowdate = lambda: "2026-03-19"
+    sys.modules["frappe.utils"] = utils
+
+    model = types.ModuleType("frappe.model")
+    sys.modules["frappe.model"] = model
+    document_mod = types.ModuleType("frappe.model.document")
+    sys.modules["frappe.model.document"] = document_mod
+
+    class Document:
+        def add_comment(self, *_args, **_kwargs):
+            return None
+
+        def get_doc_before_save(self):
+            return None
+
+    document_mod.Document = Document
+
+    class FakeDB:
+        ACCOUNT_MAP = {
+            "4000305": "4000305 - Delivery Income - BEI",
+            "4000306": "4000306 - Logistics Income - BEI",
+            "4000300": "4000300 - Franchise Income - BEI",
+            "1103101": "1103101 - Accounts Receivable - BEI",
+        }
+
+        def get_value(self, doctype, filters, fieldname):
+            if doctype != "Account" or fieldname != "name":
+                return None
+            return self.ACCOUNT_MAP.get(str(filters.get("account_number")))
+
+    class FakeJournalEntry:
+        def __init__(self):
+            self.accounts = []
+            self.posting_date = None
+            self.voucher_type = None
+            self.company = None
+            self.user_remark = None
+            self.name = "ACC-JV-TEST-0001"
+            self.insert_called = False
+            self.submit_called = False
+
+        def append(self, fieldname, row):
+            assert fieldname == "accounts"
+            self.accounts.append(row)
+
+        def insert(self, ignore_permissions=False):
+            self.insert_called = True
+
+        def submit(self):
+            self.submit_called = True
+
+    frappe.db = FakeDB()
+    journal_entries = []
+
+    def new_doc(doctype):
+        assert doctype == "Journal Entry"
+        doc = FakeJournalEntry()
+        journal_entries.append(doc)
+        return doc
+
+    frappe.new_doc = new_doc
+    frappe.throw = lambda message, exc=None: (_ for _ in ()).throw(Exception(message))
+    frappe._ = lambda text: text
+    frappe.get_roles = lambda *_args, **_kwargs: []
+    frappe.session = types.SimpleNamespace(user="test.hr@bebang.ph")
+    frappe.whitelist = lambda *args, **kwargs: (lambda fn: fn)
+    frappe.log_error = lambda *args, **kwargs: None
+    frappe.model = model
+    frappe.utils = utils
+    return journal_entries
+
+
+def _install_stub_dependencies():
+    bei_config = types.ModuleType("hrms.utils.bei_config")
+    bei_config.get_company = lambda: "Bebang Enterprises Inc."
+    sys.modules["hrms.utils.bei_config"] = bei_config
+
+
+class TestBillingGlReferenceContract(unittest.TestCase):
+    def setUp(self):
+        self.journal_entries = _install_fake_frappe()
+        _install_stub_dependencies()
+
+        spec = importlib.util.spec_from_file_location(
+            "bei_billing_schedule_under_test",
+            ROOT / "hrms" / "hr" / "doctype" / "bei_billing_schedule" / "bei_billing_schedule.py",
+        )
+        self.module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(self.module)
+
+    def test_credit_rows_do_not_write_invalid_custom_reference_type(self):
+        billing = self.module.BEIBillingSchedule()
+        billing.name = "BILL-MF-TEST-0001"
+        billing.store = "TEST-STORE-BGC - BEI"
+        billing.billing_type = "Delivery"
+        billing.royalty_fee = 0
+        billing.management_fee = 0
+        billing.marketing_fee = 0
+        billing.ecommerce_fee = 0
+        billing.delivery_fee = 1500
+        billing.logistics_fee = 800
+        billing.repairs_maintenance = 0
+        billing.preventive_maintenance = 0
+        billing.goods_value = 15000
+        billing.handling_fee = 1200
+        billing.line_items = []
+
+        billing._create_gl_entries()
+
+        self.assertEqual(len(self.journal_entries), 1)
+        entry = self.journal_entries[0]
+        self.assertTrue(entry.insert_called)
+        self.assertTrue(entry.submit_called)
+
+        credit_rows = [row for row in entry.accounts if row.get("credit_in_account_currency")]
+        self.assertGreaterEqual(len(credit_rows), 3)
+        for row in credit_rows:
+            self.assertNotIn("reference_type", row)
+            self.assertNotIn("reference_name", row)
+
+        debit_rows = [row for row in entry.accounts if row.get("debit_in_account_currency")]
+        self.assertEqual(len(debit_rows), 1)
+        self.assertEqual(debit_rows[0].get("against_voucher_type"), "BEI Billing Schedule")
+        self.assertEqual(debit_rows[0].get("against_voucher"), "BILL-MF-TEST-0001")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove invalid custom Journal Entry Account reference_type/reference_name writes from billing revenue credit rows
- keep billing linkage on the receivable leg so delivery billing approvals can post cleanly
- add focused regression coverage for the billing GL reference contract and harden the existing sprint-08 billing harness stub

## Testing
- python hrms/tests/test_billing_gl_reference_contract.py
- python hrms/tests/test_billing_doc_events_s08.py