### PR TITLE
fix(S128): copy price_override_reason in duplicate_po

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -1339,6 +1339,8 @@ def duplicate_po(source_name):
             "vat_rate": item.get("vat_rate") or 0,
             "vat_amount": item.get("vat_amount") or 0,
             "amount": item.get("amount") or 0,
+            "contracted_unit_cost": item.get("contracted_unit_cost") or 0,
+            "price_override_reason": item.get("price_override_reason") or "",
         })
 
     new_po = frappe.get_doc({


### PR DESCRIPTION
## Summary
When duplicating a PO, the S120 price variance gate blocks creation if an item's price differs from the contracted rate without an override reason. This fix copies `contracted_unit_cost` and `price_override_reason` from source PO items so the duplicate inherits the same price justification.

## Test plan
- [ ] Duplicate a PO that has items with price overrides -> new Draft PO created without variance error

Generated with Claude Code