### PR TITLE
fix(S128): set delivery_date in duplicate_po

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -1350,7 +1350,7 @@ def duplicate_po(source_name):
         "supplier": source.supplier,
         "supplier_name": source.supplier_name,
         "po_date": frappe.utils.today(),
-        "delivery_date": None,
+        "delivery_date": source.get("delivery_date") or frappe.utils.add_days(frappe.utils.today(), 7),
         "payment_terms": source.get("payment_terms"),
         "remarks": _("Duplicated from {0}").format(source.po_no or source_name),
         "items": items,


### PR DESCRIPTION
## Summary
`delivery_date` is mandatory on BEI Purchase Order. `duplicate_po()` was setting it to `None`. Now copies from source PO or defaults to today + 7 days.

Generated with Claude Code