### PR TITLE
S169 T8.7 evidence + deployment gap finding — CSV not shipped in Docker image

### DIFF
--- a/output/l3/s169/phase8_t87_findings.md
+++ b/output/l3/s169/phase8_t87_findings.md
@@ -1,0 +1,69 @@
+# S169 Phase 8 T8.7 — Live webhook test findings
+
+**Date:** 2026-04-07 (after Frappe deploy)
+**Endpoint:** https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive (LIVE)
+
+## Test results
+
+| # | Test | Expected | Actual | Verdict |
+|---|---|---|---|---|
+| 1 | POST {"event":"ping"} | 200 ping branch | 200 `{"ok":true,"handled":false,"reason":"ping"}` | ✅ PASS |
+| 2 | Live order 49575311 (canonical, still exists in Mosaic) | 401 round_trip_confirm_failed | 401 `{"ok":false,"reason":"round_trip_confirm_failed","order_id":49575311}` | ✅ PASS (but see caveat below) |
+| 3 | Already-tombstoned phantom 49575307 (Mosaic 404) | 200 handled=false already_tombstoned_or_not_found | 401 round_trip_confirm_failed | ⚠️ GAP |
+| 4 | Invalid JSON body | 400 invalid_json | 500 JSONDecodeError (framework throws before endpoint catches) | ⚠️ MINOR |
+| 5 | Unknown event (order.created) | 200 ignored | 200 `{"ok":true,"handled":false,"reason":"ignored event: order.created"}` | ✅ PASS |
+
+## Root cause of gap
+
+The endpoint's `_authenticate_webhook()` implementation reads the Mosaic credentials CSV at:
+
+```python
+MOSAIC_KEYS_CSV = Path(frappe.get_app_path("hrms")).parent / "data" / "POS_Extraction" / "MOSAIC_POS_API_KEYS.csv"
+```
+
+This resolves to `/home/frappe/frappe-bench/apps/data/POS_Extraction/MOSAIC_POS_API_KEYS.csv` inside the Frappe Docker container — but the `data/` directory at the repo root is NOT included in the Docker image build context. Only `hrms/` is copied into `apps/hrms/`.
+
+Result: `_find_credential(location_id)` returns `None` → `_authenticate_webhook()` returns `False` → endpoint returns 401 regardless of whether the round-trip would have confirmed 404 or 200.
+
+Test #2 accidentally passes because BOTH "Mosaic returns 200" AND "CSV not found" produce 401 — the 401 is correct for test #2 but only by coincidence.
+
+## What this means operationally
+
+- ✅ The endpoint is deployed and reachable
+- ✅ JSON parsing / event routing / observability context / 'ping' branch all work
+- ✅ The endpoint never accidentally tombstones (safety invariant holds — it returns 401 on every cancel request)
+- ⚠️ **No cancel request will ever successfully trigger a tombstone UPDATE until the CSV is loaded into the container**
+- ⚠️ **Every real Mosaic cancel webhook that fires will return 401** → Mosaic will retry → same 401 → eventually give up
+
+## Fix options (follow-up sprint)
+
+1. **Load credentials from Doppler/bench config** instead of CSV file (preferred — no file dependency)
+2. **Copy the CSV into the Docker image** at build time
+3. **Store credentials in a Frappe DocType** at deploy time via a fixture
+4. **Copy the CSV to `apps/hrms/hrms/data/`** so it ships with the app directory
+
+Option 1 is cleanest. Secret doesn't live on disk in the image, can be rotated via Doppler without rebuild.
+
+## Impact on S169 goals
+
+| Goal | Status |
+|---|---|
+| Schema lifecycle columns | ✅ DONE |
+| map_order fix | ✅ DONE |
+| Wrapper view + 13 view rewrites | ✅ DONE |
+| Verify script tombstone upgrade | ✅ DONE |
+| **Apr 4 SM Marikina tombstone (Phase 8 T8.1-T8.6)** | ✅ DONE (via direct SQL with round-trip 404 confirmed manually) |
+| Webhook registration (12 credential groups) | ✅ DONE |
+| **Live webhook happy-path tombstone (Phase 8 T8.7)** | ⚠️ BLOCKED on credential-loading fix |
+
+The nightly verify script (Phase 6 upgrade) is the safety net and can still tombstone future phantom-void groups without the webhook — so the S169 goal of "prevent phantom revenue drift" is still achievable via the nightly run. The webhook is additive/near-real-time and will kick in after the cred-loading fix.
+
+## Recommendation
+
+Create a small follow-up fix `S169.1` that:
+1. Changes `_authenticate_webhook` to load credentials via `_supabase_query_sql` to the Supabase `mosaic_credentials` table (create one), OR via Doppler env vars mapped from Frappe site_config
+2. Removes the filesystem CSV dependency
+3. Re-runs this test suite
+4. Verifies tests #2 and #3 produce distinct responses
+
+Estimated effort: ~30 min + redeploy.

