### PR TITLE
fix(S126): batch stock cap + filter production items to FG only

### DIFF
--- a/hrms/api/commissary_dashboard.py
+++ b/hrms/api/commissary_dashboard.py
@@ -364,6 +364,7 @@ def get_production_items() -> dict[str, Any]:
         WHERE i.disabled = 0
         AND i.is_stock_item = 1
         AND i.item_group = 'Finished Goods'
+        AND (i.name LIKE 'FG%%' OR i.name LIKE 'OUT-%%')
         ORDER BY i.item_name
     """,
 		commissary_warehouse,


### PR DESCRIPTION
2 fixes:
1. Check batch SLE stock before wastage — cap qty to available, return clear error if stock <= 0
2. Filter production items to FG prefix only — removes MN (store menu) items from commissary production log

Fixes: negative stock error on write-off + store SKUs showing in commissary