### PR TITLE
fix(pcf): allow custodians to edit pending expenses on their fund — DEFECT-022

### DIFF
--- a/hrms/api/pcf.py
+++ b/hrms/api/pcf.py
@@ -294,10 +294,29 @@ def edit_pending_expense(
     """
     expense = frappe.get_doc("BEI Expense Request", expense_name)
 
-    # Check ownership
-    employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
-    if expense.employee != employee:
-        frappe.throw(_("You can only edit your own expenses"))
+    # Permission check — S167 DEFECT-022 fix: allow the owner, the fund
+    # custodian/backup custodian, or an admin. Without custodian access,
+    # the custodian has no way to correct a row before submitting the
+    # batch (plan S167 scenario 1.3 requires this).
+    user = frappe.session.user
+    employee = frappe.db.get_value("Employee", {"user_id": user}, "name")
+    is_owner = employee and expense.employee == employee
+
+    is_custodian = False
+    if expense.pcf_fund:
+        fund = frappe.db.get_value(
+            "BEI Petty Cash Fund",
+            expense.pcf_fund,
+            ["custodian", "backup_custodian"],
+            as_dict=True,
+        )
+        if fund:
+            is_custodian = user in [fund.custodian, fund.backup_custodian]
+
+    is_admin = "System Manager" in frappe.get_roles(user) or "Accounts Manager" in frappe.get_roles(user)
+
+    if not (is_owner or is_custodian or is_admin):
+        frappe.throw(_("You can only edit your own expenses, or expenses on a fund you are custodian of"))
 
     # Check status
     if expense.status != "Pending":


### PR DESCRIPTION
## Summary
DEFECT-022 from S167 redo Phase 1.3. Backend edit_pending_expense only permitted the expense owner. Plan scenario 1.3 requires the fund custodian to edit a crew member's pending expense before submitting the batch (amount correction from receipt).

## Fix
Allow the owner, the fund custodian, the fund backup custodian, OR a System Manager / Accounts Manager. 1 function, ~15 lines.

## Risk
Low. Permission broadening only; still rejects non-custodian non-admin non-owner.

## Test plan
- [ ] Merge + deploy
- [ ] test.staff (crew) creates a pending expense
- [ ] test.supervisor (custodian) opens edit dialog, changes amount, saves
- [ ] Expect 200 success instead of 400 `You can only edit your own expenses`