### PR TITLE
S169 closeout: P5/P7/P8 evidence — Apr 4 SM Marikina tombstoned + 12 webhooks registered

### DIFF
--- a/data/POS_Extraction/MOSAIC_WEBHOOK_REGISTRATIONS.csv
+++ b/data/POS_Extraction/MOSAIC_WEBHOOK_REGISTRATIONS.csv
@@ -1,0 +1,13 @@
+credential_group,client_id,webhook_id,url,events,registered_at
+Araneta Group (3 stores),a080acf5-22e9-4c80-bfb5-14a96147dc70,019d6829-d240-73bc-a6fd-5a1370bade51,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:37:44.376309+00:00
+Shared Pool (27 stores),9ef61a14-d35e-444e-9c1a-c5b2e3253d7a,019d6829-e397-7177-a73e-f7c74eb9fdb8,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:37:48.818127+00:00
+Dedicated,a0854727-f040-4031-97bc-2f3fe897b4b4,019d6829-f424-718d-99aa-56abf2fbda78,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:37:53.056837+00:00
+Dedicated,a0854702-f740-4055-983c-7bfa34a78e0c,019d682a-045f-72ca-b674-603cdfdda4da,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:37:57.211906+00:00
+SM Caloocan Group (2 stores),a08546c1-a1f4-4012-80fe-6861537a8b6e,019d682a-175b-73d2-aa49-3ee220f003df,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:02.074543+00:00
+Dedicated,a005bcd8-9970-4df5-a13b-bdb4925f5fa0,019d682a-27d5-73ef-9c39-8b48c0573ed6,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:06.283016+00:00
+Dedicated,a085463a-76f8-4e12-8017-86a0cb8276f7,019d682a-37ef-7189-82a8-9c9b3d94e14c,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:10.410255+00:00
+Dedicated,a08546e1-5a01-42e8-a94b-786f8ff1c005,019d682a-4862-70ad-9212-958a0f09f3ba,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:14.624259+00:00
+SM Sta. Rosa Group (2 stores),a10fbc64-bfa1-4787-acdb-2fd8e6492f5e,019d682a-58d9-73b9-996c-bfff5fef22d9,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:18.838024+00:00
+Dedicated,a10fbcab-5ed3-4901-89a9-f2e4fc691dfe,019d682a-6a21-72f8-960b-7f9667463d65,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:23.283148+00:00
+Dedicated,a005bbb1-38b2-47e6-82e5-1a386a476e6e,019d682a-a342-7381-bef7-b3ce3a127454,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:37.956657+00:00
+Dedicated,a0854744-9e51-4aff-93ee-8c105c038f1c,019d682a-cef4-73b1-8a7b-cdfcdb2151cc,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:49.065221+00:00

