### PR TITLE
fix(S159): fix em-dash warehouse names causing false Source OOS

### DIFF
--- a/hrms/api/erp_sync.py
+++ b/hrms/api/erp_sync.py
@@ -54,16 +54,16 @@ WAREHOUSE_ALIAS_DOCNAME_MAP = {
 	"SHAW COMMI": "Shaw BLVD - BKI",
 }
 WAREHOUSE_ALIAS_NAME_MAP = {
-	"3MD": "3MD Logistics – Camangyanan",
-	"3MD WAREHOUSE": "3MD Logistics – Camangyanan",
-	"33MD": "3MD Logistics – Camangyanan",
+	"3MD": "3MD Logistics - Camangyanan",
+	"3MD WAREHOUSE": "3MD Logistics - Camangyanan",
+	"33MD": "3MD Logistics - Camangyanan",
 	"JENTEC": "Jentec Storage Inc.",
 	"JENTEC WAREHOUSE": "Jentec Storage Inc.",
 	"JENTECT WAREHOUSE": "Jentec Storage Inc.",
 	"PINNACLE": "Pinnacle Cold Storage Solutions",
 	"PINNACLE WAREHOUSE": "Pinnacle Cold Storage Solutions",
 	"PINACCLE": "Pinnacle Cold Storage Solutions",
-	"RCS": "Royal Cold Storage – Taytay (RCS)",
+	"RCS": "Royal Cold Storage - Taytay (RCS)",
 	"D VERDE": "D'verde Laguna",
 	"DVERDE": "D'verde Laguna",
 	"CTTM": "CTTM Tomas Morato",
@@ -327,11 +327,11 @@ def _resolve_warehouse_alias(value: str | None) -> str | None:
 		return _resolve_warehouse_exact_or_name(warehouse_name_alias)
 
 	if "3MD" in normalized or "CAMANGYANAN" in normalized:
-		return _resolve_warehouse_exact_or_name("3MD Logistics – Camangyanan")
+		return _resolve_warehouse_exact_or_name("3MD Logistics - Camangyanan")
 	if "JENTEC" in normalized or ("PASIG" in normalized and "ONG" in normalized):
 		return _resolve_warehouse_exact_or_name("Jentec Storage Inc.")
 	if "RCS" in normalized or "ROYAL COLD STORAGE" in normalized:
-		return _resolve_warehouse_exact_or_name("Royal Cold Storage – Taytay (RCS)")
+		return _resolve_warehouse_exact_or_name("Royal Cold Storage - Taytay (RCS)")
 	if "PINNACLE" in normalized or "TURBINA" in normalized or "CALAMBA" in normalized:
 		return _resolve_warehouse_exact_or_name("Pinnacle Cold Storage Solutions")
 	if "SHAW" in normalized:

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -1404,7 +1404,7 @@ def _is_delivery_window_open(next_delivery_date: str | None) -> bool:
 # Key: normalized store name (upper, stripped of company suffix)
 # Value: Frappe warehouse name for the source DC
 # All stores use a SINGLE source warehouse for both FROZEN and DRY.
-_3MD = "3MD Logistics \u2013 Camangyanan - BKI"
+_3MD = "3MD Logistics - Camangyanan - BKI"
 _PINNACLE = "Pinnacle Cold Storage Solutions - BKI"
 _JENTEC = "Jentec Storage Inc. - BKI"
 _CENTRAL_WAREHOUSE_ROUTE_MAP = {


### PR DESCRIPTION
## Summary
3MD Logistics and Royal Cold Storage warehouse constants used em-dash (U+2013)
but actual Frappe warehouses use regular hyphen. Route map pointed to a zero-stock
duplicate warehouse → every store showed "Source OOS" for Frozen Milk despite
9,599 barrels at the real 3MD warehouse.

Fixed in store.py (route map) and erp_sync.py (alias maps).

Generated with Claude Code