### PR TITLE
fix(S128): add ignore_permissions to duplicate_po

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -1354,7 +1354,7 @@ def duplicate_po(source_name):
         "status": "Draft",
     })
 
-    new_po.insert()
+    new_po.insert(ignore_permissions=True)
 
     return {
         "success": True,


### PR DESCRIPTION
## Summary
Fix PermissionError when procurement users call `duplicate_po()`. Adds `ignore_permissions=True` to the insert call, matching the pattern used by `create_purchase_order()` and other BEI procurement endpoints.

## Root cause
`test.procurement@bebang.ph` has Frappe `Procurement User` role but not explicit create permission on `BEI Purchase Order` DocType. The API proxy handles auth at the Next.js layer.

## Test plan
- [ ] Login as test.procurement → PO detail → click Duplicate PO → new Draft PO created

Generated with Claude Code