### PR TITLE
fix(S150): gracefully handle missing allowance custom fields

### DIFF
--- a/hrms/api/payroll_compensation.py
+++ b/hrms/api/payroll_compensation.py
@@ -186,6 +186,26 @@ def get_compensation_grid(filters=None):
 	count_sql = f"SELECT COUNT(*) FROM `tabEmployee` e WHERE {where}"
 	total = frappe.db.sql(count_sql, values)[0][0]
 
+	# Check if allowance custom fields exist in DB (safe for deploy-before-SSM)
+	_allowance_fields = [
+		"bei_comm_allow_monthly", "bei_deminimis_monthly", "bei_honorarium_monthly",
+		"bei_meal_allow_monthly", "bei_gasoline_allow_monthly", "bei_other_fixed_monthly",
+	]
+	_existing_cols = {
+		r[0] for r in frappe.db.sql("SHOW COLUMNS FROM tabEmployee LIKE 'bei_%'")
+	}
+	_has_allowance_cols = all(f in _existing_cols for f in _allowance_fields)
+
+	allowance_sql = ""
+	if _has_allowance_cols:
+		allowance_sql = """,
+			COALESCE(e.bei_comm_allow_monthly, 0) AS bei_comm_allow_monthly,
+			COALESCE(e.bei_deminimis_monthly, 0) AS bei_deminimis_monthly,
+			COALESCE(e.bei_honorarium_monthly, 0) AS bei_honorarium_monthly,
+			COALESCE(e.bei_meal_allow_monthly, 0) AS bei_meal_allow_monthly,
+			COALESCE(e.bei_gasoline_allow_monthly, 0) AS bei_gasoline_allow_monthly,
+			COALESCE(e.bei_other_fixed_monthly, 0) AS bei_other_fixed_monthly"""
+
 	# Get employees with salary structure assignment + gov IDs + bank + allowances
 	sql = f"""
 		SELECT
@@ -203,13 +223,7 @@ def get_compensation_grid(filters=None):
 			ssa.payroll_payable_account,
 			e.salary_mode,
 			e.bank_name,
-			e.bank_ac_no,
-			COALESCE(e.bei_comm_allow_monthly, 0) AS bei_comm_allow_monthly,
-			COALESCE(e.bei_deminimis_monthly, 0) AS bei_deminimis_monthly,
-			COALESCE(e.bei_honorarium_monthly, 0) AS bei_honorarium_monthly,
-			COALESCE(e.bei_meal_allow_monthly, 0) AS bei_meal_allow_monthly,
-			COALESCE(e.bei_gasoline_allow_monthly, 0) AS bei_gasoline_allow_monthly,
-			COALESCE(e.bei_other_fixed_monthly, 0) AS bei_other_fixed_monthly
+			e.bank_ac_no{allowance_sql}
 		FROM `tabEmployee` e
 		LEFT JOIN `tabSalary Structure Assignment` ssa
 			ON ssa.employee = e.name

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -1907,28 +1907,27 @@ def get_user_store(surface: str | None = None):
 		or "HR Manager" in user_roles
 		or "Regional Manager" in user_roles
 	):
-		# S133: System Manager always sees ALL stores, overriding Area Supervisor subset.
-		role = "Regional Manager" if "Regional Manager" in user_roles else "System Manager"
-		if surface_key in {SCHEDULE_SURFACE_STORE, SCHEDULE_SURFACE_COMMISSARY}:
-			for store_row in schedule_rows:
-				append_store(store_row)
-		else:
-			# Clear any stores from earlier role paths (e.g., Area Supervisor)
-			# so System Manager sees the full list, not just their supervised stores.
-			stores.clear()
-			seen_stores.clear()
-			store_rows = frappe.get_all(
-				"Warehouse",
-				filters={"is_group": 0, "disabled": 0},
-				fields=["name", "warehouse_name", "warehouse_type"],
-				order_by="warehouse_name",
-				limit=200,
-			)
-			for store_row in store_rows:
-				# S128/B2 + S133: Skip non-orderable warehouses by type and name.
-				if not _is_orderable_store(store_row):
-					continue
-				append_store(store_row)
+		# S136: Only show ALL stores for admins who have NO stores from earlier role paths.
+		# If Area Supervisor/Store Staff already found stores, keep those — the user
+		# has a real operational role and should see only their assigned stores.
+		if not stores:
+			role = "Regional Manager" if "Regional Manager" in user_roles else "System Manager"
+			if surface_key in {SCHEDULE_SURFACE_STORE, SCHEDULE_SURFACE_COMMISSARY}:
+				for store_row in schedule_rows:
+					append_store(store_row)
+			else:
+				store_rows = frappe.get_all(
+					"Warehouse",
+					filters={"is_group": 0, "disabled": 0},
+					fields=["name", "warehouse_name", "warehouse_type"],
+					order_by="warehouse_name",
+					limit=200,
+				)
+				for store_row in store_rows:
+					# S128/B2 + S133: Skip non-orderable warehouses by type and name.
+					if not _is_orderable_store(store_row):
+						continue
+					append_store(store_row)
 
 	default_store = stores[0]["name"] if stores else None
 


### PR DESCRIPTION
Prevents HTTP 500 on compensation grid when code deploys before SSM creates bei_*_monthly custom fields. Falls back to 0 for allowances when columns dont exist yet.