--- a/output/l3/s169/MOSAIC_WEBHOOK_REGISTRATIONS.csv
+++ b/output/l3/s169/MOSAIC_WEBHOOK_REGISTRATIONS.csv
@@ -1,0 +1,13 @@
+credential_group,client_id,webhook_id,url,events,registered_at
+Araneta Group (3 stores),a080acf5-22e9-4c80-bfb5-14a96147dc70,019d6829-d240-73bc-a6fd-5a1370bade51,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:37:44.376309+00:00
+Shared Pool (27 stores),9ef61a14-d35e-444e-9c1a-c5b2e3253d7a,019d6829-e397-7177-a73e-f7c74eb9fdb8,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:37:48.818127+00:00
+Dedicated,a0854727-f040-4031-97bc-2f3fe897b4b4,019d6829-f424-718d-99aa-56abf2fbda78,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:37:53.056837+00:00
+Dedicated,a0854702-f740-4055-983c-7bfa34a78e0c,019d682a-045f-72ca-b674-603cdfdda4da,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:37:57.211906+00:00
+SM Caloocan Group (2 stores),a08546c1-a1f4-4012-80fe-6861537a8b6e,019d682a-175b-73d2-aa49-3ee220f003df,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:02.074543+00:00
+Dedicated,a005bcd8-9970-4df5-a13b-bdb4925f5fa0,019d682a-27d5-73ef-9c39-8b48c0573ed6,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:06.283016+00:00
+Dedicated,a085463a-76f8-4e12-8017-86a0cb8276f7,019d682a-37ef-7189-82a8-9c9b3d94e14c,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:10.410255+00:00
+Dedicated,a08546e1-5a01-42e8-a94b-786f8ff1c005,019d682a-4862-70ad-9212-958a0f09f3ba,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:14.624259+00:00
+SM Sta. Rosa Group (2 stores),a10fbc64-bfa1-4787-acdb-2fd8e6492f5e,019d682a-58d9-73b9-996c-bfff5fef22d9,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:18.838024+00:00
+Dedicated,a10fbcab-5ed3-4901-89a9-f2e4fc691dfe,019d682a-6a21-72f8-960b-7f9667463d65,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:23.283148+00:00
+Dedicated,a005bbb1-38b2-47e6-82e5-1a386a476e6e,019d682a-a342-7381-bef7-b3ce3a127454,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:37.956657+00:00
+Dedicated,a0854744-9e51-4aff-93ee-8c105c038f1c,019d682a-cef4-73b1-8a7b-cdfcdb2151cc,https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive,order.cancelled,2026-04-07T13:38:49.065221+00:00

--- a/output/l3/s169/api_mutations.json
+++ b/output/l3/s169/api_mutations.json
@@ -1,0 +1,154 @@
+[
+  {
+    "endpoint": "https://api.supabase.com/v1/projects/csnniykjrychgajfrgua/database/query",
+    "method": "POST",
+    "phase": "P1",
+    "payload": "ALTER TABLE pos_orders ADD COLUMN cancelled_at,cancellation_reason,order_status,completed_at + partial index + sync_verification CHECK constraint",
+    "status": 200,
+    "response_body": "[]"
+  },
+  {
+    "endpoint": "https://api.supabase.com/v1/projects/csnniykjrychgajfrgua/database/query",
+    "method": "POST",
+    "phase": "P4",
+    "payload": "CREATE OR REPLACE VIEW v_pos_orders_live + 13 view/MV rewrites (5 rewritten by killed subagent + 6 recovered + 2 false positives transitive)",
+    "status": 201,
+    "response_body": "all rewrites applied; deltas in view_rewrite_deltas.json"
+  },
+  {
+    "endpoint": "https://api.supabase.com/v1/projects/csnniykjrychgajfrgua/database/query",
+    "method": "POST",
+    "phase": "P8",
+    "payload": "UPDATE pos_orders SET cancelled_at=NOW(), cancellation_reason='reconciled_from_mosaic_gap', order_status='CANCELLED' WHERE id = ANY(ARRAY[49575307,49575308,49575310]::bigint[]) AND cancelled_at IS NULL RETURNING ...",
+    "status": 200,
+    "response_body": "3 rows updated, all returned with cancelled_at populated"
+  },
+  {
+    "endpoint": "https://api.supabase.com/v1/projects/csnniykjrychgajfrgua/database/query",
+    "method": "POST",
+    "phase": "P8",
+    "payload": "INSERT INTO sync_verification (loc=2317, date=2026-04-04, mosaic_total=308, supabase_total=308, status='extras_tombstoned', heal_attempted=TRUE, error_message='S169 Phase 8: 3 phantoms tombstoned ...') RETURNING ...",
+    "status": 200,
+    "response_body": "row inserted"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Araneta Group (3 stores)",
+    "webhook_id": "019d6829-d240-73bc-a6fd-5a1370bade51",
+    "registered_at": "2026-04-07T13:37:44.376309+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Shared Pool (27 stores)",
+    "webhook_id": "019d6829-e397-7177-a73e-f7c74eb9fdb8",
+    "registered_at": "2026-04-07T13:37:48.818127+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Dedicated",
+    "webhook_id": "019d6829-f424-718d-99aa-56abf2fbda78",
+    "registered_at": "2026-04-07T13:37:53.056837+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Dedicated",
+    "webhook_id": "019d682a-045f-72ca-b674-603cdfdda4da",
+    "registered_at": "2026-04-07T13:37:57.211906+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "SM Caloocan Group (2 stores)",
+    "webhook_id": "019d682a-175b-73d2-aa49-3ee220f003df",
+    "registered_at": "2026-04-07T13:38:02.074543+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Dedicated",
+    "webhook_id": "019d682a-27d5-73ef-9c39-8b48c0573ed6",
+    "registered_at": "2026-04-07T13:38:06.283016+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Dedicated",
+    "webhook_id": "019d682a-37ef-7189-82a8-9c9b3d94e14c",
+    "registered_at": "2026-04-07T13:38:10.410255+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Dedicated",
+    "webhook_id": "019d682a-4862-70ad-9212-958a0f09f3ba",
+    "registered_at": "2026-04-07T13:38:14.624259+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "SM Sta. Rosa Group (2 stores)",
+    "webhook_id": "019d682a-58d9-73b9-996c-bfff5fef22d9",
+    "registered_at": "2026-04-07T13:38:18.838024+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Dedicated",
+    "webhook_id": "019d682a-6a21-72f8-960b-7f9667463d65",
+    "registered_at": "2026-04-07T13:38:23.283148+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Dedicated",
+    "webhook_id": "019d682a-a342-7381-bef7-b3ce3a127454",
+    "registered_at": "2026-04-07T13:38:37.956657+00:00"
+  },
+  {
+    "endpoint": "https://api.mosaic-pos.com/api/v1/webhooks",
+    "method": "POST",
+    "phase": "P7",
+    "payload": "{\"url\": \"https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\", \"events\": [\"order.cancelled\"]}",
+    "status": 200,
+    "credential_group": "Dedicated",
+    "webhook_id": "019d682a-cef4-73b1-8a7b-cdfcdb2151cc",
+    "registered_at": "2026-04-07T13:38:49.065221+00:00"
+  }
+]

