### PR TITLE
fix(S165): reroute Blip notifications + CB1 boolean gating + guard

### DIFF
--- a/.github/workflows/daily-pos-sync.yml
+++ b/.github/workflows/daily-pos-sync.yml
@@ -142,15 +142,17 @@ jobs:
           python scripts/supabase_exec.py "select public.refresh_sales_dashboard_daily_store_metrics();"
 
   # ── Step 4: Anomaly detection (AFTER all syncs complete) ─────────────────
-  # S165 CB1: != 'true' form is mandatory. Do NOT use !inputs.skip_anomaly.
-  # GH Actions inputs are strings, and !"false" == false silently skips.
+  # S165 follow-up 2026-04-07: type:boolean inputs are evaluated as actual
+  # booleans by GH expressions, so the correct gating form is `!inputs.skip_X`.
+  # The original `!= 'true'` form was wrong (compares boolean to string -> always
+  # truthy -> gate never fires; proven by dispatch test 24058652557).
   # Gated to run ONLY on nightly cron or workflow_dispatch.
   anomaly-detection:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [refresh-sales-dashboard-views]
     if: >-
-      ${{ inputs.skip_anomaly != 'true' &&
+      ${{ !inputs.skip_anomaly &&
           (github.event_name == 'workflow_dispatch' ||
            github.event.schedule == '30 16 * * *') }}
 
@@ -180,14 +182,14 @@ jobs:
   # ── Workflow-level failure notification ─────────────────────────────────────
 
   # notify-failure posts to spaces/AAQABiNmpBg (workflow-level alerts)
-  # verify-sync script posts to spaces/AAQA3NVVR6c (anomaly detection space)
+  # verify-sync script posts to spaces/AAQABiNmpBg (! Blip Notifications, sam@bebang.ph private)
   # These are intentionally separate -- do not merge them.
   verify-sync:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [refresh-sales-dashboard-views]
     if: >-
-      ${{ inputs.skip_verify != 'true' &&
+      ${{ !inputs.skip_verify &&
           (github.event_name == 'workflow_dispatch' ||
            github.event.schedule == '30 16 * * *') }}
 

--- a/scripts/detect_anomalies.py
+++ b/scripts/detect_anomalies.py
@@ -22,7 +22,16 @@ from pathlib import Path
 
 import requests
 
-from hrms.utils.chat_space_lockdown import route_outbound_chat_space
+# Try to import the Frappe-side chat lockdown helper. In CI (where the `hrms`
+# package is not on PYTHONPATH) the import fails and we fall back to a no-op
+# router that always returns the hardcoded BLIP_NOTIFICATION_SPACE below.
+# Per Sam directive 2026-04-07: NO Blip notifications anywhere except
+# "! Blip Notifications" (spaces/AAQABiNmpBg).
+try:
+    from hrms.utils.chat_space_lockdown import route_outbound_chat_space  # type: ignore
+except ImportError:  # CI / standalone runtime
+    def route_outbound_chat_space(requested_space, *, logger=None, context=None, family=None):
+        return "spaces/AAQABiNmpBg"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -33,7 +42,7 @@ log = logging.getLogger("anomaly-detect")
 
 # --- Configuration ---
 SUPABASE_URL = "https://csnniykjrychgajfrgua.supabase.co"
-CHAT_SPACE = "spaces/AAQA3NVVR6c"
+CHAT_SPACE = "spaces/AAQABiNmpBg"  # ! Blip Notifications. Per Sam directive 2026-04-07: NO Blip notifications anywhere else.
 CREDENTIALS_PATH = Path(__file__).resolve().parent.parent / "credentials" / "task-manager-service.json"
 DOPPLER_BIN = r"C:\Users\Sam\bin\doppler.exe"
 

--- a/scripts/guards/check_chat_space_literals.py
+++ b/scripts/guards/check_chat_space_literals.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""S165 follow-up: prevent regression of hardcoded Google Chat space literals.
+
+Per Sam directive 2026-04-07: NO Blip notifications anywhere except
+"! Blip Notifications" (spaces/AAQABiNmpBg).
+
+This guard fails if any standalone script or workflow file contains a
+hardcoded `spaces/<id>` literal that:
+  1. is NOT spaces/AAQABiNmpBg (the Blip Notifications space), AND
+  2. lives outside the allowlisted files (Frappe-side bei_config.py + tests)
+
+Usage:
+    python scripts/guards/check_chat_space_literals.py [paths...]
+    python scripts/guards/check_chat_space_literals.py --all   # scan everything
+
+Exit codes:
+    0  no violations
+    1  one or more violations found
+    2  argument error
+
+Wire it up as a pre-commit hook in .git/hooks/pre-commit:
+    python scripts/guards/check_chat_space_literals.py $(git diff --cached --name-only --diff-filter=ACM)
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+# The ONLY space ID allowed to appear as a hardcoded literal in production code
+# (outside the allowlisted files). All other spaces must be expressed via the
+# Frappe `bei_config.SPACE_*` constants and the chat_space_lockdown router.
+ALLOWED_LITERAL = "spaces/AAQABiNmpBg"
+
+# Files allowed to contain other space literals (sources of truth, tests, fixtures)
+ALLOWLIST_PATTERNS = [
+    "hrms/utils/bei_config.py",          # canonical SPACE_* constants
+    "hrms/utils/notification_intelligence.py",  # references the constants
+    "hrms/utils/chat_space_lockdown.py", # the lockdown itself
+    "hrms/tests/",                       # test fixtures may pin old IDs
+    "hrms/test_utils/",
+    ".claude/skills/",                   # skill docs / references
+    ".agent/skills/",
+    ".agents/skills/",
+    "archive/",                          # historical scratchpads
+    "docs/",                             # historical docs
+    ".planning/",                        # historical planning
+    ".builder-worktree-",                # historical worktree snapshots
+    "scripts/guards/check_chat_space_literals.py",  # this file
+    "node_modules/",
+    ".git/",
+    "recruitment/",                      # one-off data files
+]
+
+# Files that MUST be scanned even if they're under an allowlisted prefix
+SCAN_FILES_EXTENSIONS = {".py", ".yml", ".yaml", ".ts", ".tsx", ".js", ".mjs", ".sh"}
+
+LITERAL_RE = re.compile(r"spaces/[A-Z][A-Za-z0-9_-]{6,}")
+
+
+def is_allowlisted(rel_path: str) -> bool:
+    rel_path_norm = rel_path.replace("\\", "/")
+    return any(rel_path_norm.startswith(p) or p in rel_path_norm for p in ALLOWLIST_PATTERNS)
+
+
+def scan_file(path: Path) -> list[tuple[int, str, str]]:
+    """Return list of (line_no, line, literal) violations in *path*."""
+    violations: list[tuple[int, str, str]] = []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except (PermissionError, OSError):
+        return violations
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for match in LITERAL_RE.findall(line):
+            if match != ALLOWED_LITERAL:
+                violations.append((lineno, line.strip()[:160], match))
+    return violations
+
+
+def collect_files(args: list[str]) -> list[Path]:
+    if not args:
+        return []
+    if args == ["--all"]:
+        out: list[Path] = []
+        for ext in SCAN_FILES_EXTENSIONS:
+            out.extend(REPO.rglob(f"*{ext}"))
+        return out
+    out = []
+    for a in args:
+        p = Path(a)
+        if not p.is_absolute():
+            p = REPO / p
+        if p.is_file():
+            out.append(p)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    files = collect_files(argv)
+    if not files:
+        # No files to check (e.g. pre-commit ran with no staged files)
+        return 0
+
+    total_violations = 0
+    for f in files:
+        rel = f.relative_to(REPO).as_posix() if f.is_absolute() and REPO in f.parents else str(f)
+        if is_allowlisted(rel):
+            continue
+        if f.suffix not in SCAN_FILES_EXTENSIONS:
+            continue
+        for lineno, snippet, literal in scan_file(f):
+            print(f"{rel}:{lineno}: hardcoded {literal} (only {ALLOWED_LITERAL} allowed)")
+            print(f"    {snippet}")
+            total_violations += 1
+
+    if total_violations:
+        print()
+        print(f"FAIL: {total_violations} forbidden space literal(s) found.")
+        print(f"Per Sam directive 2026-04-07: only {ALLOWED_LITERAL} may be hardcoded.")
+        print("All other Chat sends must route through hrms.utils.chat_space_lockdown.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/verify_mosaic_pos_sync.py
+++ b/scripts/verify_mosaic_pos_sync.py
@@ -125,7 +125,7 @@ sentry_sdk.set_tag("module", "sync_verification")
 sentry_sdk.set_tag("action", "verify_mosaic_pos_sync")
 
 PHT = timezone(timedelta(hours=8))
-CHAT_SPACE_ANOMALY = "spaces/AAQA3NVVR6c"  # same space as detect_anomalies.py
+CHAT_SPACE_ANOMALY = "spaces/AAQABiNmpBg"  # ! Blip Notifications (sam@bebang.ph private). Per Sam directive 2026-04-07: NO Blip notifications anywhere else.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What this fixes

Two production issues exposed by the post-merge dispatch test of S165 (PR #466).

### 1. Blip notifications were leaking to the wrong Chat space

S165 hardcoded `spaces/AAQA3NVVR6c` as the alert target — that ID is the **ERP/HR Automation Committee** (an external space with vendors and HR people), NOT the private Blip space. Sam saw the leak today and ordered: **all Blip notifications go ONLY to `spaces/AAQABiNmpBg` (\"! Blip Notifications\", sam@bebang.ph private)**.

### 2. CB1 boolean-gating in `daily-pos-sync.yml` was wrong

The S165 plan claimed `inputs.skip_X != 'true'` was the correct form for `workflow_dispatch` boolean inputs. **Proven false** by dispatch test [run 24058652557](https://github.com/Bebang-Enterprise-Inc/hrms/actions/runs/24058652557): with `skip_verify=true skip_anomaly=true`, both jobs ran anyway.

Root cause: GH expressions cast `boolean true vs string 'true'` as `1 != NaN` = always truthy, so the gate never fires. The correct form for `type: boolean` inputs is `!inputs.skip_X`.

## Changes

| File | Change |
|---|---|
| `scripts/verify_mosaic_pos_sync.py` | `CHAT_SPACE_ANOMALY` → `spaces/AAQABiNmpBg` |
| `scripts/detect_anomalies.py` | `CHAT_SPACE` → `spaces/AAQABiNmpBg` + import shim that no longer crashes when `hrms` is unavailable in CI (root cause of weeks of silent anomaly-detection failures) |
| `.github/workflows/daily-pos-sync.yml` | `anomaly-detection.if` and `verify-sync.if` → `!inputs.skip_X` (correct boolean form). Corrected misleading CB1 comment. Removed stale verify-sync space comment. |
| `scripts/guards/check_chat_space_literals.py` | NEW pre-commit guard that fails on any hardcoded `spaces/<id>` literal outside `spaces/AAQABiNmpBg` in standalone scripts and workflows |

## Tier-1 / Tier-2 architecture

| Tier | What | Status |
|---|---|---|
| 1 — Frappe `@whitelist` endpoints | Route via `hrms.utils.chat_space_lockdown.route_outbound_chat_space()` | ✅ Already correct. Verified live on `frappe_backend.1.utqxs9i6f376z77542f1y2ar5` via bench console self-test: `is_strict_blip_only_enabled() = True`, `route_outbound_chat_space('spaces/AAQA3NVVR6c') = 'spaces/AAQABiNmpBg'`. No code change needed. |
| 2 — Standalone scripts (`scripts/`, `analytics-agent/`, `blip-sentinel/`) | Bypass the lockdown — call `chat.spaces().messages().create()` directly | Fixed in this PR. `analytics-agent/tools/gchat_tool.py` already correct. `blip-sentinel/notifier.py` reads `BLIP_NOTIFICATION_SPACE` env which is set to `spaces/AAQABiNmpBg` on the EC2 container (verified via SSM). |
| 3 — Tests | Pin old space ID in fixtures | Out of scope, no real send |

## Verification

- ✅ Live SSM check on `i-026b7477d27bd46d6` confirmed Frappe lockdown is active and blip-sentinel container env is correct
- ✅ Pre-commit guard runs clean against all touched files
- ✅ The 2 misrouted Blip messages from the dispatch test were deleted from `spaces/AAQA3NVVR6c` via Chat API + bot credentials before this PR was opened

## Test plan after merge

- [ ] Trigger `workflow_dispatch` with `skip_verify=true skip_anomaly=true target_date=2026-04-04` — confirm both jobs show `skipped`
- [ ] Trigger `workflow_dispatch` with `target_date=2026-04-04` (no skips) — confirm `verify-sync` runs, posts to `! Blip Notifications` only
- [ ] Wire `scripts/guards/check_chat_space_literals.py` into `.git/hooks/pre-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)