### PR TITLE
feat(S158): add bank_account_name field for Union Bank API

### DIFF
--- a/hrms/api/payroll_compensation.py
+++ b/hrms/api/payroll_compensation.py
@@ -116,6 +116,7 @@ def compute_monthly_tax(base):
 SENSITIVE_FIELDS = frozenset({
 	"bank_name",
 	"bank_ac_no",
+	"bank_account_name",
 	"tin_number",
 	"sss_number",
 	"philhealth_number",
@@ -125,6 +126,7 @@ SENSITIVE_FIELDS = frozenset({
 SENSITIVE_FIELD_LABELS = {
 	"bank_name": "Bank Name",
 	"bank_ac_no": "Bank Account Number",
+	"bank_account_name": "Bank Account Name",
 	"tin_number": "TIN",
 	"sss_number": "SSS Number",
 	"philhealth_number": "PhilHealth Number",
@@ -331,7 +333,7 @@ def get_employee_compensation_detail(employee):
 	# Employee identity + allowances
 	emp_fields = [
 		"name", "employee_name", "department", "branch", "designation",
-		"employment_type", "date_of_joining", "salary_mode", "bank_name", "bank_ac_no",
+		"employment_type", "date_of_joining", "salary_mode", "bank_name", "bank_ac_no", "bank_account_name",
 	]
 
 	# Check for bei_* custom fields
@@ -361,6 +363,7 @@ def get_employee_compensation_detail(employee):
 		"salary_mode": emp.salary_mode,
 		"bank_name": emp.bank_name,
 		"bank_ac_no": emp.bank_ac_no,
+		"bank_account_name": emp.get("bank_account_name") or None,
 	}
 
 	# Mask bank account number

--- a/hrms/fixtures/custom_field.json
+++ b/hrms/fixtures/custom_field.json
@@ -567,5 +567,15 @@
         "options": "\nToppings\nFrozen\nSauces\nPackaging\nSupplies\nOther",
         "insert_after": "item_group",
         "description": "S154: Store ordering category for grouping items in the ordering page"
+    },
+    {
+        "doctype": "Custom Field",
+        "name": "Employee-bank_account_name",
+        "dt": "Employee",
+        "fieldname": "bank_account_name",
+        "fieldtype": "Data",
+        "label": "Bank Account Name",
+        "insert_after": "bank_name",
+        "description": "Account holder name for payroll disbursement (Union Bank API: beneficiary.name, max 30 chars)"
     }
 ]

--- a/hrms/hr/doctype/bei_sensitive_change_request/bei_sensitive_change_request.json
+++ b/hrms/hr/doctype/bei_sensitive_change_request/bei_sensitive_change_request.json
@@ -94,7 +94,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Field Changed",
-   "options": "bank_name\nbank_ac_no\ntin_number\nsss_number\nphilhealth_number\npagibig_number",
+   "options": "bank_name\nbank_ac_no\nbank_account_name\ntin_number\nsss_number\nphilhealth_number\npagibig_number",
    "reqd": 1
   },
   {


### PR DESCRIPTION
## Summary
- Add `bank_account_name` Custom Field on Employee DocType (requires `bench migrate`)
- Add to `SENSITIVE_FIELDS` + `SENSITIVE_FIELD_LABELS` for dual-control approval
- Return `bank_account_name` in `get_employee_compensation_detail` endpoint
- Add `bank_account_name` to `BEI Sensitive Change Request` field_name Select options

Maps to Union Bank API `beneficiary.name` (max 30 chars) for payroll fund transfers.

## Test plan
- [ ] `bench migrate` creates the `bank_account_name` column on Employee
- [ ] `get_employee_compensation_detail` returns `bank_account_name` field
- [ ] Sensitive Change Request accepts `bank_account_name` as field_name

🤖 Generated with [Claude Code](https://claude.com/claude-code)