--- a/output/l3/s169/form_submissions.json
+++ b/output/l3/s169/form_submissions.json
@@ -1,0 +1,195 @@
+[
+  {
+    "phase": "P0",
+    "form": "phantom-scan SQL probe",
+    "inputs": {
+      "window": "2026-01-01..now"
+    },
+    "submit_action": "Supabase Mgmt API SELECT",
+    "response": "535 phantom groups (10.7x threshold). Sam approved override."
+  },
+  {
+    "phase": "P0",
+    "form": "view dependency audit",
+    "inputs": {
+      "pg_views+pg_matviews": "definition ILIKE %pos_orders%"
+    },
+    "submit_action": "Supabase Mgmt API SELECT",
+    "response": "13 objects discovered (plan said 12)"
+  },
+  {
+    "phase": "P0",
+    "form": "webhook signing probe (desk)",
+    "inputs": {
+      "docs/api/MOSAIC_API.md": "full read"
+    },
+    "submit_action": "manual review",
+    "response": "No HMAC documented, defaulting to Path B round-trip confirm"
+  },
+  {
+    "phase": "P1",
+    "form": "schema migration",
+    "inputs": {
+      "file": "data/supabase/migrations/2026-04-07-pos-orders-lifecycle-columns.sql"
+    },
+    "submit_action": "POST Supabase Mgmt API",
+    "response": "4 columns + index + CHECK constraint applied (HTTP 200, [])"
+  },
+  {
+    "phase": "P2",
+    "form": "map_order edit",
+    "inputs": {
+      "file": "scripts/sync_pos_to_supabase.py:401-405"
+    },
+    "submit_action": "Edit tool",
+    "response": "BLOCKER 1 fix: NULL-safe payment_status, +order_status +completed_at, no cancelled_at write"
+  },
+  {
+    "phase": "P3",
+    "form": "webhook endpoint code",
+    "inputs": {
+      "files": [
+        "hrms/api/mosaic_webhook.py",
+        "hrms/utils/supabase.py"
+      ]
+    },
+    "submit_action": "Write tool",
+    "response": "Path B round-trip confirm, Sentry DM-7, idempotent UPDATE; 217+151 lines"
+  },
+  {
+    "phase": "P4",
+    "form": "workflow disable",
+    "inputs": {
+      "workflow": "daily-pos-sync.yml"
+    },
+    "submit_action": "gh workflow disable",
+    "response": "disabled_manually"
+  },
+  {
+    "phase": "P4",
+    "form": "v_pos_orders_live wrapper",
+    "inputs": {
+      "sql": "CREATE OR REPLACE VIEW v_pos_orders_live AS SELECT * FROM pos_orders WHERE cancelled_at IS NULL"
+    },
+    "submit_action": "Supabase Mgmt API",
+    "response": "created"
+  },
+  {
+    "phase": "P4",
+    "form": "13 view rewrites",
+    "inputs": {
+      "objects": [
+        "daily_revenue",
+        "discount_summary",
+        "payment_reconciliation",
+        "sales_dashboard_daily_store_metrics",
+        "store_daily_baselines",
+        "store_daily_closing",
+        "v_all_channel_daily",
+        "v_orders",
+        "v_monthly_store_summary",
+        "v_system_daily_totals",
+        "v_discount_identity_order_usage",
+        "v_ops_weekly",
+        "v_discount_identity_rolling_30d_usage"
+      ]
+    },
+    "submit_action": "DROP+CREATE per object",
+    "response": "all 13 rewritten/recovered, deltas in view_rewrite_deltas.json"
+  },
+  {
+    "phase": "P4",
+    "form": "workflow re-enable",
+    "inputs": {
+      "workflow": "daily-pos-sync.yml"
+    },
+    "submit_action": "gh workflow enable",
+    "response": "state: active"
+  },
+  {
+    "phase": "P4",
+    "form": "sales_dashboard refresh smoke test",
+    "inputs": {
+      "sql": "SELECT public.refresh_sales_dashboard_daily_store_metrics()"
+    },
+    "submit_action": "Supabase Mgmt API",
+    "response": "success"
+  },
+  {
+    "phase": "P5",
+    "form": "30-day backfill",
+    "inputs": {
+      "cmd": "python scripts/sync_pos_to_supabase.py --from 2026-03-08 --to 2026-04-06 --parallel"
+    },
+    "submit_action": "shell",
+    "response": "33 store-days synced, 1317 skipped (sync_progress dedup), 359 orders. Lifecycle fields populated on newly synced rows; existing rows unchanged due to dedup."
+  },
+  {
+    "phase": "P6",
+    "form": "verify_mosaic_pos_sync upgrade",
+    "inputs": {
+      "file": "scripts/verify_mosaic_pos_sync.py"
+    },
+    "submit_action": "Edit",
+    "response": "488->766 lines: tombstone_extras() + cancelled_at=is.null filter + extras_tombstoned status path + dry-run flag"
+  },
+  {
+    "phase": "P7",
+    "form": "webhook registration",
+    "inputs": {
+      "cmd": "python scripts/s169_register_webhooks.py",
+      "groups": 12
+    },
+    "submit_action": "shell",
+    "response": "12 registered, 0 skipped, 0 failed"
+  },
+  {
+    "phase": "P8",
+    "form": "round-trip 404 confirm",
+    "inputs": {
+      "ids": [
+        49575307,
+        49575308,
+        49575310,
+        49575311
+      ]
+    },
+    "submit_action": "GET https://api.mosaic-pos.com/api/v1/orders/{id} with Accept: application/json",
+    "response": "3 phantoms HTTP 404 'Receipt not found', canonical 49575311 HTTP 200"
+  },
+  {
+    "phase": "P8",
+    "form": "tombstone phantoms",
+    "inputs": {
+      "ids": [
+        49575307,
+        49575308,
+        49575310
+      ]
+    },
+    "submit_action": "UPDATE pos_orders",
+    "response": "3 rows tombstoned, post-state 308 live (matches Mosaic)"
+  },
+  {
+    "phase": "P8",
+    "form": "daily_revenue MV refresh",
+    "inputs": {
+      "mv": "daily_revenue"
+    },
+    "submit_action": "REFRESH MATERIALIZED VIEW",
+    "response": "SM Marikina POS Apr 4 order_count: 305 -> 302 (3 phantoms filtered out)"
+  },
+  {
+    "phase": "P8",
+    "form": "sync_verification record",
+    "inputs": {
+      "loc": 2317,
+      "date": "2026-04-04",
+      "mosaic": 308,
+      "supabase": 308,
+      "status": "extras_tombstoned"
+    },
+    "submit_action": "INSERT",
+    "response": "row written, delta=0, heal_attempted=true"
+  }
+]

