### PR TITLE
fix(S154): delivery schedule API crash — _is_orderable_store string vs dict

### DIFF
--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -6043,7 +6043,7 @@ def get_weekly_schedule(
 	store_meta = {}
 	# Gracefully handle custom_territory_cluster: field exists in fixtures but may
 	# not be in DB yet if bench migrate hasn't run after the fixture was added.
-	_wh_fields = ["name", "parent_warehouse"]
+	_wh_fields = ["name", "parent_warehouse", "warehouse_type"]
 	try:
 		if frappe.get_meta("Warehouse").has_field("custom_territory_cluster"):
 			_wh_fields.append("custom_territory_cluster")
@@ -6061,7 +6061,7 @@ def get_weekly_schedule(
 	)
 	for wh in all_warehouses:
 		# Skip non-orderable warehouses (3PLs, commissaries, meta warehouses)
-		if not _is_orderable_store(wh.name):
+		if not _is_orderable_store(wh):
 			continue
 		normalized = (wh.name or "").upper().replace(" - BEBANG ENTERPRISE INC.", "").replace(" - BEI", "").replace(" - BKI", "").strip()
 		source_wh = _CENTRAL_WAREHOUSE_ROUTE_MAP.get(normalized, "")


### PR DESCRIPTION
## Summary
Two bugs fixed from direct API testing:

1. **`_is_orderable_store(wh.name)`** passes a string but the function expects a dict with `.get()`. Fix: pass the full warehouse row object `wh`.
2. **Missing `warehouse_type` in query fields** — `_is_orderable_store` checks `warehouse_type` but the query didn't include it. Added to fields list.

Also includes the `has_field()` graceful handling for `custom_territory_cluster` from PR #422.

**Verified by:** Direct API call to `https://hq.bebang.ph/api/method/hrms.api.store.get_weekly_schedule` returned the AttributeError.

## Test plan
- [ ] `curl hq.bebang.ph/api/method/hrms.api.store.get_weekly_schedule?week_start=2026-03-30` returns 200
- [ ] Delivery schedule page loads with all stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)