### PR TITLE
fix(S155): audit fixes — INT4, demand display, pipeline bugs

### DIFF
--- a/docs/plans/2026-04-03-sprint-155-scm-integration-pipeline.md
+++ b/docs/plans/2026-04-03-sprint-155-scm-integration-pipeline.md
@@ -1,17 +1,24 @@
 ---
 canonical_sprint_id: S155
 display: Sprint 155
-status: IN_PROGRESS
+status: DEPLOYED_NOT_VERIFIED
 branch: s155-scm-integration-pipeline
 lane: single
 created_date: 2026-04-03
 execution_started: 2026-04-03
 completed_date:
-deployed_at:
+deployed_at: 2026-04-03
 backend_pr: "#425"
 frontend_pr: "BEI-Tasks#314"
-l3_result:
-execution_summary:
+l3_result: pending-redeploy
+execution_summary: |
+  All code implemented. Audit fixes pushed (INT4, FX5, UX3, UX4).
+  Custom Fields created via API. EX1 (136/138 items classified),
+  EX1b (13/15 BOMs), EX3 (208 schedule entries published),
+  EX2b (765 demand snapshots). Ordering page demand display fix
+  requires redeploy (avg_daily_demand condition). Pipeline scripts
+  fixed (Supabase columns, warehouse mapping, source_reference).
+  VF1-VF3 pending after redeploy.
 depends_on: S154
 ---
 

--- a/hrms/api/route_planner.py
+++ b/hrms/api/route_planner.py
@@ -346,23 +346,35 @@ def optimize_route(stores_json, goods_type="cold", departure_time=None):
 	warnings = []
 
 	# Calculate per-store totals
+	# S155/INT4: Accept projected_kg directly when stores come from schedule
+	# (no item-level data). Falls back to item-based weight calculation.
 	stores_with_totals = []
 	for s in stores:
-		store_kg = 0
-		store_m3 = 0
-		item_count = 0
-		for item in s.get("items", []):
-			w = sku_weights.get(item["sku"], 1.0)
-			qty = float(item.get("qty", 0))
-			store_kg += w * qty
-			item_count += 1
-		stores_with_totals.append({
-			"store": s["store"],
-			"items": s.get("items", []),
-			"total_kg": round(store_kg, 1),
-			"total_m3": None,  # Mode 1: weight-only
-			"item_count": item_count,
-		})
+		projected = s.get("projected_kg")
+		if projected is not None and not s.get("items"):
+			# Schedule-sourced store with projected load from BOM demand
+			stores_with_totals.append({
+				"store": s["store"],
+				"items": [],
+				"total_kg": round(float(projected), 1),
+				"total_m3": None,
+				"item_count": s.get("item_count", 0),
+			})
+		else:
+			store_kg = 0
+			item_count = 0
+			for item in s.get("items", []):
+				w = sku_weights.get(item["sku"], 1.0)
+				qty = float(item.get("qty", 0))
+				store_kg += w * qty
+				item_count += 1
+			stores_with_totals.append({
+				"store": s["store"],
+				"items": s.get("items", []),
+				"total_kg": round(store_kg, 1),
+				"total_m3": None,
+				"item_count": item_count,
+			})
 
 	total_kg = sum(s["total_kg"] for s in stores_with_totals)
 	total_m3 = None  # Mode 1

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -2317,12 +2317,10 @@ def get_orderable_items(store: str, date: str | None = None) -> dict:
 
 		projected_sales = flt(snapshot.get("projected_sales"), 2)
 		bom_consumption = flt(snapshot.get("bom_consumption"), 2)
-		if projected_sales > 0 or bom_consumption > 0:
+		snapshot_demand = flt(snapshot.get("avg_daily_demand"), 4)
+		if projected_sales > 0 or bom_consumption > 0 or snapshot_demand > 0:
 			recommendation_source = snapshot.get("signal_source") or "sales_demand_snapshot"
