### PR TITLE
fix(pcf): set fund_label in before_naming to avoid empty PCF- autoname

### DIFF
--- a/hrms/hr/doctype/bei_petty_cash_fund/bei_petty_cash_fund.py
+++ b/hrms/hr/doctype/bei_petty_cash_fund/bei_petty_cash_fund.py
@@ -7,6 +7,18 @@ from frappe.model.document import Document
 
 
 class BEIPettyCashFund(Document):
+    def before_naming(self):
+        """S167 DEFECT-003 fix: the DocType autoname is
+        ``format:PCF-{fund_label}`` and runs BEFORE validate(), so
+        validate()'s generate_fund_label() is too late. Without this,
+        every fund is named ``PCF-`` (empty suffix) and the second
+        creation attempt fails with ``DuplicateEntryError: PCF-
+        already exists``. before_naming runs immediately before
+        Frappe applies the name formula.
+        """
+        if not self.fund_label:
+            self.generate_fund_label()
+
     def validate(self):
         self.validate_fund_type()
         self.validate_threshold()


### PR DESCRIPTION
## Summary
- Add `before_naming()` controller hook on `BEI Petty Cash Fund` that calls `generate_fund_label()` so the `format:PCF-{fund_label}` naming formula has the correct label to interpolate.

## Defect (DEFECT-003 from S167 acceptance test)
The DocType autoname is `format:PCF-{fund_label}`. `fund_label` was only being set inside `validate()`. Frappe runs `set_new_name()` — which applies the naming formula — BEFORE `validate()`, so at naming time `fund_label` was still empty and every fund was named `PCF-`.

Only the FIRST department fund could be created. Every subsequent `create_pcf_fund` call failed with:
```
DuplicateEntryError: BEI Petty Cash Fund PCF- already exists
```

This completely blocked department PCF rollout — caught while running S167 Phase 0.1 after hrms #474 was deployed.

## Fix
`before_naming()` is a Frappe controller hook that runs immediately before `set_new_name()` applies the naming formula. Setting `fund_label` there guarantees the format expression has the correct value.

```python
def before_naming(self):
    if not self.fund_label:
        self.generate_fund_label()
```

## Data cleanup required after merge
One corrupt record named `PCF-` already exists in production (the very first HR dept fund). Post-deploy SSM:
```sql
DELETE FROM \`tabBEI Petty Cash Fund\` WHERE name = 'PCF-';
```
S167 execution will handle this via `/frappe-bulk-edits` once deploy is live.

## Risk
- Very low. 1 method, 3 lines added. Pure name-formatting. No GL impact.
- `before_naming` is a standard Frappe hook — safe to add without affecting other code paths.

## Test plan
- [ ] Merge + deploy
- [ ] Delete corrupt `PCF-` record via SSM
- [ ] POST `/api/pcf` create_pcf_fund for `HR and Admin - BEI`, `Supply Chain - BEI`, `Commissary - BEI`
- [ ] Verify each lands with name `PCF-HR and Admin`, `PCF-Supply Chain`, `PCF-Commissary`
- [ ] Continue S167 Phases 1–6

## Related
- hrms#474 — fix(pcf): dict.get() for pending count/total (merged)
- BEI-Tasks#349 — fix(pcf): fetch Frappe departments live (merged)