### PR TITLE
feat: raise employee masterlist page_size cap to 1000

### DIFF
--- a/hrms/api/hr_reports.py
+++ b/hrms/api/hr_reports.py
@@ -54,7 +54,7 @@ def get_employee_masterlist(
 		return _get_employee_detail(detail)
 
 	page = max(int(page or 1), 1)
-	page_size = min(max(int(page_size or 50), 1), 200)
+	page_size = min(max(int(page_size or 50), 1), 1000)
 
 	filters = {}
 	if status:


### PR DESCRIPTION
## Summary

Raise the page_size cap on `get_employee_masterlist` from 200 to 1000 to support the frontend page size selector (100/200/500/1000).

Follow-up to merged #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)