### PR TITLE
fix(S163): check_scm_permission kwarg bug blocks group resolution (L3 S7)

### DIFF
--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -3573,8 +3573,8 @@ def resolve_group_order_item(
 		)
 
 	check_scm_permission(
-		allowed_roles=SCM_ADMIN_ROLES.union(SCM_APPROVAL_ROLES),
-		operation=f"resolve grouped order line on {order_name}",
+		SCM_ADMIN_ROLES.union(SCM_APPROVAL_ROLES),
+		f"resolve grouped order line on {order_name}",
 	)
 
 	order = frappe.get_doc("BEI Store Order", order_name)


### PR DESCRIPTION
## Summary

**HOTFIX** — L3 scenario 7 found that `resolve_group_order_item` returns 500 every time:

```
check_scm_permission() got an unexpected keyword argument 'operation'
```

The function signature is `check_scm_permission(allowed_roles, action="...")` but S163 code passed `operation=` as a keyword arg. One-line fix: switch to positional arguments matching every other call site in store.py.

**This blocks ALL manual group resolution** — SCM cannot override auto-resolved groups until this is deployed.

## Root cause

My mistake in the original S163 PR #461 — I used `operation=` instead of `action=` when calling `check_scm_permission`. The function signature in `hrms/utils/scm_roles.py:150` is:
```python
def check_scm_permission(allowed_roles, action="access this resource"):
```

## Fix

```python
# Before (broken)
check_scm_permission(
    allowed_roles=SCM_ADMIN_ROLES.union(SCM_APPROVAL_ROLES),
    operation=f"resolve grouped order line on {order_name}",
)

# After (fixed)
check_scm_permission(
    SCM_ADMIN_ROLES.union(SCM_APPROVAL_ROLES),
    f"resolve grouped order line on {order_name}",
)
```

## Test plan

- [ ] Deploy, then re-run L3 scenario 7: SCM clicks Override on a grouped order line → enters split qty → Save → should return 200 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)