### PR TITLE
feat(S163): seed 6 BEI Store Item Group records (live)

### DIFF
--- a/docs/s163_pending_group_review.md
+++ b/docs/s163_pending_group_review.md
@@ -1,0 +1,69 @@
+# S163 — 3 Product Groups Pending SCM Review
+
+**Context:** S163 Phase 4.4 seeded 6 of the 9 groups identified in the S161 product group audit (`output/s161_product_group_audit.txt`). These 3 were deliberately skipped because they contain mixed UOMs. Using `conversion_to_display = 1.0` for mixed UOMs would silently break aggregated stock math (e.g., 1 BOX of 120 thermal bags would be counted as 1 piece).
+
+SCM needs to confirm member conversion factors before these groups are seeded.
+
+---
+
+## GRP-BANANA-CINNAMON
+
+From audit: 3 SKUs sharing "Banana Cinnamon" name.
+
+| Item Code | Item Name | Stock UOM | Notes |
+|---|---|---|---|
+| FG002 | BANANA CINNAMON | KG | Finished Goods |
+| FG002-A | BANANA CINNAMON | KG | Finished Goods (variant) |
+| MN004 | BANANA CINNAMON | CUP | Finished Goods |
+
+**Questions for SCM:**
+- Display UOM — KG or CUP?
+- If KG display: what is the CUP → KG conversion? (a single halo-halo serving weighs roughly how much?)
+- Priority order for auto-resolution — FG002 first, or FG002-A first?
+- Delivery lane — Frozen?
+
+---
+
+## GRP-FROZEN-ICE-MILK
+
+From audit: 3 SKUs.
+
+| Item Code | Item Name | Stock UOM |
+|---|---|---|
+| FG020 | FROZEN ICE MILK | BARREL |
+| FG020-GRIFFITH | FROZEN ICE MILK (GRIFFITH POWDER) | KG |
+| FG020-ORIGINAL | FROZEN ICE MILK (TRADITIONAL) | KG |
+
+**Questions for SCM:**
+- Display UOM — KG or BARREL?
+- Are GRIFFITH and ORIGINAL variants of the same thing, or genuinely different products that should NOT be aggregated under one order line?
+- If KG: how many KG per BARREL?
+- Priority order?
+
+---
+
+## GRP-THERMAL
+
+From audit: 2 SKUs.
+
+| Item Code | Item Name | Stock UOM |
+|---|---|---|
+| PM006 | THERMAL BAG | PIECE |
+| PM006-1 | THERMAL BAG (120) | BOX |
+
+**Questions for SCM:**
+- "(120)" in the name suggests 120 pieces per BOX — is that correct, or is the box size different?
+- Display UOM — PIECE or BOX?
+- Priority order?
+
+---
+
+## How to seed the remaining 3
+
+Once SCM confirms the details, update `scripts/s163_seed_item_groups.py` with a second `GROUPS_PENDING` list and run:
+
+```bash
+python scripts/s163_run_seed.py
+```
+
+The seed script is idempotent, so the 6 already-seeded groups will be skipped on re-run.

--- a/output/s163/seed_evidence.json
+++ b/output/s163/seed_evidence.json
@@ -1,0 +1,84 @@
+{
+  "sprint": "S163",
+  "task": "seed BEI Store Item Group",
+  "timestamp_utc": "2026-04-06T12:45:50.634732Z",
+  "groups": [
+    {
+      "group_code": "GRP-FROZEN-MANGO",
+      "status": "created",
+      "member_count": 2
+    },
+    {
+      "group_code": "GRP-FRESH-RIPE-MANGO",
+      "status": "created",
+      "member_count": 2
+    },
+    {
+      "group_code": "GRP-SAGO",
+      "status": "created",
+      "member_count": 2
+    },
+    {
+      "group_code": "GRP-RAG",
+      "status": "created",
+      "member_count": 7
+    },
+    {
+      "group_code": "GRP-CUP-HOLDER",
+      "status": "created",
+      "member_count": 2
+    },
+    {
+      "group_code": "GRP-LECHE-FLAN-X",
+      "status": "created",
+      "member_count": 2
+    }
+  ],
+  "post_seed_group_count": 6,
+  "post_seed_member_count": 17,
+  "all_groups_in_db": [
+    {
+      "group_code": "GRP-CUP-HOLDER",
+      "display_name": "Cup Holder",
+      "display_uom": "PIECE",
+      "delivery_lane": "Dry",
+      "disabled": 0
+    },
+    {
+      "group_code": "GRP-FRESH-RIPE-MANGO",
+      "display_name": "Fresh Ripe Mango",
+      "display_uom": "KG",
+      "delivery_lane": "Frozen",
+      "disabled": 0
+    },
+    {
+      "group_code": "GRP-FROZEN-MANGO",
+      "display_name": "Frozen Mango",
+      "display_uom": "KG",
+      "delivery_lane": "Frozen",
+      "disabled": 0
+    },
+    {
+      "group_code": "GRP-LECHE-FLAN-X",
+      "display_name": "Leche Flan",
+      "display_uom": "PIECE",
+      "delivery_lane": "Frozen",
+      "disabled": 0
+    },
+    {
+      "group_code": "GRP-RAG",
+      "display_name": "Rag",
+      "display_uom": "PIECE",
+      "delivery_lane": "Dry",
+      "disabled": 0
+    },
+    {
+      "group_code": "GRP-SAGO",
+      "display_name": "Sago",
+      "display_uom": "KG",
+      "delivery_lane": "Frozen",
+      "disabled": 0
+    }
+  ],
+  "ok": true
+}

