### PR TITLE
docs(s110): closeout — leave-overtime guards COMPLETED

### DIFF
--- a/docs/plans/2026-03-24-sprint-108-leave-type-e2e-validation.md
+++ b/docs/plans/2026-03-24-sprint-108-leave-type-e2e-validation.md
@@ -1,16 +1,17 @@
-# Sprint 108 — Leave Type E2E Validation
+# Sprint 110 — Leave Type E2E Validation + OT-Leave Guards
 
 ```yaml
-canonical_sprint_id: S108
-status: PR_CREATED
+canonical_sprint_id: S110
+status: COMPLETED
 created: 2026-03-24
 execution_started: 2026-03-24
+completed_date: 2026-03-24
 branch: s108-leave-type-validation
 lane: single
 depends_on: S106, S107
 backend_pr: "#339"
-completed_date: null
-execution_summary: "Phase 1 API tests 27/27 PASS. P2.5 OT-leave guards + compensation tagging built. PR #339 created. Awaiting governor merge + deploy for L3 scenarios 11-17."
+frontend_pr: "#235 (bei-tasks)"
+execution_summary: "Leave-overtime mutual exclusion guards deployed and verified. VL/SL/EL/LWOP full lifecycle 27/27 PASS. OT blocks leave (S12 PASS), leave blocks OT (S11 PASS), pending OT auto-rejected (S13 PASS). Compensation eligibility tagging for office/store/commissary verified. Leave dropdown filter hides dead types. Policy doc + reference doc committed. L3 ALL PASS, 0 FAIL, 0 SKIP."
 ```
 
 ## Summary

--- a/docs/plans/SPRINT_REGISTRY.md
+++ b/docs/plans/SPRINT_REGISTRY.md
@@ -105,9 +105,10 @@ These documents contain sprint-like naming but are not part of the canonical seq
 
 | `S108` | Sprint 108 | `s108-pr-form-luwi-fix` | #341 (hrms), #236 (bei-tasks) | COMPLETED 2026-03-24 — PR form fix: auto-set request_date/requested_by/date_required/purpose, map justification→purpose, item_code fallback, Sentry. L3 3/3 PASS (PR-2026-02968, PR-2026-02969). | `docs/plans/2026-03-24-sprint-108-procurement-module-hardening.md` |
 | `S109` | Sprint 109 | `s109-procurement-full-audit` | — | PLANNED — Full procurement module hardening: Sentry for 93 endpoints, comprehensive L1/L2/L3 audit of all 107 endpoints + 36 pages, fix all bugs. | — |
+| `S110` | Sprint 110 | `s108-leave-type-validation` | #339 (hrms), #235 (bei-tasks) | COMPLETED 2026-03-24 — Leave-overtime mutual exclusion guards, compensation eligibility tagging, leave dropdown filter, policy doc, reference doc. VL/SL/EL/LWOP lifecycle 27/27. OT-leave guards S11-S13 ALL PASS. L3 0 FAIL 0 SKIP. | `docs/plans/2026-03-24-sprint-108-leave-type-e2e-validation.md` |
 
 ## Next Sprint Reservation
-1. Next canonical sprint ID to assign: `S110`.
+1. Next canonical sprint ID to assign: `S111`.
 2. Reserve branch name: `s{number}-{slug}` (fill slug from plan filename).
 3. Create new sprint plan only after adding row here first.
 4. **Agent MUST `git checkout -b <branch>` before writing any code.**


### PR DESCRIPTION
## Summary
- Closeout for leave-overtime mutual exclusion sprint (reassigned from S108→S110 due to ID collision)
- Updates plan status to COMPLETED and adds S110 row to sprint registry
- All code already deployed via PR #339 + bei-tasks #235

## L3 Results: ALL PASS, 0 FAIL, 0 SKIP
- VL/SL/EL/LWOP lifecycle: 27/27
- OT-leave guards (S11-S13): 3/3
- Compensation tagging (S15-17): 3/3
- Dropdown filter (S14): PASS
- Collateral checks: 2/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)