### PR TITLE
fix(S161): fix suggested_qty=0, missing items, variant merge

### DIFF
--- a/hrms/api/hr_reports.py
+++ b/hrms/api/hr_reports.py
@@ -213,9 +213,10 @@ def _get_employee_detail(employee_id: str) -> dict:
 		"custom_philhealth_verified", "custom_pagibig_verified",
 	]
 
-	# Guard custom fields — filter out any that don't exist on the DocType (S161 lesson)
+	# Guard ALL fields — filter out any that don't exist on the DocType (S161 lesson)
 	_meta = frappe.get_meta("Employee")
-	emp_fields = [f for f in emp_fields if not f.startswith("custom_") or _meta.has_field(f)]
+	_valid_fields = {f.fieldname for f in _meta.fields} | {"name"}
+	emp_fields = [f for f in emp_fields if f in _valid_fields]
 
 	# Check bei_* allowance columns exist
 	allowance_fields = [
@@ -321,13 +322,15 @@ def _get_employee_detail(employee_id: str) -> dict:
 	compensation["bank_ac_no"] = ("****" + bank_ac_no[-4:]) if len(bank_ac_no) > 4 else bank_ac_no
 
 	# Pending compensation changes count
-	compensation["pending_changes_count"] = frappe.db.count(
-		"BEI Compensation Change",
-		filters={
-			"employee": employee_id,
-			"status": ("in", ["Pending HR Manager", "Pending Accounts Manager"]),
-		},
-	)
+	compensation["pending_changes_count"] = 0
+	if frappe.db.exists("DocType", "BEI Compensation Change"):
+		compensation["pending_changes_count"] = frappe.db.count(
+			"BEI Compensation Change",
+			filters={
+				"employee": employee_id,
+				"status": ("in", ["Pending HR Manager", "Pending Accounts Manager"]),
+			},
+		)
 
 	# --- Gov IDs (masked) ---
 	def _mask(val):
@@ -342,17 +345,19 @@ def _get_employee_detail(employee_id: str) -> dict:
 	}
 
 	# --- Enrichment status ---
