### PR TITLE
fix(S128): correct price_variance_override field in duplicate_po

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -1340,7 +1340,9 @@ def duplicate_po(source_name):
             "vat_amount": item.get("vat_amount") or 0,
             "amount": item.get("amount") or 0,
             "contracted_unit_cost": item.get("contracted_unit_cost") or 0,
-            "price_override_reason": item.get("price_override_reason") or "",
+            "price_variance_override": item.get("price_variance_override") or "",
+            "price_variance_override_by": item.get("price_variance_override_by") or "",
+            "price_variance_override_date": item.get("price_variance_override_date"),
         })
 
     new_po = frappe.get_doc({


### PR DESCRIPTION
## Summary
Previous fix used wrong field name `price_override_reason` — the DocType field is `price_variance_override`. Now correctly copies:
- `price_variance_override` (the reason text)
- `price_variance_override_by` (who approved the override)
- `price_variance_override_date` (when)

This preserves the S120 price variance approval trail when duplicating POs.

Generated with Claude Code