### PR TITLE
fix(hrms): add missing 'name' field to bei_clearance_station fixture (unblocks migrate)

### DIFF
--- a/hrms/fixtures/bei_clearance_station.json
+++ b/hrms/fixtures/bei_clearance_station.json
@@ -1,74 +1,82 @@
 [
-  {
-    "doctype": "BEI Clearance Station",
-    "station_code": "IT",
-    "station_name": "IT / Devices",
-    "default_responsible_role": "System Manager",
-    "enabled": 1,
-    "sort_order": 10,
-    "description": "Laptops, mobile phones, tablets, peripherals, software accounts."
-  },
-  {
-    "doctype": "BEI Clearance Station",
-    "station_code": "POS",
-    "station_name": "POS / Cash Handling",
-    "default_responsible_role": "Store Supervisor",
-    "enabled": 1,
-    "sort_order": 20,
-    "description": "POS access, cash drawer keys, end-of-shift float reconciliation."
-  },
-  {
-    "doctype": "BEI Clearance Station",
-    "station_code": "UNIFORM",
-    "station_name": "Uniform / PPE",
-    "default_responsible_role": "HR User",
-    "enabled": 1,
-    "sort_order": 30,
-    "description": "Issued uniforms, aprons, name tags, PPE."
-  },
-  {
-    "doctype": "BEI Clearance Station",
-    "station_code": "KEYS",
-    "station_name": "Keys / Access Cards",
-    "default_responsible_role": "Store Supervisor",
-    "enabled": 1,
-    "sort_order": 40,
-    "description": "Physical keys, biometric enrollment, RFID/access cards."
-  },
-  {
-    "doctype": "BEI Clearance Station",
-    "station_code": "FINANCE",
-    "station_name": "Finance / Advances",
-    "default_responsible_role": "HQ Finance",
-    "enabled": 1,
-    "sort_order": 50,
-    "description": "Outstanding advances, petty cash float, expense liquidations."
-  },
-  {
-    "doctype": "BEI Clearance Station",
-    "station_code": "HR",
-    "station_name": "HR / 201 File",
-    "default_responsible_role": "HR Manager",
-    "enabled": 1,
-    "sort_order": 60,
-    "description": "201 file handover, exit interview, BIR/SSS/PhilHealth/Pag-IBIG forms."
-  },
-  {
-    "doctype": "BEI Clearance Station",
-    "station_code": "SECURITY",
-    "station_name": "Security / Building Access",
-    "default_responsible_role": "Store Supervisor",
-    "enabled": 1,
-    "sort_order": 70,
-    "description": "Building access, parking, visitor badge."
-  },
-  {
-    "doctype": "BEI Clearance Station",
-    "station_code": "MANAGER",
-    "station_name": "Store Manager Sign-Off",
-    "default_responsible_role": "Store Supervisor",
-    "enabled": 1,
-    "sort_order": 80,
-    "description": "Final store manager sign-off before clearance is released."
-  }
+ {
+  "doctype": "BEI Clearance Station",
+  "station_code": "IT",
+  "station_name": "IT / Devices",
+  "default_responsible_role": "System Manager",
+  "enabled": 1,
+  "sort_order": 10,
+  "description": "Laptops, mobile phones, tablets, peripherals, software accounts.",
+  "name": "IT"
+ },
+ {
+  "doctype": "BEI Clearance Station",
+  "station_code": "POS",
+  "station_name": "POS / Cash Handling",
+  "default_responsible_role": "Store Supervisor",
+  "enabled": 1,
+  "sort_order": 20,
+  "description": "POS access, cash drawer keys, end-of-shift float reconciliation.",
+  "name": "POS"
+ },
+ {
+  "doctype": "BEI Clearance Station",
+  "station_code": "UNIFORM",
+  "station_name": "Uniform / PPE",
+  "default_responsible_role": "HR User",
+  "enabled": 1,
+  "sort_order": 30,
+  "description": "Issued uniforms, aprons, name tags, PPE.",
+  "name": "UNIFORM"
+ },
+ {
+  "doctype": "BEI Clearance Station",
+  "station_code": "KEYS",
+  "station_name": "Keys / Access Cards",
+  "default_responsible_role": "Store Supervisor",
+  "enabled": 1,
+  "sort_order": 40,
+  "description": "Physical keys, biometric enrollment, RFID/access cards.",
+  "name": "KEYS"
+ },
+ {
+  "doctype": "BEI Clearance Station",
+  "station_code": "FINANCE",
+  "station_name": "Finance / Advances",
+  "default_responsible_role": "HQ Finance",
+  "enabled": 1,
+  "sort_order": 50,
+  "description": "Outstanding advances, petty cash float, expense liquidations.",
+  "name": "FINANCE"
+ },
+ {
+  "doctype": "BEI Clearance Station",
+  "station_code": "HR",
+  "station_name": "HR / 201 File",
+  "default_responsible_role": "HR Manager",
+  "enabled": 1,
+  "sort_order": 60,
+  "description": "201 file handover, exit interview, BIR/SSS/PhilHealth/Pag-IBIG forms.",
+  "name": "HR"
+ },
+ {
+  "doctype": "BEI Clearance Station",
+  "station_code": "SECURITY",
+  "station_name": "Security / Building Access",
+  "default_responsible_role": "Store Supervisor",
+  "enabled": 1,
+  "sort_order": 70,
+  "description": "Building access, parking, visitor badge.",
+  "name": "SECURITY"
+ },
+ {
+  "doctype": "BEI Clearance Station",
+  "station_code": "MANAGER",
+  "station_name": "Store Manager Sign-Off",
+  "default_responsible_role": "Store Supervisor",
+  "enabled": 1,
+  "sort_order": 80,
+  "description": "Final store manager sign-off before clearance is released.",
+  "name": "MANAGER"
+ }
 ]