--- a/output/l3/s169/webhook_live_test.log
+++ b/output/l3/s169/webhook_live_test.log
@@ -1,0 +1,7 @@
+[2026-04-07 23:10:02] Picked credential group: Dedicated (1 locations)
+[2026-04-07 23:10:02] Test location: Ayala Solenad (id=2547)
+[2026-04-07 23:10:02] Mode: verify | bill_number: 999992
+[2026-04-07 23:10:02] Step 1: OAuth
+[2026-04-07 23:10:04] Step 2: create test order
+[2026-04-07 23:10:07]   [CREATE_WARN] 422 -- retrying without items
+[2026-04-07 23:10:09] FATAL: Mosaic API error: 422 Client Error: Unprocessable Entity for url: https://api.mosaic-pos.com/api/v1/orders -- body: {"errors":[{"status":422,"detail":"The items field is required.","source":{"pointer":"items"}}]}

--- a/output/l3/s169/webhook_live_test_payload.json
+++ b/output/l3/s169/webhook_live_test_payload.json
@@ -1,0 +1,47 @@
+{
+  "tests": [
+    {
+      "name": "1. ping",
+      "payload": {
+        "event": "ping"
+      }
+    },
+    {
+      "name": "2. live order (round-trip should refuse \u2014 49575311 canonical, still exists)",
+      "payload": {
+        "event": "order.cancelled",
+        "data": {
+          "id": 49575311,
+          "location_id": 2317,
+          "cancelled_at": "2026-04-07T21:00:00+08:00",
+          "cancellation_reason": "webhook test"
+        }
+      }
+    },
+    {
+      "name": "3. already-tombstoned phantom (49575307 \u2014 404 confirm + idempotent UPDATE returns 0 rows)",
+      "payload": {
+        "event": "order.cancelled",
+        "data": {
+          "id": 49575307,
+          "location_id": 2317,
+          "cancelled_at": "2026-04-07T21:00:00+08:00",
+          "cancellation_reason": "webhook test"
+        }
+      }
+    },
+    {
+      "name": "4. invalid JSON body",
+      "payload": null
+    },
+    {
+      "name": "5. unknown event (order.created)",
+      "payload": {
+        "event": "order.created",
+        "data": {
+          "id": 99999999
+        }
+      }
+    }
+  ]
+}

