### PR TITLE
fix(S159): map all 46 POS stores to Frappe warehouses

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -1518,7 +1518,12 @@ def _sync_store_demand_snapshot_rows(
 	for row in rows:
 		try:
 			item_code = str(_first_non_empty(row, "item_code", "sku") or "").strip()
-			warehouse = _resolve_warehouse(_first_non_empty(row, "warehouse", "store", "location"))
+			raw_warehouse = _first_non_empty(row, "warehouse", "store", "location")
+			# If already a valid Frappe Warehouse DocName (pre-resolved by pipeline), use it directly
+			if raw_warehouse and frappe.db.exists("Warehouse", raw_warehouse):
+				warehouse = raw_warehouse
+			else:
+				warehouse = _resolve_warehouse(raw_warehouse)
 			snapshot_date = (
 				_safe_date(_first_non_empty(row, "snapshot_date", "as_of_date", "date")) or nowdate()
 			)

--- a/hrms/utils/store_order_demand_snapshot.py
+++ b/hrms/utils/store_order_demand_snapshot.py
@@ -729,6 +729,17 @@ def _build_store_warehouse_map() -> dict[str, str]:
 				mapping[store_name] = docname
 			if warehouse_name and docname and warehouse_name != store_name:
 				mapping[warehouse_name] = docname
+
+	# POS store names that differ from registry store_name/warehouse_name
+	pos_aliases = {
+		"D'Verde Calamba": "D'verde Laguna - Bebang Enterprise Inc.",
+		"NAIA Terminal 3": "NAIA T3 - BEI",
+		"Robinsons Galleria South": "Robisons Galleria South - Bebang Enterprise Inc.",
+		"SM San Pablo": "SM San Pablo - BEI",
+	}
+	for alias, docname in pos_aliases.items():
+		mapping.setdefault(alias, docname)
+
 	return mapping
 
 

--- a/scripts/s159_create_sm_san_pablo.py
+++ b/scripts/s159_create_sm_san_pablo.py
@@ -1,0 +1,38 @@
+import os, sys
+
+for d in [
+    "/home/frappe/logs",
+    "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+    "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+]:
+    os.makedirs(d, exist_ok=True)
+
+import frappe
+
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+WH_NAME = "SM San Pablo"
+COMPANY = "Bebang Enterprise Inc."
+DOCNAME = "SM San Pablo - Bebang Enterprise Inc."
+
+if frappe.db.exists("Warehouse", DOCNAME):
+    print("SKIP: Warehouse already exists: %s" % DOCNAME)
+else:
+    # Find parent warehouse for store locations
+    parent = frappe.db.get_value("Warehouse", {"warehouse_name": "Store Locations"}, "name")
+    if not parent:
+        parent = frappe.db.get_value("Warehouse", {"is_group": 1, "company": COMPANY}, "name")
+
+    wh = frappe.new_doc("Warehouse")
+    wh.warehouse_name = WH_NAME
+    wh.company = COMPANY
+    wh.parent_warehouse = parent
+    wh.insert(ignore_permissions=True)
+    frappe.db.commit()
+    print("Created: %s (parent: %s)" % (wh.name, parent))
+
+print("SM-SAN-PABLO-DONE")
+frappe.destroy()


### PR DESCRIPTION
## Summary
Only 12 of 46 stores got demand snapshots because the sync layer re-resolved
already-resolved warehouse DocNames, failing for names with full company suffix.

**Fix:** Check if warehouse is already a valid DocName before calling `_resolve_warehouse()`.

Also:
- Added 4 POS name aliases (D'Verde Calamba, NAIA Terminal 3, Robinsons Galleria South, SM San Pablo)
- Created SM San Pablo warehouse in Frappe (new store)

## Expected result after deploy + trigger
- ~2000 snapshot rows across all 46 stores (was 566 across 12)
- Ordering page shows Demand/Day for every store

Generated with Claude Code