### PR TITLE
fix(S138): set Temporary Opening as SR difference_account for BKI

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -1338,6 +1338,15 @@ def _sync_inventory_rows(
 			sr.company = _company_for_warehouse(warehouse)
 			expense_account = _default_expense_account(sr.company)
 			cost_center = _default_cost_center(sr.company)
+			# For first-time stock (Opening Entry), Frappe requires an Asset/Liability
+			# difference account. Use Temporary Opening if available.
+			temp_opening = frappe.db.get_value(
+				"Account",
+				{"company": sr.company, "account_type": "Temporary", "is_group": 0},
+				"name",
+			)
+			if temp_opening and _doctype_has_field("Stock Reconciliation", "difference_account"):
+				sr.difference_account = temp_opening
 			if _doctype_has_field("Stock Reconciliation", "expense_account"):
 				if not expense_account:
 					frappe.throw(


### PR DESCRIPTION
## Summary
Fixes inventory sync failure for BKI warehouses (3MD, Pinnacle, Jentec, RCS, Shaw BLVD).

**Root cause:** New BKI 3PL warehouses have no Stock Ledger Entry history. Frappe v15 auto-detects the first Stock Reconciliation as an "Opening Entry" which requires an Asset/Liability difference_account. The default `STOCK ADJUSTMENT - BKI` is Expense type, causing validation failure.

**Fix:** When creating Stock Reconciliation, explicitly set `difference_account` to the `Temporary Opening` account (Asset type) if one exists for the company.

## Impact
After merge + deploy, run `python scripts/testing/sync_warehouse_inventory.py` to populate BKI 3PL warehouse stock from Ian's Google Sheet. This will fix the store ordering page showing 0 stock for all items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)