--- a/output/l3/s169/phase7_registration.log
+++ b/output/l3/s169/phase7_registration.log
@@ -1,0 +1,30 @@
+[2026-04-07 21:37:40] Loaded 12 unique credential groups from MOSAIC_POS_API_KEYS.csv
+[2026-04-07 21:37:40] Webhook URL: https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive
+[2026-04-07 21:37:40] Events: ['order.cancelled']
+[2026-04-07 21:37:40] --- Araneta Group (3 stores) (a080acf5...) [3 locations]
+[2026-04-07 21:37:44]   REGISTERED: webhook id=019d6829-d240-73bc-a6fd-5a1370bade51
+[2026-04-07 21:37:45] --- Shared Pool (27 stores) (9ef61a14...) [30 locations]
+[2026-04-07 21:37:48]   REGISTERED: webhook id=019d6829-e397-7177-a73e-f7c74eb9fdb8
+[2026-04-07 21:37:49] --- Dedicated (a0854727...) [1 locations]
+[2026-04-07 21:37:53]   REGISTERED: webhook id=019d6829-f424-718d-99aa-56abf2fbda78
+[2026-04-07 21:37:54] --- Dedicated (a0854702...) [1 locations]
+[2026-04-07 21:37:57]   REGISTERED: webhook id=019d682a-045f-72ca-b674-603cdfdda4da
+[2026-04-07 21:37:58] --- SM Caloocan Group (2 stores) (a08546c1...) [2 locations]
+[2026-04-07 21:38:02]   REGISTERED: webhook id=019d682a-175b-73d2-aa49-3ee220f003df
+[2026-04-07 21:38:03] --- Dedicated (a005bcd8...) [1 locations]
+[2026-04-07 21:38:06]   REGISTERED: webhook id=019d682a-27d5-73ef-9c39-8b48c0573ed6
+[2026-04-07 21:38:07] --- Dedicated (a085463a...) [1 locations]
+[2026-04-07 21:38:10]   REGISTERED: webhook id=019d682a-37ef-7189-82a8-9c9b3d94e14c
+[2026-04-07 21:38:11] --- Dedicated (a08546e1...) [1 locations]
+[2026-04-07 21:38:14]   REGISTERED: webhook id=019d682a-4862-70ad-9212-958a0f09f3ba
+[2026-04-07 21:38:15] --- SM Sta. Rosa Group (2 stores) (a10fbc64...) [2 locations]
+[2026-04-07 21:38:18]   REGISTERED: webhook id=019d682a-58d9-73b9-996c-bfff5fef22d9
+[2026-04-07 21:38:19] --- Dedicated (a10fbcab...) [1 locations]
+[2026-04-07 21:38:23]   REGISTERED: webhook id=019d682a-6a21-72f8-960b-7f9667463d65
+[2026-04-07 21:38:24] --- Dedicated (a005bbb1...) [1 locations]
+[2026-04-07 21:38:37]   REGISTERED: webhook id=019d682a-a342-7381-bef7-b3ce3a127454
+[2026-04-07 21:38:38] --- Dedicated (a0854744...) [1 locations]
+[2026-04-07 21:38:49]   REGISTERED: webhook id=019d682a-cef4-73b1-8a7b-cdfcdb2151cc
+[2026-04-07 21:38:50] ============================================================
+[2026-04-07 21:38:50] Summary: Registered 12 new, skipped 0 existing, failed 0
+[2026-04-07 21:38:50] Registration log: F:\Dropbox\Projects\BEI-ERP-s169-isolated\data\POS_Extraction\MOSAIC_WEBHOOK_REGISTRATIONS.csv

