### PR TITLE
fix(S132): PO CEO approval — 6 backend fixes

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -1227,6 +1227,10 @@ def create_purchase_order(data: dict[str, Any] | str | None = None) -> dict[str,
 @frappe.whitelist()
 def submit_po_for_approval(name):
     """Submit PO for Mae's approval."""
+    from hrms.utils.sentry import set_backend_observability_context
+    set_backend_observability_context(
+        module="procurement", action="submit_po_for_approval", mutation_type="update",
+    )
     po = frappe.get_doc("BEI Purchase Order", name)
     return po.submit_for_approval()
 
@@ -1234,6 +1238,10 @@ def submit_po_for_approval(name):
 @frappe.whitelist()
 def approve_po_mae(name, comment=None):
     """Mae approves PO."""
+    from hrms.utils.sentry import set_backend_observability_context
+    set_backend_observability_context(
+        module="procurement", action="approve_po_mae", mutation_type="update",
+    )
     po = frappe.get_doc("BEI Purchase Order", name)
     return po.approve_mae(comment)
 
@@ -1241,8 +1249,25 @@ def approve_po_mae(name, comment=None):
 @frappe.whitelist()
 def approve_po_butch(name, comment=None):
     """Butch (CFO) approves PO for >500K."""
+    from hrms.utils.sentry import set_backend_observability_context
+    set_backend_observability_context(
+        module="procurement", action="approve_po_butch", mutation_type="update",
+    )
     po = frappe.get_doc("BEI Purchase Order", name)
     return po.approve_butch(comment)
+
+
+@frappe.whitelist()
+def approve_po_ceo(name, comment=None):
+    """CEO approves PO (for new vendor POs requiring CEO sign-off)."""
+    from hrms.utils.sentry import set_backend_observability_context
+    set_backend_observability_context(
+        module="procurement",
+        action="approve_po_ceo",
+        mutation_type="update",
+    )
+    po = frappe.get_doc("BEI Purchase Order", name)
+    return po.approve_ceo(comment)
 
 
 @frappe.whitelist()
@@ -1372,6 +1397,10 @@ def duplicate_po(source_name):
 @frappe.whitelist()
 def reject_po(name, reason, rejector="mae"):
     """Reject PO."""
+    from hrms.utils.sentry import set_backend_observability_context
+    set_backend_observability_context(
+        module="procurement", action="reject_po", mutation_type="update",
+    )
     po = frappe.get_doc("BEI Purchase Order", name)
     return po.reject(reason, rejector)
 

--- a/hrms/hr/doctype/bei_purchase_order/bei_purchase_order.json
+++ b/hrms/hr/doctype/bei_purchase_order/bei_purchase_order.json
@@ -93,7 +93,7 @@
       "in_list_view": 1,
       "in_standard_filter": 1,
       "label": "Status",
-      "options": "Draft\nPending Mae Approval\nPending Butch Approval\nApproved\nSent to Supplier\nPartially Received\nFully Received\nCancelled"
+      "options": "Draft\nPending Mae Approval\nPending Butch Approval\nPending CEO Approval\nApproved\nSent to Supplier\nPartially Received\nFully Received\nCancelled"
     },
     {
       "fieldname": "pr_reference",

--- a/hrms/hr/doctype/bei_purchase_order/bei_purchase_order.py
+++ b/hrms/hr/doctype/bei_purchase_order/bei_purchase_order.py
@@ -267,9 +267,13 @@ class BEIPurchaseOrder(Document):
 		"""Send Google Chat notification to Butch (CFO) for PO approval."""
 		self._send_approval_notification(self._get_approver_email("cfo"), "CFO (Butch)")
 
+	def notify_ceo(self):
+		"""Send Google Chat notification to CEO for new-vendor PO approval."""
+		self._send_approval_notification(self._get_approver_email("ceo"), "CEO (Sam)")
+
 	def _get_approver_email(self, role: str) -> str:
 		"""Get approver email from BEI Settings, fall back to delivery_billing_policy constants."""
-		field_map = {"cpo": "cpo_approver_email", "cfo": "cfo_approver_email"}
+		field_map = {"cpo": "cpo_approver_email", "cfo": "cfo_approver_email", "ceo": "ceo_approver_email"}
 		try:
 			email = frappe.db.get_single_value("BEI Settings", field_map.get(role, ""))
 			if email:
@@ -278,6 +282,8 @@ class BEIPurchaseOrder(Document):
 			pass
 		# Fall back to hardcoded constants (pre-S099)
 		from hrms.utils.delivery_billing_policy import CPO_APPROVER_EMAIL, CFO_APPROVER_EMAIL
+		if role == "ceo":
+			return "sam@bebang.ph"
 		return CPO_APPROVER_EMAIL if role == "cpo" else CFO_APPROVER_EMAIL
 
 	def _send_approval_notification(self, approver_email: str, approver_label: str):
@@ -334,6 +340,7 @@ class BEIPurchaseOrder(Document):
 			# New vendor — needs CEO approval
 			self.status = "Pending CEO Approval"
 			self.save()
+			self.notify_ceo()
 			return {"success": True, "message": _("Mae approved. PO now pending CEO approval (new vendor)")}
 		else:
 			# Single approval sufficient
@@ -365,6 +372,7 @@ class BEIPurchaseOrder(Document):
 		if cint(self.get("requires_ceo_approval")) and self.get("ceo_approval") != "Approved":
 			self.status = "Pending CEO Approval"
 			self.save()
+			self.notify_ceo()
 			return {"success": True, "message": _("CFO approved. PO now pending CEO approval (new vendor)")}
 
 		self.status = "Approved"
@@ -417,13 +425,17 @@ class BEIPurchaseOrder(Document):
 	@frappe.whitelist()
 	def reject(self, reason: str, rejector: str = "mae"):
 		"""Reject the PO."""
-		if self.status not in ["Pending Mae Approval", "Pending Butch Approval"]:
+		if self.status not in ["Pending Mae Approval", "Pending Butch Approval", "Pending CEO Approval"]:
 			frappe.throw(_("PO is not pending approval"))
 
 		if not reason:
 			frappe.throw(_("Please provide a rejection reason"))
 
-		if rejector == "mae":
+		if rejector == "ceo":
+			self.ceo_approval = "Rejected"
+			self.ceo_comment = reason
+			self.ceo_approval_date = now_datetime()
+		elif rejector == "mae":
 			self.mae_approval = "Rejected"
 			self.mae_comment = reason
 			self.mae_approval_date = now_datetime()
@@ -439,6 +451,8 @@ class BEIPurchaseOrder(Document):
 
 	def has_required_procurement_approvals(self) -> bool:
 		"""Return whether the commercial approval chain is complete."""
+		if cint(self.get("requires_ceo_approval")) and self.get("ceo_approval") != "Approved":
+			return False
 		if self.requires_dual_approval:
 			return self.mae_approval == "Approved" and self.butch_approval == "Approved"
 		return self.mae_approval == "Approved"


### PR DESCRIPTION
## Summary
- Add "Pending CEO Approval" to DocType status options (was missing, blocking all new-vendor PO approvals)
- Add `approve_po_ceo()` API endpoint with Sentry instrumentation
- Fix `reject()` guard to accept CEO-pending POs + handle `rejector="ceo"`
- Add Sentry to 4 existing endpoints: submit, approve_mae, approve_butch, reject_po
- Fix `has_required_procurement_approvals()` to check CEO approval (audit risk: Frappe POs were created without CEO sign-off)
- Add `notify_ceo()` method — Sam gets Google Chat notification when PO needs CEO approval

## Impact
CEO approval for new-vendor POs has **never worked** in production. Any supplier created within 30 days triggers `requires_ceo_approval=1`, but the status option wasn't in the DocType JSON, causing save failures. This PR fixes all 5 broken layers of the CEO approval flow.

## Test plan
- [ ] Create PO for a supplier created <30 days ago → submit → approve as Mae → status should be "Pending CEO Approval"
- [ ] Login as sam@bebang.ph → approve CEO-pending PO → status should be "Approved"
- [ ] Reject a CEO-pending PO → should work (was blocked before)
- [ ] Verify Sentry context on approve_po_mae calls in bei-hrms project

🤖 Generated with [Claude Code](https://claude.com/claude-code)