### PR TITLE
S065: harden expense review notification side effects

### DIFF
--- a/hrms/api/expense_review.py
+++ b/hrms/api/expense_review.py
@@ -373,31 +373,60 @@ def _create_pcf_jv(expense):
 	return {"created": False, "journal_entry": None, "reason": "pcf_jv_policy_pending"}
 
 
+def _safe_log_notification_error(message: str) -> None:
+	"""Notification failures must never break expense mutation outcomes."""
+	try:
+		logger = getattr(frappe, "logger", None)
+		if callable(logger):
+			logger("expense_review").warning(message)
+	except Exception:
+		pass
+
+	try:
+		frappe.log_error(
+			title="Expense Review Notification Error",
+			message=message[:500],
+		)
+	except Exception:
+		pass
+
+
 def _notify_employee(expense, action: str):
 	"""Notify employee of expense status change."""
-	try:
-		from hrms.api.google_chat import send_notification_to_user
+	user = frappe.db.get_value("Employee", expense.employee, "user_id")
+	if not user:
+		return
 
-		user = frappe.db.get_value("Employee", expense.employee, "user_id")
-		if not user:
-			return
-
-		if action == "approved":
-			message = f"""*Expense Approved*
+	if action == "approved":
+		message = f"""*Expense Approved*
 
 Your expense request {expense.name} has been approved.
-*Amount:* PHP {expense.internal_approved_amount:,.2f}
+*Amount:* PHP {flt(expense.internal_approved_amount):,.2f}
 *COA:* {expense.internal_final_coa}"""
-		else:
-			message = f"""*Expense Rejected*
+	else:
+		message = f"""*Expense Rejected*
 
 Your expense request {expense.name} was rejected.
 Please resubmit with a clearer receipt photo."""
 
-		send_notification_to_user(user, message)
+	try:
+		from hrms.api.google_chat import send_notification_to_user
+	except Exception as exc:
+		_safe_log_notification_error(
+			f"expense={expense.name}, action={action}, user={user}, stage=import, error={str(exc)[:250]}"
+		)
+		return
 
-	except Exception as e:
-		frappe.log_error(f"Employee notification failed: {e}")
+	try:
+		result = send_notification_to_user(user, message)
+		if result is False:
+			_safe_log_notification_error(
+				f"expense={expense.name}, action={action}, user={user}, stage=deliver, error=notification_not_sent"
+			)
+	except Exception as exc:
+		_safe_log_notification_error(
+			f"expense={expense.name}, action={action}, user={user}, stage=deliver, error={str(exc)[:250]}"
+		)
 
 
 @frappe.whitelist()

--- a/hrms/api/google_chat.py
+++ b/hrms/api/google_chat.py
@@ -331,6 +331,45 @@ def send_message_to_user_direct(
 	)
 
 
+def send_notification_to_user(
+	user_identifier: str | None,
+	message: str,
+	*,
+	family: str | None = None,
+	context: str = "hrms.api.google_chat.send_notification_to_user",
+) -> bool:
+	"""Legacy compatibility wrapper for direct user notifications."""
+	logger = frappe.logger("google_chat")
+	normalized_user = str(user_identifier or "").strip()
+	if not normalized_user:
+		return False
+
+	try:
+		result = send_message_to_user_direct(
+			normalized_user,
+			message,
+			family=family,
+			context=context,
+		)
+		if not result.get("success"):
+			logger.warning(
+				"send_notification_to_user skipped for %s reason=%s",
+				normalized_user,
+				result.get("reason", "unknown"),
+			)
+		return bool(result.get("success"))
+	except Exception as exc:
+		logger.warning("send_notification_to_user failed for %s: %s", normalized_user, exc)
+		try:
+			frappe.log_error(
+				title="Google Chat User Notification Error",
+				message=f"user={normalized_user[:120]}, family={family or 'legacy'}, error={str(exc)[:500]}",
+			)
+		except Exception:
+			pass
+		return False
+
+
 def _notification_cache() -> object | None:
 	cache_factory = getattr(frappe, "cache", None)
 	if not callable(cache_factory):

