### PR TITLE
fix(s112): supplier auto-gen + Sentry for procurement training

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -350,8 +350,19 @@ def create_supplier(data):
     AUDIT CONTROL 2.5: Duplicate detection (phone, email, bank account, TIN)
     Ref: Internal Audit Jan 30, 2026 - Same phone number across multiple suppliers
     """
+    from hrms.utils.sentry import set_backend_observability_context
+    set_backend_observability_context(
+        module="procurement",
+        action="create_supplier",
+        mutation_type="create",
+    )
     if isinstance(data, str):
         data = frappe.parse_json(data)
+
+    # S112 B-02: Auto-generate supplier_code if not provided
+    # DocType has autoname: field:supplier_code with reqd: 1
+    if not data.get("supplier_code"):
+        data["supplier_code"] = f"SUPP-{frappe.utils.now_datetime().strftime('%Y%m%d%H%M%S')}"
 
     warnings = []
 
@@ -2458,6 +2469,8 @@ def mark_payment_complete(name, transaction_reference=None, payment_proof=None):
 @frappe.whitelist()
 def get_pending_payment_approvals():
     """Get all payments pending approval at each level."""
+    from hrms.utils.sentry import set_backend_observability_context
+    set_backend_observability_context(module="procurement", action="get_pending_payment_approvals", mutation_type="read")
     levels = {
         "review": "Pending Review",
         "budget": "Pending Budget Approval",

--- a/hrms/hr/doctype/bei_supplier/bei_supplier.py
+++ b/hrms/hr/doctype/bei_supplier/bei_supplier.py
@@ -33,8 +33,13 @@ class BEISupplier(Document):
         self.validate_invoice_exception_control()
 
     def validate_supplier_code(self):
-        """Ensure supplier code is unique and properly formatted."""
-        if self.supplier_code:
+        """Ensure supplier code is unique and properly formatted.
+        Auto-generates if not provided (S112 B-02 dual-file fix).
+        """
+        if not self.supplier_code:
+            from frappe.utils import now_datetime
+            self.supplier_code = f"SUPP-{now_datetime().strftime('%Y%m%d%H%M%S')}"
+        else:
             self.supplier_code = self.supplier_code.strip().upper()
 
     def validate_required_documents(self):

--- a/output/l3/S112/seed_data.json
+++ b/output/l3/S112/seed_data.json
@@ -1,0 +1,24 @@
+{
+  "sprint": "S112",
+  "date": "2026-03-24",
+  "seed_required": false,
+  "reason": "Verified invoices already exist in production",
+  "existing_verified_invoices": [
+    {
+      "name": "INV-2026-00089",
+      "status": "Verified",
+      "supplier": "Test Supplier Inc."
+    },
+    {
+      "name": "INV-2026-00154",
+      "status": "Verified",
+      "supplier": "E2E Test Supplier 1442281092"
+    },
+    {
+      "name": "INV-2026-00618",
+      "status": "Verified",
+      "supplier": "Cutover Readiness Supplier 20260309_205617"
+    }
+  ],
+  "note": "Payment Request form C5 test can use any of these verified invoices. No seed chain needed."
+}


### PR DESCRIPTION
## Summary
- B3: Auto-generate supplier_code in `create_supplier()` AND `bei_supplier.py` (dual-file fix)
  - DocType has `autoname: field:supplier_code` with `reqd: 1` — blank code crashes without auto-gen
- Add Sentry DM-7 to `create_supplier` and `get_pending_payment_approvals`
- B2: Verified invoices already exist in production — no seed chain needed

## Context
S112 — Close all blockers for Luwi's procurement training (tomorrow morning).

## Deploy
Requires `skip_build=false, no_cache=true` (Python code changes).

## Test plan
- [ ] Create supplier with blank supplier_code → auto-generates SUPP-{timestamp}
- [ ] Create supplier via Frappe desk with blank code → also auto-generates
- [ ] Sentry context visible on create_supplier errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)