### PR TITLE
fix(S137): priority only critical/high when item has consumption

### DIFF
--- a/hrms/api/commissary_planning.py
+++ b/hrms/api/commissary_planning.py
@@ -191,8 +191,8 @@ def get_production_recommendations():
 		wastage_factor = flt(1 + (wastage_7d / production_7d), 4) if production_7d > 0 else 1
 		recommended_qty = flt(recommended_qty * wastage_factor, 2)
 
-		# Step 10: Priority
-		if days_inventory == 0 or (avg_daily > 0 and days_inventory < 1):
+		# Step 10: Priority (only critical/high if there IS consumption demand)
+		if avg_daily > 0 and (days_inventory == 0 or days_inventory < 1):
 			priority = "critical"
 		elif avg_daily > 0 and days_inventory < target_di * 0.5:
 			priority = "high"


### PR DESCRIPTION
## Summary
- Items with DI=0 and avg_daily=0 (idle, no demand) were marked "critical" — 39/40 items incorrectly showing red priority badges
- Fix: only items WITH active consumption can be critical or high priority

## Found by
L3 production data verification (PV-009): cross-validated `get_production_recommendations` against `get_days_inventory` on live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)