### PR TITLE
fix(S159): fix 3 demand pipeline bugs — warehouse, source_reference, commit

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -1578,6 +1578,10 @@ def _sync_store_demand_snapshot_rows(
 		frappe.db.savepoint(savepoint)
 		try:
 			source_reference = dict(snapshot["source_reference"])
+			# Strip verbose debug fields that bloat JSON beyond DB field limits
+			source_reference.pop("source_targets", None)
+			source_reference.pop("total_demand_window", None)
+			source_reference.pop("days_with_sales", None)
 			source_reference.update(
 				{
 					"sync_ref": sync_ref,
@@ -1647,6 +1651,11 @@ def _sync_store_demand_snapshot_rows(
 			frappe.db.rollback(save_point=savepoint)
 			results["errors"].append(f"{warehouse}/{item_code}: {exc!s}")
 			results["rows_failed"] += 1
+
+	# Commit all successful upserts (required for standalone script execution;
+	# Frappe request handler auto-commits but SSM/cron scripts do not)
+	if results["rows_created"] > 0 or results["rows_updated"] > 0:
+		frappe.db.commit()
 
 	return results
 

--- a/hrms/hr/doctype/bei_inventory_risk_snapshot/bei_inventory_risk_snapshot.json
+++ b/hrms/hr/doctype/bei_inventory_risk_snapshot/bei_inventory_risk_snapshot.json
@@ -42,7 +42,7 @@
   {"fieldname": "risk_level", "fieldtype": "Select", "label": "Risk Level", "options": "Low\nModerate\nHigh\nCritical", "in_list_view": 1},
   {"fieldname": "value_at_risk", "fieldtype": "Currency", "label": "Value At Risk"},
   {"fieldname": "margin_at_risk", "fieldtype": "Currency", "label": "Margin At Risk"},
-  {"fieldname": "source_reference", "fieldtype": "Data", "label": "Source Reference"}
+  {"fieldname": "source_reference", "fieldtype": "Small Text", "label": "Source Reference"}
  ],
  "index_web_pages_for_search": 1,
  "links": [],

--- a/hrms/utils/store_order_demand_snapshot.py
+++ b/hrms/utils/store_order_demand_snapshot.py
@@ -714,6 +714,24 @@ def write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, Any]]) -> 
 		writer.writerows(rows)
 
 
+def _build_store_warehouse_map() -> dict[str, str]:
+	"""Load store_name → Frappe warehouse DocName from the shadow sync registry."""
+	registry_path = FIXTURE_DIR.parent / "store_inventory_shadow_sync" / "store_inventory_shadow_sync_registry.csv"
+	mapping: dict[str, str] = {}
+	if not registry_path.exists():
+		return mapping
+	with registry_path.open(encoding="utf-8-sig", newline="") as f:
+		for row in csv.DictReader(f):
+			store_name = (row.get("store_name") or "").strip()
+			warehouse_name = (row.get("warehouse_name") or "").strip()
+			docname = (row.get("warehouse_docname") or "").strip()
+			if store_name and docname:
+				mapping[store_name] = docname
+			if warehouse_name and docname and warehouse_name != store_name:
+				mapping[warehouse_name] = docname
+	return mapping
+
+
 def build_outputs(snapshot_date: date, lookback_days: int) -> dict[str, Any]:
 	start_date = snapshot_date - timedelta(days=lookback_days)
 	end_date = snapshot_date - timedelta(days=1)
@@ -721,6 +739,7 @@ def build_outputs(snapshot_date: date, lookback_days: int) -> dict[str, Any]:
 	fg_display_by_norm, crosswalk_by_norm, bom_rows_by_fg_norm = load_bom_catalog()
 	policies_by_code, policies_by_name = load_product_policy_catalog()
 	component_recipes_by_key = load_component_recipe_catalog()
+	store_warehouse_map = _build_store_warehouse_map()
 	pos_web_rows = fetch_pos_web_product_rows(start_date, end_date)
 	foodpanda_rows = [
 		row
@@ -882,11 +901,14 @@ def build_outputs(snapshot_date: date, lookback_days: int) -> dict[str, Any]:
 			item_daily_map[item_key]["demand_qty"] += demand_qty
 			item_daily_map[item_key]["source_targets"].add(target_key)
 
-			snapshot_key = (store_name, item_code)
+			resolved_warehouse = store_warehouse_map.get(
+				store_name, f"{store_name} - Bebang Enterprise Inc."
+			)
+			snapshot_key = (resolved_warehouse, item_code)
 			if snapshot_key not in snapshot_map:
 				snapshot_map[snapshot_key] = {
 					"snapshot_date": snapshot_date.isoformat(),
-					"warehouse": store_name,
+					"warehouse": resolved_warehouse,
 					"item_code": item_code,
 					"item_name": component_item_name,
 					"total_demand_window": 0.0,


### PR DESCRIPTION
## Summary — 3 root causes, all fixed

**Bug 1: Warehouse name mismatch** (caused "Warehouse not found" for all 2099 rows)
- `build_outputs()` wrote raw POS store names. Now resolves to Frappe warehouse DocNames using the shadow sync registry CSV.

**Bug 2: source_reference truncation** (caused silent insert failures)  
- Stripped verbose debug fields from JSON. Changed DocType field from `Data` (VARCHAR 255) to `Small Text` (TEXT).

**Bug 3: No commit** (caused zero persistence when called from SSM scripts)
- Added `frappe.db.commit()` after upsert loop.

## After merge + deploy
Trigger demand pipeline. All 2099 snapshot rows should persist. Ordering page will show real Demand/Day.

## Files changed
- `hrms/utils/store_order_demand_snapshot.py` — warehouse resolution via registry
- `hrms/api/erp_sync.py` — source_reference cleanup + commit
- `hrms/hr/doctype/bei_inventory_risk_snapshot/bei_inventory_risk_snapshot.json` — field type fix

Generated with Claude Code