### PR TITLE
fix(S160): guard custom fields in employee detail endpoint

### DIFF
--- a/hrms/api/hr_reports.py
+++ b/hrms/api/hr_reports.py
@@ -213,6 +213,10 @@ def _get_employee_detail(employee_id: str) -> dict:
 		"custom_philhealth_verified", "custom_pagibig_verified",
 	]
 
+	# Guard custom fields — filter out any that don't exist on the DocType (S161 lesson)
+	_meta = frappe.get_meta("Employee")
+	emp_fields = [f for f in emp_fields if not f.startswith("custom_") or _meta.has_field(f)]
+
 	# Check bei_* allowance columns exist
 	allowance_fields = [
 		"bei_comm_allow_monthly", "bei_deminimis_monthly", "bei_honorarium_monthly",


### PR DESCRIPTION
## Summary
- Fix `_get_employee_detail()` crashing with "Unknown column" when custom fields don't exist on the Employee DocType
- Guards `custom_*` fields with `frappe.get_meta("Employee").has_field()` before including them in the SQL SELECT
- One-line fix per S161 lesson: always guard custom field SQL references

## Root Cause
The employee detail dialog showed "No employee data available" because fields like `custom_nickname`, `custom_uniform_size`, `custom_work_phone`, `custom_*_verified` were passed directly to `frappe.db.get_value()` which generates a SQL SELECT. If any field doesn't exist as a column, the query crashes.

## Test plan
- [ ] Call `get_employee_masterlist(detail="HR-EMP-00001")` — should return structured JSON instead of 500 error
- [ ] Employee Master page → click employee name → dialog loads with data

🤖 Generated with [Claude Code](https://claude.com/claude-code)