### PR TITLE
fix(ordering): S133 — System Manager sees all stores + blocks 'Stores' group

### DIFF
--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -1809,13 +1809,16 @@ def get_user_store(surface: str | None = None):
 		or "HR Manager" in user_roles
 		or "Regional Manager" in user_roles
 	):
-		role = role or ("Regional Manager" if "Regional Manager" in user_roles else "HR User")
+		# S133: System Manager always sees ALL stores, overriding Area Supervisor subset.
+		role = "Regional Manager" if "Regional Manager" in user_roles else "System Manager"
 		if surface_key in {SCHEDULE_SURFACE_STORE, SCHEDULE_SURFACE_COMMISSARY}:
 			for store_row in schedule_rows:
 				append_store(store_row)
-		elif not stores:
-			# S133: For System Manager, return all leaf warehouses then filter.
-			# The _is_orderable_store() name-based filter removes 3PLs, commissary, etc.
+		else:
+			# Clear any stores from earlier role paths (e.g., Area Supervisor)
+			# so System Manager sees the full list, not just their supervised stores.
+			stores.clear()
+			seen_stores.clear()
 			store_rows = frappe.get_all(
 				"Warehouse",
 				filters={"is_group": 0, "disabled": 0},


### PR DESCRIPTION
## Summary
Two fixes:
1. **System Manager override**: Clears Area Supervisor's 1-store result and loads ALL leaf warehouses. sam@bebang.ph has both roles — Area Sup ran first, adding only Araneta Gateway. System Manager path had `elif not stores` which was FALSE.
2. **Exact-name blocklist**: Blocks "Stores", "Stores - BEI", "All Warehouses" plus 3PLs by name substring.

## Root Cause
- Area Supervisor path runs at line 1733 before System Manager at line 1806
- `elif not stores` skipped the System Manager store loading because Area Sup already populated 1 store
- Result: sam@bebang.ph saw only Araneta Gateway with a loading spinner

## Test plan
- [ ] sam@bebang.ph: dropdown with 46+ real stores, no 3PLs/groups
- [ ] test.crew1@bebang.ph: unchanged (1 assigned store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)