### PR TITLE
S082: harden backend sentry cleanup surfaces

### DIFF
--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -22,12 +22,7 @@ from hrms.utils.delivery_billing_policy import (
 )
 
 # P0-10: Import centralized RBAC role sets
-from hrms.utils.scm_roles import (
-	SCM_ADMIN_ROLES,
-	SCM_DISPATCH_ROLES,
-	SCM_ROUTE_MANAGEMENT_ROLES,
-	SCM_STORE_ROLES,
-)
+from hrms.utils.scm_roles import SCM_ADMIN_ROLES, SCM_DISPATCH_ROLES, SCM_STORE_ROLES
 from hrms.utils.scm_roles import check_scm_permission as _check_scm_permission
 from hrms.utils.sentry import set_backend_observability_context
 from hrms.utils.supply_chain_contracts import (
@@ -106,45 +101,9 @@ def _infer_vehicle_type(vehicle_label: str | None) -> str:
 	return "Truck"
 
 
-def _normalize_vehicle_type(vehicle_type: str | None, vehicle_label: str | None = None) -> str:
-	"""Map portal shorthand into the valid BEI Vehicle master options."""
-	text = (vehicle_type or "").strip().lower()
-	if not text:
-		return _infer_vehicle_type(vehicle_label)
-	if text in {"reefer", "reefer truck"}:
-		return "Reefer Truck"
-	if text == "reefer van":
-		return "Reefer Van"
-	if text in {"non-reefer", "truck"}:
-		return "Truck"
-	if text in {"motorcycle", "motorbike", "bike"}:
-		return "Motorcycle"
-	if text == "l300":
-		return "L300"
-	if text == "van":
-		return "Van"
-	return vehicle_type
-
-
-def _resolve_threepl_partner_link(threepl_partner: str | None) -> str:
-	"""Resolve either a Supplier name or supplier_name into a valid Supplier link."""
-	partner = (threepl_partner or "").strip()
-	if not partner:
-		return ""
-	exact_name = frappe.db.get_value("Supplier", partner, "name")
-	if exact_name:
-		return str(exact_name)
-	match_by_supplier_name = frappe.db.get_value("Supplier", {"supplier_name": partner}, "name")
-	if match_by_supplier_name:
-		return str(match_by_supplier_name)
-	return partner
-
-
 def _resolve_or_create_departure_vehicle(
 	vehicle_label: str | None,
 	vehicle_plate: str | None,
-	vehicle_type: str | None = None,
-	threepl_partner: str | None = None,
 ) -> tuple[str, str]:
 	"""
 	Resolve a BEI Vehicle link for trip departure.
@@ -161,9 +120,7 @@ def _resolve_or_create_departure_vehicle(
 	if vehicle_label:
 		existing_name = frappe.db.get_value("BEI Vehicle", vehicle_label, "name")
 		if existing_name:
-			existing_plate = (
-				frappe.db.get_value("BEI Vehicle", existing_name, "vehicle_plate") or vehicle_plate
-			)
+			existing_plate = frappe.db.get_value("BEI Vehicle", existing_name, "vehicle_plate") or vehicle_plate
 			return str(existing_name), str(existing_plate or "")
 
 	if vehicle_plate:
@@ -186,10 +143,8 @@ def _resolve_or_create_departure_vehicle(
 		vehicle_doc = frappe.new_doc("BEI Vehicle")
 		vehicle_doc.naming_series = "BEI-VEH-.####"
 		vehicle_doc.vehicle_plate = vehicle_plate
-		vehicle_doc.vehicle_type = _normalize_vehicle_type(vehicle_type, vehicle_label)
+		vehicle_doc.vehicle_type = _infer_vehicle_type(vehicle_label)
 		vehicle_doc.owner_type = "3PL"
-		if _has_column("BEI Vehicle", "threepl_partner") and threepl_partner:
-			vehicle_doc.threepl_partner = _resolve_threepl_partner_link(threepl_partner)
 		vehicle_doc.status = "Available"
 		if hasattr(vehicle_doc, "notes"):
 			vehicle_doc.notes = vehicle_label or vehicle_plate
@@ -217,35 +172,6 @@ def _get_employee_phone(record: Any) -> str:
 	if not phone_field:
 		return ""
 	return str(_get_record_value(record, phone_field) or "")
-
-
-def _get_vehicle_type_map(vehicle_names: list[str] | tuple[str, ...]) -> dict[str, str]:
-	"""Resolve BEI Vehicle.type in bulk for trip cards and detail panels."""
-	names = sorted({name for name in vehicle_names if name})
-	if not names:
-		return {}
-
-	rows = frappe.get_all(
-		"BEI Vehicle",
-		filters={"name": ["in", names]},
-		fields=["name", "vehicle_type"],
-		limit_page_length=max(20, len(names)),
-	)
-	return {str(row.name): str(row.vehicle_type or "") for row in rows}
-
-
-def _append_route_audit_comment(route: Any, action: str, details: str | None = None) -> None:
-	"""Append a timeline note so route changes are traceable outside field diffs."""
-	try:
-		message = f"Dispatch route {action} by {frappe.session.user}"
-		if details:
-			message = f"{message}. {details}"
-		route.add_comment("Comment", text=message)
-	except Exception:
-		frappe.log_error(
-			title="Route Audit Comment Failed",
-			message=f"route={getattr(route, 'name', '')!r} action={action!r}",
-		)
 
 
 @frappe.whitelist()
@@ -280,8 +206,6 @@ def get_trips(date: str | None = None, status: str | None = None):
 		order_by="creation",
 	)
 
-	vehicle_types = _get_vehicle_type_map([str(trip.get("vehicle") or "") for trip in trips])
-
 	# Get stop counts and delivery progress
 	for trip in trips:
 		stops = frappe.get_all("BEI Trip Stop", filters={"parent": trip.name}, fields=["status"])
@@ -290,7 +214,6 @@ def get_trips(date: str | None = None, status: str | None = None):
 		trip["driver_display"] = (
 			trip.get("driver_name") or trip.get("threepl_driver_name") or trip.get("driver") or ""
 		)
-		trip["vehicle_type"] = vehicle_types.get(str(trip.get("vehicle") or ""), "")
 
 	return {"trips": trips}
 
@@ -302,9 +225,6 @@ def get_trip_detail(trip_name: str):
 
 	trip = frappe.get_doc("BEI Distribution Trip", trip_name)
 	driver_name = getattr(trip, "driver_name", "") or getattr(trip, "threepl_driver_name", "") or ""
-	vehicle_type = ""
-	if getattr(trip, "vehicle", None):
-		vehicle_type = str(frappe.db.get_value("BEI Vehicle", trip.vehicle, "vehicle_type") or "")
 
 	return {
 		"trip": {
@@ -316,7 +236,6 @@ def get_trip_detail(trip_name: str):
 			"threepl_driver_name": getattr(trip, "threepl_driver_name", ""),
 			"vehicle": trip.vehicle,
 			"vehicle_plate": trip.vehicle_plate,
-			"vehicle_type": vehicle_type,
 			"status": trip.status,
 			"departure_time": trip.departure_time,
 			"departure_temp": trip.departure_temp,
@@ -1197,11 +1116,11 @@ def _send_delivery_notification(driver: str, store: str, eta_range: str):
 	G-003: Routes to per-store Chat space first, falls back to global.
 	MUST NOT block delivery confirmation if it fails.
 	"""
-	from hrms.api.google_chat import send_message_to_space
+	from hrms.api.google_chat import resolve_store_chat_space, send_message_to_space
 	from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
 
 	# G-003: Try per-store Chat space first, fall back to global
-	store_space = frappe.db.get_value("Warehouse", store, "custom_gchat_space")
+	store_space = resolve_store_chat_space(store)
 	space = store_space or get_chat_space(SPACE_NOTIFICATIONS)
 
 	message = (
@@ -1447,7 +1366,7 @@ def create_route(
 	notes: str | None = None,
 ):
 	"""Create a new route master."""
-	_check_scm_permission(SCM_ROUTE_MANAGEMENT_ROLES, "create routes")
+	_check_scm_permission(SCM_ADMIN_ROLES, "create routes")
 
 	if isinstance(stops, str):
 		stops = frappe.parse_json(stops)
@@ -1476,24 +1395,18 @@ def create_route(
 
 	_enable_role_gated_write(route)
 	route.insert(ignore_permissions=True)
-	_append_route_audit_comment(
-		route,
-		"created",
-		f"Cargo={cargo_type}; source={source_warehouse}; stops={len(stops or [])}",
-	)
 	return {"success": True, "route": route.name}
 
 
 @frappe.whitelist()
 def update_route(route_name: str, updates: dict[str, Any] | str | None = None):
 	"""Update a route master. Accepts partial updates."""
-	_check_scm_permission(SCM_ROUTE_MANAGEMENT_ROLES, "update routes")
+	_check_scm_permission(SCM_ADMIN_ROLES, "update routes")
 
 	if isinstance(updates, str):
 		updates = frappe.parse_json(updates)
 
 	route = frappe.get_doc("BEI Route", route_name)
-	changed_fields: list[str] = []
 
 	simple_fields = [
 		"route_name",
@@ -1508,7 +1421,6 @@ def update_route(route_name: str, updates: dict[str, Any] | str | None = None):
 	for field in simple_fields:
 		if field in updates:
 			setattr(route, field, updates[field])
-			changed_fields.append(field)
 
 	if "stops" in updates:
 		route.stops = []
@@ -1523,81 +1435,22 @@ def update_route(route_name: str, updates: dict[str, Any] | str | None = None):
 					"mall_permit_required": stop_data.get("mall_permit_required", 0),
 				},
 			)
-		changed_fields.append(f"stops({len(updates['stops'])})")
 
 	_enable_role_gated_write(route)
 	route.save(ignore_permissions=True)
-	_append_route_audit_comment(
-		route,
-		"updated",
-		f"Changed: {', '.join(changed_fields) if changed_fields else 'no-op save'}",
-	)
 	return {"success": True, "route": route.name}
 
 
 @frappe.whitelist()
 def delete_route(route_name: str):
 	"""Soft-delete a route (set active=0)."""
-	_check_scm_permission(SCM_ROUTE_MANAGEMENT_ROLES, "delete routes")
+	_check_scm_permission(SCM_ADMIN_ROLES, "delete routes")
 
 	route = frappe.get_doc("BEI Route", route_name)
 	route.active = 0
 	_enable_role_gated_write(route)
 	route.save(ignore_permissions=True)
-	_append_route_audit_comment(route, "deactivated")
 	return {"success": True, "message": f"Route {route_name} deactivated"}
-
-
-@frappe.whitelist()
-def create_vehicle(
-	vehicle_plate: str,
-	vehicle_type: str | None = None,
-	owner_type: str | None = "3PL",
-	threepl_partner: str | None = None,
-	notes: str | None = None,
-):
-	"""Create or reuse a BEI Vehicle master for logistics onboarding."""
-	_check_scm_permission(SCM_ROUTE_MANAGEMENT_ROLES, "create vehicles")
-
-	vehicle_plate = (vehicle_plate or "").strip()
-	if not vehicle_plate:
-		frappe.throw(_("Vehicle plate is required"))
-
-	existing = frappe.db.get_value(
-		"BEI Vehicle",
-		{"vehicle_plate": vehicle_plate},
-		["name", "vehicle_plate", "vehicle_type", "owner_type", "threepl_partner", "status"],
-		as_dict=True,
-	)
-	if existing:
-		return {"success": True, "created": False, "vehicle": existing}
-
-	vehicle_doc = frappe.new_doc("BEI Vehicle")
-	vehicle_doc.naming_series = "BEI-VEH-.####"
-	vehicle_doc.vehicle_plate = vehicle_plate
-	vehicle_doc.vehicle_type = _normalize_vehicle_type(vehicle_type, notes or vehicle_plate)
-	vehicle_doc.owner_type = owner_type or "3PL"
-	if _has_column("BEI Vehicle", "threepl_partner") and threepl_partner:
-		vehicle_doc.threepl_partner = _resolve_threepl_partner_link(threepl_partner)
-	vehicle_doc.status = "Available"
-	if hasattr(vehicle_doc, "notes") and notes:
-		vehicle_doc.notes = notes
-	_enable_role_gated_write(vehicle_doc)
-	vehicle_doc.insert(ignore_permissions=True)
-	if hasattr(vehicle_doc, "add_comment"):
-		vehicle_doc.add_comment("Comment", text=f"Vehicle onboarded by {frappe.session.user}")
-	return {
-		"success": True,
-		"created": True,
-		"vehicle": {
-			"name": vehicle_doc.name,
-			"vehicle_plate": vehicle_doc.vehicle_plate,
-			"vehicle_type": vehicle_doc.vehicle_type,
-			"owner_type": vehicle_doc.owner_type,
-			"threepl_partner": getattr(vehicle_doc, "threepl_partner", "") or "",
-			"status": vehicle_doc.status,
-		},
-	}
 
 
 @frappe.whitelist()
@@ -1754,48 +1607,12 @@ def preview_trip_stops(route_name: str, trip_date: str | None = None):
 	)
 	_check_scm_permission(SCM_DISPATCH_ROLES, "preview trip stops")
 	route = frappe.get_doc("BEI Route", route_name)
-	trip_route_name = route.route_name or route_name
 
 	if not route.active:
 		frappe.throw(_("Route is not active"))
 
 	stops = _build_stop_preview(route, trip_date)
-	return {"route_name": trip_route_name, "trip_date": trip_date, "stops": stops}
-
-
-def _duplicate_trip_response(route_name: str, trip_date: str, existing_trip: str):
-	return {
-		"success": False,
-		"code": "TRIP_ALREADY_EXISTS",
-		"error_code": "TRIP_ALREADY_EXISTS",
-		"trip": existing_trip,
-		"existing_trip": existing_trip,
-		"trip_name": existing_trip,
-		"route_name": route_name,
-		"trip_date": trip_date,
-		"message": _("A trip already exists for route '{0}' on {1}: {2}").format(
-			route_name, trip_date, existing_trip
-		),
-	}
-
-
-def _is_duplicate_trip_insert_error(exc: Exception) -> bool:
-	duplicate_types: list[type[Exception]] = []
-	for candidate in (
-		getattr(frappe, "DuplicateEntryError", None),
-		getattr(getattr(frappe, "exceptions", None), "DuplicateEntryError", None),
-	):
-		if isinstance(candidate, type) and issubclass(candidate, Exception):
-			duplicate_types.append(candidate)
-
-	if duplicate_types and isinstance(exc, tuple(duplicate_types)):
-		return True
-
-	if exc.__class__.__name__ == "DuplicateEntryError":
-		return True
-
-	message = str(exc).lower()
-	return "trip already exists" in message or ("duplicate" in message and "route" in message)
+	return {"route_name": route_name, "trip_date": trip_date, "stops": stops}
 
 
 @frappe.whitelist()
@@ -1805,10 +1622,6 @@ def create_trip_from_route(
 	vehicle: str | None = None,
 	driver: str | None = None,
 	threepl_driver_name: str | None = None,
-	vehicle_plate: str | None = None,
-	vehicle_type: str | None = None,
-	vehicle_label: str | None = None,
-	threepl_partner: str | None = None,
 	selected_stops: list[dict[str, Any]] | str | None = None,
 ):
 	"""One-click trip creation from a route template.
@@ -1837,31 +1650,28 @@ def create_trip_from_route(
 	_check_scm_permission(SCM_DISPATCH_ROLES, "create trips from routes")
 
 	route = frappe.get_doc("BEI Route", route_name)
-	trip_route_name = route.route_name or route_name
 
 	if not route.active:
 		frappe.throw(_("Route is not active"))
 
 	# G-069: UX pre-check for duplicate trip (DB constraint is the real guard)
 	existing_trip = frappe.db.get_value(
-		"BEI Distribution Trip", {"route_name": trip_route_name, "trip_date": trip_date}, "name"
+		"BEI Distribution Trip", {"route_name": route_name, "trip_date": trip_date}, "name"
 	)
 	if existing_trip:
-		return _duplicate_trip_response(trip_route_name, trip_date, existing_trip)
-
-	# Resolve vehicle details. Logistics can either pick an existing master or
-	# onboard a new 3PL vehicle inline by plate before creating the trip.
-	resolved_vehicle = vehicle or route.default_vehicle or ""
-	resolved_vehicle_plate = None
-	if resolved_vehicle:
-		resolved_vehicle_plate = frappe.db.get_value("BEI Vehicle", resolved_vehicle, "vehicle_plate")
-	elif vehicle_plate:
-		resolved_vehicle, resolved_vehicle_plate = _resolve_or_create_departure_vehicle(
-			vehicle_label or threepl_partner or vehicle_type or vehicle_plate,
-			vehicle_plate,
-			vehicle_type=vehicle_type,
-			threepl_partner=threepl_partner,
+		frappe.throw(
+			_("A trip already exists for route '{0}' on {1}: {2}").format(
+				route_name, trip_date, existing_trip
+			)
 		)
+
+	# Resolve vehicle details
+	vehicle_plate = None
+	if vehicle:
+		vehicle_plate = frappe.db.get_value("BEI Vehicle", vehicle, "vehicle_plate")
+	elif route.default_vehicle:
+		vehicle = route.default_vehicle
+		vehicle_plate = frappe.db.get_value("BEI Vehicle", route.default_vehicle, "vehicle_plate")
 
 	if isinstance(selected_stops, str):
 		selected_stops = frappe.parse_json(selected_stops)
@@ -1920,8 +1730,8 @@ def create_trip_from_route(
 	trip = _build_trip_doc(trip_date, route.route_name, stops)
 	trip.route = route.name
 	trip.driver = driver or route.default_driver
-	trip.vehicle = resolved_vehicle
-	trip.vehicle_plate = resolved_vehicle_plate
+	trip.vehicle = vehicle
+	trip.vehicle_plate = vehicle_plate
 	trip.cargo_type = route.cargo_type
 
 	if trip.driver:
@@ -1930,8 +1740,6 @@ def create_trip_from_route(
 	is_threepl_vehicle = bool(trip.vehicle) and (
 		frappe.db.get_value("BEI Vehicle", trip.vehicle, "owner_type") == "3PL"
 	)
-	if not is_threepl_vehicle and threepl_partner:
-		is_threepl_vehicle = True
 	external_driver = (threepl_driver_name or "").strip()
 	if is_threepl_vehicle and external_driver:
 		trip.driver = ""
@@ -1946,17 +1754,7 @@ def create_trip_from_route(
 			trip.stops[idx].store_order = stop_data["store_order"]
 
 	_enable_role_gated_write(trip)
-	try:
-		trip.insert(ignore_permissions=True)
-	except Exception as exc:
-		if not _is_duplicate_trip_insert_error(exc):
-			raise
-		existing_trip = frappe.db.get_value(
-			"BEI Distribution Trip", {"route_name": trip_route_name, "trip_date": trip_date}, "name"
-		)
-		if existing_trip:
-			return _duplicate_trip_response(trip_route_name, trip_date, existing_trip)
-		raise exc
+	trip.insert(ignore_permissions=True)
 
 	return {
 		"success": True,
@@ -1968,7 +1766,7 @@ def create_trip_from_route(
 @frappe.whitelist()
 def duplicate_route(route_name: str, new_name: str):
 	"""Clone a route with a new name."""
-	_check_scm_permission(SCM_ROUTE_MANAGEMENT_ROLES, "duplicate routes")
+	_check_scm_permission(SCM_ADMIN_ROLES, "duplicate routes")
 
 	source = frappe.get_doc("BEI Route", route_name)
 
@@ -1996,18 +1794,13 @@ def duplicate_route(route_name: str, new_name: str):
 
 	_enable_role_gated_write(new_route)
 	new_route.insert(ignore_permissions=True)
-	_append_route_audit_comment(
-		new_route,
-		"duplicated",
-		f"Copied from {route_name}",
-	)
 	return {"success": True, "route": new_route.name}
 
 
 @frappe.whitelist()
 def reorder_stops(route_name: str, stop_order_map: dict[str, int] | str):
 	"""Reorder stops in a route. stop_order_map: {store: new_order}"""
-	_check_scm_permission(SCM_ROUTE_MANAGEMENT_ROLES, "reorder stops")
+	_check_scm_permission(SCM_ADMIN_ROLES, "reorder stops")
 
 	if isinstance(stop_order_map, str):
 		stop_order_map = frappe.parse_json(stop_order_map)
@@ -2026,7 +1819,6 @@ def reorder_stops(route_name: str, stop_order_map: dict[str, int] | str):
 
 	_enable_role_gated_write(route)
 	route.save(ignore_permissions=True)
-	_append_route_audit_comment(route, "reordered stops", f"Stops={len(route.stops)}")
 	return {"success": True, "route": route.name}
 
 
@@ -2061,23 +1853,6 @@ def get_driver_list():
 # ============================================================================
 
 DRIVER_DESIGNATIONS = ["Driver", "Helper", "Relief Driver", "Delivery Driver", "Truck Driver"]
-_NORMALIZED_DRIVER_DESIGNATIONS = {
-	"driver",
-	"helper",
-	"relief driver",
-	"delivery driver",
-	"truck driver",
-	"executive driver",
-}
-
-
-def _normalize_driver_designation(value: str | None) -> str:
-	return " ".join(str(value or "").strip().lower().split())
-
-
-def _is_driver_designation(value: str | None) -> bool:
-	normalized = _normalize_driver_designation(value)
-	return normalized in _NORMALIZED_DRIVER_DESIGNATIONS or normalized.endswith(" driver")
 
 
 @frappe.whitelist()
@@ -2112,16 +1887,13 @@ def get_available_drivers(date: str | None = None):
 	if phone_field:
 		driver_fields.append(phone_field)
 
-	# Designation labels are not normalized consistently in live data
-	# (for example DRIVER vs Driver vs Executive Driver), so filter in
-	# Python after loading active employees.
+	# All active employees with driver designations
 	all_drivers = frappe.get_all(
 		"Employee",
-		filters={"status": "Active"},
+		filters={"status": "Active", "designation": ["in", DRIVER_DESIGNATIONS]},
 		fields=driver_fields,
 		order_by="employee_name",
 	)
-	all_drivers = [driver for driver in all_drivers if _is_driver_designation(driver.designation)]
 
 	# Build a map of employee -> trip for the date
 	trips_on_date = frappe.get_all(

--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -120,7 +120,9 @@ def _resolve_or_create_departure_vehicle(
 	if vehicle_label:
 		existing_name = frappe.db.get_value("BEI Vehicle", vehicle_label, "name")
 		if existing_name:
-			existing_plate = frappe.db.get_value("BEI Vehicle", existing_name, "vehicle_plate") or vehicle_plate
+			existing_plate = (
+				frappe.db.get_value("BEI Vehicle", existing_name, "vehicle_plate") or vehicle_plate
+			)
 			return str(existing_name), str(existing_plate or "")
 
 	if vehicle_plate:

--- a/hrms/api/enrichment.py
+++ b/hrms/api/enrichment.py
@@ -933,12 +933,12 @@ def queue_enrichment_reminders(
 	"""Queue enrichment reminders with direct-call fallback."""
 	try:
 		frappe.enqueue(
-			"hrms.api.enrichment.send_enrichment_reminders",
+			"hrms.api.enrichment.send_enrichment_reminders_job",
 			queue="short",
 			employees=employees,
 			branch=branch,
 			status_filter=status_filter,
-			method=method,
+			channel=method,
 			enqueue_after_commit=True,
 		)
 		return {
@@ -960,6 +960,21 @@ def queue_enrichment_reminders(
 		result["status"] = "queued_fallback"
 		result["mode"] = "sync_fallback"
 		return result
+
+
+def send_enrichment_reminders_job(
+	employees: list | None = None,
+	branch: str | None = None,
+	status_filter: str | None = None,
+	channel: str = "email",
+):
+	"""Queue-safe wrapper so Frappe's reserved `method` kwarg is not reused."""
+	return send_enrichment_reminders(
+		employees=employees,
+		branch=branch,
+		status_filter=status_filter,
+		method=channel,
+	)
 
 
 @frappe.whitelist()

--- a/hrms/api/google_chat.py
+++ b/hrms/api/google_chat.py
@@ -199,6 +199,7 @@ def _send_message_to_space_internal(
 	*,
 	family: str | None = None,
 	context: str = "hrms.api.google_chat.send_message_to_space",
+	bypass_lockdown: bool = False,
 ) -> dict[str, object]:
 	"""Low-level Google Chat transport with optional family-aware routing."""
 	logger = frappe.logger("google_chat")
@@ -217,11 +218,15 @@ def _send_message_to_space_internal(
 		from hrms.utils.bei_config import get_service_account_path
 
 		cred_path = get_service_account_path()
-		target_space = route_outbound_chat_space(
-			space_name,
-			logger=logger,
-			context=context,
-			family=family,
+		target_space = (
+			space_name
+			if bypass_lockdown
+			else route_outbound_chat_space(
+				space_name,
+				logger=logger,
+				context=context,
+				family=family,
+			)
 		)
 
 		if not os.path.exists(cred_path):
@@ -274,7 +279,7 @@ def send_message_to_space(space_name: str, message: str) -> bool:
 	return bool(result.get("success"))
 
 
-def send_notification_to_user(
+def _create_pwa_notification(
 	user: str,
 	message: str,
 	reference_document_type: str = "User",
@@ -308,6 +313,76 @@ def send_notification_to_user(
 		return {"success": False, "sent": False, "reason": "insert_failed", "error": str(exc)}
 
 
+def _normalize_direct_message_user(user_identifier: str | None) -> str | None:
+	value = str(user_identifier or "").strip()
+	if not value:
+		return None
+	if value.startswith("users/"):
+		return value
+	return f"users/{value}"
+
+
+def find_direct_message_space(user_identifier: str | None) -> str | None:
+	"""Resolve an existing Google Chat direct-message space for the given user."""
+	logger = frappe.logger("google_chat")
+	normalized_user = _normalize_direct_message_user(user_identifier)
+	if not normalized_user:
+		return None
+
+	try:
+		from google.oauth2 import service_account
+		from googleapiclient.discovery import build
+	except ImportError:
+		logger.warning("google-auth package not installed — direct-message lookup skipped")
+		return None
+
+	try:
+		from hrms.utils.bei_config import get_service_account_path
+
+		cred_path = get_service_account_path()
+		if not os.path.exists(cred_path):
+			logger.warning("find_direct_message_space: service account file missing at %s", cred_path)
+			return None
+
+		creds = service_account.Credentials.from_service_account_file(
+			cred_path,
+			scopes=["https://www.googleapis.com/auth/chat.bot"],
+		)
+		chat = build("chat", "v1", credentials=creds)
+		result = chat.spaces().findDirectMessage(name=normalized_user).execute()
+		space_name = result.get("name")
+		if space_name:
+			return space_name
+	except Exception as exc:
+		logger.warning("find_direct_message_space failed for %s: %s", normalized_user, exc)
+	return None
+
+
+def send_message_to_user_direct(
+	user_identifier: str | None,
+	message: str,
+	*,
+	family: str | None = None,
+	context: str = "hrms.api.google_chat.send_message_to_user_direct",
+) -> dict[str, object]:
+	"""Send a bot-authored message to a user's existing Google Chat direct message space."""
+	space_name = find_direct_message_space(user_identifier)
+	if not space_name:
+		return {
+			"success": False,
+			"sent": False,
+			"reason": "direct_message_not_found",
+			"user_identifier": user_identifier,
+		}
+	return _send_message_to_space_internal(
+		space_name,
+		message,
+		family=family,
+		context=context,
+		bypass_lockdown=True,
+	)
+
+
 def send_notification_to_user(
 	user_identifier: str | None,
 	message: str,
@@ -329,14 +404,41 @@ def send_notification_to_user(
 			context=context,
 		)
 		if not result.get("success"):
+			fallback_result = _create_pwa_notification(
+				normalized_user,
+				message,
+				reference_document_name=normalized_user,
+			)
+			if fallback_result.get("success"):
+				logger.info(
+					"send_notification_to_user fell back to PWA notification for %s",
+					normalized_user,
+				)
+				return True
 			logger.warning(
-				"send_notification_to_user skipped for %s reason=%s",
+				"send_notification_to_user skipped for %s reason=%s fallback=%s",
 				normalized_user,
 				result.get("reason", "unknown"),
+				fallback_result.get("reason", "unknown"),
 			)
-		return bool(result.get("success"))
+			return False
+		return True
 	except Exception as exc:
 		logger.warning("send_notification_to_user failed for %s: %s", normalized_user, exc)
+		try:
+			fallback_result = _create_pwa_notification(
+				normalized_user,
+				message,
+				reference_document_name=normalized_user,
+			)
+			if fallback_result.get("success"):
+				logger.info(
+					"send_notification_to_user recovered with PWA notification for %s",
+					normalized_user,
+				)
+				return True
+		except Exception:
+			pass
 		try:
 			frappe.log_error(
 				title="Google Chat User Notification Error",

--- a/hrms/api/google_chat.py
+++ b/hrms/api/google_chat.py
@@ -175,13 +175,30 @@ def _truthy(value: object) -> bool:
 	return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _has_warehouse_chat_space_column() -> bool:
+	try:
+		return bool(frappe.db.has_column("Warehouse", "custom_gchat_space"))
+	except Exception:
+		return False
+
+
+def resolve_store_chat_space(store_warehouse: str | None) -> str | None:
+	"""Resolve a store Warehouse chat space safely across schema revisions."""
+	store_warehouse = str(store_warehouse or "").strip()
+	if not store_warehouse or not _has_warehouse_chat_space_column():
+		return None
+	try:
+		return frappe.db.get_value("Warehouse", store_warehouse, "custom_gchat_space") or None
+	except Exception:
+		return None
+
+
 def _send_message_to_space_internal(
 	space_name: str,
 	message: str,
 	*,
 	family: str | None = None,
 	context: str = "hrms.api.google_chat.send_message_to_space",
-	bypass_lockdown: bool = False,
 ) -> dict[str, object]:
 	"""Low-level Google Chat transport with optional family-aware routing."""
 	logger = frappe.logger("google_chat")
@@ -200,15 +217,11 @@ def _send_message_to_space_internal(
 		from hrms.utils.bei_config import get_service_account_path
 
 		cred_path = get_service_account_path()
-		target_space = (
-			space_name
-			if bypass_lockdown
-			else route_outbound_chat_space(
-				space_name,
-				logger=logger,
-				context=context,
-				family=family,
-			)
+		target_space = route_outbound_chat_space(
+			space_name,
+			logger=logger,
+			context=context,
+			family=family,
 		)
 
 		if not os.path.exists(cred_path):
@@ -261,74 +274,38 @@ def send_message_to_space(space_name: str, message: str) -> bool:
 	return bool(result.get("success"))
 
 
-def _normalize_direct_message_user(user_identifier: str | None) -> str | None:
-	value = str(user_identifier or "").strip()
-	if not value:
-		return None
-	if value.startswith("users/"):
-		return value
-	return f"users/{value}"
-
-
-def find_direct_message_space(user_identifier: str | None) -> str | None:
-	"""Resolve an existing Google Chat direct-message space for the given user."""
-	logger = frappe.logger("google_chat")
-	normalized_user = _normalize_direct_message_user(user_identifier)
-	if not normalized_user:
-		return None
-
-	try:
-		from google.oauth2 import service_account
-		from googleapiclient.discovery import build
-	except ImportError:
-		logger.warning("google-auth package not installed — direct-message lookup skipped")
-		return None
-
-	try:
-		from hrms.utils.bei_config import get_service_account_path
-
-		cred_path = get_service_account_path()
-		if not os.path.exists(cred_path):
-			logger.warning("find_direct_message_space: service account file missing at %s", cred_path)
-			return None
-
-		creds = service_account.Credentials.from_service_account_file(
-			cred_path,
-			scopes=["https://www.googleapis.com/auth/chat.bot"],
-		)
-		chat = build("chat", "v1", credentials=creds)
-		result = chat.spaces().findDirectMessage(name=normalized_user).execute()
-		space_name = result.get("name")
-		if space_name:
-			return space_name
-	except Exception as exc:
-		logger.warning("find_direct_message_space failed for %s: %s", normalized_user, exc)
-	return None
-
-
-def send_message_to_user_direct(
-	user_identifier: str | None,
+def send_notification_to_user(
+	user: str,
 	message: str,
-	*,
-	family: str | None = None,
-	context: str = "hrms.api.google_chat.send_message_to_user_direct",
+	reference_document_type: str = "User",
+	reference_document_name: str | None = None,
+	from_user: str | None = None,
 ) -> dict[str, object]:
-	"""Send a bot-authored message to a user's existing Google Chat direct message space."""
-	space_name = find_direct_message_space(user_identifier)
-	if not space_name:
+	"""Best-effort in-app user notification used by legacy finance/procurement flows."""
+	target_user = str(user or "").strip()
+	if not target_user or target_user == "Guest":
+		return {"success": False, "sent": False, "reason": "missing_user"}
+
+	try:
+		notification = frappe.new_doc("PWA Notification")
+		notification.to_user = target_user
+		notification.from_user = from_user or frappe.session.user
+		notification.message = str(message or "").strip()
+		notification.reference_document_type = reference_document_type
+		notification.reference_document_name = reference_document_name or target_user
+		notification.insert(ignore_permissions=True)
 		return {
-			"success": False,
-			"sent": False,
-			"reason": "direct_message_not_found",
-			"user_identifier": user_identifier,
+			"success": True,
+			"sent": True,
+			"channel": "pwa_notification",
+			"notification": notification.name,
 		}
-	return _send_message_to_space_internal(
-		space_name,
-		message,
-		family=family,
-		context=context,
-		bypass_lockdown=True,
-	)
+	except Exception as exc:
+		frappe.log_error(
+			title="User Notification Error",
+			message=f"user={target_user}, error={str(exc)[:300]}",
+		)
+		return {"success": False, "sent": False, "reason": "insert_failed", "error": str(exc)}
 
 
 def send_notification_to_user(
@@ -892,7 +869,7 @@ def on_store_order_update(doc, method=None):
 		space = None
 		store_warehouse = getattr(doc, "warehouse", None) or getattr(doc, "store_warehouse", None)
 		if store_warehouse:
-			space = frappe.db.get_value("Warehouse", store_warehouse, "custom_gchat_space")
+			space = resolve_store_chat_space(store_warehouse)
 
 		if not space:
 			from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space

--- a/hrms/api/marketing_giveaways.py
+++ b/hrms/api/marketing_giveaways.py
@@ -34,7 +34,13 @@ APPROVED_STATES = {"Approved / Active", "Partially Fulfilled"}
 OPS_REVIEW_ROLES = {"Area Supervisor", "Supply Chain Manager", "HQ User", "System Manager", "Administrator"}
 FINANCE_REVIEW_ROLES = {"HQ Finance", "Accounts Manager", "HQ User", "System Manager", "Administrator"}
 REQUEST_ROLES = {"Marketing User", "Marketing Manager", "HQ User", "System Manager", "Administrator"}
-FULFILLMENT_ROLES = {"Store Supervisor", "Area Supervisor", "Supply Chain Manager", "System Manager", "Administrator"}
+FULFILLMENT_ROLES = {
+	"Store Supervisor",
+	"Area Supervisor",
+	"Supply Chain Manager",
+	"System Manager",
+	"Administrator",
+}
 EXCEPTION_ROLES = {
 	"HQ Finance",
 	"Accounts Manager",
@@ -127,7 +133,7 @@ def _capture(
 def _safe_json(value: Any, default: Any):
 	if value in (None, ""):
 		return default
-	if isinstance(value, (dict, list)):
+	if isinstance(value, dict | list):
 		return value
 	try:
 		return json.loads(value)
@@ -159,7 +165,9 @@ def _finished_goods_item(item_code: str) -> dict[str, Any]:
 		frappe.throw(_("Item {0} does not exist.").format(item_code))
 
 	item_group = str(item.get("item_group") or "").strip()
-	is_finished_goods = item_group in FINISHED_GOODS_ITEM_GROUPS or str(item.get("name") or "").upper().startswith("FG")
+	is_finished_goods = item_group in FINISHED_GOODS_ITEM_GROUPS or str(
+		item.get("name") or ""
+	).upper().startswith("FG")
 	if cint(item.get("disabled") or 0):
 		frappe.throw(_("Item {0} is disabled.").format(item_code))
 	if not cint(item.get("is_stock_item") or 0):
@@ -216,7 +224,9 @@ def _require_assigned_reviewer(campaign_doc, action: str) -> None:
 	queue_name = str(campaign_doc.active_queue_name or "").strip()
 	if not queue_name or not frappe.db.exists("BEI Approval Queue", queue_name):
 		return
-	assigned_approver = str(frappe.db.get_value("BEI Approval Queue", queue_name, "assigned_approver") or "").strip()
+	assigned_approver = str(
+		frappe.db.get_value("BEI Approval Queue", queue_name, "assigned_approver") or ""
+	).strip()
 	if assigned_approver and assigned_approver != frappe.session.user:
 		_capture(
 			action,
@@ -232,15 +242,21 @@ def _require_assigned_reviewer(campaign_doc, action: str) -> None:
 		frappe.throw(_("This review step is assigned to another approver."), _permission_error_class())
 
 
-def _validate_campaign_payload(payload: dict[str, Any], *, existing_name: str | None = None) -> dict[str, Any]:
+def _validate_campaign_payload(
+	payload: dict[str, Any], *, existing_name: str | None = None
+) -> dict[str, Any]:
 	data = dict(payload or {})
 	existing = None
 	if existing_name:
 		existing = _campaign_doc(existing_name)
 		_require_request_owner(existing, "save_campaign_giveaway")
 
-	data["requester_user"] = str(existing.requester_user if existing and existing.requester_user else frappe.session.user).strip()
-	data["owning_department"] = _require_master_record("Department", data.get("owning_department") or "Marketing", "Department")
+	data["requester_user"] = str(
+		existing.requester_user if existing and existing.requester_user else frappe.session.user
+	).strip()
+	data["owning_department"] = _require_master_record(
+		"Department", data.get("owning_department") or "Marketing", "Department"
+	)
 	data["budget_owner"] = _require_master_record(
 		"User",
 		data.get("budget_owner"),
@@ -256,7 +272,9 @@ def _validate_campaign_payload(payload: dict[str, Any], *, existing_name: str | 
 		allow_blank=True,
 	)
 
-	source_locations = _normalize_list(data.get("source_locations") or data.get("source_locations_json") or [])
+	source_locations = _normalize_list(
+		data.get("source_locations") or data.get("source_locations_json") or []
+	)
 	if not source_locations:
 		frappe.throw(_("At least one approved source location is required."))
 	for source_location in source_locations:
@@ -276,7 +294,9 @@ def _validate_campaign_payload(payload: dict[str, Any], *, existing_name: str | 
 		approved_quantity = flt(raw_item.get("approved_quantity") or 0, 3)
 		if approved_quantity <= 0:
 			frappe.throw(_("Approved quantity for {0} must be greater than 0.").format(item_code))
-		if source_locations and not any(_source_supports_item(source_location, item_code) for source_location in source_locations):
+		if source_locations and not any(
+			_source_supports_item(source_location, item_code) for source_location in source_locations
+		):
 			frappe.throw(_("Item {0} is not stocked in any approved source location.").format(item_code))
 		normalized_items.append(
 			{
@@ -294,7 +314,9 @@ def _validate_campaign_payload(payload: dict[str, Any], *, existing_name: str | 
 	schedule_rows = data.get("schedule_rows") or data.get("schedule_json") or []
 	normalized_schedule: list[dict[str, Any]] = []
 	approved_item_codes = {row["item_code"] for row in normalized_items}
-	approved_qty_by_item = {row["item_code"]: flt(row["approved_quantity"] or 0, 3) for row in normalized_items}
+	approved_qty_by_item = {
+		row["item_code"]: flt(row["approved_quantity"] or 0, 3) for row in normalized_items
+	}
 	start_date = getdate(data.get("start_date")) if data.get("start_date") else None
 	end_date = getdate(data.get("end_date")) if data.get("end_date") else None
 	for row in schedule_rows if isinstance(schedule_rows, list) else []:
@@ -307,9 +329,13 @@ def _validate_campaign_payload(payload: dict[str, Any], *, existing_name: str | 
 		if not row_date or not item_code or not source_location or quantity <= 0:
 			continue
 		if item_code not in approved_item_codes:
-			frappe.throw(_("Schedule row item {0} is not in the approved campaign item list.").format(item_code))
+			frappe.throw(
+				_("Schedule row item {0} is not in the approved campaign item list.").format(item_code)
+			)
 		if source_location not in source_locations:
-			frappe.throw(_("Schedule row source {0} is not in the approved source list.").format(source_location))
+			frappe.throw(
+				_("Schedule row source {0} is not in the approved source list.").format(source_location)
+			)
 		if start_date and end_date:
 			schedule_day = getdate(row_date[:10])
 			if schedule_day < start_date or schedule_day > end_date:
@@ -326,7 +352,9 @@ def _validate_campaign_payload(payload: dict[str, Any], *, existing_name: str | 
 		scheduled_qty_by_item: dict[str, float] = {}
 		for row in normalized_schedule:
 			item_code = row["item_code"]
-			scheduled_qty_by_item[item_code] = scheduled_qty_by_item.get(item_code, 0.0) + flt(row["quantity"] or 0, 3)
+			scheduled_qty_by_item[item_code] = scheduled_qty_by_item.get(item_code, 0.0) + flt(
+				row["quantity"] or 0, 3
+			)
 		for item_code, scheduled_qty in scheduled_qty_by_item.items():
 			if scheduled_qty > flt(approved_qty_by_item.get(item_code) or 0, 3):
 				frappe.throw(_("Scheduled quantity for {0} exceeds the approved quantity.").format(item_code))
@@ -392,11 +420,14 @@ def _resolve_marketing_expense_account(company: str | None = None) -> str:
 	if account:
 		return account
 	like_name = f"{DEFAULT_EXPENSE_ACCOUNT_NUMBER} - {DEFAULT_EXPENSE_ACCOUNT_NAME}%"
-	return frappe.db.get_value(
-		"Account",
-		{"company": company_name, "name": ["like", like_name], "is_group": 0},
-		"name",
-	) or f"{DEFAULT_EXPENSE_ACCOUNT_NUMBER} - {DEFAULT_EXPENSE_ACCOUNT_NAME} - {company_name}"
+	return (
+		frappe.db.get_value(
+			"Account",
+			{"company": company_name, "name": ["like", like_name], "is_group": 0},
+			"name",
+		)
+		or f"{DEFAULT_EXPENSE_ACCOUNT_NUMBER} - {DEFAULT_EXPENSE_ACCOUNT_NAME} - {company_name}"
+	)
 
 
 def _resolve_item_cost(item_code: str) -> float:
@@ -479,9 +510,7 @@ def _update_campaign_tracking(campaign) -> float:
 	else:
 		campaign.remaining_days = 0
 	campaign.required_daily_pace = (
-		round(campaign.remaining_quantity / campaign.remaining_days, 3)
-		if campaign.remaining_days > 0
-		else 0
+		round(campaign.remaining_quantity / campaign.remaining_days, 3) if campaign.remaining_days > 0 else 0
 	)
 	return max(round(flt(campaign.estimated_peso_value or 0, 2) - total_value, 2), 0.0)
 
@@ -694,11 +723,15 @@ def _create_or_update_campaign(payload: dict[str, Any], *, existing_name: str | 
 		"owning_department",
 		"ops_review_notes",
 		"finance_review_notes",
-		):
+	):
 		if fieldname in payload:
 			setattr(doc, fieldname, payload.get(fieldname))
-	doc.requester_user = str(payload.get("requester_user") or doc.requester_user or frappe.session.user).strip()
-	doc.source_locations_json = json.dumps(payload.get("source_locations") or payload.get("source_locations_json") or [])
+	doc.requester_user = str(
+		payload.get("requester_user") or doc.requester_user or frappe.session.user
+	).strip()
+	doc.source_locations_json = json.dumps(
+		payload.get("source_locations") or payload.get("source_locations_json") or []
+	)
 	doc.schedule_json = json.dumps(payload.get("schedule_rows") or payload.get("schedule_json") or [])
 	doc.supporting_attachments_json = json.dumps(
 		payload.get("supporting_attachments") or payload.get("supporting_attachments_json") or []
@@ -713,7 +746,8 @@ def _create_or_update_campaign(payload: dict[str, Any], *, existing_name: str | 
 				"item_name": item.get("item_name"),
 				"uom": item.get("uom"),
 				"approved_quantity": item.get("approved_quantity"),
-				"estimated_unit_cost": item.get("estimated_unit_cost") or _resolve_item_cost(item.get("item_code")),
+				"estimated_unit_cost": item.get("estimated_unit_cost")
+				or _resolve_item_cost(item.get("item_code")),
 			},
 		)
 	doc.save(ignore_permissions=True)
@@ -742,12 +776,15 @@ def _current_time_string() -> str:
 def _post_stock_entry_for_issue(campaign, issue_doc) -> str:
 	source_company = resolve_warehouse_company(issue_doc.source_location) or get_company()
 	expense_account = campaign.finance_expense_account or _resolve_marketing_expense_account(source_company)
-	item_meta = frappe.db.get_value(
-		"Item",
-		issue_doc.item_code,
-		["item_name", "description", "stock_uom"],
-		as_dict=True,
-	) or {}
+	item_meta = (
+		frappe.db.get_value(
+			"Item",
+			issue_doc.item_code,
+			["item_name", "description", "stock_uom"],
+			as_dict=True,
+		)
+		or {}
+	)
 	stock_entry = frappe.new_doc("Stock Entry")
 	stock_entry.stock_entry_type = "Material Issue"
 	stock_entry.company = source_company
@@ -782,7 +819,9 @@ def _post_stock_entry_for_issue(campaign, issue_doc) -> str:
 	return stock_entry.name
 
 
-def _validate_issue_request(campaign, source_location: str, item_code: str, quantity: float, issue_day: date) -> tuple[Any, float]:
+def _validate_issue_request(
+	campaign, source_location: str, item_code: str, quantity: float, issue_day: date
+) -> tuple[Any, float]:
 	if campaign.status not in APPROVED_STATES:
 		frappe.throw(_("Only approved or active campaigns can issue stock."))
 	_finished_goods_item(item_code)
@@ -918,7 +957,9 @@ def _supabase_headers() -> dict[str, str]:
 	}
 
 
-def _supabase_get(resource: str, params: list[tuple[str, Any]] | dict[str, Any] | None = None) -> list[dict[str, Any]]:
+def _supabase_get(
+	resource: str, params: list[tuple[str, Any]] | dict[str, Any] | None = None
+) -> list[dict[str, Any]]:
 	response = requests.get(
 		f"{_get_supabase_url()}/rest/v1/{resource}",
 		headers=_supabase_headers(),
@@ -926,7 +967,9 @@ def _supabase_get(resource: str, params: list[tuple[str, Any]] | dict[str, Any] 
 		timeout=30,
 	)
 	if not response.ok:
-		raise RuntimeError(f"Supabase GET failed for {resource}: {response.status_code} {response.text[:250]}")
+		raise RuntimeError(
+			f"Supabase GET failed for {resource}: {response.status_code} {response.text[:250]}"
+		)
 	payload = response.json()
 	return payload if isinstance(payload, list) else []
 
@@ -974,7 +1017,10 @@ def _query_probable_giveaway_leakage(start_day: date, end_day: date) -> list[dic
 	for index in range(0, len(order_ids), 200):
 		chunk = order_ids[index : index + 200]
 		item_params: list[tuple[str, Any]] = [
-			("select", "order_id,product_name,quantity,discount_amount,discount_name,discount_name_normalized"),
+			(
+				"select",
+				"order_id,product_name,quantity,discount_amount,discount_name,discount_name_normalized",
+			),
 			("discount_amount", "gt.0"),
 			("order_id", f"in.({','.join(str(order_id) for order_id in chunk)})"),
 			("order", "order_id.asc"),
@@ -998,7 +1044,10 @@ def _query_probable_giveaway_leakage(start_day: date, end_day: date) -> list[dic
 					if str(row.get("discount_name") or "").strip()
 				}
 			)
-			normalized_names = {_normalize_text(row.get("discount_name_normalized") or row.get("discount_name")) for row in rows}
+			normalized_names = {
+				_normalize_text(row.get("discount_name_normalized") or row.get("discount_name"))
+				for row in rows
+			}
 			is_marketing = any("marketing" in name for name in normalized_names)
 			is_effectively_free = bool(order_gross and total_discounts >= round(order_gross * 0.95, 2))
 			if not (is_marketing or is_effectively_free):
@@ -1062,12 +1111,18 @@ def _store_label_for_location(location_id: int) -> str:
 
 @frappe.whitelist()
 def get_campaign_giveaways_dashboard(campaign: str | None = None) -> dict[str, Any]:
-	_observe("get_campaign_giveaways_dashboard", phase="read", mutation_type="load", extras={"campaign": campaign})
+	_observe(
+		"get_campaign_giveaways_dashboard", phase="read", mutation_type="load", extras={"campaign": campaign}
+	)
 	_require_enabled()
 	_require_roles(DASHBOARD_ROLES, "You do not have access to Campaign Giveaways.")
-	campaign_names = frappe.get_all(CAMPAIGN_DT, filters={}, fields=["name"], order_by="modified desc", limit_page_length=200)
+	campaign_names = frappe.get_all(
+		CAMPAIGN_DT, filters={}, fields=["name"], order_by="modified desc", limit_page_length=200
+	)
 	campaign_rows = [_serialize_campaign_row(_campaign_doc(row["name"])) for row in campaign_names]
-	selected = next((row for row in campaign_rows if row["name"] == campaign), campaign_rows[0] if campaign_rows else None)
+	selected = next(
+		(row for row in campaign_rows if row["name"] == campaign), campaign_rows[0] if campaign_rows else None
+	)
 	today = _manila_today().isoformat()
 	active_statuses = (*APPROVED_STATES, "Pending Ops Review", "Pending Finance Approval")
 	active_campaigns = [row for row in campaign_rows if row["status"] in active_statuses]
@@ -1076,7 +1131,9 @@ def get_campaign_giveaways_dashboard(campaign: str | None = None) -> dict[str, A
 			"campaign": row["name"],
 			"campaign_name": row["campaign_name"],
 			"campaign_code": row["campaign_code"],
-			"rows": [schedule for schedule in row["schedule_rows"] if str(schedule.get("date") or "")[:10] == today],
+			"rows": [
+				schedule for schedule in row["schedule_rows"] if str(schedule.get("date") or "")[:10] == today
+			],
 		}
 		for row in active_campaigns
 	]
@@ -1088,13 +1145,21 @@ def get_campaign_giveaways_dashboard(campaign: str | None = None) -> dict[str, A
 		order_by="modified desc",
 		limit_page_length=20,
 	)
-	upcoming = [row for row in active_campaigns if row["remaining_days"] > 0 and row["required_daily_pace"] > 0 and row["status"] in APPROVED_STATES]
+	upcoming = [
+		row
+		for row in active_campaigns
+		if row["remaining_days"] > 0 and row["required_daily_pace"] > 0 and row["status"] in APPROVED_STATES
+	]
 	return {
 		"summary": {
 			"total_campaigns": len(campaign_rows),
 			"active_campaigns": len([row for row in active_campaigns if row["status"] in APPROVED_STATES]),
-			"pending_ops_review": len([row for row in campaign_rows if row["status"] == "Pending Ops Review"]),
-			"pending_finance_review": len([row for row in campaign_rows if row["status"] == "Pending Finance Approval"]),
+			"pending_ops_review": len(
+				[row for row in campaign_rows if row["status"] == "Pending Ops Review"]
+			),
+			"pending_finance_review": len(
+				[row for row in campaign_rows if row["status"] == "Pending Finance Approval"]
+			),
 			"open_exceptions": len(exceptions),
 			"today_scheduled_issues": sum(len(entry["rows"]) for entry in todays_schedule),
 		},
@@ -1102,7 +1167,9 @@ def get_campaign_giveaways_dashboard(campaign: str | None = None) -> dict[str, A
 		"campaigns": campaign_rows,
 		"active_campaigns": active_campaigns,
 		"todays_schedule": todays_schedule,
-		"pace_watch": sorted(upcoming, key=lambda row: (-row["required_daily_pace"], row["campaign_name"]))[:10],
+		"pace_watch": sorted(upcoming, key=lambda row: (-row["required_daily_pace"], row["campaign_name"]))[
+			:10
+		],
 		"open_exceptions": [_serialize_exception_row(row) for row in exceptions],
 		"probable_leakage": [],
 		"probable_leakage_deferred": True,
@@ -1114,13 +1181,21 @@ def list_campaign_giveaways(status: str | None = None) -> dict[str, Any]:
 	_observe("list_campaign_giveaways", phase="read", mutation_type="load", extras={"status": status})
 	_require_enabled()
 	_require_roles(DASHBOARD_ROLES, "You do not have access to Campaign Giveaways.")
-	rows = frappe.get_all(CAMPAIGN_DT, filters=_campaign_filters(status), fields=["name"], order_by="modified desc", limit_page_length=200)
+	rows = frappe.get_all(
+		CAMPAIGN_DT,
+		filters=_campaign_filters(status),
+		fields=["name"],
+		order_by="modified desc",
+		limit_page_length=200,
+	)
 	return {"rows": [_serialize_campaign_row(_campaign_doc(row["name"])) for row in rows]}
 
 
 @frappe.whitelist()
 def get_campaign_giveaway_detail(campaign: str) -> dict[str, Any]:
-	_observe("get_campaign_giveaway_detail", phase="read", mutation_type="load", extras={"campaign": campaign})
+	_observe(
+		"get_campaign_giveaway_detail", phase="read", mutation_type="load", extras={"campaign": campaign}
+	)
 	_require_enabled()
 	_require_roles(DASHBOARD_ROLES, "You do not have access to Campaign Giveaways.")
 	doc = _campaign_doc(campaign)
@@ -1129,14 +1204,46 @@ def get_campaign_giveaway_detail(campaign: str) -> dict[str, Any]:
 	issues = frappe.get_all(
 		ISSUE_DT,
 		filters={"campaign": campaign},
-		fields=["name", "status", "issue_date", "source_location", "item_code", "item_name", "quantity", "actual_unit_cost", "actual_total_cost", "stock_entry", "finance_expense_account", "cost_center", "budget_owner", "notes"],
+		fields=[
+			"name",
+			"status",
+			"issue_date",
+			"source_location",
+			"item_code",
+			"item_name",
+			"quantity",
+			"actual_unit_cost",
+			"actual_total_cost",
+			"stock_entry",
+			"finance_expense_account",
+			"cost_center",
+			"budget_owner",
+			"notes",
+		],
 		order_by="issue_date desc, creation desc",
 		limit_page_length=200,
 	)
 	exceptions = frappe.get_all(
 		EXCEPTION_DT,
 		filters={"campaign": campaign},
-		fields=["name", "status", "severity", "exception_type", "source_location", "item_code", "issue_date", "requested_quantity", "attempted_value", "message", "linked_alert_reference", "linked_alert_payload_json", "resolution_code", "resolution_notes", "resolved_by", "resolved_at"],
+		fields=[
+			"name",
+			"status",
+			"severity",
+			"exception_type",
+			"source_location",
+			"item_code",
+			"issue_date",
+			"requested_quantity",
+			"attempted_value",
+			"message",
+			"linked_alert_reference",
+			"linked_alert_payload_json",
+			"resolution_code",
+			"resolution_notes",
+			"resolved_by",
+			"resolved_at",
+		],
 		order_by="modified desc",
 		limit_page_length=200,
 	)
@@ -1161,7 +1268,12 @@ def save_campaign_giveaway(payload: str | dict[str, Any]) -> dict[str, Any]:
 
 @frappe.whitelist()
 def submit_campaign_giveaway_for_ops_review(campaign: str) -> dict[str, Any]:
-	_observe("submit_campaign_giveaway_for_ops_review", phase="mutation", mutation_type="mutation", extras={"campaign": campaign})
+	_observe(
+		"submit_campaign_giveaway_for_ops_review",
+		phase="mutation",
+		mutation_type="mutation",
+		extras={"campaign": campaign},
+	)
 	_require_enabled()
 	_require_roles(REQUEST_ROLES, "Only authorized requestors can submit campaign giveaway requests.")
 	doc = _campaign_doc(campaign)
@@ -1185,7 +1297,12 @@ def review_campaign_giveaway_ops(
 	source_locations_json: str | None = None,
 	schedule_json: str | None = None,
 ) -> dict[str, Any]:
-	_observe("review_campaign_giveaway_ops", phase="mutation", mutation_type="mutation", extras={"campaign": campaign, "decision": decision})
+	_observe(
+		"review_campaign_giveaway_ops",
+		phase="mutation",
+		mutation_type="mutation",
+		extras={"campaign": campaign, "decision": decision},
+	)
 	_require_enabled()
 	_require_roles(OPS_REVIEW_ROLES, "Only Ops reviewers can process this stage.")
 	doc = _campaign_doc(campaign)
@@ -1229,7 +1346,12 @@ def review_campaign_giveaway_finance(
 	budget_owner: str | None = None,
 	approved_value_tolerance_pct: float | str | None = None,
 ) -> dict[str, Any]:
-	_observe("review_campaign_giveaway_finance", phase="mutation", mutation_type="mutation", extras={"campaign": campaign, "decision": decision})
+	_observe(
+		"review_campaign_giveaway_finance",
+		phase="mutation",
+		mutation_type="mutation",
+		extras={"campaign": campaign, "decision": decision},
+	)
 	_require_enabled()
 	_require_roles(FINANCE_REVIEW_ROLES, "Only Finance reviewers can process this stage.")
 	doc = _campaign_doc(campaign)
@@ -1243,9 +1365,13 @@ def review_campaign_giveaway_finance(
 	doc.finance_reviewed_at = now_datetime()
 	doc.finance_review_notes = notes or doc.finance_review_notes
 	if cost_center:
-		doc.cost_center = _require_master_record("Cost Center", cost_center, "Cost Center", filters={"is_group": 0})
+		doc.cost_center = _require_master_record(
+			"Cost Center", cost_center, "Cost Center", filters={"is_group": 0}
+		)
 	if budget_owner:
-		doc.budget_owner = _require_master_record("User", budget_owner, "Budget Owner", filters={"enabled": 1})
+		doc.budget_owner = _require_master_record(
+			"User", budget_owner, "Budget Owner", filters={"enabled": 1}
+		)
 	if approved_value_tolerance_pct is not None:
 		doc.approved_value_tolerance_pct = flt(approved_value_tolerance_pct, 2)
 	if decision_normalized == "reject":
@@ -1267,9 +1393,13 @@ def review_campaign_giveaway_finance(
 
 @frappe.whitelist()
 def cancel_campaign_giveaway(campaign: str, reason: str | None = None) -> dict[str, Any]:
-	_observe("cancel_campaign_giveaway", phase="mutation", mutation_type="mutation", extras={"campaign": campaign})
+	_observe(
+		"cancel_campaign_giveaway", phase="mutation", mutation_type="mutation", extras={"campaign": campaign}
+	)
 	_require_enabled()
-	_require_roles(REQUEST_ROLES | {"System Manager", "Administrator"}, "Only authorized users can cancel this request.")
+	_require_roles(
+		REQUEST_ROLES | {"System Manager", "Administrator"}, "Only authorized users can cancel this request."
+	)
 	doc = _campaign_doc(campaign)
 	_require_request_owner(doc, "cancel_campaign_giveaway")
 	if doc.status not in {"Draft", "Pending Ops Review", "Pending Finance Approval"}:
@@ -1293,7 +1423,12 @@ def post_campaign_giveaway_issue(
 	idempotency_key: str | None = None,
 	notes: str | None = None,
 ) -> dict[str, Any]:
-	_observe("post_campaign_giveaway_issue", phase="mutation", mutation_type="mutation", extras={"campaign": campaign, "item_code": item_code, "source_location": source_location})
+	_observe(
+		"post_campaign_giveaway_issue",
+		phase="mutation",
+		mutation_type="mutation",
+		extras={"campaign": campaign, "item_code": item_code, "source_location": source_location},
+	)
 	_require_enabled()
 	_require_roles(FULFILLMENT_ROLES, "Only approved fulfillment roles can issue campaign giveaways.")
 	quantity_value = flt(quantity or 0, 3)
@@ -1317,7 +1452,9 @@ def post_campaign_giveaway_issue(
 		}
 	campaign_doc = _campaign_doc(campaign)
 	issue_day = getdate(issue_date) if issue_date else _manila_today()
-	item_row, unit_cost = _validate_issue_request(campaign_doc, source_location, item_code, quantity_value, issue_day)
+	item_row, unit_cost = _validate_issue_request(
+		campaign_doc, source_location, item_code, quantity_value, issue_day
+	)
 	frappe.db.savepoint(f"campaign_issue_{campaign_doc.name.replace('-', '_')}")
 	try:
 		issue_doc = frappe.new_doc(ISSUE_DT)
@@ -1332,7 +1469,9 @@ def post_campaign_giveaway_issue(
 		issue_doc.quantity = quantity_value
 		issue_doc.actual_unit_cost = unit_cost
 		issue_doc.actual_total_cost = round(quantity_value * unit_cost, 2)
-		issue_doc.finance_expense_account = campaign_doc.finance_expense_account or _resolve_marketing_expense_account()
+		issue_doc.finance_expense_account = (
+			campaign_doc.finance_expense_account or _resolve_marketing_expense_account()
+		)
 		issue_doc.cost_center = campaign_doc.cost_center
 		issue_doc.budget_owner = campaign_doc.budget_owner
 		issue_doc.notes = notes
@@ -1366,7 +1505,9 @@ def post_campaign_giveaway_issue(
 def get_campaign_giveaway_approvals() -> dict[str, Any]:
 	_observe("get_campaign_giveaway_approvals", phase="read", mutation_type="load")
 	_require_enabled()
-	_require_roles(OPS_REVIEW_ROLES | FINANCE_REVIEW_ROLES, "You do not have approval access to Campaign Giveaways.")
+	_require_roles(
+		OPS_REVIEW_ROLES | FINANCE_REVIEW_ROLES, "You do not have approval access to Campaign Giveaways."
+	)
 	rows = frappe.get_all(
 		CAMPAIGN_DT,
 		filters={"status": ["in", ["Pending Ops Review", "Pending Finance Approval"]]},
@@ -1379,19 +1520,28 @@ def get_campaign_giveaway_approvals() -> dict[str, Any]:
 
 @frappe.whitelist()
 def get_campaign_giveaway_fulfillment_queue(campaign: str | None = None) -> dict[str, Any]:
-	_observe("get_campaign_giveaway_fulfillment_queue", phase="read", mutation_type="load", extras={"campaign": campaign})
+	_observe(
+		"get_campaign_giveaway_fulfillment_queue",
+		phase="read",
+		mutation_type="load",
+		extras={"campaign": campaign},
+	)
 	_require_enabled()
 	_require_roles(FULFILLMENT_ROLES, "You do not have fulfillment access to Campaign Giveaways.")
 	filters: dict[str, Any] = {"status": ["in", list(APPROVED_STATES)]}
 	if campaign:
 		filters["name"] = campaign
-	rows = frappe.get_all(CAMPAIGN_DT, filters=filters, fields=["name"], order_by="modified desc", limit_page_length=200)
+	rows = frappe.get_all(
+		CAMPAIGN_DT, filters=filters, fields=["name"], order_by="modified desc", limit_page_length=200
+	)
 	return {"rows": [_serialize_campaign_row(_campaign_doc(row["name"])) for row in rows]}
 
 
 @frappe.whitelist()
 def get_campaign_giveaway_exceptions(campaign: str | None = None) -> dict[str, Any]:
-	_observe("get_campaign_giveaway_exceptions", phase="read", mutation_type="load", extras={"campaign": campaign})
+	_observe(
+		"get_campaign_giveaway_exceptions", phase="read", mutation_type="load", extras={"campaign": campaign}
+	)
 	_require_enabled()
 	_require_roles(EXCEPTION_ROLES, "You do not have exception access to Campaign Giveaways.")
 	filters: dict[str, Any] = {}
@@ -1400,7 +1550,27 @@ def get_campaign_giveaway_exceptions(campaign: str | None = None) -> dict[str, A
 	rows = frappe.get_all(
 		EXCEPTION_DT,
 		filters=filters,
-		fields=["name", "campaign", "campaign_issue", "status", "severity", "exception_type", "source_location", "item_code", "issue_date", "requested_quantity", "attempted_value", "message", "linked_alert_reference", "linked_alert_payload_json", "resolution_code", "resolution_notes", "created_by", "resolved_by", "resolved_at"],
+		fields=[
+			"name",
+			"campaign",
+			"campaign_issue",
+			"status",
+			"severity",
+			"exception_type",
+			"source_location",
+			"item_code",
+			"issue_date",
+			"requested_quantity",
+			"attempted_value",
+			"message",
+			"linked_alert_reference",
+			"linked_alert_payload_json",
+			"resolution_code",
+			"resolution_notes",
+			"created_by",
+			"resolved_by",
+			"resolved_at",
+		],
 		order_by="modified desc",
 		limit_page_length=300,
 	)
@@ -1413,7 +1583,12 @@ def get_campaign_giveaway_exceptions(campaign: str | None = None) -> dict[str, A
 
 @frappe.whitelist()
 def get_campaign_giveaway_probable_leakage(campaign: str | None = None) -> dict[str, Any]:
-	_observe("get_campaign_giveaway_probable_leakage", phase="read", mutation_type="load", extras={"campaign": campaign})
+	_observe(
+		"get_campaign_giveaway_probable_leakage",
+		phase="read",
+		mutation_type="load",
+		extras={"campaign": campaign},
+	)
 	_require_enabled()
 	_require_roles(EXCEPTION_ROLES, "You do not have probable leakage access to Campaign Giveaways.")
 	leakage_start, leakage_end = _leakage_window()
@@ -1425,8 +1600,15 @@ def get_campaign_giveaway_probable_leakage(campaign: str | None = None) -> dict[
 
 
 @frappe.whitelist()
-def resolve_campaign_giveaway_exception(exception_name: str, resolution_code: str, resolution_notes: str | None = None) -> dict[str, Any]:
-	_observe("resolve_campaign_giveaway_exception", phase="mutation", mutation_type="mutation", extras={"exception_name": exception_name, "resolution_code": resolution_code})
+def resolve_campaign_giveaway_exception(
+	exception_name: str, resolution_code: str, resolution_notes: str | None = None
+) -> dict[str, Any]:
+	_observe(
+		"resolve_campaign_giveaway_exception",
+		phase="mutation",
+		mutation_type="mutation",
+		extras={"exception_name": exception_name, "resolution_code": resolution_code},
+	)
 	_require_enabled()
 	_require_roles(EXCEPTION_ROLES, "You do not have exception access to Campaign Giveaways.")
 	doc = frappe.get_doc(EXCEPTION_DT, exception_name)
@@ -1446,11 +1628,18 @@ def link_probable_leakage_to_campaign(
 	alert_payload: str | dict[str, Any] | None = None,
 	resolution_notes: str | None = None,
 ) -> dict[str, Any]:
-	_observe("link_probable_leakage_to_campaign", phase="mutation", mutation_type="mutation", extras={"campaign": campaign, "alert_reference": alert_reference})
+	_observe(
+		"link_probable_leakage_to_campaign",
+		phase="mutation",
+		mutation_type="mutation",
+		extras={"campaign": campaign, "alert_reference": alert_reference},
+	)
 	_require_enabled()
 	_require_roles(EXCEPTION_ROLES, "You do not have exception access to Campaign Giveaways.")
 	payload = _safe_json(alert_payload, {})
-	existing = frappe.db.get_value(EXCEPTION_DT, {"campaign": campaign, "linked_alert_reference": alert_reference}, "name")
+	existing = frappe.db.get_value(
+		EXCEPTION_DT, {"campaign": campaign, "linked_alert_reference": alert_reference}, "name"
+	)
 	if existing:
 		doc = frappe.get_doc(EXCEPTION_DT, existing)
 		if resolution_notes:
@@ -1474,10 +1663,21 @@ def link_probable_leakage_to_campaign(
 
 @frappe.whitelist()
 def get_campaign_giveaway_reconciliation(campaign: str | None = None) -> dict[str, Any]:
-	_observe("get_campaign_giveaway_reconciliation", phase="read", mutation_type="load", extras={"campaign": campaign})
+	_observe(
+		"get_campaign_giveaway_reconciliation",
+		phase="read",
+		mutation_type="load",
+		extras={"campaign": campaign},
+	)
 	_require_enabled()
 	_require_roles(RECONCILIATION_ROLES, "You do not have reconciliation access to Campaign Giveaways.")
-	rows = frappe.get_all(CAMPAIGN_DT, filters={"name": campaign} if campaign else {}, fields=["name"], order_by="modified desc", limit_page_length=200)
+	rows = frappe.get_all(
+		CAMPAIGN_DT,
+		filters={"name": campaign} if campaign else {},
+		fields=["name"],
+		order_by="modified desc",
+		limit_page_length=200,
+	)
 	results = []
 	for row in rows:
 		doc = _campaign_doc(row["name"])
@@ -1490,10 +1690,14 @@ def get_campaign_giveaway_reconciliation(campaign: str | None = None) -> dict[st
 		by_store: dict[str, dict[str, Any]] = {}
 		for issue in issues:
 			source = str(issue.get("source_location") or "Unknown")
-			entry = by_store.setdefault(source, {"source_location": source, "quantity": 0.0, "actual_value": 0.0})
+			entry = by_store.setdefault(
+				source, {"source_location": source, "quantity": 0.0, "actual_value": 0.0}
+			)
 			entry["quantity"] += flt(issue.get("quantity") or 0, 3)
 			entry["actual_value"] += flt(issue.get("actual_total_cost") or 0, 2)
-		exception_count = frappe.db.count(EXCEPTION_DT, {"campaign": doc.name, "status": ["not in", ["Resolved", "Ignored"]]})
+		exception_count = frappe.db.count(
+			EXCEPTION_DT, {"campaign": doc.name, "status": ["not in", ["Resolved", "Ignored"]]}
+		)
 		results.append(
 			{
 				"campaign": _serialize_campaign_row(doc),
@@ -1503,7 +1707,9 @@ def get_campaign_giveaway_reconciliation(campaign: str | None = None) -> dict[st
 				"approved_value": flt(doc.estimated_peso_value or 0, 2),
 				"actual_issued_value": round(sum(entry["actual_value"] for entry in by_store.values()), 2),
 				"open_exception_count": exception_count,
-				"by_store": sorted(by_store.values(), key=lambda entry: (-entry["actual_value"], entry["source_location"])),
+				"by_store": sorted(
+					by_store.values(), key=lambda entry: (-entry["actual_value"], entry["source_location"])
+				),
 			}
 		)
 	return {"rows": results}

--- a/hrms/api/marketing_giveaways.py
+++ b/hrms/api/marketing_giveaways.py
@@ -4,6 +4,7 @@ import json
 import os
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
+from functools import lru_cache
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -1015,7 +1016,6 @@ def _query_probable_giveaway_leakage(start_day: date, end_day: date) -> list[dic
 					"alert_reference": f"pos-order:{order_id}",
 					"order_id": order_id,
 					"business_date": str(order.get("business_date") or ""),
-<<<<<<< HEAD
 					"store_name": _store_label_for_location(cint(order.get("location_id") or 0)),
 					"location_id": cint(order.get("location_id") or 0),
 					"bill_number": str(order.get("bill_number") or ""),
@@ -1058,6 +1058,8 @@ def _store_label_for_location(location_id: int) -> str:
 	if not location_id:
 		return ""
 	return _location_store_labels().get(location_id, f"Location {location_id}")
+
+
 @frappe.whitelist()
 def get_campaign_giveaways_dashboard(campaign: str | None = None) -> dict[str, Any]:
 	_observe("get_campaign_giveaways_dashboard", phase="read", mutation_type="load", extras={"campaign": campaign})
@@ -1102,6 +1104,8 @@ def get_campaign_giveaways_dashboard(campaign: str | None = None) -> dict[str, A
 		"todays_schedule": todays_schedule,
 		"pace_watch": sorted(upcoming, key=lambda row: (-row["required_daily_pace"], row["campaign_name"]))[:10],
 		"open_exceptions": [_serialize_exception_row(row) for row in exceptions],
+		"probable_leakage": [],
+		"probable_leakage_deferred": True,
 	}
 
 
@@ -1400,17 +1404,11 @@ def get_campaign_giveaway_exceptions(campaign: str | None = None) -> dict[str, A
 		order_by="modified desc",
 		limit_page_length=300,
 	)
-	return {"rows": [_serialize_exception_row(row) for row in rows]}
-
-
-@frappe.whitelist()
-def get_campaign_giveaway_probable_leakage(campaign: str | None = None) -> dict[str, Any]:
-	_observe("get_campaign_giveaway_probable_leakage", phase="read", mutation_type="load", extras={"campaign": campaign})
-	_require_enabled()
-	_require_roles(EXCEPTION_ROLES, "You do not have probable leakage access to Campaign Giveaways.")
-	leakage_end = _manila_today()
-	leakage_start = leakage_end - timedelta(days=16)
-	return {"rows": _query_probable_giveaway_leakage(leakage_start, leakage_end)}
+	return {
+		"rows": [_serialize_exception_row(row) for row in rows],
+		"probable_leakage": [],
+		"probable_leakage_deferred": True,
+	}
 
 
 @frappe.whitelist()

--- a/hrms/api/marketing_giveaways.py
+++ b/hrms/api/marketing_giveaways.py
@@ -4,7 +4,6 @@ import json
 import os
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
-from functools import lru_cache
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -811,6 +810,17 @@ def _validate_issue_request(campaign, source_location: str, item_code: str, quan
 	item_row = _find_item_row(campaign, item_code)
 	if not item_row:
 		frappe.throw(_("Item is not approved for this campaign."))
+	if not _source_supports_item(source_location, item_code):
+		exception_name = _create_exception(
+			campaign=campaign.name,
+			exception_type="Invalid Source Item Combination",
+			message="Selected source location does not stock the approved giveaway item.",
+			source_location=source_location,
+			item_code=item_code,
+			issue_date=issue_day.isoformat(),
+			requested_quantity=quantity,
+		)
+		frappe.throw(_("Issue blocked: invalid source/item combination ({0}).").format(exception_name))
 	remaining_qty = flt(item_row.remaining_quantity or item_row.approved_quantity or 0, 3)
 	if quantity > remaining_qty:
 		exception_name = _create_exception(
@@ -1005,6 +1015,7 @@ def _query_probable_giveaway_leakage(start_day: date, end_day: date) -> list[dic
 					"alert_reference": f"pos-order:{order_id}",
 					"order_id": order_id,
 					"business_date": str(order.get("business_date") or ""),
+<<<<<<< HEAD
 					"store_name": _store_label_for_location(cint(order.get("location_id") or 0)),
 					"location_id": cint(order.get("location_id") or 0),
 					"bill_number": str(order.get("bill_number") or ""),
@@ -1047,8 +1058,6 @@ def _store_label_for_location(location_id: int) -> str:
 	if not location_id:
 		return ""
 	return _location_store_labels().get(location_id, f"Location {location_id}")
-
-
 @frappe.whitelist()
 def get_campaign_giveaways_dashboard(campaign: str | None = None) -> dict[str, Any]:
 	_observe("get_campaign_giveaways_dashboard", phase="read", mutation_type="load", extras={"campaign": campaign})
@@ -1093,8 +1102,6 @@ def get_campaign_giveaways_dashboard(campaign: str | None = None) -> dict[str, A
 		"todays_schedule": todays_schedule,
 		"pace_watch": sorted(upcoming, key=lambda row: (-row["required_daily_pace"], row["campaign_name"]))[:10],
 		"open_exceptions": [_serialize_exception_row(row) for row in exceptions],
-		"probable_leakage": [],
-		"probable_leakage_deferred": True,
 	}
 
 
@@ -1393,11 +1400,17 @@ def get_campaign_giveaway_exceptions(campaign: str | None = None) -> dict[str, A
 		order_by="modified desc",
 		limit_page_length=300,
 	)
-	return {
-		"rows": [_serialize_exception_row(row) for row in rows],
-		"probable_leakage": [],
-		"probable_leakage_deferred": True,
-	}
+	return {"rows": [_serialize_exception_row(row) for row in rows]}
+
+
+@frappe.whitelist()
+def get_campaign_giveaway_probable_leakage(campaign: str | None = None) -> dict[str, Any]:
+	_observe("get_campaign_giveaway_probable_leakage", phase="read", mutation_type="load", extras={"campaign": campaign})
+	_require_enabled()
+	_require_roles(EXCEPTION_ROLES, "You do not have probable leakage access to Campaign Giveaways.")
+	leakage_end = _manila_today()
+	leakage_start = leakage_end - timedelta(days=16)
+	return {"rows": _query_probable_giveaway_leakage(leakage_start, leakage_end)}
 
 
 @frappe.whitelist()

--- a/hrms/api/ordering.py
+++ b/hrms/api/ordering.py
@@ -169,7 +169,7 @@ def _generate_dr_internal(order_name: str, order: Any = None) -> dict[str, Any]:
 		_send_order_notification(
 			store=order.store,
 			message=_(
-				"Delivery Receipt {0} has been generated for your order {1}. Delivery scheduled for {2}."
+				"Delivery Receipt {0} has been generated for your order {1}. " "Delivery scheduled for {2}."
 			).format(dr_number, order_name, order.delivery_date or "TBD"),
 		)
 	except Exception as e:
@@ -218,17 +218,15 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 	Returns:
 	    dict: {"orders": [...], "total": int}
 	"""
+	_check_ordering_permission(ORDERING_WAREHOUSE_ROLES, "view order review queue")
+
 	filter_date = date or today()
 	current_user = frappe.session.user
 	current_roles = set(frappe.get_roles(current_user))
 	from hrms.api.store import _get_order_approval_fallback_user
 
-	fallback_approver = _get_order_approval_fallback_user()
-	is_fallback_viewer = bool(fallback_approver and current_user == fallback_approver)
-	if not current_roles.intersection(ORDERING_WAREHOUSE_ROLES) and not is_fallback_viewer:
-		frappe.throw(_("You do not have permission to view order review queue"), frappe.PermissionError)
-
 	conditions = ["so.order_date = %(date)s", "so.docstatus < 2"]
+	fallback_approver = _get_order_approval_fallback_user()
 	params = {
 		"date": filter_date,
 		"current_user": current_user,
@@ -240,6 +238,7 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 		params["status"] = status
 
 	admin_viewer_roles = {"System Manager", "Administrator", "Supply Chain Manager", "Warehouse Manager"}
+	is_fallback_viewer = bool(fallback_approver and current_user == fallback_approver)
 	is_admin_viewer = bool(current_roles.intersection(admin_viewer_roles)) or is_fallback_viewer
 	if not is_admin_viewer:
 		conditions.append(
@@ -247,8 +246,9 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 		)
 
 	where_clause = " AND ".join(conditions)
-	query = (
-		"""
+
+	orders = frappe.db.sql(
+		f"""
 		SELECT
 			so.name,
 			so.store,
@@ -286,18 +286,16 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 		LEFT JOIN `tabWarehouse` wh ON wh.name = so.store
 		LEFT JOIN `tabWarehouse` wh_parent ON wh_parent.name = wh.parent_warehouse
 		LEFT JOIN `tabBEI Store Order Item` soi ON soi.parent = so.name
-		WHERE """
-		+ where_clause
-		+ """
+		WHERE {where_clause}
 		GROUP BY so.name
 		ORDER BY
 			CASE so.status WHEN 'Pending Approval' THEN 0 ELSE 1 END,
 			COALESCE(pending_queue.pending_since, so.creation) ASC,
 			so.store ASC
-		"""
+		""",
+		params,
+		as_dict=True,
 	)
-
-	orders = frappe.db.sql(query, params, as_dict=True)
 
 	return {
 		"orders": orders,
@@ -410,10 +408,10 @@ def _send_order_notification(store: str, message: str) -> None:
 	Silently fails if Google Chat integration is not configured.
 	"""
 	try:
-		from hrms.api.google_chat import send_message_to_space
+		from hrms.api.google_chat import resolve_store_chat_space, send_message_to_space
 
 		# Look up store's notification space from Warehouse custom fields or config
-		space_id = frappe.db.get_value("Warehouse", store, "custom_gchat_space") or None
+		space_id = resolve_store_chat_space(store)
 		if space_id:
 			send_message_to_space(space_id, message)
 	except ImportError:

--- a/hrms/api/ordering.py
+++ b/hrms/api/ordering.py
@@ -169,7 +169,7 @@ def _generate_dr_internal(order_name: str, order: Any = None) -> dict[str, Any]:
 		_send_order_notification(
 			store=order.store,
 			message=_(
-				"Delivery Receipt {0} has been generated for your order {1}. " "Delivery scheduled for {2}."
+				"Delivery Receipt {0} has been generated for your order {1}. Delivery scheduled for {2}."
 			).format(dr_number, order_name, order.delivery_date or "TBD"),
 		)
 	except Exception as e:

--- a/hrms/api/ordering.py
+++ b/hrms/api/ordering.py
@@ -225,30 +225,21 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 	current_roles = set(frappe.get_roles(current_user))
 	from hrms.api.store import _get_order_approval_fallback_user
 
-	conditions = ["so.order_date = %(date)s", "so.docstatus < 2"]
 	fallback_approver = _get_order_approval_fallback_user()
 	params = {
 		"date": filter_date,
 		"current_user": current_user,
 		"fallback_user": fallback_approver or "",
+		"status": status or None,
 	}
-
-	if status:
-		conditions.append("so.status = %(status)s")
-		params["status"] = status
 
 	admin_viewer_roles = {"System Manager", "Administrator", "Supply Chain Manager", "Warehouse Manager"}
 	is_fallback_viewer = bool(fallback_approver and current_user == fallback_approver)
 	is_admin_viewer = bool(current_roles.intersection(admin_viewer_roles)) or is_fallback_viewer
-	if not is_admin_viewer:
-		conditions.append(
-			"(so.status != 'Pending Approval' OR pending_queue.assigned_approver = %(current_user)s)"
-		)
-
-	where_clause = " AND ".join(conditions)
+	params["is_admin_viewer"] = 1 if is_admin_viewer else 0
 
 	orders = frappe.db.sql(
-		f"""
+		"""
 		SELECT
 			so.name,
 			so.store,
@@ -286,7 +277,14 @@ def get_order_review_queue(date: str | None = None, status: str | None = None) -
 		LEFT JOIN `tabWarehouse` wh ON wh.name = so.store
 		LEFT JOIN `tabWarehouse` wh_parent ON wh_parent.name = wh.parent_warehouse
 		LEFT JOIN `tabBEI Store Order Item` soi ON soi.parent = so.name
-		WHERE {where_clause}
+		WHERE so.order_date = %(date)s
+		  AND so.docstatus < 2
+		  AND (%(status)s IS NULL OR so.status = %(status)s)
+		  AND (
+			%(is_admin_viewer)s = 1
+			OR so.status != 'Pending Approval'
+			OR pending_queue.assigned_approver = %(current_user)s
+		  )
 		GROUP BY so.name
 		ORDER BY
 			CASE so.status WHEN 'Pending Approval' THEN 0 ELSE 1 END,

--- a/hrms/api/projects.py
+++ b/hrms/api/projects.py
@@ -1163,12 +1163,12 @@ def set_maintenance_charge(request_id: Any, charge_amount: Any, charging_reason:
 def _notify_maintenance_charge_pending_ack(doc):
 	"""Notify store and ops channels when a maintenance charge awaits acknowledgement."""
 	try:
-		from hrms.api.google_chat import send_message_to_space
+		from hrms.api.google_chat import resolve_store_chat_space, send_message_to_space
 		from hrms.utils.bei_config import SPACE_NOTIFICATIONS, get_chat_space
 
 		spaces = []
 		if getattr(doc, "store", None):
-			store_space = frappe.db.get_value("Warehouse", doc.store, "custom_gchat_space")
+			store_space = resolve_store_chat_space(doc.store)
 			if store_space:
 				spaces.append(store_space)
 

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -917,7 +917,9 @@ def _build_orderable_source_stock_context(store_warehouse, items):
 			continue
 		lane = _resolve_delivery_lane(item)
 		cargo_category = _lane_to_cargo_category(lane)
-		source_warehouse = _resolve_store_order_source_warehouse(store_warehouse, cargo_category) or store_warehouse
+		source_warehouse = (
+			_resolve_store_order_source_warehouse(store_warehouse, cargo_category) or store_warehouse
+		)
 		source_warehouse_by_item[item_code] = source_warehouse
 		lane_by_item[item_code] = lane
 		if source_warehouse:
@@ -1705,9 +1707,7 @@ def submit_order(
 	first_source = routing["first_source"]
 
 	requires_manual_approval = bool(
-		is_bulk_order
-		or edited_lines_count > 0
-		or (is_emergency_flag and submitted_after_cutoff)
+		is_bulk_order or edited_lines_count > 0 or (is_emergency_flag and submitted_after_cutoff)
 	)
 	if requires_manual_approval and not first_approver:
 		frappe.throw(
@@ -1770,9 +1770,7 @@ def submit_order(
 			requires_manual_approval and first_source == "area_supervisor"
 		),
 		"requires_regional_manager_review": False,
-		"requires_fallback_approval": bool(
-			requires_manual_approval and first_source == "fallback_approver"
-		),
+		"requires_fallback_approval": bool(requires_manual_approval and first_source == "fallback_approver"),
 		"edited_lines_count": edited_lines_count,
 		"message": f"Order {order.name} submitted successfully",
 		"approval_queue_status": queue_status,
@@ -1780,9 +1778,7 @@ def submit_order(
 		"approval_approver_source": first_source if requires_manual_approval else "not_required",
 		"approval_assigned_approver": first_approver if requires_manual_approval else None,
 		"fallback_approver": (
-			first_approver
-			if requires_manual_approval and first_source == "fallback_approver"
-			else None
+			first_approver if requires_manual_approval and first_source == "fallback_approver" else None
 		),
 		"submitted_after_cutoff": bool(submitted_after_cutoff),
 		"is_emergency": bool(is_emergency_flag),
@@ -1880,7 +1876,9 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 		is_fallback_user = bool(fallback_approver and user == fallback_approver)
 		if not user_roles.intersection(allowed_roles) and not is_fallback_user:
 			frappe.throw(
-				_("Only assigned approvers, Area Supervisors, fallback approvers, or System Managers can approve."),
+				_(
+					"Only assigned approvers, Area Supervisors, fallback approvers, or System Managers can approve."
+				),
 				frappe.PermissionError,
 			)
 
@@ -1969,7 +1967,7 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 				"dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
 			},
 		},
-			requested_space=store_space or get_chat_space(SPACE_OPS),
+		requested_space=store_space or get_chat_space(SPACE_OPS),
 	)
 
 	return {
@@ -2028,7 +2026,9 @@ def _create_mr_for_store_order(order):
 		)
 		finance_treatment = infer_finance_treatment(source_company, billing_target_company)
 		is_intercompany = finance_treatment == FINANCE_TREATMENT_INTERCOMPANY
-		operational_dispatch_warehouse = source_warehouse if is_intercompany and source_warehouse else store_warehouse
+		operational_dispatch_warehouse = (
+			source_warehouse if is_intercompany and source_warehouse else store_warehouse
+		)
 		mr.material_request_type = "Material Issue" if is_intercompany else "Material Transfer"
 		# Frappe validates Material Transfer requests against the operational stock
 		# owner on the source side of the move. The buyer entity used later for
@@ -2046,7 +2046,7 @@ def _create_mr_for_store_order(order):
 			target_company=billing_target_company,
 			finance_treatment=finance_treatment,
 		)
-		mr.remarks = f"Warehouse dispatch request for store order {order.name} " f"({cargo_category})"
+		mr.remarks = f"Warehouse dispatch request for store order {order.name} ({cargo_category})"
 
 		for item in order.items:
 			qty = flt(getattr(item, "qty_approved", None) or getattr(item, "qty_requested", 0))
@@ -2627,9 +2627,7 @@ def _resolve_store_order_item_pricing(store_order_name: str | None) -> dict[str,
 		result[item_code] = {
 			"unit_price": flt(row.get("unit_price"), 6),
 			"delivered_qty": (
-				flt(row.get("qty_delivered"))
-				or flt(row.get("qty_approved"))
-				or flt(row.get("qty_requested"))
+				flt(row.get("qty_delivered")) or flt(row.get("qty_approved")) or flt(row.get("qty_requested"))
 			),
 		}
 	return result
@@ -3029,11 +3027,7 @@ def create_store_return(
 		"finance_treatment": finance_treatment,
 		"message": (
 			f"Store return {primary_entry.name} created"
-			+ (
-				f" with warehouse receipt {warehouse_receipt.name}"
-				if warehouse_receipt
-				else ""
-			)
+			+ (f" with warehouse receipt {warehouse_receipt.name}" if warehouse_receipt else "")
 			+ f" — {len(primary_entry.items)} item(s) returned to warehouse"
 		),
 	}

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -6,13 +6,11 @@ Store Operations API
 Handles store ordering, receiving, and FQI reports for my.bebang.ph
 """
 
-import ast
 import base64
 import hashlib
 import json
 import re
 from contextlib import contextmanager
-from pathlib import Path
 
 import frappe
 from frappe import _
@@ -26,7 +24,6 @@ from hrms.utils.supply_chain_contracts import (
 	REQUEST_SOURCE_STORE_DISPOSAL,
 	REQUEST_SOURCE_STORE_ORDER,
 	REQUEST_SOURCE_STORE_RETURN,
-	get_preferred_commissary_warehouses,
 	infer_finance_treatment,
 	resolve_material_request_contract,
 	resolve_route_source_warehouse,
@@ -198,22 +195,6 @@ STORE_OPS_ALLOWED_ROLES = [
 AREA_SUPERVISOR_ROLE = "Area Supervisor"
 ORDER_APPROVAL_FALLBACK_EMAIL = "edlice@bebang.ph"
 SYSTEM_APPROVER_ROLES = {"System Manager", "Administrator"}
-SCHEDULE_CANONICAL_STORE_TYPES = {"JV", "Managed Franchise", "Full Franchise"}
-SCHEDULE_STORE_TYPE_ALIASES = {
-	"jv": "JV",
-	"joint venture": "JV",
-	"managed franchise": "Managed Franchise",
-	"managedfranchise": "Managed Franchise",
-	"full franchise": "Full Franchise",
-	"fullfranchise": "Full Franchise",
-}
-_SCHEDULE_FALLBACK_STORE_ROWS_CACHE = None
-COMMISSARY_WAREHOUSE_ALIAS_MAP = {
-	"COMMISSARYSHAW": "Shaw BLVD - BKI",
-	"SHAWCOMMISSARY": "Shaw BLVD - BKI",
-	"SHAWCOMMI": "Shaw BLVD - BKI",
-	"SHAWBLVDCOMMISSARY": "Shaw BLVD - BKI",
-}
 
 
 def _has_column(doctype: str, fieldname: str) -> bool:
@@ -252,18 +233,10 @@ def resolve_warehouse(store_or_branch):
 	if frappe.db.exists("Warehouse", warehouse_with_company):
 		return warehouse_with_company
 
-	warehouse_with_commissary_company = f"{store_or_branch} - BKI"
-	if frappe.db.exists("Warehouse", warehouse_with_commissary_company):
-		return warehouse_with_commissary_company
-
 	# Try to find warehouse by warehouse_name (without company suffix)
 	warehouse = frappe.db.get_value("Warehouse", {"warehouse_name": store_or_branch}, "name")
 	if warehouse:
 		return warehouse
-
-	alias_warehouse = COMMISSARY_WAREHOUSE_ALIAS_MAP.get(_normalize_store_key(store_or_branch))
-	if alias_warehouse and frappe.db.exists("Warehouse", alias_warehouse):
-		return alias_warehouse
 
 	frappe.throw(_("Could not find Store: {0}").format(store_or_branch))
 
@@ -333,315 +306,6 @@ def _normalize_store_key(value):
 def _designation_is_store_lead(designation):
 	label = str(designation or "").upper()
 	return "STORE SUPERVISOR" in label or "STORE OIC" in label or " OIC" in label or label == "OIC"
-
-
-def _designation_is_area_supervisor(designation):
-	return "AREA SUPERVISOR" in str(designation or "").upper()
-
-
-def _normalize_schedule_store_type(value: str | None) -> str:
-	text = " ".join(str(value or "").strip().replace("_", " ").replace("-", " ").split()).lower()
-	if not text:
-		return ""
-	return SCHEDULE_STORE_TYPE_ALIASES.get(text, str(value or "").strip())
-
-
-def _get_schedule_store_type_by_department() -> dict[str, str]:
-	if not frappe.db.table_exists("tabBEI Store Type"):
-		return {}
-
-	store_type_rows = frappe.get_all(
-		"BEI Store Type",
-		filters={"store": ["is", "set"]},
-		fields=["store", "store_type"],
-		order_by="store asc",
-	)
-	store_type_by_department = {}
-	for row in store_type_rows or []:
-		department = str(row.get("store") or "").strip()
-		if not department:
-			continue
-		store_type = _normalize_schedule_store_type(row.get("store_type"))
-		if store_type in SCHEDULE_CANONICAL_STORE_TYPES:
-			store_type_by_department[department] = store_type
-	return store_type_by_department
-
-
-def _load_schedule_fallback_store_rows() -> list[dict]:
-	"""Load canonical schedule stores from the checked-in store-type seed script."""
-	global _SCHEDULE_FALLBACK_STORE_ROWS_CACHE
-	if _SCHEDULE_FALLBACK_STORE_ROWS_CACHE is not None:
-		return list(_SCHEDULE_FALLBACK_STORE_ROWS_CACHE)
-
-	rows = []
-	try:
-		script_path = Path(__file__).resolve().parents[2] / "scripts" / "seed_store_types.py"
-		source = script_path.read_text(encoding="utf-8")
-		module = ast.parse(source)
-		seed_rows = []
-		for node in module.body:
-			if not isinstance(node, ast.Assign):
-				continue
-			for target in node.targets:
-				if isinstance(target, ast.Name) and target.id == "STORE_TYPES":
-					seed_rows = ast.literal_eval(node.value)
-					break
-			if seed_rows:
-				break
-		for row in seed_rows or []:
-			store_name = str((row or {}).get("store") or "").strip()
-			store_type = _normalize_schedule_store_type((row or {}).get("store_type"))
-			if store_name and store_type in SCHEDULE_CANONICAL_STORE_TYPES:
-				rows.append({"store": store_name, "store_type": store_type})
-	except Exception:
-		rows = []
-
-	# Keep a safe manual QA sandbox available even when master data is empty.
-	rows.append({"store": "TEST-STORE-BGC", "store_type": "Managed Franchise"})
-	seen = set()
-	deduped = []
-	for row in rows:
-		key = (str(row.get("store") or "").strip(), str(row.get("store_type") or "").strip())
-		if not key[0] or key in seen:
-			continue
-		seen.add(key)
-		deduped.append(row)
-	_SCHEDULE_FALLBACK_STORE_ROWS_CACHE = deduped
-	return list(_SCHEDULE_FALLBACK_STORE_ROWS_CACHE)
-
-
-def _normalize_user_store_surface(surface: str | None) -> str | None:
-	normalized = re.sub(r"[^a-z_]", "", str(surface or "").strip().lower())
-	return normalized or None
-
-
-def _schedule_row_keys(row: dict | None) -> set[str]:
-	row = row or {}
-	return {
-		_normalize_store_key(value)
-		for value in _clean_warehouse_branch_candidates(row.get("name"), row.get("warehouse_name"))
-		if value
-	}
-
-
-def _find_schedule_store_row(schedule_rows: list[dict], *candidates: str | None) -> dict | None:
-	candidate_keys = {
-		_normalize_store_key(value) for value in _clean_warehouse_branch_candidates(*candidates) if value
-	}
-	if not candidate_keys:
-		return None
-	for row in schedule_rows:
-		if candidate_keys.intersection(_schedule_row_keys(row)):
-			return row
-	return None
-
-
-def _resolve_schedule_warehouse_row(warehouse_rows: list[dict], *candidates: str | None) -> dict | None:
-	warehouse_by_name = {str(row.get("name") or "").strip(): row for row in warehouse_rows if row.get("name")}
-	for candidate in candidates:
-		text = str(candidate or "").strip()
-		if not text:
-			continue
-		try:
-			resolved = resolve_warehouse(text)
-		except Exception:
-			resolved = None
-		if resolved and warehouse_by_name.get(resolved):
-			return warehouse_by_name[resolved]
-	matched = _find_schedule_store_row(warehouse_rows, *candidates)
-	if matched:
-		return matched
-	return None
-
-
-def _is_store_schedule_employee(
-	employee: dict | None, user_roles: list[str] | tuple[str, ...] | set[str]
-) -> bool:
-	roles = set(user_roles or [])
-	designation = employee.get("designation") if isinstance(employee, dict) else None
-	return bool(
-		roles.intersection({"Store Supervisor", "Store Staff", "Area Supervisor", "Employee"})
-		or _designation_is_store_lead(designation)
-		or _designation_is_area_supervisor(designation)
-	)
-
-
-def _is_commissary_schedule_employee(
-	employee: dict | None, user_roles: list[str] | tuple[str, ...] | set[str]
-) -> bool:
-	roles = set(user_roles or [])
-	designation = str((employee or {}).get("designation") or "").upper()
-	branch = str((employee or {}).get("branch") or "").upper()
-	return bool(
-		roles.intersection({"Commissary Supervisor", "Warehouse User", "Supply Chain Manager"})
-		or "COMMISSARY" in designation
-		or "COMMISSARY" in branch
-	)
-
-
-def _employee_schedule_role(
-	employee: dict | None, user_roles: list[str] | tuple[str, ...] | set[str], surface: str | None
-):
-	roles = set(user_roles or [])
-	designation = (employee or {}).get("designation")
-	if surface == "commissary_schedule":
-		if "Supply Chain Manager" in roles:
-			return "Supply Chain Manager"
-		if "Warehouse User" in roles:
-			return "Warehouse User"
-		if "Commissary Supervisor" in roles or "COMMISSARY" in str(designation or "").upper():
-			return "Commissary Supervisor"
-		return None
-	if _designation_is_area_supervisor(designation) or "Area Supervisor" in roles:
-		return "Area Supervisor"
-	if _designation_is_store_lead(designation) or "Store Supervisor" in roles:
-		return "Store Supervisor"
-	if "Store Staff" in roles or "Employee" in roles:
-		return "Store Staff"
-	return None
-
-
-def _employee_schedule_store_row(
-	employee: dict | None,
-	*,
-	surface: str | None,
-	schedule_rows: list[dict],
-	user_roles: list[str] | tuple[str, ...] | set[str],
-) -> dict | None:
-	if not employee:
-		return None
-
-	store_context = resolve_employee_store_context(employee)
-	warehouse = str(store_context.get("warehouse") or "").strip()
-	if not warehouse:
-		return None
-
-	matched = _find_schedule_store_row(
-		schedule_rows,
-		warehouse,
-		store_context.get("warehouse_name"),
-		store_context.get("branch"),
-	)
-	if matched:
-		return matched
-
-	if surface == "store_schedule" and not _is_store_schedule_employee(employee, user_roles):
-		return None
-	if surface == "commissary_schedule" and not _is_commissary_schedule_employee(employee, user_roles):
-		return None
-
-	return {
-		"name": warehouse,
-		"warehouse_name": str(store_context.get("warehouse_name") or warehouse).strip(),
-	}
-
-
-def _get_store_schedule_locations() -> list[dict]:
-	"""Return active BEI retail store warehouses for scheduling surfaces."""
-	mapping_rows = []
-	if frappe.db.table_exists("tabBEI Warehouse Department Mapping"):
-		mapping_rows = frappe.get_all(
-			"BEI Warehouse Department Mapping",
-			filters={"is_active": 1},
-			fields=["warehouse", "department", "store_type"],
-			order_by="warehouse asc",
-		)
-
-	store_type_rows = []
-	if frappe.db.table_exists("tabBEI Store Type"):
-		store_type_rows = frappe.get_all(
-			"BEI Store Type",
-			filters={"store": ["is", "set"]},
-			fields=["store", "store_type"],
-			order_by="store asc",
-		)
-	if not mapping_rows and not store_type_rows:
-		store_type_rows = _load_schedule_fallback_store_rows()
-
-	warehouse_rows = frappe.get_all(
-		"Warehouse",
-		filters={"is_group": 0, "disabled": 0},
-		fields=["name", "warehouse_name", "custom_area_supervisor"],
-		order_by="warehouse_name asc",
-	)
-
-	locations = []
-	seen = set()
-
-	def append_location(
-		warehouse_row: dict | None, *, department: str | None = None, store_type: str | None = None
-	):
-		if not warehouse_row:
-			return
-		warehouse_name = str(warehouse_row.get("name") or "").strip()
-		if not warehouse_name or warehouse_name in seen:
-			return
-		resolved_department = str(department or "").strip()
-		resolved_store_type = _normalize_schedule_store_type(store_type)
-		if resolved_store_type not in SCHEDULE_CANONICAL_STORE_TYPES:
-			return
-		locations.append(
-			{
-				"name": warehouse_name,
-				"warehouse_name": warehouse_row.get("warehouse_name") or warehouse_name,
-				"department": resolved_department or None,
-				"store_type": resolved_store_type,
-				"custom_area_supervisor": warehouse_row.get("custom_area_supervisor"),
-			}
-		)
-		seen.add(warehouse_name)
-
-	if mapping_rows:
-		for mapping in mapping_rows:
-			append_location(
-				_resolve_schedule_warehouse_row(
-					warehouse_rows,
-					mapping.get("warehouse"),
-					mapping.get("department"),
-				),
-				department=mapping.get("department"),
-				store_type=mapping.get("store_type"),
-			)
-
-	for store_type_row in store_type_rows:
-		append_location(
-			_resolve_schedule_warehouse_row(warehouse_rows, store_type_row.get("store")),
-			department=store_type_row.get("store"),
-			store_type=store_type_row.get("store_type"),
-		)
-
-	return locations
-
-
-def _get_commissary_schedule_locations() -> list[dict]:
-	"""Return active commissary scheduling units only."""
-	preferred = [
-		warehouse
-		for warehouse in get_preferred_commissary_warehouses(include_legacy=True)
-		if warehouse and not str(warehouse).upper().startswith("TEST-")
-	]
-	if not preferred:
-		return []
-
-	warehouse_rows = frappe.get_all(
-		"Warehouse",
-		filters={
-			"name": ["in", preferred],
-			"is_group": 0,
-			"disabled": 0,
-		},
-		fields=["name", "warehouse_name", "company"],
-		order_by="warehouse_name asc",
-	)
-	return [
-		{
-			"name": row["name"],
-			"warehouse_name": row.get("warehouse_name") or row["name"],
-			"department": None,
-			"company": row.get("company"),
-		}
-		for row in warehouse_rows
-	]
 
 
 def _is_test_user(user_id):
@@ -1253,9 +917,7 @@ def _build_orderable_source_stock_context(store_warehouse, items):
 			continue
 		lane = _resolve_delivery_lane(item)
 		cargo_category = _lane_to_cargo_category(lane)
-		source_warehouse = (
-			_resolve_store_order_source_warehouse(store_warehouse, cargo_category) or store_warehouse
-		)
+		source_warehouse = _resolve_store_order_source_warehouse(store_warehouse, cargo_category) or store_warehouse
 		source_warehouse_by_item[item_code] = source_warehouse
 		lane_by_item[item_code] = lane
 		if source_warehouse:
@@ -1584,7 +1246,7 @@ def _sanitize_submitted_items(items):
 
 
 @frappe.whitelist()
-def get_user_store(surface: str | None = None):
+def get_user_store():
 	"""
 	Resolve the current user's store(s) based on their role.
 
@@ -1601,142 +1263,41 @@ def get_user_store(surface: str | None = None):
 	"""
 	user = frappe.session.user
 	user_roles = frappe.get_roles(user)
-	surface_key = _normalize_user_store_surface(surface)
-	schedule_rows = []
-	if surface_key == "store_schedule":
-		schedule_rows = _get_store_schedule_locations()
-	elif surface_key == "commissary_schedule":
-		schedule_rows = _get_commissary_schedule_locations()
-	schedule_store_map = {row["name"]: row for row in schedule_rows}
 
 	stores = []
 	role = None
-	seen_stores = set()
-	active_employee = None
 
-	if surface_key in {"store_schedule", "commissary_schedule"}:
-		active_employee = frappe.db.get_value(
-			"Employee",
-			{"user_id": user, "status": "Active"},
-			["name", "branch", "employee_name", "reports_to", "designation"],
-			as_dict=True,
-		)
-
-	def append_store(row: dict | None, *, allow_unmapped: bool = False):
-		if not row:
-			return
-		store_name = str(row.get("name") or "").strip()
-		if not store_name or store_name in seen_stores:
-			return
-		if surface_key in {"store_schedule", "commissary_schedule"}:
-			matched_row = schedule_store_map.get(store_name) or _find_schedule_store_row(
-				schedule_rows,
-				store_name,
-				row.get("warehouse_name"),
-			)
-			if matched_row:
-				row = matched_row
-			elif not allow_unmapped:
-				return
-		stores.append(
-			{
-				"name": store_name,
-				"warehouse_name": str(row.get("warehouse_name") or store_name).strip(),
-			}
-		)
-		seen_stores.add(store_name)
-
-	if "Area Supervisor" in user_roles or _designation_is_area_supervisor(
-		(active_employee or {}).get("designation")
-	):
+	if "Area Supervisor" in user_roles:
 		# Area supervisors see all stores assigned to them
 		role = "Area Supervisor"
 		area_stores = frappe.get_all(
 			"Warehouse",
-			filters={"custom_area_supervisor": user, "is_group": 0, "disabled": 0},
+			filters={"custom_area_supervisor": user, "is_group": 0},
 			fields=["name", "warehouse_name"],
 			order_by="warehouse_name",
 		)
-		allow_area_unmapped = surface_key not in {"store_schedule", "commissary_schedule"}
-		for store_row in area_stores:
-			append_store(store_row, allow_unmapped=allow_area_unmapped)
-		if surface_key in {"store_schedule", "commissary_schedule"} and (
-			"System Manager" in user_roles
-			or "HR User" in user_roles
-			or "HR Manager" in user_roles
-			or "Regional Manager" in user_roles
-		):
-			for store_row in schedule_rows:
-				append_store(store_row)
-
-	if not stores and active_employee and surface_key in {"store_schedule", "commissary_schedule"}:
-		employee_store_row = _employee_schedule_store_row(
-			active_employee,
-			surface=surface_key,
-			schedule_rows=schedule_rows,
-			user_roles=user_roles,
-		)
-		if employee_store_row:
-			role = role or _employee_schedule_role(active_employee, user_roles, surface_key)
-			append_store(employee_store_row, allow_unmapped=True)
+		stores = area_stores
 
 	if not stores and (
 		"Store Supervisor" in user_roles or "Store Staff" in user_roles or "Employee" in user_roles
 	):
 		# Store staff/supervisors get their branch from Employee record
-		role = role or ("Store Supervisor" if "Store Supervisor" in user_roles else "Store Staff")
-		employee = active_employee or frappe.db.get_value(
+		role = "Store Supervisor" if "Store Supervisor" in user_roles else "Store Staff"
+		employee = frappe.db.get_value(
 			"Employee",
 			{"user_id": user, "status": "Active"},
-			["name", "branch", "employee_name", "reports_to", "designation"],
+			["name", "branch", "employee_name", "reports_to"],
 			as_dict=True,
 		)
 		if employee:
 			store_context = resolve_employee_store_context(employee)
 			if store_context.get("warehouse"):
-				append_store(
+				stores = [
 					{
 						"name": store_context["warehouse"],
 						"warehouse_name": store_context["warehouse_name"],
-					},
-					allow_unmapped=surface_key in {"store_schedule", "commissary_schedule"},
-				)
-
-	if (
-		not stores
-		and surface_key == "commissary_schedule"
-		and (
-			"Commissary Supervisor" in user_roles
-			or "Warehouse User" in user_roles
-			or "Supply Chain Manager" in user_roles
-		)
-	):
-		role = (
-			"Supply Chain Manager"
-			if "Supply Chain Manager" in user_roles
-			else "Commissary Supervisor"
-			if "Commissary Supervisor" in user_roles
-			else "Warehouse User"
-		)
-		employee = active_employee or frappe.db.get_value(
-			"Employee",
-			{"user_id": user, "status": "Active"},
-			["name", "branch", "employee_name", "reports_to", "designation"],
-			as_dict=True,
-		)
-		if employee:
-			store_context = resolve_employee_store_context(employee)
-			if store_context.get("warehouse"):
-				append_store(
-					{
-						"name": store_context["warehouse"],
-						"warehouse_name": store_context["warehouse_name"],
-					},
-					allow_unmapped=True,
-				)
-		if not stores:
-			for store_row in schedule_rows:
-				append_store(store_row)
+					}
+				]
 
 	# System / HR / Regional fallback - return all stores
 	if not stores and (
@@ -1746,19 +1307,13 @@ def get_user_store(surface: str | None = None):
 		or "Regional Manager" in user_roles
 	):
 		role = "Regional Manager" if "Regional Manager" in user_roles else "HR User"
-		if surface_key in {"store_schedule", "commissary_schedule"}:
-			for store_row in schedule_rows:
-				append_store(store_row)
-		else:
-			store_rows = frappe.get_all(
-				"Warehouse",
-				filters={"is_group": 0, "disabled": 0},
-				fields=["name", "warehouse_name"],
-				order_by="warehouse_name",
-				limit=50,
-			)
-			for store_row in store_rows:
-				append_store(store_row)
+		stores = frappe.get_all(
+			"Warehouse",
+			filters={"is_group": 0, "disabled": 0},
+			fields=["name", "warehouse_name"],
+			order_by="warehouse_name",
+			limit=50,
+		)
 
 	default_store = stores[0]["name"] if stores else None
 
@@ -2035,7 +1590,7 @@ def submit_order(
 		frappe.throw(_("Cargo category is required (FC, DRY, or FM)"))
 
 	is_emergency_flag = frappe.utils.cint(is_emergency)
-	cutoff_hour, cutoff_time = _get_order_cutoff()
+	cutoff_hour, _cutoff_time = _get_order_cutoff()
 	submitted_after_cutoff = now_datetime().hour >= cutoff_hour
 
 	# Validate ordering schedule cutoff
@@ -2059,23 +1614,23 @@ def submit_order(
 
 	order_date = nowdate()
 
-	# Same-day follow-up orders are allowed before cutoff so stores can add missed
-	# items without waiting for the emergency lane. They still route to Area
-	# Supervisor review and stay blocked after the noon cutoff.
-	existing_same_day_orders = []
+	# Duplicate check: no existing non-cancelled order for same store + date + category
 	if not is_emergency_flag:
-		existing_same_day_orders = frappe.get_all(
+		existing = frappe.db.exists(
 			"BEI Store Order",
-			filters={
+			{
 				"store": warehouse,
 				"order_date": order_date,
 				"cargo_category": normalized_cargo_category,
 				"status": ["not in", ["Cancelled"]],
 			},
-			fields=["name", "status"],
-			order_by="creation asc",
-			limit_page_length=20,
 		)
+		if existing:
+			frappe.throw(
+				_("An order already exists for {0} on {1} for category {2}: {3}").format(
+					warehouse, order_date, normalized_cargo_category, existing
+				)
+			)
 
 	# Validate quantities - prevent unreasonable orders
 	MAX_ORDER_QTY = 10000
@@ -2108,8 +1663,6 @@ def submit_order(
 
 	# Determine is_bulk_order: bulk if more than 10 line items
 	is_bulk_order = 1 if len(items) > 10 else 0
-	is_same_day_additional_order = 1 if len(existing_same_day_orders) > 0 else 0
-	same_day_order_sequence = len(existing_same_day_orders) + 1
 
 	order = frappe.new_doc("BEI Store Order")
 	order.store = warehouse
@@ -2154,7 +1707,6 @@ def submit_order(
 	requires_manual_approval = bool(
 		is_bulk_order
 		or edited_lines_count > 0
-		or is_same_day_additional_order
 		or (is_emergency_flag and submitted_after_cutoff)
 	)
 	if requires_manual_approval and not first_approver:
@@ -2209,13 +1761,6 @@ def submit_order(
 				first_approver
 			),
 		)
-	if is_same_day_additional_order:
-		_append_order_comment(
-			order.name,
-			_(
-				"Additional scheduled order #{0} for {1} / {2}; routed for manual approval before cutoff."
-			).format(same_day_order_sequence, warehouse, normalized_cargo_category),
-		)
 
 	result = {
 		"success": True,
@@ -2225,24 +1770,22 @@ def submit_order(
 			requires_manual_approval and first_source == "area_supervisor"
 		),
 		"requires_regional_manager_review": False,
-		"requires_fallback_approval": bool(requires_manual_approval and first_source == "fallback_approver"),
-		"edited_lines_count": edited_lines_count,
-		"message": (
-			f"Additional scheduled order {order.name} submitted successfully"
-			if is_same_day_additional_order
-			else f"Order {order.name} submitted successfully"
+		"requires_fallback_approval": bool(
+			requires_manual_approval and first_source == "fallback_approver"
 		),
+		"edited_lines_count": edited_lines_count,
+		"message": f"Order {order.name} submitted successfully",
 		"approval_queue_status": queue_status,
 		"approval_queue_name": queue_name,
 		"approval_approver_source": first_source if requires_manual_approval else "not_required",
 		"approval_assigned_approver": first_approver if requires_manual_approval else None,
 		"fallback_approver": (
-			first_approver if requires_manual_approval and first_source == "fallback_approver" else None
+			first_approver
+			if requires_manual_approval and first_source == "fallback_approver"
+			else None
 		),
 		"submitted_after_cutoff": bool(submitted_after_cutoff),
 		"is_emergency": bool(is_emergency_flag),
-		"is_same_day_additional_order": bool(is_same_day_additional_order),
-		"same_day_order_sequence": same_day_order_sequence,
 		"cargo_category": normalized_cargo_category,
 		"dropped_invalid_lines": len(dropped_items),
 	}
@@ -2337,9 +1880,7 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 		is_fallback_user = bool(fallback_approver and user == fallback_approver)
 		if not user_roles.intersection(allowed_roles) and not is_fallback_user:
 			frappe.throw(
-				_(
-					"Only assigned approvers, Area Supervisors, fallback approvers, or System Managers can approve."
-				),
+				_("Only assigned approvers, Area Supervisors, fallback approvers, or System Managers can approve."),
 				frappe.PermissionError,
 			)
 
@@ -2406,11 +1947,9 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 			).format(order_name)
 		)
 
-	store_space = None
-	try:
-		store_space = frappe.db.get_value("Warehouse", order.store, "custom_gchat_space")
-	except Exception:
-		store_space = None
+	from hrms.api.google_chat import resolve_store_chat_space
+
+	store_space = resolve_store_chat_space(order.store)
 
 	_notify_store_ops(
 		event={
@@ -2430,8 +1969,9 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 				"dashboard_url": "https://my.bebang.ph/dashboard/store-ops/order-approvals",
 			},
 		},
-		requested_space=store_space or get_chat_space(SPACE_OPS),
+			requested_space=store_space or get_chat_space(SPACE_OPS),
 	)
+
 	return {
 		"success": True,
 		"message": f"Order {order_name} approved",
@@ -2488,9 +2028,7 @@ def _create_mr_for_store_order(order):
 		)
 		finance_treatment = infer_finance_treatment(source_company, billing_target_company)
 		is_intercompany = finance_treatment == FINANCE_TREATMENT_INTERCOMPANY
-		operational_dispatch_warehouse = (
-			source_warehouse if is_intercompany and source_warehouse else store_warehouse
-		)
+		operational_dispatch_warehouse = source_warehouse if is_intercompany and source_warehouse else store_warehouse
 		mr.material_request_type = "Material Issue" if is_intercompany else "Material Transfer"
 		# Frappe validates Material Transfer requests against the operational stock
 		# owner on the source side of the move. The buyer entity used later for
@@ -2508,7 +2046,7 @@ def _create_mr_for_store_order(order):
 			target_company=billing_target_company,
 			finance_treatment=finance_treatment,
 		)
-		mr.remarks = f"Warehouse dispatch request for store order {order.name} ({cargo_category})"
+		mr.remarks = f"Warehouse dispatch request for store order {order.name} " f"({cargo_category})"
 
 		for item in order.items:
 			qty = flt(getattr(item, "qty_approved", None) or getattr(item, "qty_requested", 0))
@@ -3089,7 +2627,9 @@ def _resolve_store_order_item_pricing(store_order_name: str | None) -> dict[str,
 		result[item_code] = {
 			"unit_price": flt(row.get("unit_price"), 6),
 			"delivered_qty": (
-				flt(row.get("qty_delivered")) or flt(row.get("qty_approved")) or flt(row.get("qty_requested"))
+				flt(row.get("qty_delivered"))
+				or flt(row.get("qty_approved"))
+				or flt(row.get("qty_requested"))
 			),
 		}
 	return result
@@ -3489,7 +3029,11 @@ def create_store_return(
 		"finance_treatment": finance_treatment,
 		"message": (
 			f"Store return {primary_entry.name} created"
-			+ (f" with warehouse receipt {warehouse_receipt.name}" if warehouse_receipt else "")
+			+ (
+				f" with warehouse receipt {warehouse_receipt.name}"
+				if warehouse_receipt
+				else ""
+			)
 			+ f" — {len(primary_entry.items)} item(s) returned to warehouse"
 		),
 	}

--- a/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py
+++ b/hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py
@@ -189,6 +189,8 @@ def _resolve_store_chat_space(store):
 	if not store:
 		return None
 	try:
-		return frappe.db.get_value("Warehouse", store, "custom_gchat_space")
+		from hrms.api.google_chat import resolve_store_chat_space
+
+		return resolve_store_chat_space(store)
 	except Exception:
 		return None

--- a/hrms/tests/test_enrichment_reminder_queue_fallback_s09.py
+++ b/hrms/tests/test_enrichment_reminder_queue_fallback_s09.py
@@ -170,8 +170,8 @@ class TestEnrichmentReminderQueueFallbackS09(unittest.TestCase):
 
 	def test_submit_order_requires_valid_area_supervisor_mapping_for_edited_lines(self):
 		store.frappe.local.session = types.SimpleNamespace(user="test.supervisor@bebang.ph")
-		store.frappe.new_doc = (
-			lambda doctype: _FakeOrderDoc() if doctype == "BEI Store Order" else _FakeOrderDoc("APQ-0001")
+		store.frappe.new_doc = lambda doctype: (
+			_FakeOrderDoc() if doctype == "BEI Store Order" else _FakeOrderDoc("APQ-0001")
 		)
 
 		with (

--- a/hrms/tests/test_enrichment_reminder_queue_fallback_s09.py
+++ b/hrms/tests/test_enrichment_reminder_queue_fallback_s09.py
@@ -85,13 +85,35 @@ def _install_fake_runtime():
 	sys.modules["hrms.utils"] = hrms_utils_pkg
 
 	bei_config_mod = types.ModuleType("hrms.utils.bei_config")
+	bei_config_mod.SPACE_OPS = "ops-space"
+	bei_config_mod.get_chat_space = lambda value=None: value or "ops-space"
 	bei_config_mod.get_company = lambda: "BEI"
 	sys.modules["hrms.utils.bei_config"] = bei_config_mod
+
+	contact_validation_mod = types.ModuleType("hrms.api.contact_validation")
+	contact_validation_mod.validate_email_address = lambda value, *args, **kwargs: value
+	contact_validation_mod.validate_ph_mobile_number = lambda value, *args, **kwargs: value
+	sys.modules["hrms.api.contact_validation"] = contact_validation_mod
 
 	scm_roles_mod = types.ModuleType("hrms.utils.scm_roles")
 	scm_roles_mod.check_scm_permission = lambda *args, **kwargs: None
 	scm_roles_mod.SCM_APPROVAL_ROLES = ["Area Supervisor", "System Manager"]
 	sys.modules["hrms.utils.scm_roles"] = scm_roles_mod
+
+	supply_chain_contracts_mod = types.ModuleType("hrms.utils.supply_chain_contracts")
+	supply_chain_contracts_mod.FINANCE_TREATMENT_INTERCOMPANY = "intercompany"
+	supply_chain_contracts_mod.FINANCE_TREATMENT_SAME_COMPANY = "same_company"
+	supply_chain_contracts_mod.REQUEST_SOURCE_STORE_DISPOSAL = "store_disposal"
+	supply_chain_contracts_mod.REQUEST_SOURCE_STORE_ORDER = "store_order"
+	supply_chain_contracts_mod.REQUEST_SOURCE_STORE_RETURN = "store_return"
+	supply_chain_contracts_mod.infer_finance_treatment = lambda *args, **kwargs: "same_company"
+	supply_chain_contracts_mod.resolve_material_request_contract = lambda *args, **kwargs: {}
+	supply_chain_contracts_mod.resolve_route_source_warehouse = lambda *args, **kwargs: None
+	supply_chain_contracts_mod.resolve_store_buyer_entity = lambda *args, **kwargs: None
+	supply_chain_contracts_mod.resolve_warehouse_company = lambda *args, **kwargs: "BEI"
+	supply_chain_contracts_mod.stamp_material_request_contract = lambda *args, **kwargs: None
+	supply_chain_contracts_mod.stamp_stock_entry_contract = lambda *args, **kwargs: None
+	sys.modules["hrms.utils.supply_chain_contracts"] = supply_chain_contracts_mod
 
 
 def _load_module(name: str, relative_path: str):

--- a/hrms/tests/test_marketing_giveaways_api.py
+++ b/hrms/tests/test_marketing_giveaways_api.py
@@ -56,14 +56,10 @@ def _install_fake_dependencies(user_roles: list[str] | None = None):
 			return payload.get(str(fields or "name"))
 		return None
 
-<<<<<<< HEAD
-=======
 	def _db_exists(doctype, filters=None, *args, **kwargs):
 		if doctype == "Bin":
 			return "BIN-0001"
 		return None
-
->>>>>>> a621231fc (fix: harden backend sentry cleanup surfaces)
 	class PermissionError(Exception):
 		pass
 

--- a/hrms/tests/test_marketing_giveaways_api.py
+++ b/hrms/tests/test_marketing_giveaways_api.py
@@ -56,6 +56,14 @@ def _install_fake_dependencies(user_roles: list[str] | None = None):
 			return payload.get(str(fields or "name"))
 		return None
 
+<<<<<<< HEAD
+=======
+	def _db_exists(doctype, filters=None, *args, **kwargs):
+		if doctype == "Bin":
+			return "BIN-0001"
+		return None
+
+>>>>>>> a621231fc (fix: harden backend sentry cleanup surfaces)
 	class PermissionError(Exception):
 		pass
 
@@ -85,7 +93,7 @@ def _install_fake_dependencies(user_roles: list[str] | None = None):
 	frappe.local = types.SimpleNamespace(
 		db=types.SimpleNamespace(
 			get_value=_db_get_value,
-			exists=lambda *args, **kwargs: None,
+			exists=_db_exists,
 			count=lambda *args, **kwargs: 0,
 			savepoint=lambda *args, **kwargs: None,
 			release_savepoint=lambda *args, **kwargs: None,

--- a/hrms/tests/test_marketing_giveaways_api.py
+++ b/hrms/tests/test_marketing_giveaways_api.py
@@ -51,7 +51,7 @@ def _install_fake_dependencies(user_roles: list[str] | None = None):
 			}
 			if as_dict:
 				return payload
-			if isinstance(fields, (list, tuple)):
+			if isinstance(fields, list | tuple):
 				return [payload.get(field) for field in fields]
 			return payload.get(str(fields or "name"))
 		return None
@@ -60,6 +60,7 @@ def _install_fake_dependencies(user_roles: list[str] | None = None):
 		if doctype == "Bin":
 			return "BIN-0001"
 		return None
+
 	class PermissionError(Exception):
 		pass
 
@@ -206,7 +207,7 @@ class FakeCampaignDoc:
 	cost_center: str = "Main - BEI"
 	budget_owner: str = "Marketing"
 	requester_user: str = "marketing@bebang.ph"
-	source_locations_json: str = "[\"SM Megamall - Bebang Enterprise Inc.\"]"
+	source_locations_json: str = '["SM Megamall - Bebang Enterprise Inc."]'
 	schedule_json: str = "[]"
 	items: list[FakeItemRow] = field(default_factory=list)
 	total_approved_quantity: float = 10.0
@@ -252,7 +253,11 @@ class FakeIssueDoc:
 def test_validate_issue_request_blocks_quantity_overrun(monkeypatch):
 	module = _load_module("marketing_giveaways_quantity_overrun")
 	campaign = FakeCampaignDoc(
-		items=[FakeItemRow(item_code="ITEM-001", approved_quantity=10, remaining_quantity=2, estimated_unit_cost=5)]
+		items=[
+			FakeItemRow(
+				item_code="ITEM-001", approved_quantity=10, remaining_quantity=2, estimated_unit_cost=5
+			)
+		]
 	)
 	exceptions: list[dict] = []
 
@@ -278,7 +283,11 @@ def test_validate_issue_request_blocks_quantity_overrun(monkeypatch):
 def test_validate_issue_request_blocks_non_approved_source(monkeypatch):
 	module = _load_module("marketing_giveaways_source_block")
 	campaign = FakeCampaignDoc(
-		items=[FakeItemRow(item_code="ITEM-001", approved_quantity=10, remaining_quantity=10, estimated_unit_cost=5)]
+		items=[
+			FakeItemRow(
+				item_code="ITEM-001", approved_quantity=10, remaining_quantity=10, estimated_unit_cost=5
+			)
+		]
 	)
 	exceptions: list[dict] = []
 
@@ -305,7 +314,11 @@ def test_validate_issue_request_blocks_daily_cap(monkeypatch):
 	module = _load_module("marketing_giveaways_daily_cap")
 	campaign = FakeCampaignDoc(
 		daily_cap_quantity=5,
-		items=[FakeItemRow(item_code="ITEM-001", approved_quantity=10, remaining_quantity=10, estimated_unit_cost=5)],
+		items=[
+			FakeItemRow(
+				item_code="ITEM-001", approved_quantity=10, remaining_quantity=10, estimated_unit_cost=5
+			)
+		],
 	)
 	exceptions: list[dict] = []
 
@@ -338,7 +351,11 @@ def test_validate_issue_request_blocks_value_tolerance_breach(monkeypatch):
 	campaign = FakeCampaignDoc(
 		estimated_peso_value=100,
 		approved_value_tolerance_pct=10,
-		items=[FakeItemRow(item_code="ITEM-001", approved_quantity=10, remaining_quantity=10, estimated_unit_cost=10)],
+		items=[
+			FakeItemRow(
+				item_code="ITEM-001", approved_quantity=10, remaining_quantity=10, estimated_unit_cost=10
+			)
+		],
 	)
 	exceptions: list[dict] = []
 
@@ -348,9 +365,9 @@ def test_validate_issue_request_blocks_value_tolerance_breach(monkeypatch):
 	monkeypatch.setattr(
 		module.frappe,
 		"get_all",
-		lambda doctype, filters=None, fields=None, limit_page_length=None: [{"actual_total_cost": 95}]
-		if doctype == module.ISSUE_DT
-		else [],
+		lambda doctype, filters=None, fields=None, limit_page_length=None: (
+			[{"actual_total_cost": 95}] if doctype == module.ISSUE_DT else []
+		),
 	)
 
 	def _capture_exception(**kwargs):
@@ -383,7 +400,11 @@ def test_post_campaign_giveaway_issue_returns_idempotent_replay(monkeypatch):
 	)
 
 	def _get_value(doctype, filters=None, fieldname=None, *args, **kwargs):
-		if doctype == module.ISSUE_DT and isinstance(filters, dict) and filters.get("idempotency_key") == "dup-key":
+		if (
+			doctype == module.ISSUE_DT
+			and isinstance(filters, dict)
+			and filters.get("idempotency_key") == "dup-key"
+		):
 			return existing_issue.name
 		return None
 
@@ -408,7 +429,16 @@ def test_post_campaign_giveaway_issue_returns_idempotent_replay(monkeypatch):
 def test_post_campaign_giveaway_issue_posts_stock_entry_and_updates_campaign(monkeypatch):
 	module = _load_module("marketing_giveaways_happy_path", user_roles=["Store Supervisor"])
 	campaign = FakeCampaignDoc(
-		items=[FakeItemRow(item_code="ITEM-001", item_name="Presidential", uom="Cup", approved_quantity=10, remaining_quantity=10, estimated_unit_cost=12.5)]
+		items=[
+			FakeItemRow(
+				item_code="ITEM-001",
+				item_name="Presidential",
+				uom="Cup",
+				approved_quantity=10,
+				remaining_quantity=10,
+				estimated_unit_cost=12.5,
+			)
+		]
 	)
 	issue_doc = FakeIssueDoc()
 	savepoints: list[str] = []
@@ -423,7 +453,11 @@ def test_post_campaign_giveaway_issue_posts_stock_entry_and_updates_campaign(mon
 
 	monkeypatch.setattr(module.frappe.db, "get_value", _get_value)
 	monkeypatch.setattr(module.frappe.db, "savepoint", lambda name: savepoints.append(name))
-	monkeypatch.setattr(module.frappe.db, "rollback", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("rollback should not be called")))
+	monkeypatch.setattr(
+		module.frappe.db,
+		"rollback",
+		lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("rollback should not be called")),
+	)
 	monkeypatch.setattr(module.frappe.db, "commit", lambda: commits.append(True))
 	monkeypatch.setattr(module.frappe, "new_doc", _new_doc)
 	monkeypatch.setattr(module, "_campaign_doc", lambda name: campaign)
@@ -434,7 +468,11 @@ def test_post_campaign_giveaway_issue_posts_stock_entry_and_updates_campaign(mon
 	)
 	monkeypatch.setattr(module, "_post_stock_entry_for_issue", lambda campaign_doc, issue: "STE-0001")
 	monkeypatch.setattr(module, "_update_campaign_tracking", lambda campaign_doc: 875.0)
-	monkeypatch.setattr(module, "_serialize_campaign_row", lambda campaign_doc: {"name": campaign_doc.name, "status": campaign_doc.status})
+	monkeypatch.setattr(
+		module,
+		"_serialize_campaign_row",
+		lambda campaign_doc: {"name": campaign_doc.name, "status": campaign_doc.status},
+	)
 
 	result = module.post_campaign_giveaway_issue(
 		campaign=campaign.name,
@@ -476,8 +514,20 @@ def test_update_campaign_tracking_computes_multi_day_progress(monkeypatch):
 	def _get_all(doctype, filters=None, fields=None, limit_page_length=None):
 		assert doctype == module.ISSUE_DT
 		return [
-			{"name": "CGI-0001", "issue_date": "2026-03-18", "item_code": "ITEM-001", "quantity": 5, "actual_total_cost": 60},
-			{"name": "CGI-0002", "issue_date": "2026-03-19", "item_code": "ITEM-002", "quantity": 3, "actual_total_cost": 36},
+			{
+				"name": "CGI-0001",
+				"issue_date": "2026-03-18",
+				"item_code": "ITEM-001",
+				"quantity": 5,
+				"actual_total_cost": 60,
+			},
+			{
+				"name": "CGI-0002",
+				"issue_date": "2026-03-19",
+				"item_code": "ITEM-002",
+				"quantity": 3,
+				"actual_total_cost": 36,
+			},
 		]
 
 	monkeypatch.setattr(module.frappe, "get_all", _get_all)
@@ -574,9 +624,13 @@ def test_query_probable_giveaway_leakage_flags_marketing_and_effectively_free_or
 	monkeypatch.setattr(
 		module.frappe,
 		"get_all",
-		lambda doctype, filters=None, fields=None, limit_page_length=None: [{"campaign": "CMP-0001", "status": "Linked"}]
-		if doctype == module.EXCEPTION_DT and filters and filters.get("linked_alert_reference") == "pos-order:101"
-		else [],
+		lambda doctype, filters=None, fields=None, limit_page_length=None: (
+			[{"campaign": "CMP-0001", "status": "Linked"}]
+			if doctype == module.EXCEPTION_DT
+			and filters
+			and filters.get("linked_alert_reference") == "pos-order:101"
+			else []
+		),
 	)
 
 	rows = module._query_probable_giveaway_leakage(date(2026, 3, 1), date(2026, 3, 18))

--- a/hrms/utils/sales_location_mapping.py
+++ b/hrms/utils/sales_location_mapping.py
@@ -5,7 +5,6 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-
 MAPPING_PATH = Path(__file__).resolve().parents[1] / "fixtures" / "sales_dashboard_store_mapping.csv"
 
 
@@ -62,3 +61,25 @@ def lookup_location_id(
 	match = lookup_sales_location(warehouse_name=warehouse_name, warehouse_record_name=warehouse_record_name)
 	return int(match["location_id"]) if match else None
 
+
+@lru_cache(maxsize=1)
+def load_sales_location_mapping_by_id() -> dict[int, dict[str, Any]]:
+	mapping: dict[int, dict[str, Any]] = {}
+	for row in load_sales_location_mapping().values():
+		location_id = int(row["location_id"])
+		if location_id not in mapping:
+			mapping[location_id] = row
+	return mapping
+
+
+def lookup_store_name_by_location_id(location_id: int | str | None) -> str | None:
+	try:
+		key = int(location_id or 0)
+	except (TypeError, ValueError):
+		return None
+	if not key:
+		return None
+	match = load_sales_location_mapping_by_id().get(key)
+	if not match:
+		return None
+	return str(match.get("warehouse_name") or match.get("warehouse_record_name") or "").strip() or None


### PR DESCRIPTION
## Summary
- harden backend notification and observability cleanup paths for S082
- fix enrichment queue wrapper and marketing giveaway lookup regressions
- add focused regression coverage for the backend fixes

## Verification
- python -m ruff check hrms/api/google_chat.py hrms/api/ordering.py hrms/api/dispatch.py hrms/api/store.py hrms/api/projects.py hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py hrms/api/enrichment.py hrms/api/marketing_giveaways.py hrms/utils/sales_location_mapping.py
- python -m py_compile hrms/api/google_chat.py hrms/api/ordering.py hrms/api/dispatch.py hrms/api/store.py hrms/api/projects.py hrms/hr/doctype/bei_maintenance_request/bei_maintenance_request.py hrms/api/enrichment.py hrms/api/marketing_giveaways.py hrms/utils/sales_location_mapping.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest hrms/tests/test_enrichment_reminder_queue_fallback_s09.py hrms/tests/test_marketing_giveaways_api.py -q