-	# Check for pending enrichment
-	has_pending_enrichment = bool(
-		frappe.db.exists(
-			"BEI Onboarding Request",
-			{
-				"employee": employee_id,
-				"request_type": "update_existing",
-				"status": ("in", ["Pending", "Escalated", "Revision Requested"]),
-			},
+	# Check for pending enrichment (guard DocType existence)
+	has_pending_enrichment = False
+	if frappe.db.exists("DocType", "BEI Onboarding Request"):
+		has_pending_enrichment = bool(
+			frappe.db.exists(
+				"BEI Onboarding Request",
+				{
+					"employee": employee_id,
+					"request_type": "update_existing",
+					"status": ("in", ["Pending", "Escalated", "Revision Requested"]),
+				},
+			)
 		)
-	)
 	enrichment = {
 		"custom_enrichment_status": emp.get("custom_enrichment_status") or "Not Started",
 		"custom_enrichment_submitted_date": str(emp.custom_enrichment_submitted_date) if emp.get("custom_enrichment_submitted_date") else None,
@@ -365,30 +370,34 @@ def _get_employee_detail(employee_id: str) -> dict:
 	}
 
 	# --- Recent changes (last 10 combined) ---
-	comp_changes = frappe.get_all(
-		"BEI Compensation Change",
-		filters={"employee": employee_id},
-		fields=[
-			"name", "'compensation' as source", "change_type",
-			"salary_component", "employee_field_name",
-			"old_value", "new_value", "status",
-			"requested_by", "submission_date as change_date",
-		],
-		order_by="creation DESC",
-		limit_page_length=10,
-	)
-	sensitive_changes = frappe.get_all(
-		"BEI Sensitive Change Request",
-		filters={"employee": employee_id},
-		fields=[
-			"name", "'sensitive' as source", "field_name as change_type",
-			"'' as salary_component", "field_name as employee_field_name",
-			"old_value", "new_value", "status",
-			"initiated_by as requested_by", "submission_date as change_date",
-		],
-		order_by="creation DESC",
-		limit_page_length=10,
-	)
+	comp_changes = []
+	if frappe.db.exists("DocType", "BEI Compensation Change"):
+		comp_changes = frappe.get_all(
+			"BEI Compensation Change",
+			filters={"employee": employee_id},
+			fields=[
+				"name", "'compensation' as source", "change_type",
+				"salary_component", "employee_field_name",
+				"old_value", "new_value", "status",
+				"requested_by", "submission_date as change_date",
+			],
+			order_by="creation DESC",
+			limit_page_length=10,
+		)
+	sensitive_changes = []
+	if frappe.db.exists("DocType", "BEI Sensitive Change Request"):
+		sensitive_changes = frappe.get_all(
+			"BEI Sensitive Change Request",
+			filters={"employee": employee_id},
+			fields=[
+				"name", "'sensitive' as source", "field_name as change_type",
+				"'' as salary_component", "field_name as employee_field_name",
+				"old_value", "new_value", "status",
+				"initiated_by as requested_by", "submission_date as change_date",
+			],
+			order_by="creation DESC",
+			limit_page_length=10,
+		)
 	all_changes = sorted(
 		comp_changes + sensitive_changes,
 		key=lambda r: str(r.get("change_date") or ""),

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -1683,10 +1683,9 @@ def _build_recommendation_contract(
 		2,
 	)
 	safety_buffer = flt(max(1.0, forecast_demand * 0.15), 2)
-	recommended_qty = flt(
-		max(0.0, forecast_demand + safety_buffer - flt(available_to_promise)),
-		2,
-	)
+	# S161-fix: Don't subtract source ATP — store orders what it needs.
+	# Store-actual subtraction happens later in get_orderable_items().
+	recommended_qty = flt(forecast_demand + safety_buffer, 2)
 	return {
 		"lane": lane,
 		"available_to_promise": flt(available_to_promise, 2),
@@ -2358,6 +2357,9 @@ def get_orderable_items(store: str, date: str | None = None, include_hidden: int
 				source_item_exists.add((ok[0], display.name))
 			# Sum order_count
 			display["order_count"] = flt(display.get("order_count", 0)) + flt(other.get("order_count", 0))
+			# S161-fix: Merge last_qty_map — inherit from variant if display has no entry
+			if display.name not in last_qty_map and other_code in last_qty_map:
+				last_qty_map[display.name] = last_qty_map[other_code]
 
 		display["merged_variants"] = other_codes
 		merged_items.append(display)
@@ -2547,8 +2549,8 @@ def get_orderable_items(store: str, date: str | None = None, include_hidden: int
 	for item in items:
 		source_atp = flt(item.get("available_to_promise", 0))
 		last_ordered = item.get("last_order_date")
-		# Keep visible if: source ATP > 0, or ordered within cutoff, or not-stocked sentinel (-1)
-		if source_atp > 0 or source_atp < 0 or (last_ordered and str(last_ordered) >= str(cutoff_date)):
+		# Keep visible if: source ATP > 0, ordered within cutoff, not-stocked sentinel (-1), or has demand signal
+		if source_atp > 0 or source_atp < 0 or (last_ordered and str(last_ordered) >= str(cutoff_date)) or flt(item.get("avg_daily_demand")) > 0:
 			visible_items.append(item)
 		else:
 			item["_hidden"] = 1


### PR DESCRIPTION
## Summary

- **Fix 1:** Remove source ATP subtraction from `_build_recommendation_contract()` — the formula `max(0, forecast - source_ATP)` was returning 0 for every item because source warehouses have thousands of units. Now returns `forecast + buffer` directly; store on-hand subtraction already happens correctly downstream.
- **Fix 2:** Add `avg_daily_demand > 0` to relevance filter keep-condition — items with measured demand (like Frozen Mango) stay visible even if source is OOS.
- **Fix 3:** Merge `last_qty_map` entries for variant display items so merged variants don't lose order history.

## Test plan

- [ ] FROZEN ICE MILK: suggested_qty should be ~60+ (not 0)
- [ ] LECHE FLAN: suggested_qty should be ~900+ (not 0)
- [ ] "Fill Suggested" should fill items with non-zero quantities
- [ ] Frozen Mango should appear in the item list
- [ ] Total items >= 53

🤖 Generated with [Claude Code](https://claude.com/claude-code)