### PR TITLE
fix(s107): PR form department/UOM backend fixes

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -598,7 +598,7 @@ def create_purchase_requisition(data=None):
     })
     pr.insert()
 
-    return {"success": True, "name": pr.name, "message": _("PR created")}
+    return {"success": True, "name": pr.name, "pr_number": pr.pr_no or pr.name, "message": _("PR created")}
 
 
 @frappe.whitelist()
@@ -6181,24 +6181,36 @@ def reject_item_request(name, reason=None):
 
 @frappe.whitelist()
 def get_department_list():
-    """Return list of active departments for PR form dropdown."""
+    """Return list of active departments for PR form dropdown.
+    Returns [{value: "Commissary - BEI", label: "Commissary"}, ...].
+    value = Frappe name (Link field ID), label = display name.
+    Filtered to BEI company only, deduplicated.
+    """
     from hrms.utils.sentry import set_backend_observability_context
     set_backend_observability_context(module="procurement", action="get_department_list")
 
     departments = frappe.get_all(
         "Department",
-        filters={"is_group": 0, "disabled": 0},
+        filters={"is_group": 0, "disabled": 0, "company": "Bebang Enterprise Inc."},
         fields=["name", "department_name"],
         order_by="department_name",
     )
-    return [d.department_name or d.name for d in departments]
+    seen = set()
+    result = []
+    for d in departments:
+        if d.name not in seen:
+            seen.add(d.name)
+            result.append({"value": d.name, "label": d.department_name or d.name})
+    return result
 
 
 @frappe.whitelist()
 def get_uom_list():
-    """Return list of UOMs for PR form dropdown."""
+    """Return list of UOMs for PR form dropdown.
+    Returns [{value: "Nos", label: "Nos"}, ...] for consistency with department format.
+    """
     from hrms.utils.sentry import set_backend_observability_context
     set_backend_observability_context(module="procurement", action="get_uom_list")
 
     uoms = frappe.get_all("UOM", fields=["name"], order_by="name")
-    return [u.name for u in uoms]
+    return [{"value": u.name, "label": u.name} for u in uoms]


### PR DESCRIPTION
## Summary
- **get_department_list()** now returns `{value, label}` objects with `name` as `value` (Link field ID like `Commissary - BEI`), filtered to BEI company, deduplicated
- **get_uom_list()** now returns `{value, label}` objects for consistency
- **create_purchase_requisition()** now returns `pr_number` in response

## Root Cause
Luwi reported "Could not find Department: Commissary" — the PR form sent display names but Frappe Link fields validate against `name` (record ID with company suffix).

## Test plan
- [ ] Verify `get_department_list` returns `{value: "Commissary - BEI", label: "Commissary"}` format
- [ ] Verify departments filtered to BEI company only (not 473 across all companies)
- [ ] Verify `get_uom_list` returns `{value, label}` objects
- [ ] Verify PR creation response includes `pr_number`

🤖 Generated with [Claude Code](https://claude.com/claude-code)