### PR TITLE
fix: keep expense review queue actionable

### DIFF
--- a/hrms/api/expense_review.py
+++ b/hrms/api/expense_review.py
@@ -5,620 +5,632 @@ Handles expense review, approval, and batch processing for accounting team.
 Author: Claude Code
 Date: 2026-02-02
 """
+
+import json
+
 import frappe
 from frappe import _
-import json
-from frappe.utils import today, now_datetime, flt, getdate
-
+from frappe.utils import flt, getdate, now_datetime, today
 
 # ============================================================
 # ROLE VALIDATION
 # ============================================================
 
+
 def _check_accounting_role():
-    """Verify user has accounting role. Throw if not authorized."""
-    roles = frappe.get_roles()
-    allowed_roles = ["Accounts User", "Accounts Manager", "System Manager"]
-    if not any(r in roles for r in allowed_roles):
-        frappe.throw(_("Only accounting team can access this function"))
+	"""Verify user has accounting role. Throw if not authorized."""
+	roles = frappe.get_roles()
+	allowed_roles = ["Accounts User", "Accounts Manager", "System Manager"]
+	if not any(r in roles for r in allowed_roles):
+		frappe.throw(_("Only accounting team can access this function"))
 
 
 # ============================================================
 # DASHBOARD ENDPOINTS
 # ============================================================
 
+
 @frappe.whitelist()
 def get_review_dashboard():
-    """
-    Get dashboard statistics for accounting review.
-    Returns counts by category and recent activity.
-    """
-    _check_accounting_role()
+	"""
+	Get dashboard statistics for accounting review.
+	Returns counts by category and recent activity.
+	"""
+	_check_accounting_role()
 
-    # Count by review status
-    pending_review = frappe.db.count(
-        "BEI Expense Request",
-        filters={"internal_review_status": "pending_review"}
-    )
+	# Count by review status
+	pending_review = frappe.db.count(
+		"BEI Expense Request", filters={"internal_review_status": "pending_review"}
+	)
 
-    mismatch_review = frappe.db.count(
-        "BEI Expense Request",
-        filters={"internal_review_status": "mismatch_review"}
-    )
+	mismatch_review = frappe.db.count(
+		"BEI Expense Request", filters={"internal_review_status": "mismatch_review"}
+	)
 
-    needs_classification = frappe.db.count(
-        "BEI Expense Request",
-        filters={"internal_review_status": "needs_classification"}
-    )
+	needs_classification = frappe.db.count(
+		"BEI Expense Request", filters={"internal_review_status": "needs_classification"}
+	)
 
-    ocr_failed = frappe.db.count(
-        "BEI Expense Request",
-        filters={"internal_review_status": "ocr_failed"}
-    )
+	ocr_failed = frappe.db.count("BEI Expense Request", filters={"internal_review_status": "ocr_failed"})
 
-    auto_approved = frappe.db.count(
-        "BEI Expense Request",
-        filters={"internal_review_status": "auto_approved", "status": "Submitted"}
-    )
+	auto_approved = frappe.db.count(
+		"BEI Expense Request", filters={"internal_review_status": "auto_approved", "status": "Submitted"}
+	)
 
-    # This week's stats
-    from frappe.utils import add_days
-    week_start = add_days(today(), -7)
+	# This week's stats
+	from frappe.utils import add_days
 
-    approved_this_week = frappe.db.count(
-        "BEI Expense Request",
-        filters={
-            "status": "Approved",
-            "internal_review_date": [">=", week_start]
-        }
-    )
+	week_start = add_days(today(), -7)
 
-    total_amount_this_week = frappe.db.sql("""
+	approved_this_week = frappe.db.count(
+		"BEI Expense Request", filters={"status": "Approved", "internal_review_date": [">=", week_start]}
+	)
+
+	total_amount_this_week = (
+		frappe.db.sql(
+			"""
         SELECT COALESCE(SUM(internal_approved_amount), 0)
         FROM `tabBEI Expense Request`
         WHERE status = 'Approved'
         AND internal_review_date >= %s
-    """, week_start)[0][0] or 0
+    """,
+			week_start,
+		)[0][0]
+		or 0
+	)
 
-    return {
-        "success": True,
-        "data": {
-            "pending_review": pending_review + needs_classification,
-            "mismatch_review": mismatch_review,
-            "ocr_failed": ocr_failed,
-            "auto_approved_pending": auto_approved,
-            "approved_this_week": approved_this_week,
-            "total_amount_this_week": total_amount_this_week
-        }
-    }
+	return {
+		"success": True,
+		"data": {
+			"pending_review": pending_review + needs_classification,
+			"mismatch_review": mismatch_review,
+			"ocr_failed": ocr_failed,
+			"auto_approved_pending": auto_approved,
+			"approved_this_week": approved_this_week,
+			"total_amount_this_week": total_amount_this_week,
+		},
+	}
 
 
 @frappe.whitelist()
 def get_pending_review(
-    review_type: str = "all",
-    store: str = None,
-    limit: int = 50,
-    offset: int = 0
+	review_type: str = "all",
+	store: str | None = None,
+	limit: int = 50,
+	offset: int = 0,
 ):
-    """
-    Get expenses pending review.
+	"""
+	Get expenses pending review.
 
-    Args:
-        review_type: all | mismatch | ocr_failed | needs_classification | auto_approved
-        store: Filter by store (optional)
-        limit: Page size
-        offset: Page offset
-    """
-    _check_accounting_role()
+	Args:
+	    review_type: all | mismatch | ocr_failed | needs_classification | auto_approved
+	    store: Filter by store (optional)
+	    limit: Page size
+	    offset: Page offset
+	"""
+	_check_accounting_role()
 
-    filters = {"status": "Submitted"}
+	filters = {"status": "Submitted"}
 
-    if review_type == "mismatch":
-        filters["internal_review_status"] = "mismatch_review"
-    elif review_type == "ocr_failed":
-        filters["internal_review_status"] = "ocr_failed"
-    elif review_type == "needs_classification":
-        filters["internal_review_status"] = "needs_classification"
-    elif review_type == "auto_approved":
-        filters["internal_review_status"] = "auto_approved"
-    elif review_type != "all":
-        filters["internal_review_status"] = ["in", [
-            "pending_review", "mismatch_review", "needs_classification", "ocr_failed"
-        ]]
+	if review_type == "mismatch":
+		filters["internal_review_status"] = "mismatch_review"
+	elif review_type == "ocr_failed":
+		filters["internal_review_status"] = "ocr_failed"
+	elif review_type == "needs_classification":
+		filters["internal_review_status"] = "needs_classification"
+	elif review_type == "auto_approved":
+		filters["internal_review_status"] = "auto_approved"
+	else:
+		filters["internal_review_status"] = [
+			"in",
+			["pending_review", "mismatch_review", "needs_classification", "ocr_failed"],
+		]
 
-    if store:
-        filters["store"] = store
+	if store:
+		filters["store"] = store
 
-    expenses = frappe.get_all(
-        "BEI Expense Request",
-        filters=filters,
-        fields=[
-            "name", "employee", "store", "request_date",
-            "manual_vendor", "manual_description", "manual_amount", "manual_date",
-            "internal_ocr_vendor", "internal_ocr_amount", "internal_ocr_date",
-            "internal_match_score", "internal_match_status", "internal_amount_diff",
-            "internal_suggested_coa", "internal_coa_confidence",
-            "internal_review_status", "creation"
-        ],
-        order_by="creation asc",
-        limit_page_length=limit,
-        start=offset
-    )
+	expenses = frappe.get_all(
+		"BEI Expense Request",
+		filters=filters,
+		fields=[
+			"name",
+			"employee",
+			"store",
+			"request_date",
+			"manual_vendor",
+			"manual_description",
+			"manual_amount",
+			"manual_date",
+			"internal_ocr_vendor",
+			"internal_ocr_amount",
+			"internal_ocr_date",
+			"internal_match_score",
+			"internal_match_status",
+			"internal_amount_diff",
+			"internal_suggested_coa",
+			"internal_coa_confidence",
+			"internal_review_status",
+			"creation",
+		],
+		order_by="creation asc",
+		limit_page_length=limit,
+		start=offset,
+	)
 
-    # Enrich with employee names
-    for exp in expenses:
-        emp = frappe.db.get_value("Employee", exp["employee"], "employee_name")
-        exp["employee_name"] = emp or exp["employee"]
+	# Enrich with employee names
+	for exp in expenses:
+		emp = frappe.db.get_value("Employee", exp["employee"], "employee_name")
+		exp["employee_name"] = emp or exp["employee"]
 
-        # Parse match details
-        exp["match_status_display"] = get_match_status_display(exp)
+		# Parse match details
+		exp["match_status_display"] = get_match_status_display(exp)
 
-    return {"success": True, "data": expenses}
+	return {"success": True, "data": expenses}
 
 
 def get_match_status_display(expense):
-    """Get human-readable match status."""
-    status = expense.get("internal_review_status")
+	"""Get human-readable match status."""
+	status = expense.get("internal_review_status")
 
-    if status == "ocr_failed":
-        return {"type": "error", "label": "Receipt Unclear", "icon": "🔴"}
-    elif status == "mismatch_review":
-        diff = expense.get("internal_amount_diff", 0)
-        if diff > 0:
-            return {"type": "warning", "label": f"Amount +PHP {abs(diff):.2f}", "icon": "⚠️"}
-        elif diff < 0:
-            return {"type": "warning", "label": f"Amount -PHP {abs(diff):.2f}", "icon": "⚠️"}
-        return {"type": "warning", "label": "Mismatch", "icon": "⚠️"}
-    elif status == "needs_classification":
-        return {"type": "info", "label": "Needs COA", "icon": "🤔"}
-    elif status == "auto_approved":
-        return {"type": "success", "label": "Auto-Matched", "icon": "✅"}
+	if status == "ocr_failed":
+		return {"type": "error", "label": "Receipt Unclear", "icon": "🔴"}
+	elif status == "mismatch_review":
+		diff = expense.get("internal_amount_diff", 0)
+		if diff > 0:
+			return {"type": "warning", "label": f"Amount +PHP {abs(diff):.2f}", "icon": "⚠️"}
+		elif diff < 0:
+			return {"type": "warning", "label": f"Amount -PHP {abs(diff):.2f}", "icon": "⚠️"}
+		return {"type": "warning", "label": "Mismatch", "icon": "⚠️"}
+	elif status == "needs_classification":
+		return {"type": "info", "label": "Needs COA", "icon": "🤔"}
+	elif status == "auto_approved":
+		return {"type": "success", "label": "Auto-Matched", "icon": "✅"}
 
-    return {"type": "default", "label": "Pending", "icon": "⏳"}
+	return {"type": "default", "label": "Pending", "icon": "⏳"}
 
 
 @frappe.whitelist()
 def get_expense_detail(expense_name: str):
-    """
-    Get full expense detail with OCR comparison.
-    For accounting review - shows all internal fields.
-    """
-    _check_accounting_role()
+	"""
+	Get full expense detail with OCR comparison.
+	For accounting review - shows all internal fields.
+	"""
+	_check_accounting_role()
 
-    expense = frappe.get_doc("BEI Expense Request", expense_name)
+	expense = frappe.get_doc("BEI Expense Request", expense_name)
 
-    # Get employee details
-    emp = frappe.db.get_value(
-        "Employee",
-        expense.employee,
-        ["employee_name", "branch"],
-        as_dict=True
-    )
+	# Get employee details
+	emp = frappe.db.get_value("Employee", expense.employee, ["employee_name", "branch"], as_dict=True)
 
-    # Parse JSON fields
-    ocr_line_items = []
-    if expense.internal_ocr_line_items:
-        try:
-            ocr_line_items = json.loads(expense.internal_ocr_line_items)
-        except:
-            pass
+	# Parse JSON fields
+	ocr_line_items = []
+	if expense.internal_ocr_line_items:
+		try:
+			ocr_line_items = json.loads(expense.internal_ocr_line_items)
+		except (TypeError, ValueError):
+			pass
 
-    match_details = {}
-    if expense.internal_match_details:
-        try:
-            match_details = json.loads(expense.internal_match_details)
-        except:
-            pass
+	match_details = {}
+	if expense.internal_match_details:
+		try:
+			match_details = json.loads(expense.internal_match_details)
+		except (TypeError, ValueError):
+			pass
 
-    coa_alternatives = []
-    if expense.internal_coa_alternatives:
-        try:
-            coa_alternatives = json.loads(expense.internal_coa_alternatives)
-        except:
-            pass
+	coa_alternatives = []
+	if expense.internal_coa_alternatives:
+		try:
+			coa_alternatives = json.loads(expense.internal_coa_alternatives)
+		except (TypeError, ValueError):
+			pass
 
-    # Build comparison view
-    comparison = {
-        "vendor": {
-            "manual": expense.manual_vendor,
-            "ocr": expense.internal_ocr_vendor,
-            "match": match_details.get("vendor", 0) >= 80
-        },
-        "amount": {
-            "manual": expense.manual_amount,
-            "ocr": expense.internal_ocr_amount,
-            "diff": expense.internal_amount_diff,
-            "match": match_details.get("amount", 0) >= 90
-        },
-        "date": {
-            "manual": expense.manual_date,
-            "ocr": expense.internal_ocr_date,
-            "match": match_details.get("date", 0) >= 90
-        }
-    }
+	# Build comparison view
+	comparison = {
+		"vendor": {
+			"manual": expense.manual_vendor,
+			"ocr": expense.internal_ocr_vendor,
+			"match": match_details.get("vendor", 0) >= 80,
+		},
+		"amount": {
+			"manual": expense.manual_amount,
+			"ocr": expense.internal_ocr_amount,
+			"diff": expense.internal_amount_diff,
+			"match": match_details.get("amount", 0) >= 90,
+		},
+		"date": {
+			"manual": expense.manual_date,
+			"ocr": expense.internal_ocr_date,
+			"match": match_details.get("date", 0) >= 90,
+		},
+	}
 
-    return {
-        "success": True,
-        "data": {
-            "name": expense.name,
-            "employee": expense.employee,
-            "employee_name": emp.employee_name if emp else None,
-            "store": expense.store,
-            "request_date": expense.request_date,
-
-            # Manual input
-            "manual_vendor": expense.manual_vendor,
-            "manual_description": expense.manual_description,
-            "manual_amount": expense.manual_amount,
-            "manual_date": expense.manual_date,
-            "receipt_photo": expense.receipt_photo,
-
-            # OCR results
-            "ocr_vendor": expense.internal_ocr_vendor,
-            "ocr_amount": expense.internal_ocr_amount,
-            "ocr_date": expense.internal_ocr_date,
-            "ocr_line_items": ocr_line_items,
-            "ocr_raw_text": expense.internal_ocr_raw_text,
-            "ocr_confidence": expense.internal_ocr_confidence,
-            "ocr_status": expense.internal_ocr_status,
-
-            # Matching
-            "match_score": expense.internal_match_score,
-            "match_status": expense.internal_match_status,
-            "match_details": match_details,
-            "amount_diff": expense.internal_amount_diff,
-            "comparison": comparison,
-
-            # Classification
-            "suggested_coa": expense.internal_suggested_coa,
-            "coa_confidence": expense.internal_coa_confidence,
-            "coa_alternatives": coa_alternatives,
-            "classification_method": expense.internal_classification_method,
-
-            # Review status
-            "review_status": expense.internal_review_status,
-            "status": expense.status
-        }
-    }
+	return {
+		"success": True,
+		"data": {
+			"name": expense.name,
+			"employee": expense.employee,
+			"employee_name": emp.employee_name if emp else None,
+			"store": expense.store,
+			"request_date": expense.request_date,
+			# Manual input
+			"manual_vendor": expense.manual_vendor,
+			"manual_description": expense.manual_description,
+			"manual_amount": expense.manual_amount,
+			"manual_date": expense.manual_date,
+			"receipt_photo": expense.receipt_photo,
+			# OCR results
+			"ocr_vendor": expense.internal_ocr_vendor,
+			"ocr_amount": expense.internal_ocr_amount,
+			"ocr_date": expense.internal_ocr_date,
+			"ocr_line_items": ocr_line_items,
+			"ocr_raw_text": expense.internal_ocr_raw_text,
+			"ocr_confidence": expense.internal_ocr_confidence,
+			"ocr_status": expense.internal_ocr_status,
+			# Matching
+			"match_score": expense.internal_match_score,
+			"match_status": expense.internal_match_status,
+			"match_details": match_details,
+			"amount_diff": expense.internal_amount_diff,
+			"comparison": comparison,
+			# Classification
+			"suggested_coa": expense.internal_suggested_coa,
+			"coa_confidence": expense.internal_coa_confidence,
+			"coa_alternatives": coa_alternatives,
+			"classification_method": expense.internal_classification_method,
+			# Review status
+			"review_status": expense.internal_review_status,
+			"status": expense.status,
+		},
+	}
 
 
 # ============================================================
 # APPROVAL ENDPOINTS
 # ============================================================
 
+
 @frappe.whitelist()
 def approve_expense(
-    expense_name: str,
-    final_coa: str,
-    approved_amount: float = None,
-    approval_source: str = "manual",
-    notes: str = None
+	expense_name: str,
+	final_coa: str,
+	approved_amount: float | None = None,
+	approval_source: str = "manual",
+	notes: str | None = None,
 ):
-    """
-    Approve a single expense.
+	"""
+	Approve a single expense.
 
-    Args:
-        expense_name: Expense request ID
-        final_coa: Selected Chart of Account
-        approved_amount: Amount to approve (defaults to manual_amount)
-        approval_source: manual | ocr | edited
-        notes: Optional review notes
-    """
-    _check_accounting_role()
+	Args:
+	    expense_name: Expense request ID
+	    final_coa: Selected Chart of Account
+	    approved_amount: Amount to approve (defaults to manual_amount)
+	    approval_source: manual | ocr | edited
+	    notes: Optional review notes
+	"""
+	_check_accounting_role()
 
-    expense = frappe.get_doc("BEI Expense Request", expense_name)
+	expense = frappe.get_doc("BEI Expense Request", expense_name)
 
-    if expense.status == "Approved":
-        frappe.throw(_("Expense already approved"))
+	if expense.status == "Approved":
+		frappe.throw(_("Expense already approved"))
 
-    expense.internal_final_coa = final_coa
-    expense.internal_approved_amount = flt(approved_amount or expense.manual_amount)
-    expense.internal_approval_source = approval_source
-    expense.internal_reviewed_by = frappe.session.user
-    expense.internal_review_date = now_datetime()
-    expense.internal_review_notes = notes
-    expense.status = "Approved"
+	expense.internal_final_coa = final_coa
+	expense.internal_approved_amount = flt(approved_amount or expense.manual_amount)
+	expense.internal_approval_source = approval_source
+	expense.internal_reviewed_by = frappe.session.user
+	expense.internal_review_date = now_datetime()
+	expense.internal_review_notes = notes
+	expense.status = "Approved"
 
-    expense.save(ignore_permissions=True)
+	expense.save(ignore_permissions=True)
 
-    # Wire record_correction (Task 19A)
-    try:
-        from hrms.api.expense_classifier import record_correction
-        if expense.internal_suggested_coa and final_coa != expense.internal_suggested_coa:
-            record_correction(expense.name, expense.internal_suggested_coa, final_coa)
-    except ImportError:
-        pass
+	# Wire record_correction (Task 19A)
+	try:
+		from hrms.api.expense_classifier import record_correction
 
-    # Auto-generate PCF JV (Task F03A)
-    _create_pcf_jv(expense)
+		if expense.internal_suggested_coa and final_coa != expense.internal_suggested_coa:
+			record_correction(expense.name, expense.internal_suggested_coa, final_coa)
+	except ImportError:
+		pass
 
-    # Notify employee
-    _notify_employee(expense, "approved")
+	# Auto-generate PCF JV (Task F03A)
+	_create_pcf_jv(expense)
 
-    return {
-        "success": True,
-        "data": {
-            "name": expense.name,
-            "status": "Approved",
-            "final_coa": final_coa,
-            "approved_amount": expense.internal_approved_amount
-        },
-        "message": _("Expense approved")
-    }
+	# Notify employee
+	_notify_employee(expense, "approved")
+
+	return {
+		"success": True,
+		"data": {
+			"name": expense.name,
+			"status": "Approved",
+			"final_coa": final_coa,
+			"approved_amount": expense.internal_approved_amount,
+		},
+		"message": _("Expense approved"),
+	}
 
 
 def _create_pcf_jv(expense):
-    """
-    Best-effort PCF JV hook.
+	"""
+	Best-effort PCF JV hook.
 
-    Keeps approval flow stable even when PCF-to-JV mapping is unavailable.
-    """
-    batch_name = getattr(expense, "pcf_batch", None)
-    if not batch_name:
-        return {"created": False, "journal_entry": None, "reason": "missing_pcf_batch"}
+	Keeps approval flow stable even when PCF-to-JV mapping is unavailable.
+	"""
+	batch_name = getattr(expense, "pcf_batch", None)
+	if not batch_name:
+		return {"created": False, "journal_entry": None, "reason": "missing_pcf_batch"}
 
-    final_coa = getattr(expense, "internal_final_coa", None)
-    if not final_coa:
-        return {"created": False, "journal_entry": None, "reason": "missing_final_coa"}
+	final_coa = getattr(expense, "internal_final_coa", None)
+	if not final_coa:
+		return {"created": False, "journal_entry": None, "reason": "missing_final_coa"}
 
-    amount = flt(getattr(expense, "internal_approved_amount", None) or getattr(expense, "manual_amount", 0))
-    if amount <= 0:
-        return {"created": False, "journal_entry": None, "reason": "invalid_amount"}
+	amount = flt(getattr(expense, "internal_approved_amount", None) or getattr(expense, "manual_amount", 0))
+	if amount <= 0:
+		return {"created": False, "journal_entry": None, "reason": "invalid_amount"}
 
-    # Explicit no-op until a dedicated expense-level JV policy is finalized.
-    return {"created": False, "journal_entry": None, "reason": "pcf_jv_policy_pending"}
+	# Explicit no-op until a dedicated expense-level JV policy is finalized.
+	return {"created": False, "journal_entry": None, "reason": "pcf_jv_policy_pending"}
 
 
 def _notify_employee(expense, action: str):
-    """Notify employee of expense status change."""
-    try:
-        from hrms.api.google_chat import send_notification_to_user
+	"""Notify employee of expense status change."""
+	try:
+		from hrms.api.google_chat import send_notification_to_user
 
-        user = frappe.db.get_value("Employee", expense.employee, "user_id")
-        if not user:
-            return
+		user = frappe.db.get_value("Employee", expense.employee, "user_id")
+		if not user:
+			return
 
-        if action == "approved":
-            message = f"""*Expense Approved*
+		if action == "approved":
+			message = f"""*Expense Approved*
 
 Your expense request {expense.name} has been approved.
 *Amount:* PHP {expense.internal_approved_amount:,.2f}
 *COA:* {expense.internal_final_coa}"""
-        else:
-            message = f"""*Expense Rejected*
+		else:
+			message = f"""*Expense Rejected*
 
 Your expense request {expense.name} was rejected.
 Please resubmit with a clearer receipt photo."""
 
-        send_notification_to_user(user, message)
+		send_notification_to_user(user, message)
 
-    except Exception as e:
-        frappe.log_error(f"Employee notification failed: {e}")
+	except Exception as e:
+		frappe.log_error(f"Employee notification failed: {e}")
 
 
 @frappe.whitelist()
 def batch_approve(expense_names: str):
-    """
-    Batch approve multiple auto-matched expenses.
-    Uses AI-suggested COA and manual amount.
+	"""
+	Batch approve multiple auto-matched expenses.
+	Uses AI-suggested COA and manual amount.
 
-    Args:
-        expense_names: JSON array of expense names
-    """
-    _check_accounting_role()
+	Args:
+	    expense_names: JSON array of expense names
+	"""
+	_check_accounting_role()
 
-    if isinstance(expense_names, str):
-        expense_names = json.loads(expense_names)
+	if isinstance(expense_names, str):
+		expense_names = json.loads(expense_names)
 
-    if not expense_names:
-        frappe.throw(_("No expenses selected"))
+	if not expense_names:
+		frappe.throw(_("No expenses selected"))
 
-    approved = []
-    failed = []
+	approved = []
+	failed = []
 
-    for name in expense_names:
-        try:
-            expense = frappe.get_doc("BEI Expense Request", name)
+	for name in expense_names:
+		try:
+			expense = frappe.get_doc("BEI Expense Request", name)
 
-            if expense.status == "Approved":
-                failed.append({"name": name, "error": "Already approved"})
-                continue
+			if expense.status == "Approved":
+				failed.append({"name": name, "error": "Already approved"})
+				continue
 
-            if not expense.internal_suggested_coa:
-                failed.append({"name": name, "error": "No COA suggestion"})
-                continue
+			if not expense.internal_suggested_coa:
+				failed.append({"name": name, "error": "No COA suggestion"})
+				continue
 
-            expense.internal_final_coa = expense.internal_suggested_coa
-            expense.internal_approved_amount = expense.manual_amount
-            expense.internal_approval_source = "auto"
-            expense.internal_reviewed_by = frappe.session.user
-            expense.internal_review_date = now_datetime()
-            expense.status = "Approved"
-            expense.save(ignore_permissions=True)
+			expense.internal_final_coa = expense.internal_suggested_coa
+			expense.internal_approved_amount = expense.manual_amount
+			expense.internal_approval_source = "auto"
+			expense.internal_reviewed_by = frappe.session.user
+			expense.internal_review_date = now_datetime()
+			expense.status = "Approved"
+			expense.save(ignore_permissions=True)
 
-            approved.append(name)
+			approved.append(name)
 
-        except Exception as e:
-            failed.append({"name": name, "error": str(e)})
+		except Exception as e:
+			failed.append({"name": name, "error": str(e)})
 
-    frappe.db.commit()
+	frappe.db.commit()
 
-    return {
-        "success": True,
-        "data": {
-            "approved_count": len(approved),
-            "failed_count": len(failed),
-            "approved": approved,
-            "failed": failed
-        },
-        "message": _("{0} expenses approved").format(len(approved))
-    }
+	return {
+		"success": True,
+		"data": {
+			"approved_count": len(approved),
+			"failed_count": len(failed),
+			"approved": approved,
+			"failed": failed,
+		},
+		"message": _("{0} expenses approved").format(len(approved)),
+	}
 
 
 @frappe.whitelist()
-def reject_expense(expense_name: str, reason: str = None):
-    """
-    Reject an expense.
-    Store staff will see generic rejection message.
+def reject_expense(expense_name: str, reason: str | None = None):
+	"""
+	Reject an expense.
+	Store staff will see generic rejection message.
 
-    Args:
-        expense_name: Expense request ID
-        reason: Internal reason (not shown to store staff)
-    """
-    _check_accounting_role()
+	Args:
+	    expense_name: Expense request ID
+	    reason: Internal reason (not shown to store staff)
+	"""
+	_check_accounting_role()
 
-    expense = frappe.get_doc("BEI Expense Request", expense_name)
+	expense = frappe.get_doc("BEI Expense Request", expense_name)
 
-    if expense.status in ["Approved", "Rejected"]:
-        frappe.throw(_("Expense already processed"))
+	if expense.status in ["Approved", "Rejected"]:
+		frappe.throw(_("Expense already processed"))
 
-    expense.status = "Rejected"
-    expense.internal_reviewed_by = frappe.session.user
-    expense.internal_review_date = now_datetime()
-    expense.internal_review_notes = reason  # Internal only
+	expense.status = "Rejected"
+	expense.internal_reviewed_by = frappe.session.user
+	expense.internal_review_date = now_datetime()
+	expense.internal_review_notes = reason  # Internal only
 
-    expense.save(ignore_permissions=True)
+	expense.save(ignore_permissions=True)
 
-    # Notify employee
-    _notify_employee(expense, "rejected")
+	# Notify employee
+	_notify_employee(expense, "rejected")
 
-    return {
-        "success": True,
-        "data": {
-            "name": expense.name,
-            "status": "Rejected"
-        },
-        "message": _("Expense rejected")
-    }
+	return {
+		"success": True,
+		"data": {"name": expense.name, "status": "Rejected"},
+		"message": _("Expense rejected"),
+	}
 
 
 # ============================================================
 # AUTO-APPROVED BATCH ENDPOINTS
 # ============================================================
 
+
 @frappe.whitelist()
-def get_auto_approved_batch(store: str = None, limit: int = 100):
-    """
-    Get auto-matched expenses ready for batch approval.
-    These have match score ≥90% and COA confidence ≥90%.
-    """
-    _check_accounting_role()
+def get_auto_approved_batch(store: str | None = None, limit: int = 100):
+	"""
+	Get auto-matched expenses ready for batch approval.
+	These have match score ≥90% and COA confidence ≥90%.
+	"""
+	_check_accounting_role()
 
-    filters = {
-        "status": "Submitted",
-        "internal_review_status": "auto_approved"
-    }
+	filters = {"status": "Submitted", "internal_review_status": "auto_approved"}
 
-    if store:
-        filters["store"] = store
+	if store:
+		filters["store"] = store
 
-    expenses = frappe.get_all(
-        "BEI Expense Request",
-        filters=filters,
-        fields=[
-            "name", "employee", "store", "request_date",
-            "manual_vendor", "manual_description", "manual_amount",
-            "internal_suggested_coa", "internal_coa_confidence",
-            "internal_match_score"
-        ],
-        order_by="creation asc",
-        limit_page_length=limit
-    )
+	expenses = frappe.get_all(
+		"BEI Expense Request",
+		filters=filters,
+		fields=[
+			"name",
+			"employee",
+			"store",
+			"request_date",
+			"manual_vendor",
+			"manual_description",
+			"manual_amount",
+			"internal_suggested_coa",
+			"internal_coa_confidence",
+			"internal_match_score",
+		],
+		order_by="creation asc",
+		limit_page_length=limit,
+	)
 
-    # Enrich with employee names and COA labels
-    for exp in expenses:
-        emp = frappe.db.get_value("Employee", exp["employee"], "employee_name")
-        exp["employee_name"] = emp or exp["employee"]
+	# Enrich with employee names and COA labels
+	for exp in expenses:
+		emp = frappe.db.get_value("Employee", exp["employee"], "employee_name")
+		exp["employee_name"] = emp or exp["employee"]
 
-        if exp["internal_suggested_coa"]:
-            coa = frappe.db.get_value("Account", exp["internal_suggested_coa"], "account_name")
-            exp["coa_name"] = coa or exp["internal_suggested_coa"]
+		if exp["internal_suggested_coa"]:
+			coa = frappe.db.get_value("Account", exp["internal_suggested_coa"], "account_name")
+			exp["coa_name"] = coa or exp["internal_suggested_coa"]
 
-    # Calculate total
-    total_amount = sum(exp["manual_amount"] or 0 for exp in expenses)
+	# Calculate total
+	total_amount = sum(exp["manual_amount"] or 0 for exp in expenses)
 
-    return {
-        "success": True,
-        "data": {
-            "expenses": expenses,
-            "count": len(expenses),
-            "total_amount": total_amount
-        }
-    }
+	return {
+		"success": True,
+		"data": {"expenses": expenses, "count": len(expenses), "total_amount": total_amount},
+	}
 
 
 # ============================================================
 # STATISTICS & REPORTING
 # ============================================================
 
+
 @frappe.whitelist()
 def get_classification_stats(days: int = 30):
-    """
-    Get AI classification performance statistics.
-    """
-    _check_accounting_role()
+	"""
+	Get AI classification performance statistics.
+	"""
+	_check_accounting_role()
 
-    from frappe.utils import add_days
+	from frappe.utils import add_days
 
-    start_date = add_days(today(), -days)
+	start_date = add_days(today(), -days)
 
-    # Total processed
-    total = frappe.db.count(
-        "BEI Expense Request",
-        filters={
-            "status": "Approved",
-            "internal_review_date": [">=", start_date]
-        }
-    )
+	# Total processed
+	total = frappe.db.count(
+		"BEI Expense Request", filters={"status": "Approved", "internal_review_date": [">=", start_date]}
+	)
 
-    # Auto-approved (high confidence)
-    auto_approved = frappe.db.count(
-        "BEI Expense Request",
-        filters={
-            "status": "Approved",
-            "internal_review_date": [">=", start_date],
-            "internal_approval_source": "auto"
-        }
-    )
+	# Auto-approved (high confidence)
+	auto_approved = frappe.db.count(
+		"BEI Expense Request",
+		filters={
+			"status": "Approved",
+			"internal_review_date": [">=", start_date],
+			"internal_approval_source": "auto",
+		},
+	)
 
-    # Manual corrections
-    manual_corrections = frappe.db.sql("""
+	# Manual corrections
+	manual_corrections = (
+		frappe.db.sql(
+			"""
         SELECT COUNT(*)
         FROM `tabBEI Expense Request`
         WHERE status = 'Approved'
         AND internal_review_date >= %s
         AND internal_final_coa != internal_suggested_coa
-    """, start_date)[0][0] or 0
+    """,
+			start_date,
+		)[0][0]
+		or 0
+	)
 
-    # By COA category
-    by_coa = frappe.db.sql("""
+	# By COA category
+	by_coa = frappe.db.sql(
+		"""
         SELECT internal_final_coa, COUNT(*) as count, SUM(internal_approved_amount) as amount
         FROM `tabBEI Expense Request`
         WHERE status = 'Approved'
         AND internal_review_date >= %s
         GROUP BY internal_final_coa
         ORDER BY count DESC
-    """, start_date, as_dict=True)
+    """,
+		start_date,
+		as_dict=True,
+	)
 
-    # By store
-    by_store = frappe.db.sql("""
+	# By store
+	by_store = frappe.db.sql(
+		"""
         SELECT store, COUNT(*) as count, SUM(internal_approved_amount) as amount
         FROM `tabBEI Expense Request`
         WHERE status = 'Approved'
         AND internal_review_date >= %s
         GROUP BY store
         ORDER BY count DESC
-    """, start_date, as_dict=True)
+    """,
+		start_date,
+		as_dict=True,
+	)
 
-    return {
-        "success": True,
-        "data": {
-            "total_processed": total,
-            "auto_approved": auto_approved,
-            "auto_approval_rate": (auto_approved / total * 100) if total > 0 else 0,
-            "manual_corrections": manual_corrections,
-            "correction_rate": (manual_corrections / total * 100) if total > 0 else 0,
-            "by_coa": by_coa,
-            "by_store": by_store
-        }
-    }
+	return {
+		"success": True,
+		"data": {
+			"total_processed": total,
+			"auto_approved": auto_approved,
+			"auto_approval_rate": (auto_approved / total * 100) if total > 0 else 0,
+			"manual_corrections": manual_corrections,
+			"correction_rate": (manual_corrections / total * 100) if total > 0 else 0,
+			"by_coa": by_coa,
+			"by_store": by_store,
+		},
+	}

--- a/hrms/tests/test_expense_review_queue_filters.py
+++ b/hrms/tests/test_expense_review_queue_filters.py
@@ -1,0 +1,125 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+	sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_frappe():
+	frappe = types.ModuleType("frappe")
+	sys.modules["frappe"] = frappe
+
+	def whitelist(*args, **kwargs):
+		if args and callable(args[0]) and len(args) == 1 and not kwargs:
+			return args[0]
+
+		def decorator(fn):
+			return fn
+
+		return decorator
+
+	frappe.whitelist = whitelist
+	frappe._ = lambda text: text
+	frappe.throw = lambda message, exc=None: (_ for _ in ()).throw(Exception(message))
+	frappe.log_error = lambda *args, **kwargs: None
+	frappe.get_roles = lambda: ["Accounts Manager"]
+	frappe.session = types.SimpleNamespace(user="test.hr@bebang.ph")
+
+	class FakeDB:
+		def get_value(self, doctype, name, fieldname):
+			if doctype == "Employee" and fieldname == "employee_name":
+				return "Test Crew"
+			return None
+
+		def count(self, *args, **kwargs):
+			return 0
+
+		def sql(self, *args, **kwargs):
+			return [(0,)]
+
+	captured = {"filters": None}
+
+	def fake_get_all(_doctype, filters=None, fields=None, order_by=None, limit_page_length=None, start=None):
+		captured["filters"] = filters
+		return [
+			{
+				"name": "BEI-EXP-TEST-0001",
+				"employee": "TEST-CREW-001",
+				"store": "TEST-STORE-BGC - BEI",
+				"request_date": "2026-03-19",
+				"manual_vendor": "Test Vendor",
+				"manual_description": "Test expense",
+				"manual_amount": 100.0,
+				"manual_date": "2026-03-19",
+				"internal_ocr_vendor": None,
+				"internal_ocr_amount": None,
+				"internal_ocr_date": None,
+				"internal_match_score": 0,
+				"internal_match_status": "",
+				"internal_amount_diff": 0,
+				"internal_suggested_coa": None,
+				"internal_coa_confidence": 0,
+				"internal_review_status": "needs_classification",
+				"creation": "2026-03-19 00:00:00",
+			}
+		]
+
+	frappe.db = FakeDB()
+	frappe.get_all = fake_get_all
+	frappe.get_doc = lambda *args, **kwargs: None
+	return captured
+
+
+class TestExpenseReviewQueueFilters(unittest.TestCase):
+	def setUp(self):
+		self.captured = _install_fake_frappe()
+		if "frappe.utils" not in sys.modules:
+			utils = types.ModuleType("frappe.utils")
+			utils.now_datetime = lambda: "2026-03-19 00:00:00"
+			utils.today = lambda: "2026-03-19"
+			utils.flt = lambda value, precision=None: float(value or 0)
+			utils.getdate = lambda value=None: value
+			sys.modules["frappe.utils"] = utils
+
+		spec = importlib.util.spec_from_file_location(
+			"expense_review_under_test",
+			ROOT / "hrms" / "api" / "expense_review.py",
+		)
+		self.module = importlib.util.module_from_spec(spec)
+		assert spec and spec.loader
+		spec.loader.exec_module(self.module)
+
+	def test_all_queue_only_requests_reviewable_statuses(self):
+		result = self.module.get_pending_review(review_type="all", limit=50, offset=0)
+
+		self.assertTrue(result["success"])
+		self.assertEqual(result["data"][0]["employee_name"], "Test Crew")
+		self.assertEqual(
+			self.captured["filters"],
+			{
+				"status": "Submitted",
+				"internal_review_status": [
+					"in",
+					["pending_review", "mismatch_review", "needs_classification", "ocr_failed"],
+				],
+			},
+		)
+
+	def test_auto_approved_queue_keeps_auto_approved_filter(self):
+		self.module.get_pending_review(review_type="auto_approved", limit=50, offset=0)
+
+		self.assertEqual(
+			self.captured["filters"],
+			{
+				"status": "Submitted",
+				"internal_review_status": "auto_approved",
+			},
+		)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/hrms/tests/test_expense_review_queue_filters.py
+++ b/hrms/tests/test_expense_review_queue_filters.py
@@ -27,7 +27,8 @@ def _install_fake_frappe():
 	frappe.throw = lambda message, exc=None: (_ for _ in ()).throw(Exception(message))
 	frappe.log_error = lambda *args, **kwargs: None
 	frappe.get_roles = lambda: ["Accounts Manager"]
-	frappe.session = types.SimpleNamespace(user="test.hr@bebang.ph")
+	frappe.local = types.SimpleNamespace()
+	frappe.local.session = types.SimpleNamespace(user="test.hr@bebang.ph")
 
 	class FakeDB:
 		def get_value(self, doctype, name, fieldname):
@@ -43,7 +44,14 @@ def _install_fake_frappe():
 
 	captured = {"filters": None}
 
-	def fake_get_all(_doctype, filters=None, fields=None, order_by=None, limit_page_length=None, start=None):
+	def fake_get_all(
+		_doctype,
+		filters=None,
+		fields=None,
+		order_by=None,
+		limit_page_length=None,
+		start=None,
+	):
 		captured["filters"] = filters
 		return [
 			{
@@ -68,9 +76,18 @@ def _install_fake_frappe():
 			}
 		]
 
-	frappe.db = FakeDB()
+	frappe.local.db = FakeDB()
 	frappe.get_all = fake_get_all
 	frappe.get_doc = lambda *args, **kwargs: None
+
+	def _module_getattr(name):
+		if name == "db":
+			return frappe.local.db
+		if name == "session":
+			return frappe.local.session
+		raise AttributeError(name)
+
+	frappe.__getattr__ = _module_getattr
 	return captured
 
 


### PR DESCRIPTION
## Summary
- keep the finance review queue filtered to actionable review states when eview_type=all
- add a regression test that locks the queue filter contract
- preserve the explicit auto-approved queue behavior for batch approval

## Testing
- python hrms/tests/test_expense_review_queue_filters.py
- python hrms/tests/test_billing_gl_reference_contract.py
- ruff check hrms/api/expense_review.py hrms/tests/test_expense_review_queue_filters.py