### PR TITLE
fix(hrms): marketing giveaway patch — bulletproof (follow-up to #491)

### DIFF
--- a/hrms/patches/v16_0/ensure_marketing_giveaway_setup.py
+++ b/hrms/patches/v16_0/ensure_marketing_giveaway_setup.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 import frappe
 
 ROLE_NAMES = ("Marketing User", "Marketing Manager")
@@ -11,6 +13,26 @@ TARGET_ACCOUNT_NAME = "MARKETING GIVEAWAYS"
 # companies previously blocked every migrate when the JV company's source
 # account 6005000 was parented under a ledger account (CEO directive 2026-04-07).
 MARKETING_COMPANY = "Bebang Enterprise Inc."
+
+# Frappe Error Log "Title" field is capped at 140 chars. Keep all titles short.
+_LOG_TITLE = "Marketing Giveaway Skip"
+
+
+def _safe_log(message: str) -> None:
+	"""Log a skip/warn without ever raising.
+
+	frappe.log_error signature in Frappe v15 is log_error(title, message) with
+	title first. The Title field is capped at 140 chars. If anything in this
+	logging path raises, we fall back to stderr — the patch must NEVER block
+	migrate just because it couldn't write an error log row.
+	"""
+	try:
+		frappe.log_error(title=_LOG_TITLE, message=message)
+	except Exception:
+		try:
+			sys.stderr.write(f"[{_LOG_TITLE}] {message}\n")
+		except Exception:
+			pass
 
 
 def _ensure_role(role_name: str) -> None:
@@ -24,64 +46,67 @@ def _ensure_role(role_name: str) -> None:
 
 def _ensure_roles() -> None:
 	for role_name in ROLE_NAMES:
-		_ensure_role(role_name)
+		try:
+			_ensure_role(role_name)
+		except Exception as exc:
+			_safe_log(f"role {role_name} failed: {exc}")
 
 
 def _ensure_account_for_company(company: str) -> None:
-	existing = frappe.db.get_value(
-		"Account",
-		{"company": company, "account_number": TARGET_ACCOUNT_NUMBER},
-		"name",
-	)
-	if existing:
-		return
+	"""Create 6005001 MARKETING GIVEAWAYS for `company` if safe.
 
-	source_account_name = frappe.db.get_value(
-		"Account",
-		{"company": company, "account_number": SOURCE_ACCOUNT_NUMBER},
-		"name",
-	)
-	if not source_account_name:
-		return
-
-	source_account = frappe.get_doc("Account", source_account_name)
-
-	# DEFENSIVE: validate parent is a group before inserting. A single
-	# misconfigured source account must never block the entire migrate
-	# pipeline. Log-and-skip is the correct behavior here; Finance can
-	# fix the underlying COA data out-of-band.
-	parent_account_name = source_account.parent_account
-	if not parent_account_name:
-		frappe.log_error(
-			f"ensure_marketing_giveaway_setup: source account {source_account_name} "
-			f"on {company} has no parent_account; skipping {TARGET_ACCOUNT_NUMBER} creation.",
-			"Marketing Giveaway Patch Skip",
+	Swallows all exceptions — this is a one-time idempotent data setup patch
+	that must never block migrate. On any failure, logs a short skip entry
+	and returns.
+	"""
+	try:
+		existing = frappe.db.get_value(
+			"Account",
+			{"company": company, "account_number": TARGET_ACCOUNT_NUMBER},
+			"name",
 		)
-		return
+		if existing:
+			return
 
-	parent_is_group = frappe.db.get_value("Account", parent_account_name, "is_group")
-	if not parent_is_group:
-		frappe.log_error(
-			f"ensure_marketing_giveaway_setup: parent {parent_account_name} "
-			f"(on {company}, derived from source {source_account_name}) is a ledger "
-			f"account, not a group. Cannot create child {TARGET_ACCOUNT_NUMBER}. "
-			f"Fix COA: either convert {parent_account_name} to a group (if empty) or "
-			f"move {source_account_name} under the correct expense group.",
-			"Marketing Giveaway Patch Skip",
+		source_account_name = frappe.db.get_value(
+			"Account",
+			{"company": company, "account_number": SOURCE_ACCOUNT_NUMBER},
+			"name",
 		)
-		return
+		if not source_account_name:
+			_safe_log(f"no {SOURCE_ACCOUNT_NUMBER} on {company}; skipping.")
+			return
 
-	account = frappe.new_doc("Account")
-	account.company = company
-	account.account_name = TARGET_ACCOUNT_NAME
-	account.account_number = TARGET_ACCOUNT_NUMBER
-	account.parent_account = parent_account_name
-	account.root_type = source_account.root_type
-	account.report_type = source_account.report_type
-	account.is_group = 0
-	if hasattr(source_account, "account_type"):
-		account.account_type = source_account.account_type
-	account.insert(ignore_permissions=True)
+		source_account = frappe.get_doc("Account", source_account_name)
+
+		# DEFENSIVE: parent must exist and be a group. Otherwise skip.
+		parent_account_name = source_account.parent_account
+		if not parent_account_name:
+			_safe_log(
+				f"{source_account_name} on {company} has no parent; skipping {TARGET_ACCOUNT_NUMBER}."
+			)
+			return
+
+		parent_is_group = frappe.db.get_value("Account", parent_account_name, "is_group")
+		if not parent_is_group:
+			_safe_log(
+				f"parent {parent_account_name} on {company} is a ledger not group; skipping."
+			)
+			return
+
+		account = frappe.new_doc("Account")
+		account.company = company
+		account.account_name = TARGET_ACCOUNT_NAME
+		account.account_number = TARGET_ACCOUNT_NUMBER
+		account.parent_account = parent_account_name
+		account.root_type = source_account.root_type
+		account.report_type = source_account.report_type
+		account.is_group = 0
+		if hasattr(source_account, "account_type"):
+			account.account_type = source_account.account_type
+		account.insert(ignore_permissions=True)
+	except Exception as exc:
+		_safe_log(f"{company} insert failed: {str(exc)[:80]}")
 
 
 def _ensure_accounts() -> None:
@@ -89,18 +114,25 @@ def _ensure_accounts() -> None:
 	# BKI / JV / any other subsidiary — marketing is a centralized BEI function
 	# (CEO directive 2026-04-07). Looping over all companies previously blocked
 	# every migrate when one subsidiary's source account was misconfigured.
-	if frappe.db.exists("Company", MARKETING_COMPANY):
-		_ensure_account_for_company(MARKETING_COMPANY)
-	else:
-		frappe.log_error(
-			f"ensure_marketing_giveaway_setup: Company '{MARKETING_COMPANY}' not found; "
-			"marketing giveaway GL not created. If BEI head office company was renamed, "
-			"update MARKETING_COMPANY in this patch.",
-			"Marketing Giveaway Patch Skip",
-		)
+	try:
+		if frappe.db.exists("Company", MARKETING_COMPANY):
+			_ensure_account_for_company(MARKETING_COMPANY)
+		else:
+			_safe_log(f"Company {MARKETING_COMPANY} not found; skipping.")
+	except Exception as exc:
+		_safe_log(f"_ensure_accounts top-level: {str(exc)[:80]}")
 
 
 def execute():
-	_ensure_roles()
-	_ensure_accounts()
-	frappe.clear_cache()
+	try:
+		_ensure_roles()
+	except Exception as exc:
+		_safe_log(f"_ensure_roles failed: {str(exc)[:80]}")
+	try:
+		_ensure_accounts()
+	except Exception as exc:
+		_safe_log(f"_ensure_accounts failed: {str(exc)[:80]}")
+	try:
+		frappe.clear_cache()
+	except Exception:
+		pass


### PR DESCRIPTION
## Follow-up to #491

After #491 was merged + deployed, \`bench migrate\` still crashed on the same patch with TWO new errors exposed by the defensive path:

### Bug 1 — wrong log_error argument order
Frappe v15 \`frappe.log_error()\` signature is \`log_error(title, message)\` with title FIRST. My #491 fix called it as \`log_error(long_msg, short_title)\` — so the 140-char-limited Title field received the long skip reason and raised \`CharacterLengthExceededError\`.

### Bug 2 — BEI HO's 6005000 has NULL parent_account
The skip reason in the crash log revealed the actual data state:
> source account **LOCAL AD & PROMO - Bebang Enterprise Inc.** on Bebang Enterprise Inc. has no parent_account

So on BEI HO, account \`6005000\` (\`LOCAL AD & PROMO\`) has \`parent_account = NULL\`. My #491 guard correctly tried to skip it, but crashed in the log call before returning.

## This PR

**Bulletproof hardening** — no code path in this patch can ever halt migrate:

- New \`_safe_log(message)\` helper uses keyword args (\`title=\`, \`message=\`), catches any exception, falls back to stderr. Never raises.
- \`_ensure_account_for_company()\` wrapped in top-level try/except that catches **all** exceptions, not just parent-validation.
- \`_ensure_accounts()\` and \`execute()\` also wrapped in try/except with safe-log fallback.
- All skip-reason messages now fit comfortably under 140 chars even if log_error arg order were wrong again.

## Post-merge steps (I will execute)
1. Re-run \`bench --site hq.bebang.ph migrate\` via SSM
2. Verify all 12 Custom Fields + 8 BEI Settings fields synced via \`scripts/s168_verify_live_fields.py\`
3. Run S168 seed scripts (GL accounts → VAT template → Customer Group → Customers → cost centers → BEI Settings config)
4. Dispatch \`/fact-check-bei-erp\` fleet for final verification

## Separate Finance follow-up (not blocking)
BEI HO account \`6005000 LOCAL AD & PROMO\` has \`parent_account = NULL\`. That's a data bug — Frappe COA accounts should have a parent (or be a root account). Finance should review and set the correct parent, OR delete the account if unused, OR accept the skip if the marketing giveaway sub-account isn't needed on BEI HO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)