--- a/scripts/s163_run_seed.py
+++ b/scripts/s163_run_seed.py
@@ -1,0 +1,73 @@
+"""Run scripts/s163_seed_item_groups.py on the Frappe container via SSM.
+
+Captures output between S163_SEED_REPORT_BEGIN/END markers and writes it
+to output/s163/seed_evidence.json.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import time
+
+import boto3
+
+INSTANCE_ID = "i-026b7477d27bd46d6"
+REGION = "ap-southeast-1"
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT_PATH = os.path.join(HERE, "s163_seed_item_groups.py")
+OUTPUT_DIR = os.path.join(os.path.dirname(HERE), "output", "s163")
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def main() -> int:
+	with open(SCRIPT_PATH, encoding="utf-8") as f:
+		encoded = base64.b64encode(f.read().encode()).decode()
+	commands = [
+		"BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+		"if [ -z \"$BACKEND\" ]; then echo 'ERROR: no frappe_backend container'; exit 2; fi",
+		f"echo '{encoded}' | base64 -d > /tmp/s163_seed.py",
+		"docker cp /tmp/s163_seed.py $BACKEND:/tmp/s163_seed.py",
+		"docker exec $BACKEND /home/frappe/frappe-bench/env/bin/python /tmp/s163_seed.py",
+	]
+	ssm = boto3.client("ssm", region_name=REGION)
+	print("Sending SSM command...", flush=True)
+	resp = ssm.send_command(
+		InstanceIds=[INSTANCE_ID],
+		DocumentName="AWS-RunShellScript",
+		Parameters={"commands": commands, "executionTimeout": ["600"]},
+	)
+	command_id = resp["Command"]["CommandId"]
+	print(f"Command ID: {command_id}", flush=True)
+
+	for _ in range(40):
+		time.sleep(8)
+		inv = ssm.get_command_invocation(CommandId=command_id, InstanceId=INSTANCE_ID)
+		status = inv["Status"]
+		print(f"  status: {status}", flush=True)
+		if status in {"Success", "Failed", "Cancelled", "TimedOut"}:
+			stdout = inv.get("StandardOutputContent") or ""
+			stderr = inv.get("StandardErrorContent") or ""
+			print("=" * 70)
+			print("STDOUT:")
+			print(stdout[-6000:])
+			if stderr:
+				print("STDERR:")
+				print(stderr[-2000:])
+			if "S163_SEED_REPORT_BEGIN" not in stdout:
+				return 2
+			begin = stdout.index("S163_SEED_REPORT_BEGIN") + len("S163_SEED_REPORT_BEGIN")
+			end = stdout.index("S163_SEED_REPORT_END")
+			report = json.loads(stdout[begin:end].strip())
+			with open(os.path.join(OUTPUT_DIR, "seed_evidence.json"), "w", encoding="utf-8") as f:
+				json.dump(report, f, indent=2, default=str)
+			print(f"\nWrote output/s163/seed_evidence.json")
+			return 0 if report.get("ok") else 1
+	print("Timed out")
+	return 3
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/scripts/s163_seed_item_groups.py
+++ b/scripts/s163_seed_item_groups.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+S163 — Seed BEI Store Item Group records on hq.bebang.ph.
+
+Runs INSIDE the Frappe backend container via SSM. Idempotent:
+re-running checks frappe.db.exists before creating, skips duplicates.
+
+Seeds 6 of the 9 groups from S161 product_group_audit. The other 3
+(BANANA-CINNAMON, FROZEN-ICE-MILK, THERMAL) are intentionally skipped
+because they have mixed UOMs and need SCM to confirm conversion factors
+before seeding — using conversion_to_display=1.0 would silently break
+aggregated stock math.
+
+Groups seeded:
+  GRP-FROZEN-MANGO       (plan-specified: RM010-A p1, RM030 p2, KG, Frozen)
+  GRP-FRESH-RIPE-MANGO   (FG011 p1, RM010 p2, KG, Frozen)
+  GRP-SAGO               (FG009 p1, FG050 p2, KG, Frozen)
+  GRP-RAG                (7 CS* colored rags, PIECE, Dry)
+  GRP-CUP-HOLDER         (PM004 x4 p1, PM005 x6 p2, PIECE, Dry)
+  GRP-LECHE-FLAN-X       (FG001-A x12 p1, FG001-B x16 p2, PIECE, Frozen)
+
+All members use conversion_to_display=1.0 because all members within
+each of these 6 groups share the same stock UOM.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import traceback
+from datetime import datetime
+
+for d in [
+	"/home/frappe/logs",
+	"/home/frappe/frappe-bench/logs",
+	"/home/frappe/frappe-bench/hq.bebang.ph/logs",
+	"/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+]:
+	os.makedirs(d, exist_ok=True)
+
+import frappe  # type: ignore
+
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+GROUPS: list[dict] = [
+	{
+		"group_code": "GRP-FROZEN-MANGO",
+		"display_name": "Frozen Mango",
+		"display_uom": "KG",
+		"delivery_lane": "Frozen",
+		"note": "S163 vertical slice: Frozen Mango dedup (RM010-A vs RM030).",
+		"members": [
+			{"item_code": "RM010-A", "priority": 1, "conversion_to_display": 1.0},
+			{"item_code": "RM030", "priority": 2, "conversion_to_display": 1.0},
+		],
+	},
+	{
+		"group_code": "GRP-FRESH-RIPE-MANGO",
+		"display_name": "Fresh Ripe Mango",
+		"display_uom": "KG",
+		"delivery_lane": "Frozen",
+		"note": "S163: dedup Fresh Ripe Mango across FG011 and RM010.",
+		"members": [
+			{"item_code": "FG011", "priority": 1, "conversion_to_display": 1.0},
+			{"item_code": "RM010", "priority": 2, "conversion_to_display": 1.0},
+		],
+	},
+	{
+		"group_code": "GRP-SAGO",
+		"display_name": "Sago",
+		"display_uom": "KG",
+		"delivery_lane": "Frozen",
+		"note": "S163: dedup Sago across FG009 (Finished Goods) and FG050 (Products).",
+		"members": [
+			{"item_code": "FG009", "priority": 1, "conversion_to_display": 1.0},
+			{"item_code": "FG050", "priority": 2, "conversion_to_display": 1.0},
+		],
+	},
+	{
+		"group_code": "GRP-RAG",
+		"display_name": "Rag",
+		"display_uom": "PIECE",
+		"delivery_lane": "Dry",
+		"note": "S163: dedup 7 colored rags (CS013-CS019). All PIECE, same function.",
+		"members": [
+			{"item_code": "CS013", "priority": 1, "conversion_to_display": 1.0},  # WHITE
+			{"item_code": "CS014", "priority": 2, "conversion_to_display": 1.0},  # BLUE
+			{"item_code": "CS019", "priority": 3, "conversion_to_display": 1.0},  # CYAN
+			{"item_code": "CS016", "priority": 4, "conversion_to_display": 1.0},  # GREEN
+			{"item_code": "CS017", "priority": 5, "conversion_to_display": 1.0},  # PINK
+			{"item_code": "CS015", "priority": 6, "conversion_to_display": 1.0},  # RED
+			{"item_code": "CS018", "priority": 7, "conversion_to_display": 1.0},  # YELLOW
+		],
+	},
+	{
+		"group_code": "GRP-CUP-HOLDER",
+		"display_name": "Cup Holder",
+		"display_uom": "PIECE",
+		"delivery_lane": "Dry",
+		"note": "S163: dedup Cup Holder (PM004 x4, PM005 x6). Both PIECE.",
+		"members": [
+			{"item_code": "PM004", "priority": 1, "conversion_to_display": 1.0},  # x4
+			{"item_code": "PM005", "priority": 2, "conversion_to_display": 1.0},  # x6
+		],
+	},
+	{
+		"group_code": "GRP-LECHE-FLAN-X",
+		"display_name": "Leche Flan",
+		"display_uom": "PIECE",
+		"delivery_lane": "Frozen",
+		"note": "S163: dedup Leche Flan (FG001-A x12, FG001-B x16). Both PIECE.",
+		"members": [
+			{"item_code": "FG001-A", "priority": 1, "conversion_to_display": 1.0},  # x12
+			{"item_code": "FG001-B", "priority": 2, "conversion_to_display": 1.0},  # x16
+		],
+	},
+]
+
+
+def validate_items(group: dict) -> list[str]:
+	"""Verify every member item exists in tabItem before creating the group."""
+	errors = []
+	for m in group["members"]:
+		code = m["item_code"]
+		if not frappe.db.exists("Item", code):
+			errors.append(f"Item {code} does not exist")
+	return errors
+
+
+def seed_one(group: dict) -> dict:
+	result: dict = {"group_code": group["group_code"]}
+	try:
+		item_errors = validate_items(group)
+		if item_errors:
+			result["status"] = "skipped_missing_items"
+			result["errors"] = item_errors
+			return result
+
+		if frappe.db.exists("BEI Store Item Group", group["group_code"]):
+			# Idempotent: verify member count matches
+			existing_members = frappe.db.count(
+				"BEI Store Item Group Member", filters={"parent": group["group_code"]}
+			)
+			result["status"] = "already_exists"
+			result["existing_member_count"] = existing_members
+			result["expected_member_count"] = len(group["members"])
+			return result
+
+		# Verify display_uom exists (UOMs are a DocType)
+		if not frappe.db.exists("UOM", group["display_uom"]):
+			result["status"] = "skipped_missing_uom"
+			result["errors"] = [f"UOM {group['display_uom']} does not exist"]
+			return result
+
+		doc = frappe.new_doc("BEI Store Item Group")
+		doc.group_code = group["group_code"]
+		doc.display_name = group["display_name"]
+		doc.display_uom = group["display_uom"]
+		doc.delivery_lane = group["delivery_lane"]
+		doc.disabled = 0
+		doc.note = group.get("note") or ""
+		for m in group["members"]:
+			doc.append(
+				"members",
+				{
+					"item_code": m["item_code"],
+					"conversion_to_display": m["conversion_to_display"],
+					"priority": m["priority"],
+				},
+			)
+		doc.insert(ignore_permissions=True)
+		result["status"] = "created"
+		result["member_count"] = len(group["members"])
+	except Exception as e:
+		result["status"] = "error"
+		result["error"] = f"{type(e).__name__}: {e}"
+		result["traceback"] = traceback.format_exc()
+	return result
+
+
+def main() -> None:
+	report: dict = {
+		"sprint": "S163",
+		"task": "seed BEI Store Item Group",
+		"timestamp_utc": datetime.utcnow().isoformat() + "Z",
+		"groups": [],
+	}
+	try:
+		for g in GROUPS:
+			result = seed_one(g)
+			report["groups"].append(result)
+			frappe.db.commit()
+		# Post-seed counts
+		report["post_seed_group_count"] = frappe.db.count("BEI Store Item Group")
+		report["post_seed_member_count"] = frappe.db.count("BEI Store Item Group Member")
+		report["all_groups_in_db"] = frappe.get_all(
+			"BEI Store Item Group",
+			fields=["group_code", "display_name", "display_uom", "delivery_lane", "disabled"],
+			order_by="group_code",
+		)
+		report["ok"] = all(
+			r.get("status") in {"created", "already_exists"} for r in report["groups"]
+		)
+	except Exception:
+		report["fatal"] = traceback.format_exc()
+		report["ok"] = False
+	finally:
+		print("S163_SEED_REPORT_BEGIN")
+		print(json.dumps(report, indent=2, default=str))
+		print("S163_SEED_REPORT_END")
+		frappe.destroy()
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
## Summary

Unlocks the S163 grouping feature end-to-end by seeding the 6 unambiguous BEI Store Item Group records from the S161 product group audit. Without these records, the DocType-backed aggregation in \`get_orderable_items\` is a no-op and stores still see duplicate SKU rows.

**Seeding already ran live on hq.bebang.ph at 2026-04-06 12:45 UTC.** This PR is the code + evidence that documents what happened, so the seed script is in version control for future re-runs.

## Seeded

| Group | Members | Display UOM | Delivery Lane |
|---|---|---|---|
| \`GRP-FROZEN-MANGO\` ⭐ | RM010-A (p1), RM030 (p2) | KG | Frozen |
| \`GRP-FRESH-RIPE-MANGO\` | FG011 (p1), RM010 (p2) | KG | Frozen |
| \`GRP-SAGO\` | FG009 (p1), FG050 (p2) | KG | Frozen |
| \`GRP-RAG\` | CS013 (white, p1), CS014 (blue), CS019 (cyan), CS016 (green), CS017 (pink), CS015 (red), CS018 (yellow) | PIECE | Dry |
| \`GRP-CUP-HOLDER\` | PM004 x4 (p1), PM005 x6 (p2) | PIECE | Dry |
| \`GRP-LECHE-FLAN-X\` | FG001-A x12 (p1), FG001-B x16 (p2) | PIECE | Frozen |

⭐ \`GRP-FROZEN-MANGO\` matches the plan's Phase 4.4 vertical slice specification exactly.

**Post-seed state:** 6 groups, 17 members, all with \`conversion_to_display = 1.0\` (every member within a given group shares the same stock UOM).

## 3 groups deferred pending SCM review

See \`docs/s163_pending_group_review.md\` for full details.

| Group | Reason |
|---|---|
| \`GRP-BANANA-CINNAMON\` | FG002 (KG) + FG002-A (KG) + MN004 (**CUP**) — need CUP→KG factor |
| \`GRP-FROZEN-ICE-MILK\` | FG020 (**BARREL**) + FG020-GRIFFITH (KG) + FG020-ORIGINAL (KG) — need BARREL→KG factor |
| \`GRP-THERMAL\` | PM006 (PIECE) + PM006-1 (**BOX of 120**) — need BOX→PIECE factor (probably 120) |

Using \`conversion_to_display = 1.0\` for mixed UOMs would silently break aggregated stock math (e.g. 1 BARREL would be counted as 1 KG), so these need SCM to confirm before seeding.

## What's in this PR

| Path | Kind | Purpose |
|---|---|---|
| \`scripts/s163_seed_item_groups.py\` | new | idempotent seed script (runs in Frappe container via SSM); validates every item_code + UOM before creating; uses \`frappe.db.exists\` to skip existing groups |
| \`scripts/s163_run_seed.py\` | new | local boto3 driver, captures BEGIN/END markers, writes \`output/s163/seed_evidence.json\` |
| \`output/s163/seed_evidence.json\` | new | live run result: 6 created, 0 errors, full post-seed state |
| \`docs/s163_pending_group_review.md\` | new | review doc for the 3 groups that need SCM confirmation before seeding |

## Phase coverage

This PR finishes the **Phase 4.4 data seeding** that was ambiguous in the plan. It was called out in the previous round as needing your decision — you chose to proceed. The 6 unambiguous groups are now live and the L3 session can run scenarios against real grouped data.

## What's still NOT done

- **L3 acceptance tests** — testing, deferred per instruction
- **The 3 mixed-UOM groups** — awaiting SCM input on conversion factors
- **Phase 11.1 CSV cleanup** — plan-gated on L3 evidence
- **Plan + registry → COMPLETED** — same gate

## Test plan

- [ ] Open ordering page for Araneta Gateway (test.storesup@bebang.ph) — verify "Frozen Mango" now appears as ONE row with summed stock, not RM010-A + RM030 separately
- [ ] Verify "Fresh Ripe Mango", "Sago", "Rag", "Cup Holder", and "Leche Flan" also render as single group rows where those items appear in the store's orderable list
- [ ] SCM can Frappe Desk into \`BEI Store Item Group\` list and see 6 records
- [ ] Provide SCM conversion factors for the 3 pending groups → re-run \`python scripts/s163_run_seed.py\` after updating the GROUPS list

🤖 Generated with [Claude Code](https://claude.com/claude-code)