### PR TITLE
fix(S132): make Frappe PO sync non-blocking on approval

### DIFF
--- a/hrms/hr/doctype/bei_purchase_order/bei_purchase_order.py
+++ b/hrms/hr/doctype/bei_purchase_order/bei_purchase_order.py
@@ -580,7 +580,13 @@ class BEIPurchaseOrder(Document):
 			frappe.log_error(
 				f"Failed to create Frappe PO for BEI PO {self.name}: {e}", "BEI PO Integration Error"
 			)
-			frappe.throw(_("Failed to create Frappe Purchase Order: {0}").format(str(e)))
+			# Do NOT throw — Frappe PO sync is downstream of BEI approval.
+			# The BEI PO approval must succeed even if Frappe PO creation fails.
+			# The Frappe PO can be retried later via can_create_frappe_purchase_order().
+			frappe.msgprint(
+				_("BEI PO approved but Frappe PO sync failed: {0}. This can be retried later.").format(str(e)),
+				indicator="orange",
+			)
 
 	def _get_or_create_item(self, bei_item):
 		"""


### PR DESCRIPTION
## Summary
- `create_frappe_purchase_order()` used `frappe.throw()` on failure, which rolled back the entire `submit()` transaction
- This meant a missing warehouse on any PO item would prevent CEO/Mae approval from completing — the BEI PO stayed stuck in "Pending" even though the approval itself was valid
- Changed to `frappe.msgprint(indicator="orange")` — BEI approval succeeds, Frappe PO sync error is shown as a warning, and can be retried later via `can_create_frappe_purchase_order()`

## Root cause
Found during S132 L3 testing: Sam approved PO-2026-03112 as CEO, the approval logic passed, but `on_submit()` → `create_frappe_purchase_order()` threw because FG009 had no warehouse set on the PO item. The throw rolled back the entire transaction including the approval.

## Test plan
- [ ] Approve a PO where Frappe PO creation would fail (missing warehouse) → BEI PO moves to Approved, orange warning shown
- [ ] Approve a PO with valid warehouse → BEI PO moves to Approved AND Frappe PO created

🤖 Generated with [Claude Code](https://claude.com/claude-code)