-			avg_daily_demand = flt(
-				snapshot.get("avg_daily_demand") or (projected_sales + bom_consumption),
-				4,
-			)
+			avg_daily_demand = snapshot_demand or flt(projected_sales + bom_consumption, 4)
 		else:
 			projected_sales, bom_consumption = _estimate_projected_sales_and_bom(
 				last_order_qty, flt(item.order_count), lane

--- a/scripts/build_demand_snapshots.py
+++ b/scripts/build_demand_snapshots.py
@@ -156,20 +156,63 @@ def load_pos_crosswalk() -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 def load_store_mapping() -> tuple[dict[int, str], dict[str, int]]:
-    """Returns (location_id→warehouse_record_name, warehouse_name→location_id)."""
+    """Returns (location_id→warehouse_record_name, warehouse_name→location_id).
+
+    S155: Queries Frappe API for actual warehouse names to avoid stale CSV mapping.
+    Falls back to CSV if API fails.
+    """
     loc_to_wh: dict[int, str] = {}
     wh_to_loc: dict[str, int] = {}
+
+    # Build location_id map from CSV
+    csv_name_to_loc: dict[str, int] = {}
+    with open(STORE_MAPPING_CSV, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = (row.get("warehouse_name") or "").strip()
+            loc = int(row.get("location_id") or 0)
+            if name.startswith("TEST-") or not loc:
+                continue
+            csv_name_to_loc[name.upper()] = loc
+
+    # Fetch real warehouse names from Frappe
+    try:
+        api_key, api_secret = get_frappe_auth()
+        resp = requests.get(
+            f"{FRAPPE_URL}/api/resource/Warehouse",
+            params={
+                "filters": json.dumps([["is_group", "=", 0], ["disabled", "=", 0]]),
+                "fields": json.dumps(["name"]),
+                "limit_page_length": 200,
+            },
+            headers={"Authorization": f"token {api_key}:{api_secret}"},
+            timeout=15,
+        )
+        if resp.status_code == 200:
+            for wh in resp.json().get("data", []):
+                full_name = wh["name"]
+                # Strip suffix to match CSV display name
+                short = full_name.upper().replace(" - BEBANG ENTERPRISE INC.", "").replace(" - BEI", "").replace(" - BKI", "").strip()
+                loc = csv_name_to_loc.get(short)
+                if loc:
+                    loc_to_wh[loc] = full_name
+                    wh_to_loc[full_name] = loc
+            print(f"  Store mapping: {len(loc_to_wh)} stores (Frappe API)")
+            return loc_to_wh, wh_to_loc
+    except Exception as e:
+        print(f"  Warning: Frappe API failed ({e}), falling back to CSV")
+
+    # Fallback to CSV (may have stale names)
     with open(STORE_MAPPING_CSV, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
             name = (row.get("warehouse_name") or "").strip()
             record = (row.get("warehouse_record_name") or "").strip()
             loc = int(row.get("location_id") or 0)
-            if name.startswith("TEST-"):
+            if name.startswith("TEST-") or not loc or not record:
                 continue
-            if loc and record:
-                loc_to_wh[loc] = record
-                wh_to_loc[name] = loc
+            loc_to_wh[loc] = record
+            wh_to_loc[name] = loc
     return loc_to_wh, wh_to_loc
 
 
@@ -192,23 +235,36 @@ def fetch_pos_sales(since_date: str) -> list[dict]:
     while current <= today:
         date_str = current.strftime("%Y-%m-%d")
         try:
-            # Query pos_order_items with embedded join to pos_orders
-            rows = _supabase_get("pos_order_items", {
-                "select": "qty,item_name,pos_orders!inner(location_id,business_date,payment_status)",
-                "pos_orders.payment_status": "eq.PAID",
-                "pos_orders.business_date": f"eq.{date_str}",
-                "limit": "10000",
+            # Two-step query: orders first, then items
+            orders = _supabase_get("pos_orders", {
+                "select": "id,location_id",
+                "business_date": f"eq.{date_str}",
+                "payment_status": "eq.PAID",
+                "limit": "5000",
             })
-            for row in rows:
-                order = row.get("pos_orders") or {}
-                if isinstance(order, list):
-                    order = order[0] if order else {}
-                all_rows.append({
-                    "location_id": order.get("location_id"),
-                    "business_date": order.get("business_date") or date_str,
-                    "item_name": row.get("item_name", ""),
-                    "qty": float(row.get("qty") or 0),
+            if not orders:
+                current += timedelta(days=1)
+                continue
+            order_map = {o["id"]: o["location_id"] for o in orders}
+            order_ids = list(order_map.keys())
+            # Batch query items for these orders
+            for batch_start in range(0, len(order_ids), 200):
+                batch = order_ids[batch_start:batch_start + 200]
+                ids_str = ",".join(str(oid) for oid in batch)
+                items = _supabase_get("pos_order_items", {
+                    "select": "order_id,product_name,quantity",
+                    "order_id": f"in.({ids_str})",
+                    "limit": "10000",
                 })
+                for row in items:
+                    loc = order_map.get(row.get("order_id"))
+                    if loc:
+                        all_rows.append({
+                            "location_id": loc,
+                            "business_date": date_str,
+                            "item_name": row.get("product_name", ""),
+                            "qty": float(row.get("quantity") or 0),
+                        })
         except Exception as e:
             print(f"  Warning: POS query failed for {date_str}: {e}")
         current += timedelta(days=1)
@@ -433,13 +489,9 @@ def write_snapshots_to_frappe(
     written = 0
     for item_code, data in demand.items():
         source_ref = json.dumps({
-            "signal_source": "bom_demand_pipeline",
-            "projected_sales": data["projected_sales"],
-            "bom_consumption": data["bom_consumption"],
-            "coverage_window_days": data["coverage_days"],
-            "weather_multiplier": data["weather_multiplier"],
-            "lookback_days": LOOKBACK_DAYS,
-            "bom_breakdown_count": len(data.get("bom_breakdown", [])),
+            "src": "bom_pipeline",
+            "cov": data["coverage_days"],
+            "wx": round(data["weather_multiplier"], 3),
         })
 
         payload = {
@@ -448,6 +500,7 @@ def write_snapshots_to_frappe(
             "item_code": item_code,
             "warehouse": warehouse,
             "avg_daily_demand": data["avg_daily_demand"],
+            "coverage_window_days": data["coverage_days"],
             "source_reference": source_ref,
         }
 

--- a/scripts/s154_load_store_boms.py
+++ b/scripts/s154_load_store_boms.py
@@ -98,20 +98,44 @@ def main():
         "Content-Type": "application/json",
     }
 
+    # Build product name → item code mapping from Frappe
+    name_to_code = {}
+    try:
+        resp = requests.get(
+            f"{FRAPPE_URL}/api/resource/Item",
+            params={
+                "filters": json.dumps([["item_group", "=", "Finished Goods"]]),
+                "fields": json.dumps(["name", "item_name"]),
+                "limit_page_length": 100,
+            },
+            headers=headers,
+            timeout=15,
+        )
+        if resp.status_code == 200:
+            for item in resp.json().get("data", []):
+                name_to_code[item["item_name"].strip().upper()] = item["name"]
+            print(f"  Loaded {len(name_to_code)} FG item mappings")
+    except Exception as e:
+        print(f"  Warning: Could not load item mappings: {e}")
+
     created = 0
     for product, components in bom_data.items():
-        # Check if BOM already exists for this product
-        # BOM naming: BOM-{item}-{version}
-        # We need the Item record for the product
-        # Store consumption BOMs use a naming convention: "STORE-{product}"
+        item_code = name_to_code.get(product)
+        if not item_code:
+            print(f"  Skipping {product}: no matching Item code found")
+            continue
         bom_doc = {
             "doctype": "BOM",
-            "item": product,  # This needs to be a valid Item code
+            "item": item_code,
+            "company": "Bebang Kitchen Inc.",
             "is_active": 1,
             "is_default": 0,  # Don't override commissary BOMs
             "quantity": 1,
             "uom": "Cup",
             "custom_bom_type": "Store Consumption",
+            "bei_source_file": "s154_load_store_boms.py",
+            "bei_source_sheet": "BOM CSV",
+            "bei_source_row": product,
             "items": [],
         }
 

--- a/scripts/s154_seed_delivery_schedule.py
+++ b/scripts/s154_seed_delivery_schedule.py
@@ -78,8 +78,39 @@ def _get_secret(env_name: str) -> str:
 
 
 def load_store_mapping() -> dict[str, str]:
-    """Load warehouse_name → warehouse_record_name."""
+    """Load warehouse_name → warehouse_record_name from Frappe API."""
+    api_key = _get_secret("FRAPPE_API_KEY")
+    api_secret = _get_secret("FRAPPE_API_SECRET")
     mapping = {}
+
+    # Fetch real warehouse names from Frappe
+    try:
+        import requests as req_lib
+        resp = req_lib.get(
+            f"{FRAPPE_URL}/api/resource/Warehouse",
+            params={
+                "filters": json.dumps([["is_group", "=", 0], ["disabled", "=", 0]]),
+                "fields": json.dumps(["name"]),
+                "limit_page_length": 200,
+            },
+            headers={"Authorization": f"token {api_key}:{api_secret}"},
+            timeout=15,
+        )
+        if resp.status_code == 200:
+            for wh in resp.json().get("data", []):
+                # Build display→full name map
+                # "ARANETA CITY - BEI" → key "ARANETA CITY"
+                full_name = wh["name"]
+                short = full_name.upper().replace(" - BEBANG ENTERPRISE INC.", "").replace(" - BEI", "").replace(" - BKI", "").strip()
+                mapping[short] = full_name
+                # Also index by title-case
+                mapping[short.title()] = full_name
+            print(f"  Loaded {len(mapping) // 2} warehouse mappings from Frappe")
+            return mapping
+    except Exception as e:
+        print(f"  Warning: Frappe API fetch failed ({e}), falling back to CSV")
+
+    # Fallback to CSV
     with open(STORE_MAPPING, newline="", encoding="utf-8") as f:
         for row in csv.DictReader(f):
             name = (row.get("warehouse_name") or "").strip()


### PR DESCRIPTION
## Summary
Post-audit fixes that were pushed after the original PR #425 was merged.

- **INT4**: `optimize_route` now accepts `projected_kg` from schedule-loaded stores (was ignoring it, always computing 0)
- **Ordering page**: `avg_daily_demand` condition added — pipeline writes `avg_daily_demand` but the ordering page only checked `projected_sales`/`bom_consumption` (legacy fields)
- **Pipeline fixes**: Correct Supabase column names (`quantity`/`product_name`), two-step query, Frappe warehouse name mapping, truncated `source_reference`
- **BOM loader**: Added `company` field, item code mapping, source lineage
- **Schedule seeder**: Queries Frappe API for real warehouse names

## Critical
The ordering page currently shows demand=0 for all BOM items despite 765 snapshots existing. This fix enables the demand display.

## Test plan
- [ ] After deploy: `curl .../get_orderable_items?store=Araneta+Gateway` → items should have `avg_daily_demand > 0`
- [ ] Route planner: schedule-loaded stores should show projected weight in optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)