### PR TITLE
fix(s122): add Store Staff/Supervisor to SCM_INVENTORY_ROLES

### DIFF
--- a/hrms/utils/scm_roles.py
+++ b/hrms/utils/scm_roles.py
@@ -87,6 +87,8 @@ SCM_BILLING_ROLES = {
 # Include both backend-native warehouse titles and the portal role names so
 # inventory pages do not render as shells for otherwise-authorized users.
 SCM_INVENTORY_ROLES = {
+	"Store Staff",
+	"Store Supervisor",
 	"Area Supervisor",
 	"Regional Manager",
 	"Supply Chain Manager",


### PR DESCRIPTION
## Summary
- Adds Store Staff and Store Supervisor roles to SCM_INVENTORY_ROLES
- Without this fix, the new store inventory dashboard returns 403 for store users calling warehouse_stock API
- Backend order history endpoint (`get_store_order_history`) requires Frappe docker rebuild to deploy

## Test plan
- [ ] test.crew1@bebang.ph can now load /dashboard/store-ops/inventory with stock data
- [ ] test.supervisor@bebang.ph can see inventory
- [ ] Warehouse User permissions unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)