--- a/hrms/api/google_chat.py
+++ b/hrms/api/google_chat.py
@@ -594,9 +594,9 @@ def _deliver_notification_event(
 				"message_id": send_result.get("message_id"),
 				"rendered_text": final_text,
 				"ai_meta": ai_meta,
-			"source_ref": normalized["source_ref"],
-			"dedup_key": normalized["dedup_key"],
-		}
+				"source_ref": normalized["source_ref"],
+				"dedup_key": normalized["dedup_key"],
+			}
 	except Exception as exc:
 		logger.error("send_notification_event failed: %s", exc)
 		frappe.log_error(

--- a/hrms/tests/test_expense_model_fallback_s07.py
+++ b/hrms/tests/test_expense_model_fallback_s07.py
@@ -148,6 +148,18 @@ class TestExpenseModelFallbackS07(unittest.TestCase):
         self.assertEqual(expense.internal_final_coa, "6006003")
         self.assertEqual(expense.status, "Approved")
 
+    def test_notify_employee_swallow_import_and_logging_failures(self):
+        expense = _ExpenseDoc()
+
+        with patch.object(
+            expense_review.frappe.db,
+            "get_value",
+            return_value="test.accounting@bebang.ph",
+        ), patch.object(expense_review.frappe, "log_error", side_effect=Exception("log failed")):
+            result = expense_review._notify_employee(expense, "rejected")
+
+        self.assertIsNone(result)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/hrms/tests/test_expense_model_fallback_s07.py
+++ b/hrms/tests/test_expense_model_fallback_s07.py
@@ -12,77 +12,77 @@ from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+	sys.path.insert(0, str(ROOT))
 
 
 def _install_fake_frappe():
-    if "frappe" not in sys.modules:
-        frappe = types.ModuleType("frappe")
+	if "frappe" not in sys.modules:
+		frappe = types.ModuleType("frappe")
 
-        def whitelist(*args, **kwargs):
-            if args and callable(args[0]) and len(args) == 1 and not kwargs:
-                return args[0]
+		def whitelist(*args, **kwargs):
+			if args and callable(args[0]) and len(args) == 1 and not kwargs:
+				return args[0]
 
-            def decorator(fn):
-                return fn
+			def decorator(fn):
+				return fn
 
-            return decorator
+			return decorator
 
-        def _throw(message, exc=None):
-            if isinstance(exc, type) and issubclass(exc, Exception):
-                raise exc(message)
-            raise Exception(message)
+		def _throw(message, exc=None):
+			if isinstance(exc, type) and issubclass(exc, Exception):
+				raise exc(message)
+			raise Exception(message)
 
-        frappe.whitelist = whitelist
-        frappe._ = lambda text: text
-        frappe.throw = _throw
-        frappe.log_error = lambda *args, **kwargs: None
-        frappe.get_roles = lambda: ["Accounts Manager"]
-        frappe.session = types.SimpleNamespace(user="test.accounting@bebang.ph")
-        frappe.conf = {}
-        frappe.db = types.SimpleNamespace(
-            count=lambda *args, **kwargs: 0,
-            sql=lambda *args, **kwargs: [(0,)],
-            get_value=lambda *args, **kwargs: None,
-            get_single_value=lambda *args, **kwargs: None,
-            commit=lambda: None,
-        )
-        frappe.get_all = lambda *args, **kwargs: []
-        frappe.get_doc = lambda *args, **kwargs: None
-        sys.modules["frappe"] = frappe
+		frappe.whitelist = whitelist
+		frappe._ = lambda text: text
+		frappe.throw = _throw
+		frappe.log_error = lambda *args, **kwargs: None
+		frappe.get_roles = lambda: ["Accounts Manager"]
+		frappe.session = types.SimpleNamespace(user="test.accounting@bebang.ph")
+		frappe.conf = {}
+		frappe.db = types.SimpleNamespace(
+			count=lambda *args, **kwargs: 0,
+			sql=lambda *args, **kwargs: [(0,)],
+			get_value=lambda *args, **kwargs: None,
+			get_single_value=lambda *args, **kwargs: None,
+			commit=lambda: None,
+		)
+		frappe.get_all = lambda *args, **kwargs: []
+		frappe.get_doc = lambda *args, **kwargs: None
+		sys.modules["frappe"] = frappe
 
-    if "frappe.utils" not in sys.modules:
-        utils = types.ModuleType("frappe.utils")
-        utils.today = lambda: "2026-02-27"
-        utils.now_datetime = lambda: "2026-02-27 00:00:00"
-        utils.flt = lambda value, precision=None: float(value or 0)
-        utils.getdate = lambda value=None: value
-        sys.modules["frappe.utils"] = utils
+	if "frappe.utils" not in sys.modules:
+		utils = types.ModuleType("frappe.utils")
+		utils.today = lambda: "2026-02-27"
+		utils.now_datetime = lambda: "2026-02-27 00:00:00"
+		utils.flt = lambda value, precision=None: float(value or 0)
+		utils.getdate = lambda value=None: value
+		sys.modules["frappe.utils"] = utils
 
-    frappe = sys.modules["frappe"]
-    utils = sys.modules["frappe.utils"]
-    if not hasattr(frappe, "conf"):
-        frappe.conf = {}
-    if not hasattr(utils, "getdate"):
-        utils.getdate = lambda value=None: value
+	frappe = sys.modules["frappe"]
+	utils = sys.modules["frappe.utils"]
+	if not hasattr(frappe, "conf"):
+		frappe.conf = {}
+	if not hasattr(utils, "getdate"):
+		utils.getdate = lambda value=None: value
 
-    if "hrms" not in sys.modules:
-        hrms_pkg = types.ModuleType("hrms")
-        hrms_pkg.__path__ = []
-        sys.modules["hrms"] = hrms_pkg
+	if "hrms" not in sys.modules:
+		hrms_pkg = types.ModuleType("hrms")
+		hrms_pkg.__path__ = []
+		sys.modules["hrms"] = hrms_pkg
 
-    if "hrms.api" not in sys.modules:
-        hrms_api_pkg = types.ModuleType("hrms.api")
-        hrms_api_pkg.__path__ = []
-        sys.modules["hrms.api"] = hrms_api_pkg
+	if "hrms.api" not in sys.modules:
+		hrms_api_pkg = types.ModuleType("hrms.api")
+		hrms_api_pkg.__path__ = []
+		sys.modules["hrms.api"] = hrms_api_pkg
 
 
 def _load_module(module_name: str, relative_path: str):
-    spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[module_name] = module
-    spec.loader.exec_module(module)
-    return module
+	spec = importlib.util.spec_from_file_location(module_name, ROOT / relative_path)
+	module = importlib.util.module_from_spec(spec)
+	sys.modules[module_name] = module
+	spec.loader.exec_module(module)
+	return module
 
 
 _install_fake_frappe()
@@ -91,75 +91,81 @@ expense_review = _load_module("hrms.api.expense_review", "hrms/api/expense_revie
 
 
 class _ExpenseDoc:
-    def __init__(self):
-        self.name = "EXP-0001"
-        self.employee = "EMP-0001"
-        self.store = "TEST STORE - BEI"
-        self.status = "Submitted"
-        self.manual_amount = 120.0
-        self.internal_suggested_coa = None
-        self.internal_final_coa = None
-        self.internal_approved_amount = None
-        self.internal_approval_source = None
-        self.internal_reviewed_by = None
-        self.internal_review_date = None
-        self.internal_review_notes = None
-        self.pcf_batch = None
+	def __init__(self):
+		self.name = "EXP-0001"
+		self.employee = "EMP-0001"
+		self.store = "TEST STORE - BEI"
+		self.status = "Submitted"
+		self.manual_amount = 120.0
+		self.internal_suggested_coa = None
+		self.internal_final_coa = None
+		self.internal_approved_amount = None
+		self.internal_approval_source = None
+		self.internal_reviewed_by = None
+		self.internal_review_date = None
+		self.internal_review_notes = None
+		self.pcf_batch = None
 
-    def save(self, **kwargs):
-        return None
+	def save(self, **kwargs):
+		return None
 
 
 class TestExpenseModelFallbackS07(unittest.TestCase):
-    def test_classifier_returns_explicit_degraded_fallback_when_runtime_is_missing(self):
-        with patch.object(expense_classifier, "JOBLIB_AVAILABLE", False), patch.object(
-            expense_classifier, "REQUESTS_AVAILABLE", False
-        ), patch.object(expense_classifier.os.path, "exists", return_value=False):
-            result = expense_classifier.classify_expense("zzqv unmatched token", "unknown vendor")
+	def test_classifier_returns_explicit_degraded_fallback_when_runtime_is_missing(self):
+		with (
+			patch.object(expense_classifier, "JOBLIB_AVAILABLE", False),
+			patch.object(expense_classifier, "REQUESTS_AVAILABLE", False),
+			patch.object(expense_classifier.os.path, "exists", return_value=False),
+		):
+			result = expense_classifier.classify_expense("zzqv unmatched token", "unknown vendor")
 
-        self.assertEqual(result["method"], "fallback_degraded")
-        self.assertEqual(result["fallback_reason"], "ml_model_missing_and_openai_unavailable")
-        self.assertIn("runtime_health", result)
-        self.assertFalse(result["runtime_health"]["ml_model_available"])
-        self.assertFalse(result["runtime_health"]["openai_available"])
+		self.assertEqual(result["method"], "fallback_degraded")
+		self.assertEqual(result["fallback_reason"], "ml_model_missing_and_openai_unavailable")
+		self.assertIn("runtime_health", result)
+		self.assertFalse(result["runtime_health"]["ml_model_available"])
+		self.assertFalse(result["runtime_health"]["openai_available"])
 
-    def test_create_pcf_jv_returns_structured_skip_when_batch_is_missing(self):
-        expense = _ExpenseDoc()
-        result = expense_review._create_pcf_jv(expense)
+	def test_create_pcf_jv_returns_structured_skip_when_batch_is_missing(self):
+		expense = _ExpenseDoc()
+		result = expense_review._create_pcf_jv(expense)
 
-        self.assertFalse(result["created"])
-        self.assertEqual(result["reason"], "missing_pcf_batch")
-        self.assertIsNone(result["journal_entry"])
+		self.assertFalse(result["created"])
+		self.assertEqual(result["reason"], "missing_pcf_batch")
+		self.assertIsNone(result["journal_entry"])
 
-    def test_approve_expense_does_not_fail_on_missing_pcf_jv_hook(self):
-        expense = _ExpenseDoc()
-        with patch.object(expense_review.frappe, "get_doc", return_value=expense), patch.object(
-            expense_review, "_notify_employee", return_value=None
-        ):
-            result = expense_review.approve_expense(
-                expense_name=expense.name,
-                final_coa="6006003",
-                approved_amount=120.0,
-                approval_source="manual",
-            )
+	def test_approve_expense_does_not_fail_on_missing_pcf_jv_hook(self):
+		expense = _ExpenseDoc()
+		with (
+			patch.object(expense_review.frappe, "get_doc", return_value=expense),
+			patch.object(expense_review, "_notify_employee", return_value=None),
+		):
+			result = expense_review.approve_expense(
+				expense_name=expense.name,
+				final_coa="6006003",
+				approved_amount=120.0,
+				approval_source="manual",
+			)
 
-        self.assertTrue(result["success"])
-        self.assertEqual(result["data"]["status"], "Approved")
-        self.assertEqual(expense.internal_final_coa, "6006003")
-        self.assertEqual(expense.status, "Approved")
+		self.assertTrue(result["success"])
+		self.assertEqual(result["data"]["status"], "Approved")
+		self.assertEqual(expense.internal_final_coa, "6006003")
+		self.assertEqual(expense.status, "Approved")
 
-    def test_notify_employee_swallow_import_and_logging_failures(self):
-        expense = _ExpenseDoc()
+	def test_notify_employee_swallow_import_and_logging_failures(self):
+		expense = _ExpenseDoc()
 
-        with patch.object(
-            expense_review.frappe.db,
-            "get_value",
-            return_value="test.accounting@bebang.ph",
-        ), patch.object(expense_review.frappe, "log_error", side_effect=Exception("log failed")):
-            result = expense_review._notify_employee(expense, "rejected")
+		with (
+			patch.object(
+				expense_review.frappe.db,
+				"get_value",
+				return_value="test.accounting@bebang.ph",
+			),
+			patch.object(expense_review.frappe, "log_error", side_effect=Exception("log failed")),
+		):
+			result = expense_review._notify_employee(expense, "rejected")
 
-        self.assertIsNone(result)
+		self.assertIsNone(result)
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_expense_model_fallback_s07.py
+++ b/hrms/tests/test_expense_model_fallback_s07.py
@@ -38,9 +38,10 @@ def _install_fake_frappe():
 		frappe.throw = _throw
 		frappe.log_error = lambda *args, **kwargs: None
 		frappe.get_roles = lambda: ["Accounts Manager"]
-		frappe.session = types.SimpleNamespace(user="test.accounting@bebang.ph")
+		frappe.local = types.SimpleNamespace()
+		frappe.local.session = types.SimpleNamespace(user="test.accounting@bebang.ph")
 		frappe.conf = {}
-		frappe.db = types.SimpleNamespace(
+		frappe.local.db = types.SimpleNamespace(
 			count=lambda *args, **kwargs: 0,
 			sql=lambda *args, **kwargs: [(0,)],
 			get_value=lambda *args, **kwargs: None,
@@ -49,6 +50,15 @@ def _install_fake_frappe():
 		)
 		frappe.get_all = lambda *args, **kwargs: []
 		frappe.get_doc = lambda *args, **kwargs: None
+
+		def _module_getattr(name):
+			if name == "db":
+				return frappe.local.db
+			if name == "session":
+				return frappe.local.session
+			raise AttributeError(name)
+
+		frappe.__getattr__ = _module_getattr
 		sys.modules["frappe"] = frappe
 
 	if "frappe.utils" not in sys.modules:
@@ -156,7 +166,7 @@ class TestExpenseModelFallbackS07(unittest.TestCase):
 
 		with (
 			patch.object(
-				expense_review.frappe.db,
+				expense_review.frappe.local.db,
 				"get_value",
 				return_value="test.accounting@bebang.ph",
 			),


### PR DESCRIPTION
## Summary
- make expense approve/reject notification failures non-blocking after persistence
- add a legacy-safe direct user notification wrapper in google_chat
- add regression coverage for missing notification sender/logging failures

## Verification
- python hrms/tests/test_expense_model_fallback_s07.py
- python hrms/tests/test_expense_review_queue_filters.py
- ruff check hrms/api/expense_review.py hrms/api/google_chat.py hrms/tests/test_expense_model_fallback_s07.py