--- a/output/l3/s169/webhook_live_test_response.json
+++ b/output/l3/s169/webhook_live_test_response.json
@@ -1,0 +1,60 @@
+[
+  {
+    "test": "1. ping",
+    "expected": "ok=true handled=false reason=ping",
+    "status": 200,
+    "body": {
+      "message": {
+        "ok": true,
+        "handled": false,
+        "reason": "ping"
+      }
+    }
+  },
+  {
+    "test": "2. live order (round-trip should refuse \u2014 49575311 canonical, still exists)",
+    "expected": "401 round_trip_confirm_failed (Mosaic returns 200, not 404)",
+    "status": 401,
+    "body": {
+      "message": {
+        "ok": false,
+        "reason": "round_trip_confirm_failed",
+        "order_id": 49575311
+      }
+    }
+  },
+  {
+    "test": "3. already-tombstoned phantom (49575307 \u2014 404 confirm + idempotent UPDATE returns 0 rows)",
+    "expected": "handled=false already_tombstoned_or_not_found",
+    "status": 401,
+    "body": {
+      "message": {
+        "ok": false,
+        "reason": "round_trip_confirm_failed",
+        "order_id": 49575307
+      }
+    }
+  },
+  {
+    "test": "4. invalid JSON body",
+    "expected": "400 invalid_json",
+    "status": 500,
+    "body": {
+      "exception": "json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)",
+      "exc_type": "JSONDecodeError",
+      "exc": "[\"Traceback (most recent call last):\\n  File \\\"apps/frappe/frappe/app.py\\\", line 105, in application\\n    init_request(request)\\n  File \\\"apps/frappe/frappe/app.py\\\", line 197, in init_request\\n    make_form_dict(request)\\n  File \\\"apps/frappe/frappe/app.py\\\", line 301, in make_form_dict\\n    args = json.loads(request_data)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/usr/local/lib/python3.11/json/__init__.py\\\", line 346, in loads\\n    return _default_decoder.decode(s)\\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/usr/local/lib/python3.11/json/decoder.py\\\", line 337, in decode\\n    obj, end = self.raw_decode(s, idx=_w(s, 0).end())\\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/usr/local/lib/python3.11/json/decoder.py\\\", line 353, in raw_decode\\n    obj, end = self.scan_once(s, idx)\\n               ^^^^^^^^^^^^^^^^^^^^^^\\njson.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)\\n\"]"
+    }
+  },
+  {
+    "test": "5. unknown event (order.created)",
+    "expected": "ok=true handled=false ignored event",
+    "status": 200,
+    "body": {
+      "message": {
+        "ok": true,
+        "handled": false,
+        "reason": "ignored event: order.created"
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
Follow-up evidence PR after PR #487 merged. Ran Phase 8 T8.7 live webhook tests against the deployed endpoint at \`hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive\`. Found one real deployment gap and one minor error-handling issue.

## Test results

| # | Test | Expected | Actual | Verdict |
|---|---|---|---|---|
| 1 | POST \`{"event":"ping"}\` | 200 ping branch | 200 \`{"ok":true,"handled":false,"reason":"ping"}\` | ✅ PASS |
| 2 | Live order 49575311 (canonical) | 401 refuse | 401 refuse | ✅ PASS (safety) |
| 3 | Already-tombstoned phantom 49575307 (Mosaic 404) | 200 handled=false | **401 round_trip_confirm_failed** | ⚠️ GAP |
| 4 | Invalid JSON body | 400 invalid_json | 500 JSONDecodeError | ⚠️ MINOR |
| 5 | Unknown event | 200 ignored | 200 ignored | ✅ PASS |

## 🔴 Real gap — CSV not shipped in Docker image

\`hrms/api/mosaic_webhook.py::_authenticate_webhook\` reads credentials from:
\`\`\`python
MOSAIC_KEYS_CSV = Path(frappe.get_app_path("hrms")).parent / "data" / "POS_Extraction" / "MOSAIC_POS_API_KEYS.csv"
\`\`\`

This resolves to \`/home/frappe/frappe-bench/apps/data/POS_Extraction/MOSAIC_POS_API_KEYS.csv\` inside the Frappe container — but only the \`hrms/\` directory is copied into \`apps/hrms/\` by the Dockerfile. The BEI-ERP \`data/\` root directory doesn't ship with the image.

Result: \`_find_credential()\` returns None for every request → \`_authenticate_webhook()\` returns False → **every cancel webhook returns 401**, regardless of whether the round-trip would actually confirm 404. Test #2 accidentally passed because a live-order refusal also returns 401. Test #3 exposed the gap.

**Operational impact:**
- ✅ Endpoint is reachable and safe (won't accidentally tombstone)
- ✅ Routing, observability context, ping branch, unknown-event handling all work
- ⚠️ Real Mosaic \`order.cancelled\` webhooks fired at the 12 registered credential groups will all get 401 → Mosaic will retry → same 401 → eventually give up → no tombstoning via webhook
- ✅ **Nightly verify script (Phase 6 upgrade) is the safety net** and tombstones phantom-void groups without needing the webhook path. S169's primary goal — prevent phantom revenue drift — is still met through the nightly run.

The webhook is additive/near-real-time and will start working after the cred-loading fix lands.

## Recommended fix (new follow-up sprint S169.1)

Move credentials off the filesystem entirely. Options in order of preference:

1. **Supabase-backed credential table.** Create \`public.mosaic_credentials\` table, seed from CSV, change \`_find_credential\` to use \`supabase_query_sql\`. No file dependency, rotatable, survives container rebuilds.
2. **Doppler / site_config.** Store the CSV content as a JSON env var, read via \`frappe.conf.get('mosaic_credentials')\`.
3. **Copy CSV into hrms app directory.** Move to \`hrms/hrms/data/MOSAIC_POS_API_KEYS.csv\` and update the resolver to not climb to \`.parent\`. Simplest but still file-based.

Estimated effort: ~30 min + redeploy + re-run test suite. Test #3 should then return \`handled=false already_tombstoned_or_not_found\`.

## Minor — test #4 invalid JSON

The endpoint has a \`try/except json.JSONDecodeError\` block but Frappe's request-handling layer throws the exception before the endpoint code runs. Returning 500 instead of 400 is cosmetic — the bot can still tell something failed, just not the exact reason. Non-blocking.

## Evidence files

- \`output/l3/s169/webhook_live_test_payload.json\` — all 5 test payloads
- \`output/l3/s169/webhook_live_test_response.json\` — all 5 responses with status codes and bodies
- \`output/l3/s169/webhook_live_test.log\` — original run log (failed on order-creation phase)
- \`output/l3/s169/phase8_t87_findings.md\` — detailed analysis + fix recommendations

## Worktree cleanup still pending

\`\`\`bash
git worktree remove F:/Dropbox/Projects/BEI-ERP-s169-isolated
\`\`\`

## Still needed separately (not in this PR)

- **S169.1 credential-loading fix** (this PR documents the gap, doesn't fix it)
- **S170-investigation** — root cause the 2026-03-26 phantom regime shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)