### PR TITLE
fix(S161): keep items visible when store has stock on hand

### DIFF
--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -2538,9 +2538,12 @@ def get_orderable_items(store: str, date: str | None = None, include_hidden: int
 	for item in items:
 		source_atp = flt(item.get("available_to_promise", 0))
 		last_ordered = item.get("last_order_date")
-		# Keep visible if: source ATP > 0, ordered within cutoff, not-stocked sentinel (-1), or has demand signal
+		# Keep visible if any of: source has stock, store has stock, recent order,
+		# has demand signal, or has order history. Only hide truly dead items.
+		store_on_hand = flt(item.get("store_actual_qty", 0))
 		if (source_atp > 0
 			or source_atp < 0
+			or store_on_hand > 0
 			or (last_ordered and str(last_ordered) >= str(cutoff_date))
 			or flt(item.get("avg_daily_demand")) > 0
 			or flt(item.get("order_count", 0)) > 0):


### PR DESCRIPTION
## Summary

The relevance filter hides 68 items including 8 items the store physically has stock of (Frozen Mango 2.82 KG, rags, cleaning supplies, etc.). If the store has an item, it must be visible.

Added `store_actual_qty > 0` to the keep-visible conditions.

## Hidden items that will become visible
- RM010-A (Frozen Mango) — 2.82 KG on hand
- PM019 (CLING WRAP) — 1.5 on hand
- CS013 (RAG WHITE) — 6 on hand  
- CS018 (RAG YELLOW) — 7 on hand
- CS006 (MOP REFILL) — 1 on hand
- CM35 (SANDO ECO BAG) — 1.4 on hand
- KL002 (SANIQUAT) — 2 on hand
- CS011 (TRASH BAG GREEN) — 1 on hand

## Note on FROZEN MANGO (RM030)
RM030 has zero stock at both source and store — it stays hidden. RM010-A (also called "Frozen Mango") has 2.82 KG at the store and will now be visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)