### PR TITLE
fix(hrms): marketing giveaway patch — BEI head office only + defensive parent guard

### DIFF
--- a/hrms/patches/v16_0/ensure_marketing_giveaway_setup.py
+++ b/hrms/patches/v16_0/ensure_marketing_giveaway_setup.py
@@ -6,6 +6,11 @@ ROLE_NAMES = ("Marketing User", "Marketing Manager")
 SOURCE_ACCOUNT_NUMBER = "6005000"
 TARGET_ACCOUNT_NUMBER = "6005001"
 TARGET_ACCOUNT_NAME = "MARKETING GIVEAWAYS"
+# Marketing is a centralized BEI head office function — the giveaway GL account
+# belongs ONLY to BEI, not to BKI / JV / any subsidiary. Looping over all
+# companies previously blocked every migrate when the JV company's source
+# account 6005000 was parented under a ledger account (CEO directive 2026-04-07).
+MARKETING_COMPANY = "Bebang Enterprise Inc."
 
 
 def _ensure_role(role_name: str) -> None:
@@ -40,11 +45,37 @@ def _ensure_account_for_company(company: str) -> None:
 		return
 
 	source_account = frappe.get_doc("Account", source_account_name)
+
+	# DEFENSIVE: validate parent is a group before inserting. A single
+	# misconfigured source account must never block the entire migrate
+	# pipeline. Log-and-skip is the correct behavior here; Finance can
+	# fix the underlying COA data out-of-band.
+	parent_account_name = source_account.parent_account
+	if not parent_account_name:
+		frappe.log_error(
+			f"ensure_marketing_giveaway_setup: source account {source_account_name} "
+			f"on {company} has no parent_account; skipping {TARGET_ACCOUNT_NUMBER} creation.",
+			"Marketing Giveaway Patch Skip",
+		)
+		return
+
+	parent_is_group = frappe.db.get_value("Account", parent_account_name, "is_group")
+	if not parent_is_group:
+		frappe.log_error(
+			f"ensure_marketing_giveaway_setup: parent {parent_account_name} "
+			f"(on {company}, derived from source {source_account_name}) is a ledger "
+			f"account, not a group. Cannot create child {TARGET_ACCOUNT_NUMBER}. "
+			f"Fix COA: either convert {parent_account_name} to a group (if empty) or "
+			f"move {source_account_name} under the correct expense group.",
+			"Marketing Giveaway Patch Skip",
+		)
+		return
+
 	account = frappe.new_doc("Account")
 	account.company = company
 	account.account_name = TARGET_ACCOUNT_NAME
 	account.account_number = TARGET_ACCOUNT_NUMBER
-	account.parent_account = source_account.parent_account
+	account.parent_account = parent_account_name
 	account.root_type = source_account.root_type
 	account.report_type = source_account.report_type
 	account.is_group = 0
@@ -54,11 +85,19 @@ def _ensure_account_for_company(company: str) -> None:
 
 
 def _ensure_accounts() -> None:
-	companies = frappe.get_all("Company", fields=["name"], limit_page_length=200)
-	for row in companies:
-		name = str(row.get("name") or "").strip()
-		if name:
-			_ensure_account_for_company(name)
+	# Marketing giveaway GL belongs to BEI head office ONLY. Do NOT create on
+	# BKI / JV / any other subsidiary — marketing is a centralized BEI function
+	# (CEO directive 2026-04-07). Looping over all companies previously blocked
+	# every migrate when one subsidiary's source account was misconfigured.
+	if frappe.db.exists("Company", MARKETING_COMPANY):
+		_ensure_account_for_company(MARKETING_COMPANY)
+	else:
+		frappe.log_error(
+			f"ensure_marketing_giveaway_setup: Company '{MARKETING_COMPANY}' not found; "
+			"marketing giveaway GL not created. If BEI head office company was renamed, "
+			"update MARKETING_COMPANY in this patch.",
+			"Marketing Giveaway Patch Skip",
+		)
 
 
 def execute():


### PR DESCRIPTION
## Root cause

`hrms/patches/v16_0/ensure_marketing_giveaway_setup.py` has two bugs that together block every \`bench migrate\` on hq.bebang.ph:

### Bug 1 — Business-incorrect scope
The patch loops over every \`Company\` in Frappe and tries to create \`6005001 MARKETING GIVEAWAYS\` on all of them. But marketing is a **centralized BEI head office function** (CEO directive 2026-04-07) — BKI, JV, and other subsidiaries should not have their own marketing giveaway GL accounts.

### Bug 2 — Fragile parent inheritance
Even if scope were correct, the patch does \`account.parent_account = source_account.parent_account\` without validating the parent is a group. On the JV company, \`6005000\`'s \`parent_account\` is configured as \`FRANCHISE INCOME - JV\` — which is a **posting (ledger) account**, not a group. Frappe refuses to create children under posting accounts, so the patch raises \`ValidationError\` and **the entire migrate pipeline halts**.

### Observed effect
S168 PR #482 + #484 merged + deployed, but no \`bench migrate\` since. When I tried to run migrate to sync the S168 fixture fields (14 Custom Fields + 8 BEI Settings BKI fields), this patch crashed it. Net result: S168 code is live, but S168 **cannot be exercised end-to-end** because the custom fields don't exist in the DB.

## Fix

1. **Constrain scope** — \`_ensure_accounts()\` now only targets \`MARKETING_COMPANY = \"Bebang Enterprise Inc.\"\`. BKI / JV / any subsidiary is skipped.
2. **Defensive parent guard** — \`_ensure_account_for_company()\` now validates \`parent_account\` exists and has \`is_group=1\` before inserting. Failures log via \`frappe.log_error\` and return early instead of throwing. Finance can fix broken COA data out-of-band without blocking migrate.

## Diff summary
\`\`\`
hrms/patches/v16_0/ensure_marketing_giveaway_setup.py | 45 insertions, 6 deletions
\`\`\`

## Impact
- ✅ Unblocks \`bench migrate\` on hq.bebang.ph (S168 fixture sync becomes possible)
- ✅ BEI head office still gets its marketing giveaway account as originally intended
- ✅ No live data mutation — patch is idempotent and log-only on skip paths
- ⚠️  Existing stray \`6005001\` accounts on BKI/JV/other companies (if any from prior runs) are NOT deleted by this patch — separate \`/frappe-bulk-edits\` cleanup if Finance requests

## Post-merge steps (I will execute)
1. Wait for Sam to merge + deploy
2. Re-run \`bench --site hq.bebang.ph migrate\` via SSM — should now complete cleanly
3. Re-run L1 live audit + runtime prereqs audit to verify all 14 Custom Fields + 8 BEI Settings fields synced
4. Dispatch \`/fact-check-bei-erp\` fleet for full S168 state audit
5. Run seed scripts in order (GL accounts → VAT template → Customer Group → Customers → cost centers → BEI Settings config)
6. Identify which company has the broken \`6005000\` parent (for Finance to fix the COA)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — permanent fix, no workaround