### PR TITLE
fix(s092): ERP testing bug remediation — 7 backend fixes

### DIFF
--- a/hrms/api/commissary_quality.py
+++ b/hrms/api/commissary_quality.py
@@ -555,10 +555,10 @@ def log_wastage(
 			_rollback_savepoint(savepoint_name)
 			if attempt == 2 or not _is_retryable_stock_entry_submit_error(exc):
 				frappe.log_error(
-					f"Wastage stock entry failed for {item_code}: {str(exc)}",
+					f"Wastage stock entry failed for {item_code}: {exc!s}",
 					"Wastage Logging Error",
 				)
-				return {"success": False, "error": f"Stock entry failed: {str(exc)}"}
+				return {"success": False, "error": f"Stock entry failed: {exc!s}"}
 			time.sleep(0.2 * (attempt + 1))
 
 	# Calculate wastage value

--- a/hrms/api/commissary_quality.py
+++ b/hrms/api/commissary_quality.py
@@ -457,6 +457,7 @@ def log_wastage(
 		extras={"item_code": item_code, "qty": qty, "reason_code": reason_code, "batch_no": batch_no},
 	)
 	commissary_warehouse = get_commissary_warehouse()
+	frappe.logger().info(f"Wastage warehouse resolved to: {commissary_warehouse}")
 	normalized_batch_no = (batch_no or "").strip()
 	available_batches = _get_available_batch_rows(item_code, commissary_warehouse)
 	available_batch_numbers = {str(row.get("batch_no")).strip() for row in available_batches if row.get("batch_no")}
@@ -543,18 +544,21 @@ def log_wastage(
 			se.append("items", row)
 
 			_enable_role_gated_write(se)
-			with _run_as_system_user():
-				se.insert(ignore_permissions=True)
-				se = frappe.get_doc("Stock Entry", se.name)
-				_enable_role_gated_write(se)
-				se.submit()
+			se.insert(ignore_permissions=True)
+			se = frappe.get_doc("Stock Entry", se.name)
+			_enable_role_gated_write(se)
+			se.submit()
 
 			_release_savepoint(savepoint_name)
 			break
 		except Exception as exc:
 			_rollback_savepoint(savepoint_name)
 			if attempt == 2 or not _is_retryable_stock_entry_submit_error(exc):
-				raise
+				frappe.log_error(
+					f"Wastage stock entry failed for {item_code}: {str(exc)}",
+					"Wastage Logging Error",
+				)
+				return {"success": False, "error": f"Stock entry failed: {str(exc)}"}
 			time.sleep(0.2 * (attempt + 1))
 
 	# Calculate wastage value

--- a/hrms/api/commissary_quality.py
+++ b/hrms/api/commissary_quality.py
@@ -460,7 +460,9 @@ def log_wastage(
 	frappe.logger().info(f"Wastage warehouse resolved to: {commissary_warehouse}")
 	normalized_batch_no = (batch_no or "").strip()
 	available_batches = _get_available_batch_rows(item_code, commissary_warehouse)
-	available_batch_numbers = {str(row.get("batch_no")).strip() for row in available_batches if row.get("batch_no")}
+	available_batch_numbers = {
+		str(row.get("batch_no")).strip() for row in available_batches if row.get("batch_no")
+	}
 
 	if normalized_batch_no:
 		if normalized_batch_no not in available_batch_numbers:

--- a/hrms/api/dispatch.py
+++ b/hrms/api/dispatch.py
@@ -696,7 +696,7 @@ def _build_trip_doc(trip_date: str | None, route_name: str, stops: list[dict[str
 @frappe.whitelist()
 def create_trip(trip_date: str | None, route_name: str, stops: list[dict[str, Any]] | str):
 	"""Create a new distribution trip. stops: list of {store, items_count}."""
-	_check_scm_permission(SCM_ADMIN_ROLES, "create trips")
+	_check_scm_permission(SCM_DISPATCH_ROLES, "create trips")
 
 	if isinstance(stops, str):
 		stops = frappe.parse_json(stops)

--- a/hrms/api/supervisor.py
+++ b/hrms/api/supervisor.py
@@ -354,7 +354,9 @@ def _get_current_employee():
 
 def _user_can_manage_store_schedule(store: str):
 	user_roles = set(frappe.get_roles(frappe.session.user))
-	if user_roles.intersection({"System Manager", "Administrator", "HR User", "HR Manager", "Commissary Supervisor"}):
+	if user_roles.intersection(
+		{"System Manager", "Administrator", "HR User", "HR Manager", "Commissary Supervisor"}
+	):
 		return True
 
 	store_context = _resolve_labor_plan_store(store)

--- a/hrms/api/supervisor.py
+++ b/hrms/api/supervisor.py
@@ -354,7 +354,7 @@ def _get_current_employee():
 
 def _user_can_manage_store_schedule(store: str):
 	user_roles = set(frappe.get_roles(frappe.session.user))
-	if user_roles.intersection({"System Manager", "Administrator", "HR User", "HR Manager"}):
+	if user_roles.intersection({"System Manager", "Administrator", "HR User", "HR Manager", "Commissary Supervisor"}):
 		return True
 
 	store_context = _resolve_labor_plan_store(store)

--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -640,7 +640,7 @@ def complete_warehouse_receiving(
 			receiving.remarks = remarks or receiving.remarks
 			receiving.status = "With Issues"
 			receiving.save(ignore_permissions=True)
-			frappe.db.commit()
+			frappe.db.commit()  # nosemgrep: frappe-manual-commit — full rejection saves receiving doc outside normal stock entry flow
 			return {
 				"success": True,
 				"data": {"receiving_name": receiving.name, "status": "fully_rejected"},
@@ -764,7 +764,7 @@ def get_pending_material_requests():
 
 
 @frappe.whitelist()
-def get_material_request_items(mr_name):
+def get_material_request_items(mr_name: str):
 	"""
 	Get detailed items for a Material Request with stock availability.
 	"""

--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -633,6 +633,19 @@ def complete_warehouse_receiving(
 			)
 
 	if not accepted_items:
+		if any(flt(item_data.get("rejected_qty", 0)) > 0 for item_data in items):
+			# Full rejection — no stock entry needed, just update status
+			receiving.receiving_date = now_datetime()
+			receiving.received_by_user = frappe.session.user
+			receiving.remarks = remarks or receiving.remarks
+			receiving.status = "With Issues"
+			receiving.save(ignore_permissions=True)
+			frappe.db.commit()
+			return {
+				"success": True,
+				"data": {"receiving_name": receiving.name, "status": "fully_rejected"},
+				"message": f"All items rejected for {receiving.name}",
+			}
 		frappe.throw(_("No accepted quantity to receive into warehouse"))
 
 	stock_entry = frappe.new_doc("Stock Entry")
@@ -672,9 +685,8 @@ def complete_warehouse_receiving(
 		)
 
 	_enable_role_gated_write(stock_entry)
-	with _run_as_system_user():
-		stock_entry.insert(ignore_permissions=True)
-		stock_entry.submit()
+	stock_entry.insert(ignore_permissions=True)
+	stock_entry.submit()
 
 	receiving.stock_entry = stock_entry.name
 	receiving.receiving_date = now_datetime()
@@ -781,6 +793,9 @@ def get_material_request_items(mr_name):
 			frappe.db.get_value("Material Request Item", item["name"], "from_warehouse")
 			or contract["source_warehouse"]
 		)
+		# FIX-5 (S092): Resolve blank from_warehouse via commissary warehouse fallback
+		if not from_warehouse:
+			from_warehouse = commissary_warehouse
 		item["from_warehouse"] = from_warehouse
 		bin_qty = 0
 		if from_warehouse:
@@ -790,6 +805,13 @@ def get_material_request_items(mr_name):
 				)
 				or 0
 			)
+		else:
+			# No warehouse resolved — sum across all warehouses as last resort
+			result = frappe.db.sql(
+				"SELECT SUM(actual_qty) FROM `tabBin` WHERE item_code = %s",
+				item["item_code"],
+			)
+			bin_qty = flt(result[0][0]) if result and result[0][0] else 0
 		item["available_qty"] = bin_qty
 		item["source_warehouse_missing"] = not bool(from_warehouse)
 
@@ -997,6 +1019,13 @@ def create_stock_transfer(
 	)
 	check_scm_permission(SCM_DISPATCH_ROLES, "dispatch warehouse stock transfers")
 
+	if not source_warehouse:
+		frappe.throw(
+			_("Cannot create stock transfer: source warehouse is not set. "
+			  "Please specify a source warehouse or ensure the Material Request has one assigned."),
+			title=_("Source Warehouse Required"),
+		)
+
 	default_source_company = resolve_warehouse_company(source_warehouse) or get_company()
 	default_target_company = resolve_warehouse_company(target_warehouse) or default_source_company
 
@@ -1132,12 +1161,11 @@ def create_stock_transfer(
 		frappe.throw(_("No items to transfer"))
 
 	_enable_role_gated_write(se)
-	with _run_as_system_user():
-		se.insert(ignore_permissions=True)
-		se = frappe.get_doc("Stock Entry", se.name)
-		_enable_role_gated_write(se)
-		_clear_legacy_serial_batch_fields_after_auto_bundle(se)
-		se.submit()
+	se.insert(ignore_permissions=True)
+	se = frappe.get_doc("Stock Entry", se.name)
+	_enable_role_gated_write(se)
+	_clear_legacy_serial_batch_fields_after_auto_bundle(se)
+	se.submit()
 
 	return {
 		"success": True,

--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -1021,8 +1021,10 @@ def create_stock_transfer(
 
 	if not source_warehouse:
 		frappe.throw(
-			_("Cannot create stock transfer: source warehouse is not set. "
-			  "Please specify a source warehouse or ensure the Material Request has one assigned."),
+			_(
+				"Cannot create stock transfer: source warehouse is not set. "
+				"Please specify a source warehouse or ensure the Material Request has one assigned."
+			),
 			title=_("Source Warehouse Required"),
 		)
 

--- a/hrms/tests/test_s092_commissary_fixes.py
+++ b/hrms/tests/test_s092_commissary_fixes.py
@@ -11,72 +11,72 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 
 
 def _read_source(rel_path):
-    with open(os.path.join(REPO_ROOT, rel_path), "r", encoding="utf-8") as f:
-        return f.read()
+	with open(os.path.join(REPO_ROOT, rel_path), "r", encoding="utf-8") as f:
+		return f.read()
 
 
 def _extract_function(source, func_name):
-    marker = f"def {func_name}("
-    idx = source.find(marker)
-    if idx == -1:
-        return None
-    end_idx = source.find("\ndef ", idx + 1)
-    return source[idx : end_idx if end_idx != -1 else len(source)]
+	marker = f"def {func_name}("
+	idx = source.find(marker)
+	if idx == -1:
+		return None
+	end_idx = source.find("\ndef ", idx + 1)
+	return source[idx : end_idx if end_idx != -1 else len(source)]
 
 
 class TestWastageHardening(unittest.TestCase):
-    """FIX-6: Wastage logging error handling and permissions."""
+	"""FIX-6: Wastage logging error handling and permissions."""
 
-    def test_wastage_has_permission_check(self):
-        source = _read_source("hrms/api/commissary_quality.py")
-        func = _extract_function(source, "log_wastage")
-        self.assertIsNotNone(func)
-        self.assertIn("check_scm_permission", func)
+	def test_wastage_has_permission_check(self):
+		source = _read_source("hrms/api/commissary_quality.py")
+		func = _extract_function(source, "log_wastage")
+		self.assertIsNotNone(func)
+		self.assertIn("check_scm_permission", func)
 
-    def test_wastage_seven_reason_codes(self):
-        source = _read_source("hrms/api/commissary_quality.py")
-        for code in [
-            "expired", "damaged", "quality_fail", "contaminated",
-            "production_loss", "sampling", "other",
-        ]:
-            self.assertIn(f'"{code}"', source, f"Missing reason code: {code}")
+	def test_wastage_seven_reason_codes(self):
+		source = _read_source("hrms/api/commissary_quality.py")
+		for code in [
+			"expired", "damaged", "quality_fail", "contaminated",
+			"production_loss", "sampling", "other",
+		]:
+			self.assertIn(f'"{code}"', source, f"Missing reason code: {code}")
 
-    def test_wastage_structured_error_on_failure(self):
-        """Final stock entry failure should return structured error, not raise."""
-        source = _read_source("hrms/api/commissary_quality.py")
-        func = _extract_function(source, "log_wastage")
-        self.assertIsNotNone(func)
-        self.assertIn('"success": False', func)
-        self.assertIn("Stock entry failed", func)
+	def test_wastage_structured_error_on_failure(self):
+		"""Final stock entry failure should return structured error, not raise."""
+		source = _read_source("hrms/api/commissary_quality.py")
+		func = _extract_function(source, "log_wastage")
+		self.assertIsNotNone(func)
+		self.assertIn('"success": False', func)
+		self.assertIn("Stock entry failed", func)
 
-    def test_wastage_no_run_as_system_user(self):
-        source = _read_source("hrms/api/commissary_quality.py")
-        func = _extract_function(source, "log_wastage")
-        self.assertIsNotNone(func)
-        self.assertNotIn("_run_as_system_user", func)
+	def test_wastage_no_run_as_system_user(self):
+		source = _read_source("hrms/api/commissary_quality.py")
+		func = _extract_function(source, "log_wastage")
+		self.assertIsNotNone(func)
+		self.assertNotIn("_run_as_system_user", func)
 
-    def test_wastage_logs_warehouse_resolution(self):
-        source = _read_source("hrms/api/commissary_quality.py")
-        func = _extract_function(source, "log_wastage")
-        self.assertIsNotNone(func)
-        self.assertIn("Wastage warehouse resolved to", func)
+	def test_wastage_logs_warehouse_resolution(self):
+		source = _read_source("hrms/api/commissary_quality.py")
+		func = _extract_function(source, "log_wastage")
+		self.assertIsNotNone(func)
+		self.assertIn("Wastage warehouse resolved to", func)
 
 
 class TestLaborPlanVisibility(unittest.TestCase):
-    """FIX-7: Commissary Supervisor should have labor plan access."""
+	"""FIX-7: Commissary Supervisor should have labor plan access."""
 
-    def test_commissary_supervisor_in_store_schedule_roles(self):
-        source = _read_source("hrms/api/supervisor.py")
-        func = _extract_function(source, "_user_can_manage_store_schedule")
-        self.assertIsNotNone(func)
-        self.assertIn("Commissary Supervisor", func)
+	def test_commissary_supervisor_in_store_schedule_roles(self):
+		source = _read_source("hrms/api/supervisor.py")
+		func = _extract_function(source, "_user_can_manage_store_schedule")
+		self.assertIsNotNone(func)
+		self.assertIn("Commissary Supervisor", func)
 
-    def test_commissary_supervisor_in_commissary_schedule_roles(self):
-        source = _read_source("hrms/api/supervisor.py")
-        func = _extract_function(source, "_user_can_manage_commissary_schedule")
-        self.assertIsNotNone(func)
-        self.assertIn("Commissary Supervisor", func)
+	def test_commissary_supervisor_in_commissary_schedule_roles(self):
+		source = _read_source("hrms/api/supervisor.py")
+		func = _extract_function(source, "_user_can_manage_commissary_schedule")
+		self.assertIsNotNone(func)
+		self.assertIn("Commissary Supervisor", func)
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_s092_commissary_fixes.py
+++ b/hrms/tests/test_s092_commissary_fixes.py
@@ -1,0 +1,80 @@
+"""S092 — Commissary & RBAC Bug Fixes.
+
+Tests for FIX-6 (wastage hardening), FIX-7 (labor plan visibility),
+and _run_as_system_user removal in commissary_quality.
+"""
+
+import os
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _read_source(rel_path):
+    with open(os.path.join(REPO_ROOT, rel_path), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _extract_function(source, func_name):
+    marker = f"def {func_name}("
+    idx = source.find(marker)
+    if idx == -1:
+        return None
+    end_idx = source.find("\ndef ", idx + 1)
+    return source[idx : end_idx if end_idx != -1 else len(source)]
+
+
+class TestWastageHardening(unittest.TestCase):
+    """FIX-6: Wastage logging error handling and permissions."""
+
+    def test_wastage_has_permission_check(self):
+        source = _read_source("hrms/api/commissary_quality.py")
+        func = _extract_function(source, "log_wastage")
+        self.assertIsNotNone(func)
+        self.assertIn("check_scm_permission", func)
+
+    def test_wastage_seven_reason_codes(self):
+        source = _read_source("hrms/api/commissary_quality.py")
+        for code in ["expired", "damaged", "quality_fail", "contaminated",
+                      "production_loss", "sampling", "other"]:
+            self.assertIn(f'"{code}"', source, f"Missing reason code: {code}")
+
+    def test_wastage_structured_error_on_failure(self):
+        """Final stock entry failure should return structured error, not raise."""
+        source = _read_source("hrms/api/commissary_quality.py")
+        func = _extract_function(source, "log_wastage")
+        self.assertIsNotNone(func)
+        self.assertIn('"success": False', func)
+        self.assertIn("Stock entry failed", func)
+
+    def test_wastage_no_run_as_system_user(self):
+        source = _read_source("hrms/api/commissary_quality.py")
+        func = _extract_function(source, "log_wastage")
+        self.assertIsNotNone(func)
+        self.assertNotIn("_run_as_system_user", func)
+
+    def test_wastage_logs_warehouse_resolution(self):
+        source = _read_source("hrms/api/commissary_quality.py")
+        func = _extract_function(source, "log_wastage")
+        self.assertIsNotNone(func)
+        self.assertIn("Wastage warehouse resolved to", func)
+
+
+class TestLaborPlanVisibility(unittest.TestCase):
+    """FIX-7: Commissary Supervisor should have labor plan access."""
+
+    def test_commissary_supervisor_in_store_schedule_roles(self):
+        source = _read_source("hrms/api/supervisor.py")
+        func = _extract_function(source, "_user_can_manage_store_schedule")
+        self.assertIsNotNone(func)
+        self.assertIn("Commissary Supervisor", func)
+
+    def test_commissary_supervisor_in_commissary_schedule_roles(self):
+        source = _read_source("hrms/api/supervisor.py")
+        func = _extract_function(source, "_user_can_manage_commissary_schedule")
+        self.assertIsNotNone(func)
+        self.assertIn("Commissary Supervisor", func)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hrms/tests/test_s092_commissary_fixes.py
+++ b/hrms/tests/test_s092_commissary_fixes.py
@@ -35,8 +35,10 @@ class TestWastageHardening(unittest.TestCase):
 
     def test_wastage_seven_reason_codes(self):
         source = _read_source("hrms/api/commissary_quality.py")
-        for code in ["expired", "damaged", "quality_fail", "contaminated",
-                      "production_loss", "sampling", "other"]:
+        for code in [
+            "expired", "damaged", "quality_fail", "contaminated",
+            "production_loss", "sampling", "other",
+        ]:
             self.assertIn(f'"{code}"', source, f"Missing reason code: {code}")
 
     def test_wastage_structured_error_on_failure(self):

--- a/hrms/tests/test_s092_commissary_fixes.py
+++ b/hrms/tests/test_s092_commissary_fixes.py
@@ -11,7 +11,7 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 
 
 def _read_source(rel_path):
-	with open(os.path.join(REPO_ROOT, rel_path), "r", encoding="utf-8") as f:
+	with open(os.path.join(REPO_ROOT, rel_path), encoding="utf-8") as f:
 		return f.read()
 
 
@@ -36,8 +36,13 @@ class TestWastageHardening(unittest.TestCase):
 	def test_wastage_seven_reason_codes(self):
 		source = _read_source("hrms/api/commissary_quality.py")
 		for code in [
-			"expired", "damaged", "quality_fail", "contaminated",
-			"production_loss", "sampling", "other",
+			"expired",
+			"damaged",
+			"quality_fail",
+			"contaminated",
+			"production_loss",
+			"sampling",
+			"other",
 		]:
 			self.assertIn(f'"{code}"', source, f"Missing reason code: {code}")
 

--- a/hrms/tests/test_s092_logistics_warehouse_fixes.py
+++ b/hrms/tests/test_s092_logistics_warehouse_fixes.py
@@ -1,0 +1,102 @@
+"""S092 — Logistics & Warehouse Bug Fixes.
+
+Tests for FIX-2 (trip role), FIX-3 (transfer guard), FIX-4 (full rejection),
+FIX-5 (zero-qty display), and _run_as_system_user removal.
+
+Uses source-code inspection since Frappe framework is not available locally.
+"""
+
+import os
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _read_source(rel_path):
+    with open(os.path.join(REPO_ROOT, rel_path), "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _extract_function(source, func_name):
+    """Extract a function body from source text."""
+    marker = f"def {func_name}("
+    idx = source.find(marker)
+    if idx == -1:
+        return None
+    end_idx = source.find("\ndef ", idx + 1)
+    return source[idx : end_idx if end_idx != -1 else len(source)]
+
+
+class TestTripCreationRole(unittest.TestCase):
+    """FIX-2: create_trip should use SCM_DISPATCH_ROLES, not SCM_ADMIN_ROLES."""
+
+    def test_create_trip_uses_dispatch_roles(self):
+        source = _read_source("hrms/api/dispatch.py")
+        func = _extract_function(source, "create_trip")
+        self.assertIsNotNone(func, "create_trip function not found")
+        self.assertIn("SCM_DISPATCH_ROLES", func)
+        self.assertNotIn("SCM_ADMIN_ROLES", func)
+
+
+class TestTransferSourceWarehouseGuard(unittest.TestCase):
+    """FIX-3A: create_stock_transfer must reject blank source_warehouse."""
+
+    def test_blank_source_warehouse_guard_exists(self):
+        source = _read_source("hrms/api/warehouse.py")
+        func = _extract_function(source, "create_stock_transfer")
+        self.assertIsNotNone(func)
+        self.assertIn("source warehouse", func.lower())
+
+
+class TestFullRejection(unittest.TestCase):
+    """FIX-4: 100% rejected items should set 'With Issues', not throw."""
+
+    def test_full_rejection_uses_with_issues_status(self):
+        source = _read_source("hrms/api/warehouse.py")
+        func = _extract_function(source, "complete_warehouse_receiving")
+        self.assertIsNotNone(func)
+        self.assertIn('"With Issues"', func)
+
+    def test_full_rejection_does_not_use_rejected_status(self):
+        source = _read_source("hrms/api/warehouse.py")
+        func = _extract_function(source, "complete_warehouse_receiving")
+        self.assertIsNotNone(func)
+        # "Rejected" as a status assignment should not exist
+        # (it appears in variable names like rejected_qty which is fine)
+        self.assertNotIn('.status = "Rejected"', func)
+
+
+class TestRunAsSystemUserRemoved(unittest.TestCase):
+    """FIX-3C/FIX-4b: _run_as_system_user removed from stock operations."""
+
+    def test_no_run_as_system_user_in_complete_receiving(self):
+        source = _read_source("hrms/api/warehouse.py")
+        func = _extract_function(source, "complete_warehouse_receiving")
+        self.assertIsNotNone(func)
+        self.assertNotIn("_run_as_system_user", func)
+
+    def test_no_run_as_system_user_in_create_stock_transfer(self):
+        source = _read_source("hrms/api/warehouse.py")
+        func = _extract_function(source, "create_stock_transfer")
+        self.assertIsNotNone(func)
+        self.assertNotIn("_run_as_system_user", func)
+
+
+class TestZeroQuantityDisplay(unittest.TestCase):
+    """FIX-5: Blank from_warehouse should resolve via commissary warehouse fallback."""
+
+    def test_commissary_warehouse_fallback_exists(self):
+        source = _read_source("hrms/api/warehouse.py")
+        func = _extract_function(source, "get_material_request_items")
+        self.assertIsNotNone(func)
+        self.assertIn("commissary_warehouse", func)
+
+    def test_sum_all_warehouses_fallback(self):
+        source = _read_source("hrms/api/warehouse.py")
+        func = _extract_function(source, "get_material_request_items")
+        self.assertIsNotNone(func)
+        self.assertIn("SUM(actual_qty)", func)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hrms/tests/test_s092_logistics_warehouse_fixes.py
+++ b/hrms/tests/test_s092_logistics_warehouse_fixes.py
@@ -13,90 +13,90 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 
 
 def _read_source(rel_path):
-    with open(os.path.join(REPO_ROOT, rel_path), "r", encoding="utf-8") as f:
-        return f.read()
+	with open(os.path.join(REPO_ROOT, rel_path), "r", encoding="utf-8") as f:
+		return f.read()
 
 
 def _extract_function(source, func_name):
-    """Extract a function body from source text."""
-    marker = f"def {func_name}("
-    idx = source.find(marker)
-    if idx == -1:
-        return None
-    end_idx = source.find("\ndef ", idx + 1)
-    return source[idx : end_idx if end_idx != -1 else len(source)]
+	"""Extract a function body from source text."""
+	marker = f"def {func_name}("
+	idx = source.find(marker)
+	if idx == -1:
+		return None
+	end_idx = source.find("\ndef ", idx + 1)
+	return source[idx : end_idx if end_idx != -1 else len(source)]
 
 
 class TestTripCreationRole(unittest.TestCase):
-    """FIX-2: create_trip should use SCM_DISPATCH_ROLES, not SCM_ADMIN_ROLES."""
+	"""FIX-2: create_trip should use SCM_DISPATCH_ROLES, not SCM_ADMIN_ROLES."""
 
-    def test_create_trip_uses_dispatch_roles(self):
-        source = _read_source("hrms/api/dispatch.py")
-        func = _extract_function(source, "create_trip")
-        self.assertIsNotNone(func, "create_trip function not found")
-        self.assertIn("SCM_DISPATCH_ROLES", func)
-        self.assertNotIn("SCM_ADMIN_ROLES", func)
+	def test_create_trip_uses_dispatch_roles(self):
+		source = _read_source("hrms/api/dispatch.py")
+		func = _extract_function(source, "create_trip")
+		self.assertIsNotNone(func, "create_trip function not found")
+		self.assertIn("SCM_DISPATCH_ROLES", func)
+		self.assertNotIn("SCM_ADMIN_ROLES", func)
 
 
 class TestTransferSourceWarehouseGuard(unittest.TestCase):
-    """FIX-3A: create_stock_transfer must reject blank source_warehouse."""
+	"""FIX-3A: create_stock_transfer must reject blank source_warehouse."""
 
-    def test_blank_source_warehouse_guard_exists(self):
-        source = _read_source("hrms/api/warehouse.py")
-        func = _extract_function(source, "create_stock_transfer")
-        self.assertIsNotNone(func)
-        self.assertIn("source warehouse", func.lower())
+	def test_blank_source_warehouse_guard_exists(self):
+		source = _read_source("hrms/api/warehouse.py")
+		func = _extract_function(source, "create_stock_transfer")
+		self.assertIsNotNone(func)
+		self.assertIn("source warehouse", func.lower())
 
 
 class TestFullRejection(unittest.TestCase):
-    """FIX-4: 100% rejected items should set 'With Issues', not throw."""
+	"""FIX-4: 100% rejected items should set 'With Issues', not throw."""
 
-    def test_full_rejection_uses_with_issues_status(self):
-        source = _read_source("hrms/api/warehouse.py")
-        func = _extract_function(source, "complete_warehouse_receiving")
-        self.assertIsNotNone(func)
-        self.assertIn('"With Issues"', func)
+	def test_full_rejection_uses_with_issues_status(self):
+		source = _read_source("hrms/api/warehouse.py")
+		func = _extract_function(source, "complete_warehouse_receiving")
+		self.assertIsNotNone(func)
+		self.assertIn('"With Issues"', func)
 
-    def test_full_rejection_does_not_use_rejected_status(self):
-        source = _read_source("hrms/api/warehouse.py")
-        func = _extract_function(source, "complete_warehouse_receiving")
-        self.assertIsNotNone(func)
-        # "Rejected" as a status assignment should not exist
-        # (it appears in variable names like rejected_qty which is fine)
-        self.assertNotIn('.status = "Rejected"', func)
+	def test_full_rejection_does_not_use_rejected_status(self):
+		source = _read_source("hrms/api/warehouse.py")
+		func = _extract_function(source, "complete_warehouse_receiving")
+		self.assertIsNotNone(func)
+		# "Rejected" as a status assignment should not exist
+		# (it appears in variable names like rejected_qty which is fine)
+		self.assertNotIn('.status = "Rejected"', func)
 
 
 class TestRunAsSystemUserRemoved(unittest.TestCase):
-    """FIX-3C/FIX-4b: _run_as_system_user removed from stock operations."""
+	"""FIX-3C/FIX-4b: _run_as_system_user removed from stock operations."""
 
-    def test_no_run_as_system_user_in_complete_receiving(self):
-        source = _read_source("hrms/api/warehouse.py")
-        func = _extract_function(source, "complete_warehouse_receiving")
-        self.assertIsNotNone(func)
-        self.assertNotIn("_run_as_system_user", func)
+	def test_no_run_as_system_user_in_complete_receiving(self):
+		source = _read_source("hrms/api/warehouse.py")
+		func = _extract_function(source, "complete_warehouse_receiving")
+		self.assertIsNotNone(func)
+		self.assertNotIn("_run_as_system_user", func)
 
-    def test_no_run_as_system_user_in_create_stock_transfer(self):
-        source = _read_source("hrms/api/warehouse.py")
-        func = _extract_function(source, "create_stock_transfer")
-        self.assertIsNotNone(func)
-        self.assertNotIn("_run_as_system_user", func)
+	def test_no_run_as_system_user_in_create_stock_transfer(self):
+		source = _read_source("hrms/api/warehouse.py")
+		func = _extract_function(source, "create_stock_transfer")
+		self.assertIsNotNone(func)
+		self.assertNotIn("_run_as_system_user", func)
 
 
 class TestZeroQuantityDisplay(unittest.TestCase):
-    """FIX-5: Blank from_warehouse should resolve via commissary warehouse fallback."""
+	"""FIX-5: Blank from_warehouse should resolve via commissary warehouse fallback."""
 
-    def test_commissary_warehouse_fallback_exists(self):
-        source = _read_source("hrms/api/warehouse.py")
-        func = _extract_function(source, "get_material_request_items")
-        self.assertIsNotNone(func)
-        self.assertIn("commissary_warehouse", func)
+	def test_commissary_warehouse_fallback_exists(self):
+		source = _read_source("hrms/api/warehouse.py")
+		func = _extract_function(source, "get_material_request_items")
+		self.assertIsNotNone(func)
+		self.assertIn("commissary_warehouse", func)
 
-    def test_sum_all_warehouses_fallback(self):
-        source = _read_source("hrms/api/warehouse.py")
-        func = _extract_function(source, "get_material_request_items")
-        self.assertIsNotNone(func)
-        self.assertIn("SUM(actual_qty)", func)
+	def test_sum_all_warehouses_fallback(self):
+		source = _read_source("hrms/api/warehouse.py")
+		func = _extract_function(source, "get_material_request_items")
+		self.assertIsNotNone(func)
+		self.assertIn("SUM(actual_qty)", func)
 
 
 if __name__ == "__main__":
-    unittest.main()
+	unittest.main()

--- a/hrms/tests/test_s092_logistics_warehouse_fixes.py
+++ b/hrms/tests/test_s092_logistics_warehouse_fixes.py
@@ -13,7 +13,7 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 
 
 def _read_source(rel_path):
-	with open(os.path.join(REPO_ROOT, rel_path), "r", encoding="utf-8") as f:
+	with open(os.path.join(REPO_ROOT, rel_path), encoding="utf-8") as f:
 		return f.read()
 
 


### PR DESCRIPTION
## Summary

Sprint S092 — fixes 7 bugs reported during ERP user testing (March 19-20, 2026).

### Fixes included

| Fix | Bug | Change |
|-----|-----|--------|
| FIX-2 | BUG-006 | `create_trip` uses `SCM_DISPATCH_ROLES` (was `SCM_ADMIN_ROLES`) |
| FIX-3A | BUG-008/009 | Source warehouse guard in `create_stock_transfer` |
| FIX-3C | BUG-008/009 | Remove `_run_as_system_user` from `create_stock_transfer` |
| FIX-4 | BUG-012 | Full rejection → "With Issues" status, remove `_run_as_system_user` |
| FIX-5 | BUG-013 | Resolve blank `from_warehouse` via commissary warehouse fallback |
| FIX-6 | BUG-010 | Wastage: structured error on failure, remove `_run_as_system_user`, add logging |
| FIX-7 | BUG-011 | Add Commissary Supervisor to store schedule fast-path roles |

### Not changed (by design)

- `scm_roles.py` — untouched (regression requirement)
- Backend TIN threshold — already correct via `_normalize_purchase_order_payload`
- MR status alignment — `approve_material_request` sets "Ordered" which is already accepted

### Test plan

- [x] 8 source-code inspection tests (logistics/warehouse)
- [x] 7 source-code inspection tests (commissary/RBAC)
- [x] 14 existing procurement tests (regression)
- [x] 90 total tests passing, 0 failures
- [ ] L1 API smoke after deploy
- [ ] L2 page render verification
- [ ] L3 workflow scenarios
- [ ] L4 negative/regression probes

Generated with [Claude Code](https://claude.com/claude-code)