### PR TITLE
fix(S144): approval queue store = Warehouse, not BEI Store

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -609,9 +609,9 @@ def submit_supplier_edit_for_approval(name, data):
         return {"success": True, "message": _("Supplier updated (no critical fields changed)"), "approval_required": False}
 
     # Queue critical changes for Mae approval
-    # Store field is required — use first store for non-store-specific approvals
-    _store = frappe.db.sql("SELECT name FROM `tabBEI Store` ORDER BY creation LIMIT 1", as_list=True)
-    default_store = _store[0][0] if _store and _store[0] else ""
+    # Store field (links to Warehouse) is required — use HQ warehouse for supplier approvals
+    _store = frappe.db.sql("SELECT name FROM `tabWarehouse` WHERE name LIKE '%BEI' ORDER BY creation LIMIT 1", as_list=True)
+    default_store = _store[0][0] if _store and _store[0] else "Stores - BEI"
 
     queue_entry = frappe.get_doc({
         "doctype": "BEI Approval Queue",


### PR DESCRIPTION
Store Link field points to Warehouse DocType. Use 'Stores - BEI' as default for non-store-specific supplier approvals.