### PR TITLE
S172 P1-P3: compensation chain + OT apply RBAC fixes

### DIFF
--- a/hrms/api/payroll_compensation.py
+++ b/hrms/api/payroll_compensation.py
@@ -386,11 +386,15 @@ def get_employee_compensation_detail(employee):
 		as_dict=True,
 	)
 	if ssa:
+		result["has_ssa"] = True
 		result["base_salary"] = float(ssa[0].base or 0)
 		result["salary_structure"] = ssa[0].salary_structure
 		result["tax_slab"] = ssa[0].income_tax_slab
 		result["ssa_from_date"] = str(ssa[0].from_date) if ssa[0].from_date else None
 	else:
+		# S172 Defect #21 fix: return stub so frontend Edit button can enable
+		# and HR can set up the first salary for employees without SSA.
+		result["has_ssa"] = False
 		result["base_salary"] = 0
 		result["salary_structure"] = None
 		result["tax_slab"] = None

--- a/hrms/api/payroll_compensation.py
+++ b/hrms/api/payroll_compensation.py
@@ -628,19 +628,30 @@ def approve_compensation_change(change_id, approver_action, remarks=None):
 	elif doc.status == "Pending Accounts Manager":
 		if "Accounts Manager" not in roles and "System Manager" not in roles:
 			frappe.throw(_("Only Accounts Manager can approve at this stage"))
-		doc.status = "Approved"
-		doc.final_approver = frappe.session.user
-		doc.approval_date = now_datetime()
-		doc.save(ignore_permissions=True)
 
-		# Activate the approved change
+		# S172 Defect #16 fix: wrap status-change + activation in ONE savepoint so
+		# that activation failure reverts the Approved status instead of silently
+		# stranding the BCC with status=Approved but no SSA created.
 		try:
 			frappe.db.savepoint("compensation_activation")
+			doc.status = "Approved"
+			doc.final_approver = frappe.session.user
+			doc.approval_date = now_datetime()
+			doc.save(ignore_permissions=True)
 			_activate_compensation_change(doc)
 			frappe.db.release_savepoint("compensation_activation")
-		except Exception:
+		except Exception as e:
 			frappe.db.rollback_to_savepoint("compensation_activation")
-			frappe.log_error("Compensation activation failed")
+			frappe.log_error(
+				message=frappe.get_traceback(),
+				title=f"S172: Compensation activation failed for {doc.name}",
+			)
+			# Propagate the real error to the caller so the frontend can show it
+			# and HR knows to fix the underlying issue (e.g., missing salary structure).
+			frappe.throw(
+				_("Compensation activation failed: {0}. Change not applied.").format(str(e)),
+				title=_("Activation Failed"),
+			)
 
 		return {"status": "success", "message": _("Compensation change approved")}
 
@@ -1060,13 +1071,20 @@ def _activate_compensation_change(doc):
 
 	Called at final approval (Approved status). Handles:
 	- bei_* fields: direct Employee field update
-	- Salary changes: create new SSA
+	- Salary changes: create new SSA (with fallback to default structure for new hires)
 	- Other Salary Detail components: extend when needed