--- a/output/l3/s169/state_verification.json
+++ b/output/l3/s169/state_verification.json
@@ -1,0 +1,84 @@
+{
+  "test": "S169 Phase 8 T8.1-T8.6 Apr 4 SM Marikina tombstone",
+  "incident_id": "S165 alert 2026-04-07T02:47:12 \u2014 SM Marikina 2026-04-04 Mosaic=308 Supabase=311 status=extra",
+  "phantom_ids": [
+    49575307,
+    49575308,
+    49575310
+  ],
+  "canonical_id": 49575311,
+  "round_trip_confirmation": {
+    "method": "GET https://api.mosaic-pos.com/api/v1/orders/{id} with Accept: application/json",
+    "49575307": "HTTP 404 Receipt not found",
+    "49575308": "HTTP 404 Receipt not found",
+    "49575310": "HTTP 404 Receipt not found",
+    "49575311": "HTTP 200 (canonical, still exists)"
+  },
+  "pre_state": {
+    "total_rows": 311,
+    "live_rows_table": 311,
+    "live_rows_wrapper": 311
+  },
+  "tombstone_action": "UPDATE pos_orders SET cancelled_at=NOW(), cancellation_reason='reconciled_from_mosaic_gap', order_status='CANCELLED' WHERE id IN (49575307,49575308,49575310) AND cancelled_at IS NULL",
+  "post_state": [
+    {
+      "total_rows": 311,
+      "live_rows_table": 308,
+      "live_rows_wrapper": 308
+    }
+  ],
+  "tombstoned_rows": [
+    {
+      "id": 49575307,
+      "cancelled_at": "2026-04-07 13:37:02.539657+00",
+      "cancellation_reason": "reconciled_from_mosaic_gap",
+      "order_status": "CANCELLED"
+    },
+    {
+      "id": 49575308,
+      "cancelled_at": "2026-04-07 13:37:02.539657+00",
+      "cancellation_reason": "reconciled_from_mosaic_gap",
+      "order_status": "CANCELLED"
+    },
+    {
+      "id": 49575310,
+      "cancelled_at": "2026-04-07 13:37:02.539657+00",
+      "cancellation_reason": "reconciled_from_mosaic_gap",
+      "order_status": "CANCELLED"
+    }
+  ],
+  "sync_verification_row": [
+    {
+      "location_id": 2317,
+      "business_date": "2026-04-04",
+      "mosaic_total": 308,
+      "supabase_total": 308,
+      "delta": 0,
+      "status": "extras_tombstoned",
+      "heal_attempted": true,
+      "error_message": "S169 Phase 8: 3 phantoms tombstoned (49575307, 49575308, 49575310). Round-trip 404 confirmed via Mosaic GET /orders/{id}."
+    }
+  ],
+  "daily_revenue_mv_post": [
+    {
+      "store_name": "SM Marikina",
+      "channel": "POS",
+      "business_date": "2026-04-04",
+      "order_count": 302,
+      "gross_revenue": "153262.00"
+    },
+    {
+      "store_name": "SM Marikina",
+      "channel": "Website",
+      "business_date": "2026-04-04",
+      "order_count": 3,
+      "gross_revenue": "4545.00"
+    }
+  ],
+  "lifecycle_field_population": [
+    {
+      "rows_with_order_status": 1643,
+      "distinct_order_status": 5
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Follow-up PR to land S169 closeout evidence after PR #485 merged. Phase 5 (backfill), Phase 7 (12 webhook registrations), and Phase 8 T8.1–T8.6 (Apr 4 SM Marikina tombstone) are all complete and verified live in production Supabase.

## What's in this PR

| Phase | Action | Evidence |
|---|---|---|
| **5** | 30-day backfill via `sync_pos_to_supabase.py --from 2026-03-08 --to 2026-04-06 --parallel` — ran in 80s, 33 store-days synced, 1317 skipped (sync_progress dedup), 359 orders | output/l3/s169/phase5_backfill.log |
| **7** | All 12 Mosaic credential groups registered with order.cancelled webhook → hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive | output/l3/s169/MOSAIC_WEBHOOK_REGISTRATIONS.csv (12 rows), phase7_registration.log |
| **8 T8.1-T8.6** | 3 phantoms (49575307, 49575308, 49575310) tombstoned. Round-trip 404 confirmed via Mosaic GET /api/v1/orders/{id}. SM Marikina Apr 4 live count 311→308. daily_revenue MV refreshed: POS order_count 305→302. sync_verification row written status=extras_tombstoned. | output/l3/s169/state_verification.json, api_mutations.json, form_submissions.json |

## ⚠️ Mosaic API "outage" was a false alarm

My earlier diagnosis (committed in `mosaic_api_outage_report.md`) was wrong. The HTTP 500s I saw came from my probe using **form-encoded OAuth body** + **missing `Accept: application/json` header**. With the correct call shape (JSON body + Accept header — see scripts/sync_pos_to_supabase.py:280-330), every endpoint returns 200/404/etc as expected. Mosaic API is fully healthy. The outage report file is preserved as historical context but should not be treated as authoritative.

## ⚠️ Phase 5 backfill caveat

The backfill completed in 80s because `sync_progress` table marks store-days complete and `get_completed_store_days()` skips them. 1317 store-days were skipped (already marked complete), only 33 actually re-synced. **This means the existing ~10M historical pos_orders rows still have the old hardcoded `payment_status='PAID'` and NULL lifecycle fields.** Going forward every new sync uses the BLOCKER 1 fix from S169-P2 — confirmed by query: `SELECT COUNT(*) FROM pos_orders WHERE order_status IS NOT NULL AND business_date >= '2026-03-08'` returns 956 rows with 4 distinct order_status values (COLLECTED, DELIVERED, etc.).

To force full re-sync, the script would need a `--force` flag (out of scope for S169). The lifecycle fields will populate naturally as new days roll in.

## ⚠️ Phase 8 T8.7 still deferred

The live self-induced webhook test requires the new `hrms/api/mosaic_webhook.py` endpoint to be deployed to production Frappe. Once you trigger `Build and Deploy Frappe HRMS` workflow with `skip_build=false no_cache=true`, run:
\`\`\`bash
cd F:/Dropbox/Projects/BEI-ERP-s169-isolated
python scripts/s169_self_induced_cancel_test.py --mode verify
\`\`\`

## Worktree cleanup
After merging this PR, run:
\`\`\`bash
git worktree remove F:/Dropbox/Projects/BEI-ERP-s169-isolated
\`\`\`

## 535-phantom regime shift still unresolved
S170-investigation should diff the sync pipeline since 2026-03-25 to find the root cause of the 2026-03-26 phantom regime shift (10x background rate). The S169 tombstone webhook will mask new phantoms going forward but the underlying double-sync defect remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)