### PR DESCRIPTION
## Root cause

`hrms/fixtures/bei_clearance_station.json` shipped in S170-P4 with 8 entries that ALL lack the `name` field. Frappe's fixture import flow at `frappe/modules/import_file.py:125` calls `doc["name"]` to check `db_modified_timestamp` — KeyError aborts the entire `sync_fixtures()` phase of every `bench migrate`.

```python
# frappe/modules/import_file.py:125
db_modified_timestamp = frappe.db.get_value(doc["doctype"], doc["name"], "modified")
                                                             ^^^^^^^^^^^
# KeyError: 'name'
```

## Impact

This blocked all S168 Custom Field fixture sync (12 fields across Sales Invoice, BEI Store Receiving, BEI Billing Schedule, Stock Entry, Customer). The S168 code was deployed but the DB schema couldn't keep up because every migrate attempt crashed in the fixture phase after the patches phase was unblocked by PR #491 + #494.

## Fix

`BEI Clearance Station` DocType has `autoname: field:station_code`, so the fixture `name` equals `station_code`. Added the missing `name` key to each of the 8 entries:

| name | station_name |
|------|--------------|
| IT | IT / Devices |
| POS | POS / Cash Handling |
| UNIFORM | Uniform / PPE |
| KEYS | Keys / Access Cards |
| FINANCE | Finance / Advances |
| HR | HR / 201 File |
| SECURITY | Security / Building Access |
| MANAGER | Store Manager Sign-Off |

Content otherwise unchanged. Fixture remains idempotent.

## Why S170 didn't hit this

S170-P4 probably installed the clearance DocType via `bench install-app` or direct doc creation, bypassing the fixture sync path. The fixture file was committed for future fresh-site installs but never actually re-synced via `bench migrate` — until today.

## Post-merge

I will re-run `bench migrate`, verify all 12 Custom Fields + 8 BEI Settings BKI fields synced, then proceed with the S168 seed scripts and fact-check fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)