+
+	S172 Defect #16 fix: when the employee has no prior SSA (new hire), fall back
+	to the first active salary structure instead of silently skipping. If no
+	active salary structure exists at all, raise a clear error so the caller
+	can surface it (previously: silent corrupt-success).
 	"""
 	if doc.employee_field_name and doc.employee_field_name.startswith("bei_"):
 		# Direct Employee field (bei_* allowances)
 		frappe.db.set_value("Employee", doc.employee, doc.employee_field_name, flt(doc.new_value))
-	elif doc.change_type == "Salary":
+		return
+
+	if doc.change_type == "Salary":
 		# New SSA required — NOT set_value on Employee
 		latest_ssa = frappe.db.get_value(
 			"Salary Structure Assignment",
@@ -1075,18 +1093,46 @@ def _activate_compensation_change(doc):
 			order_by="from_date DESC",
 			as_dict=True,
 		)
+
 		if latest_ssa:
-			new_ssa = frappe.get_doc({
-				"doctype": "Salary Structure Assignment",
-				"employee": doc.employee,
-				"salary_structure": latest_ssa.salary_structure,
-				"income_tax_slab": latest_ssa.income_tax_slab,
-				"base": flt(doc.new_value),
-				"from_date": doc.effective_date,
-				"company": frappe.db.get_value("Employee", doc.employee, "company"),
-			})
-			new_ssa.insert(ignore_permissions=True)
-			new_ssa.submit()
+			salary_structure = latest_ssa.salary_structure
+			income_tax_slab = latest_ssa.income_tax_slab
+		else:
+			# S172 Defect #16: no prior SSA — fall back to first active structure.
+			fallback = frappe.db.get_value(
+				"Salary Structure",
+				{"docstatus": 1, "is_active": "Yes"},
+				["name"],
+				order_by="creation ASC",
+			)
+			if not fallback:
+				frappe.throw(
+					_(
+						"Cannot activate salary change for {0}: no existing Salary "
+						"Structure Assignment and no active Salary Structure available "
+						"as a template. Please create an active Salary Structure first."
+					).format(doc.employee)
+				)
+			salary_structure = fallback
+			# Look up any active tax slab for the company.
+			income_tax_slab = frappe.db.get_value(
+				"Income Tax Slab",
+				{"disabled": 0},
+				"name",
+				order_by="effective_from DESC",
+			)
+
+		new_ssa = frappe.get_doc({
+			"doctype": "Salary Structure Assignment",
+			"employee": doc.employee,
+			"salary_structure": salary_structure,
+			"income_tax_slab": income_tax_slab,
+			"base": flt(doc.new_value),
+			"from_date": doc.effective_date,
+			"company": frappe.db.get_value("Employee", doc.employee, "company"),
+		})
+		new_ssa.insert(ignore_permissions=True)
+		new_ssa.submit()
 
 
 def _get_current_cutoff_start():

--- a/output/s172/diagnostics/DEFECT_19_DIAGNOSIS.md
+++ b/output/s172/diagnostics/DEFECT_19_DIAGNOSIS.md
@@ -1,0 +1,37 @@
+# Defect #19 Diagnosis — `/dashboard/hr/overtime/apply` test.crew1 Access Restricted
+
+## Source trace
+
+| File | Line | Finding |
+|---|---|---|
+| `bei-tasks/app/dashboard/hr/overtime/apply/page.tsx` | 237-254 | Wraps `ApplyOvertimeForm` in `<RoleGuard roles={[EMPLOYEE, STORE_STAFF, STORE_SUPERVISOR, AREA_SUPERVISOR, HR_USER, HR_MANAGER, HQ_FINANCE, SYSTEM_MANAGER, ADMINISTRATOR]}>` |
+| `bei-tasks/components/layout/role-guard.tsx` | 88-131 | `RoleGuard` calls `hasRole(userRoles, requiredRoles)` — fails-closed when user has zero matching roles |
+| `bei-tasks/lib/roles.ts` | 986-988 | `hasRole` = `userRoles.some((role) => requiredRoles.includes(role))` — pure string includes |
+| `bei-tasks/lib/roles.ts` | 16-59 | `ROLES` enum does NOT contain any "Crew" or "BEI Crew" entry |
+
+## Root cause
+
+`test.crew1@bebang.ph`'s actual Frappe role set is not in the RoleGuard allowlist. Two possible root causes:
+
+1. **test.crew1 has a Frappe role like "BEI Crew" or "Crew"** — not in the `ROLES` enum, so `hasRole` returns false.
+2. **test.crew1 has only `"Employee"` role** — but the RoleGuard already includes `ROLES.EMPLOYEE = "Employee"`, so this case should already pass.
+
+Without production query access from this session, the most likely cause is #1: the user has a role string that doesn't match any of the 9 allowed strings.
+
+## Fix rationale
+
+`/dashboard/hr/overtime/apply` is a self-service OT filing page — by design, every employee who can log into my.bebang.ph should be able to file OT for themselves. There is no business reason to restrict this page by role; the dashboard layout already requires authentication, and the backend `overtime_request.py` validates the employee identity server-side.
+
+The correct fix is to remove the RoleGuard wrapper entirely. The page is gated by auth middleware (dashboard layout), and the OT apply form operates on `frappe.session.user`'s own employee record — there is no way for an unauthorized user to file OT on behalf of someone else.
+
+## Alternatives considered
+
+| Option | Why rejected |
+|---|---|
+| Add "Crew" to `ROLES` enum + add to RoleGuard allowlist | Would fix test.crew1 but leaves ANY other unenumerated role (e.g., "BEI Driver", "Commissary Staff") broken. Not structurally correct for a self-service page. |
+| Build dynamic role list from Employee doctype | Over-engineered for a self-service page. |
+| Keep RoleGuard but pass no `roles` prop | When `requiredRoles` is empty, `RoleGuard` returns `hasAccess = true` (line 112) — equivalent to removing the wrapper but less explicit. |
+
+## Fix applied
+
+Removed the `<RoleGuard>` wrapper from `ApplyOvertimePage` export. The page is now accessible to any authenticated my.bebang.ph user, and the backend validates the actual Employee → User binding on submit.

--- a/scripts/s172_backfill_stranded_bccs.py
+++ b/scripts/s172_backfill_stranded_bccs.py
@@ -1,0 +1,113 @@
+"""
+S172 Phase 2 Task 2.3 — Backfill SSAs for BCCs that reached Approved without
+creating an SSA (caused by Defect #16 silent activation failure).
+
+Context:
+  Prior to S172, `process_compensation_approval` had a bare `except Exception:`
+  that swallowed activation failures, and `_activate_compensation_change` had
+  an `if latest_ssa:` guard that silently skipped SSA creation for employees
+  with no prior SSA. Net effect: BCCs for new hires reached status=Approved
+  but no Salary Structure Assignment was ever created.
+
+How to find stranded rows:
+  SELECT bcc.name, bcc.employee, bcc.new_value, bcc.effective_date
+  FROM `tabBEI Compensation Change` bcc
+  LEFT JOIN `tabSalary Structure Assignment` ssa
+    ON ssa.employee = bcc.employee
+    AND ssa.docstatus = 1
+    AND ssa.from_date = bcc.effective_date
+  WHERE bcc.status = 'Approved'
+    AND bcc.change_type = 'Salary'
+    AND ssa.name IS NULL;
+
+Run via SSM following the /frappe-bulk-edits pattern:
+  1. Encode this file to base64
+  2. docker exec into the frappe-prod-1 container
+  3. Decode + run via `bench --site hq.bebang.ph execute /tmp/s172_backfill.py`
+
+Or via bench directly in a dev environment:
+  bench --site <site> execute scripts.s172_backfill_stranded_bccs.main
+"""
+
+import csv
+import sys
+
+import frappe
+
+from hrms.api.payroll_compensation import _activate_compensation_change
+
+
+OUTPUT_CSV = "/tmp/s172_backfill_results.csv"
+
+
+def find_stranded_bccs():
+	"""Return BCCs where status=Approved but no matching SSA exists."""
+	return frappe.db.sql(
+		"""
+		SELECT bcc.name, bcc.employee, bcc.change_type, bcc.employee_field_name,
+		       bcc.new_value, bcc.effective_date
+		FROM `tabBEI Compensation Change` bcc
+		LEFT JOIN `tabSalary Structure Assignment` ssa
+		  ON ssa.employee = bcc.employee
+		 AND ssa.docstatus = 1
+		 AND ssa.from_date = bcc.effective_date
+		WHERE bcc.status = 'Approved'
+		  AND bcc.change_type = 'Salary'
+		  AND ssa.name IS NULL
+		ORDER BY bcc.approval_date ASC
+		""",
+		as_dict=True,
+	)
+
+
+def main():
+	stranded = find_stranded_bccs()
+	print(f"[S172] Found {len(stranded)} stranded BCC rows")
+
+	results = []
+	fixed = 0
+	failed = 0
+
+	for row in stranded:
+		bcc_name = row["name"]
+		employee = row["employee"]
+		try:
+			doc = frappe.get_doc("BEI Compensation Change", bcc_name)
+			frappe.db.savepoint(f"s172_backfill_{bcc_name}")
+			_activate_compensation_change(doc)
+			frappe.db.release_savepoint(f"s172_backfill_{bcc_name}")
+			frappe.db.commit()
+			results.append({
+				"bcc": bcc_name,
+				"employee": employee,
+				"new_value": row["new_value"],
+				"status": "FIXED",
+				"error": "",
+			})
+			fixed += 1
+			print(f"  [OK]  {bcc_name} / {employee} / base={row['new_value']}")
+		except Exception as e:  # noqa: BLE001 - backfill tool needs the context
+			frappe.db.rollback_to_savepoint(f"s172_backfill_{bcc_name}")
+			results.append({
+				"bcc": bcc_name,
+				"employee": employee,
+				"new_value": row["new_value"],
+				"status": "FAILED",
+				"error": str(e)[:300],
+			})
+			failed += 1
+			print(f"  [ERR] {bcc_name} / {employee}: {e}")
+
+	# Write audit trail
+	with open(OUTPUT_CSV, "w", encoding="utf-8", newline="") as f:
+		writer = csv.DictWriter(f, fieldnames=["bcc", "employee", "new_value", "status", "error"])
+		writer.writeheader()
+		writer.writerows(results)
+
+	print(f"\n[S172] Backfill complete: fixed={fixed} failed={failed} total={len(stranded)}")
+	print(f"[S172] Audit CSV: {OUTPUT_CSV}")
+	return {"fixed": fixed, "failed": failed, "total": len(stranded), "csv": OUTPUT_CSV}
+
+
+if __name__ == "__main__":
+	sys.exit(0 if main()["failed"] == 0 else 1)


### PR DESCRIPTION
## S172 Phases 1-3 slice

This PR delivers **4 of 15 defects** from the S172 plan: the compensation chain (#6, #21, #16) + OT self-service RBAC (#19). Phases 4-7 (defects #5, #8, #9, #11, #13, #14, #15, #18, #20) are deferred to a fresh session to prevent post-compaction drift on a 70-unit sprint.

## Defects fixed

### Defect #21 + #6 — Compensation Edit chicken-and-egg (CRITICAL)
- **Problem:** Edit button on \`/dashboard/hr/payroll/compensation-setup/[employee]\` was permanently disabled when employee had no Salary Structure Assignment. HR couldn't set up the first salary. Same path also caused the list-page modal to show only Bio ID (R3 fabrication caught by 2026-04-08 audit).
- **Fix:** \`get_employee_compensation_detail\` now always returns a stub with \`has_ssa: false\` when no SSA exists. Paired frontend PR gates Edit on \`isLoading\` instead of \`!detail\`.
- **Files:** \`hrms/api/payroll_compensation.py\` (backend) + bei-tasks companion PR (frontend)

### Defect #16 — \`_activate_compensation_change\` silent failure (HIGH)
- **Problem:** Two compounding bugs silently stranded BCCs at status=Approved without creating an SSA:
  1. Caller had a bare \`except Exception:\` that returned \`{\"status\":\"success\"}\` even on activation failure
  2. Helper had \`if latest_ssa:\` which silently skipped SSA creation for employees with no prior SSA (all new hires)
- **Fix:**
  - Caller now wraps status change + save + activation in ONE savepoint. On failure: rollback, log full traceback, propagate via \`frappe.throw\` so the frontend surfaces the real error.
  - Helper now falls back to the first active Salary Structure as a template when no prior SSA exists. If no active structure exists either, raises a clear actionable error.
  - New \`scripts/s172_backfill_stranded_bccs.py\` finds and re-activates already-stranded BCCs, writing audit CSV.

## Paired frontend PR
\`Bebang-Enterprise-Inc/BEI-Tasks\` branch \`s172-s166-followup-defect-fixes\`:
- \`components/hr/compensation-detail-panel.tsx\` — Edit button \`disabled={isLoading}\`
- \`app/dashboard/hr/payroll/compensation-setup/[employee]/page.tsx\` — list-page dialog Edit button \`disabled={isLoading}\`
- \`app/dashboard/hr/overtime/apply/page.tsx\` — removed overly-restrictive \`RoleGuard\` wrapper (Defect #19)

## Deferred to fresh session

Defects **#5, #8, #9, #11, #13, #14, #15, #18, #20** (Phases 4-7) are NOT in this PR. Context budget after compaction + 5000-line skill sidebar injections made a full 70-unit single-session execution high-risk for drift. Remaining work is well-scoped in the plan; a fresh agent can pick up cleanly from phase 4.

**Known debt (not addressed by S172 at all):** The 86-row S166 browser-proof test debt ledger lives in S173/S174 per \`docs/plans/2026-04-08-sprint-173-s166-retest-debt-ledger.md\`.

## Checklist
- [x] Phase 1: Defect #6 + #21 backend + frontend
- [x] Phase 2: Defect #16 silent-failure fix + backfill script
- [x] Phase 3: Defect #19 RoleGuard removal + diagnosis doc
- [ ] Phase 4: Defect #18 (doctype Warehouse→Branch)
- [ ] Phase 5: Defect #8 (create_employee_direct cached id)
- [ ] Phase 6: Defect #13 (emergency_phone_number drop)
- [ ] Phase 7: Defects #5 #9 #11 #14 #15 #20 bundle
- [ ] Phase 8: L3 retest (gated on this PR deploying first)
- [ ] Phase 9: Closeout (after Phase 4-8)

## Plan reference
\`docs/plans/2026-04-08-sprint-172-s166-followup-defect-fixes.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)