### PR TITLE
fix(S152): invoice amount calc + GR photo auto-link

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -2480,6 +2480,14 @@ def create_invoice(data: dict[str, Any] | str) -> dict[str, Any]:
     # Extract line items before sanitizing
     line_items = data.pop("items", None) or data.pop("line_items", None) or []
 
+    # DEFECT-4 fix: Auto-link invoice_attachment from GR's supplier_invoice_photo
+    if not data.get("invoice_attachment") and data.get("goods_receipt"):
+        gr_photo = frappe.db.get_value(
+            "BEI Goods Receipt", data["goods_receipt"], "supplier_invoice_photo"
+        )
+        if gr_photo:
+            data["invoice_attachment"] = gr_photo
+
     # DM-2: Savepoint for atomic invoice + child table creation
     frappe.db.savepoint("invoice_creation")
     invoice = frappe.get_doc({
@@ -2490,15 +2498,46 @@ def create_invoice(data: dict[str, Any] | str) -> dict[str, Any]:
     # C2: Add line items to child table if provided
     if line_items:
         for item_data in line_items:
+            qty = flt(item_data.get("qty"))
+            rate = flt(item_data.get("rate") or item_data.get("unit_cost"))
+            vat_rate = flt(item_data.get("vat_rate", 12))
+            # DEFECT-5 fix: Calculate amount = qty * rate
+            amount = qty * rate
+            vat_amount = amount * vat_rate / 100
+
             invoice.append("items", {
                 "item_code": item_data.get("item_code"),
                 "item_name": item_data.get("item_name"),
-                "qty": flt(item_data.get("qty")),
-                "rate": flt(item_data.get("rate") or item_data.get("unit_cost")),
-                "vat_rate": flt(item_data.get("vat_rate", 12)),
+                "qty": qty,
+                "rate": rate,
+                "amount": amount,
+                "vat_rate": vat_rate,
+                "vat_amount": vat_amount,
                 "matched_gr_item": item_data.get("matched_gr_item"),
                 "match_status": item_data.get("match_status", "Unmatched"),
             })
+    else:
+        # DEFECT-5 fix: When no line items provided, populate from PO and compute amounts
+        if purchase_order:
+            po_items = frappe.db.sql("""
+                SELECT item_code, item_name, qty, unit_cost as rate, vat_rate, vat_amount
+                FROM `tabBEI PO Item` WHERE parent = %s ORDER BY idx
+            """, purchase_order, as_dict=True)
+            for pi in po_items:
+                qty = flt(pi.qty)
+                rate = flt(pi.rate)
+                vat_rate = flt(pi.vat_rate or 12)
+                amount = qty * rate
+                vat_amount = amount * vat_rate / 100
+                invoice.append("items", {
+                    "item_code": pi.item_code,
+                    "item_name": pi.item_name,
+                    "qty": qty,
+                    "rate": rate,
+                    "amount": amount,
+                    "vat_rate": vat_rate,
+                    "vat_amount": vat_amount,
+                })
 
     invoice.insert()
     frappe.db.release_savepoint("invoice_creation")

--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -57,7 +57,15 @@ class BEIInvoice(Document):
 		self.db_set("invoice_no", self.name, update_modified=False)
 
 	def calculate_totals(self):
-		"""Calculate grand total and balance."""
+		"""Calculate grand total and balance from items."""
+		# Compute subtotal and VAT from line items if they have amounts
+		if self.items:
+			items_subtotal = sum(flt(item.amount) for item in self.items)
+			items_vat = sum(flt(item.vat_amount) for item in self.items)
+			if items_subtotal > 0:
+				self.subtotal = flt(items_subtotal, 2)
+				self.vat_amount = flt(items_vat, 2)
+
 		self.grand_total = flt(self.subtotal, 2) + flt(self.vat_amount, 2) - flt(self.withholding_tax, 2)
 		self.balance_due = flt(self.grand_total, 2) - flt(self.amount_paid, 2)
 


### PR DESCRIPTION
## Summary
- **DEFECT-4**: Auto-link GR supplier_invoice_photo to Invoice invoice_attachment
- **DEFECT-5**: Calculate amount = qty * rate for invoice line items (was 0). Compute subtotal from items.

Found during S152 E2E acceptance testing — blocked Invoice → RFP → Approval chain.

## Files
- hrms/api/procurement.py — create_invoice: auto-link GR photo, calc item amounts, populate from PO
- hrms/hr/doctype/bei_invoice/bei_invoice.py — calculate_totals: compute subtotal from items