### PR TITLE
fix(S158): correct ADMS DB container name — verified via SSM

### DIFF
--- a/hrms/utils/adms_monitor.py
+++ b/hrms/utils/adms_monitor.py
@@ -12,7 +12,7 @@ import frappe
 from frappe import _
 
 INSTANCE_ID = "i-026b7477d27bd46d6"
-DB_CONTAINER = "adms_receiver-adms-db-1"
+DB_CONTAINER = "62c9d67fd960_adms_receiver_adms-db_1"
 REGION = "ap-southeast-1"
 SSM_TIMEOUT_SECONDS = 60
 SSM_POLL_INTERVAL = 2

--- a/scripts/sync_adms_to_supabase.py
+++ b/scripts/sync_adms_to_supabase.py
@@ -52,7 +52,7 @@ is_roving = _roving_mod.is_roving
 # ---------------------------------------------------------------------------
 
 INSTANCE_ID = "i-026b7477d27bd46d6"
-DB_CONTAINER = os.environ.get("ADMS_DB_CONTAINER", "adms_receiver-adms-db-1")
+DB_CONTAINER = os.environ.get("ADMS_DB_CONTAINER", "62c9d67fd960_adms_receiver_adms-db_1")
 REGION = "ap-southeast-1"
 SSM_TIMEOUT = 60
 SSM_POLL_INTERVAL = 2


### PR DESCRIPTION
## Summary
Follow-up to #431. The DB container on EC2 has a hash prefix from manual recreation.

Verified via SSM `docker ps`:
```
adms_receiver_adms-api_1                 ← normal v1 name
adms_receiver_adms-nginx_1               ← normal v1 name
62c9d67fd960_adms_receiver_adms-db_1     ← hash prefix!
```

## After merge
1. Wait for next 5-min cron → should show actual punch counts
2. Backfill: `python scripts/sync_adms_to_supabase.py --backfill --from 2026-03-24 --to 2026-04-04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)