### PR TITLE
fix(S138): commit per-warehouse to prevent inventory sync lock timeout

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -1378,6 +1378,10 @@ def _sync_inventory_rows(
 			sr.submit()
 			results["rows_created"] += len(items)
 			_release_savepoint(savepoint)
+			# Commit per-warehouse to release tabBin locks immediately.
+			# Without this, 46 sequential SR submits hold locks for the entire
+			# run duration, causing Lock wait timeout for concurrent requests.
+			frappe.db.commit()
 
 		except Exception as exc:
 			frappe.db.rollback(save_point=savepoint)


### PR DESCRIPTION
## Summary
Adds `frappe.db.commit()` after each Stock Reconciliation submit in `_sync_inventory_rows`. This releases tabBin locks between warehouses immediately.

## Root cause
The store inventory shadow sync processes 46 stores serially, each creating a Stock Reconciliation with ~100 items. Without intermediate commits, all SRs run in one transaction, holding ~5,000 tabBin row locks for 10+ minutes. By store #5, concurrent API calls hit `Lock wait timeout exceeded (1205)`.

## Fix
One line: `frappe.db.commit()` after `sr.submit()` + `_release_savepoint()`. Each SR is an independent unit — if store #7 fails, stores 1-6 are already committed.

## Impact
- Store inventory sync should complete in ~3 minutes instead of timing out at 10+
- No more lock contention between the sync job and API calls
- Each store's inventory data is immediately visible after its SR commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)