### PR TITLE
S172 P4-P6: Defects #18 (Incident Report) + #8 (employee_id stale) + #13 (emergency_phone)

### DIFF
--- a/hrms/api/disciplinary.py
+++ b/hrms/api/disciplinary.py
@@ -15,6 +15,7 @@ from hrms.utils.api_helpers import (
     _check_manager_permission,
     _paginate,
 )
+from hrms.utils.sentry import set_backend_observability_context
 
 
 @frappe.whitelist()
@@ -31,6 +32,12 @@ def create_incident_report(data):
 
     Access: Supervisor
     """
+    set_backend_observability_context(
+        module="hr",
+        action="create_incident_report",
+        mutation_type="create",
+    )
+
     import json
 
     if isinstance(data, str):
@@ -50,12 +57,17 @@ def create_incident_report(data):
     if not is_hr:
         _check_manager_permission(data["employee"])
 
+    # S172 Defect #18 fix: `store` is a Link to Branch (was incorrectly Link to
+    # Warehouse). If the caller didn't send a store/branch, default to the
+    # employee's current branch so the IR is always tagged to the right store.
+    store_value = data.get("store") or frappe.db.get_value("Employee", data["employee"], "branch")
+
     # Create incident report
     ir = frappe.get_doc({
         "doctype": "BEI Incident Report",
         "employee": data["employee"],
         "reported_by": current_employee,
-        "store": data.get("store"),
+        "store": store_value,
         "incident_date": getdate(data["incident_date"]),
         "incident_category": data["incident_category"],
         "description": data["description"],

--- a/hrms/api/employee_create.py
+++ b/hrms/api/employee_create.py
@@ -242,10 +242,14 @@ def create_employee_direct(
 			message=get_traceback(),
 		)
 
+	# S172 Defect #8 fix: include both the BEI business ID (employee_id) and
+	# the Frappe primary key (name = HR-EMP-NNNNN) so callers can look up the
+	# record by either identifier without a separate query.
 	return {
 		"success": True,
 		"data": {
 			"employee_id": employee_id,
+			"name": employee_doc.name,
 			"employee_name": employee_name,
 			"bio_id": bio_id,
 			"adms_enrollment": adms_result,

--- a/hrms/hr/doctype/bei_incident_report/bei_incident_report.json
+++ b/hrms/hr/doctype/bei_incident_report/bei_incident_report.json
@@ -68,7 +68,7 @@
    "fieldname": "store",
    "fieldtype": "Link",
    "label": "Store",
-   "options": "Warehouse"
+   "options": "Branch"
   },
   {
    "fieldname": "incident_date",

--- a/hrms/utils/employee_id.py
+++ b/hrms/utils/employee_id.py
@@ -17,20 +17,29 @@ def generate_bei_employee_id() -> str:
 	Uses a SELECT ... FOR UPDATE lock to prevent concurrent collision.
 	Must be called inside a transaction (Frappe's default request context
 	provides one).
+
+	S172 Defect #8 fix: query the `employee` field, not `name`. When Employee
+	records are inserted via the ORM (`create_employee_direct`), Frappe's
+	autoname generates `name` as HR-EMP-NNNNN per the naming_series rule,
+	not as BEI-EMP-YYYY-NNNNN. The previous `SELECT name WHERE name LIKE
+	'BEI-EMP-YYYY-%'` therefore returned the same stale maximum forever
+	(cached at BEI-EMP-2026-00004 in prod), causing every call to return
+	the same employee_id. Querying the `employee` field tracks the BEI
+	sequence independently of however Frappe chooses to name the record.
 	"""
 	year = frappe.utils.nowdate()[:4]
 	last_emp = frappe.db.sql(
 		"""
-        SELECT name FROM tabEmployee
-        WHERE name LIKE %s
-        ORDER BY name DESC LIMIT 1 FOR UPDATE
+        SELECT employee FROM tabEmployee
+        WHERE employee LIKE %s
+        ORDER BY employee DESC LIMIT 1 FOR UPDATE
     """,
 		(f"BEI-EMP-{year}-%",),
 		as_dict=True,
 	)
 
 	if last_emp:
-		last_num = int(last_emp[0]["name"].split("-")[-1])
+		last_num = int(last_emp[0]["employee"].split("-")[-1])
 		new_num = last_num + 1
 	else:
 		new_num = 1

--- a/output/s172/diagnostics/DEFECT_18_DECISION.md
+++ b/output/s172/diagnostics/DEFECT_18_DECISION.md
@@ -1,0 +1,50 @@
+# Defect #18 — Decision: Option A (change field options to Branch)
+
+## Reference inventory
+
+### Backend (`hrms/`)
+- `hrms/api/disciplinary.py:58` — `"store": data.get("store")` in `create_incident_report` — reads from request payload
+- `hrms/api/disciplinary.py:226` — `"store": ir.store` in `get_incident_detail` return — passes through
+- `hrms/hr/doctype/bei_incident_report/bei_incident_report.json` — field `store: Link Warehouse, reqd: 0`
+- `hrms/utils/brain_sync.py` — uses the DocType name only, no `.store` field access
+- `hrms/hooks.py` — DocType registration only
+
+### Frontend (`bei-tasks/`)
+- `lib/queries/hr-disciplinary.ts:12-26` — `interface IncidentReport` has `branch?: string`, **no `store` field**
+- `lib/queries/hr-disciplinary.ts:179-187` — `useCreateIncidentReport` mutation signature does NOT send `store` or `branch`
+- `app/dashboard/hr/disciplinary/[id]/page.tsx:221` — reads `caseDetail.branch` (not `store`)
+
+### Reports / queries / joins
+**None.** No SQL query in the codebase JOINs `tabBEI Incident Report.store` to `tabWarehouse` or `tabBranch`. No filter uses `store=` as a Warehouse reference.
+
+## Why Option A is correct
+
+1. **Only one consumer writes the field** — `create_incident_report`, via `data.get("store")`. If we change the field options from Warehouse to Branch, any value the caller sends will validate against `tabBranch` instead.
+2. **No data migration needed** — the field is `reqd: 0`, the frontend has never sent it, and in production the column is likely all NULL. Changing Link target does not corrupt existing NULL values.
+3. **Field name stays `store`** — no rename migration, no fixture updates, no dashboards break.
+4. **Frontend already thinks in Branch** — the `IncidentReport` interface has `branch?: string`, not `store`. Changing the Link target to Branch aligns backend with frontend semantics.
+
+## Why Option B is wrong for this case
+
+Renaming `store` → `warehouse` would:
+- Require a doctype rename migration (risky on an active DocType)
+- Break any existing backups/exports that reference `store`
+- Not match the actual user-facing concept (HR thinks in terms of the employee's store/branch, not a Warehouse inventory location)
+- Still require the same backend payload fix
+
+## The fix
+
+1. Change `bei_incident_report.json` field `store.options` from `"Warehouse"` to `"Branch"`
+2. In `create_incident_report`, if `data.get("store")` is empty, default to the employee's current branch (so the IR is tagged even when the frontend doesn't send the field explicitly)
+3. Add `set_backend_observability_context` per DM-7
+
+## Risk assessment
+
+- **Data loss risk:** none (column is nullable and currently unused for real Warehouse links)
+- **API break risk:** none (the field is optional and no existing caller sends a valid Warehouse name anyway — that's the bug)
+- **UI break risk:** none (frontend doesn't display `store`, it displays `branch` from elsewhere)
+- **Migration risk:** low — `bench migrate` applies the schema change; existing NULLs stay NULL; new inserts validate against Branch
+
+## Note on incident_type vs incident_category mismatch (out of scope for S172)
+
+Observed during inventory but NOT part of Defect #18: the frontend `useCreateIncidentReport` mutation sends `incident_type`, but the backend `create_incident_report` requires `incident_category`. This is a separate bug that would also block the create path — flagging for a follow-up sprint. Not fixing in S172 since it's not in the canonical defect list.


### PR DESCRIPTION
## S172 Phases 4-6 slice

Continuation of S172 after PR #507/#362/#363/#364 merged and deployed. Fixes 3 more defects from the plan. Phase 7 (defects #5, #9, #11, #14, #15, #20 — 6 smaller items bundled) deferred to a fresh session.

## Defects fixed

### Defect #18 [HIGH] — BEI Incident Report.store Link Warehouse → Branch
- **Problem:** \`tabBEI Incident Report.store\` was \`Link Warehouse\`; the disciplinary workflow semantically expects a Branch reference. Creating an IR with a Branch name like \"ARANETA GATEWAY\" threw LinkValidationError. Blocked all 4 EMP-DISCIPLINARY-001..004 scenarios.
- **Fix (Option A, reference inventory in \`output/s172/diagnostics/DEFECT_18_DECISION.md\`):**
  - \`bei_incident_report.json\`: change field \`store.options\` from \`Warehouse\` to \`Branch\`
  - \`disciplinary.py::create_incident_report\`: default \`store_value\` to employee's \`branch\` when caller omits it, so every IR is tagged regardless of whether the frontend sends the field
  - Sentry observability context added per DM-7
- **Why Option A:** No reports/joins use \`tabBEI Incident Report.store\` as a Warehouse link. Field is nullable and historically unused for Warehouse references. Field name stays \`store\`, no rename migration.

### Defect #8 [HIGH] — \`create_employee_direct\` returning stale employee_id
- **Problem:** \`create_employee_direct\` returned the same \`employee_id=BEI-EMP-2026-00004\` for every call (Lane B + Lane C audit confirmed across 9001891/92/93/94/95). bio_id incremented correctly; employee_id did not.
- **Root cause:** \`generate_bei_employee_id()\` in \`hrms/utils/employee_id.py\` queried \`SELECT name FROM tabEmployee WHERE name LIKE 'BEI-EMP-YYYY-%'\`. But when \`create_employee_direct\` inserts via the ORM, Frappe's Employee autoname generates \`name\` as HR-EMP-NNNNN (naming_series), not as BEI-EMP-YYYY-NNNNN. The \`employee\` field gets the BEI value; \`name\` does not. The LIKE query against \`name\` therefore returned the same stale historical maximum forever.
- **Fix:** query the \`employee\` field instead of \`name\`. Also include the Frappe primary key (\`name\` = HR-EMP-NNNNN) in the response dict so callers can look up the record by either identifier without a separate query.

### Defect #13 [MEDIUM] — \`emergency_phone_number\` silently dropped on Employee save (companion PR on BEI-Tasks)
- **Problem:** EmployeeDetailDialog Personal section save submitted \`person_to_be_contacted\`, \`relation\`, \`emergency_phone_number\` together. First two saved; third returned \`null\` on post-save GET. Lane A2 + audit verified.
- **Root cause:** \`useUpdateEmployeeField\` called \`frappe.client.set_value\` directly, triggering the full Employee \`.save()\` validator chain. Something in that chain silently drops \`emergency_phone_number\` (our backend contact validator accepts the value, so the drop is inside the Employee doc's internal save path, not in BEI validators).
- **Fix (frontend-only, in PR Bebang-Enterprise-Inc/BEI-Tasks):** route SELF_SERVICE_FIELDS through the dedicated \`hrms.api.enrichment.update_self_service_field\` endpoint, which uses \`frappe.db.set_value\` for a direct SQL write, bypassing the validator chain entirely. Other fields still use \`frappe.client.set_value\` for HR-only edits.
- **Security bonus:** self-service fields now route through a whitelisted endpoint with explicit field-level permission checks instead of the generic set_value.

## Paired frontend PR
\`Bebang-Enterprise-Inc/BEI-Tasks\` branch \`s172-phase4-s166-remaining-defects\` — Defect #13 frontend fix.

## Deferred to a fresh session (Phase 7)
Defects **#5** (Generate Slips disabled), **#9** (test.hr proxy 403), **#11** (soft-delete order), **#14** (Reports To autocomplete), **#15** (first-of-session BSCR rollback), **#20** (OT requires attendance — doc update only). All are smaller scope; bundling them into a single Phase 7 PR is clean follow-up work.

## Checklist
- [x] Phase 1: Defects #6 + #21 (previous PR #507)
- [x] Phase 2: Defect #16 (previous PR #507)
- [x] Phase 3: Defect #19 (previous PR #507)
- [x] Phase 4: Defect #18 (this PR)
- [x] Phase 5: Defect #8 (this PR)
- [x] Phase 6: Defect #13 (companion PR)
- [ ] Phase 7: Defects #5 #9 #11 #14 #15 #20 bundle
- [ ] Phase 8: L3 retest (gated on all PRs deploying first)
- [ ] Phase 9: Closeout

## Plan reference
\`docs/plans/2026-04-08-sprint-172-s166-followup-defect-fixes.md\`

## Note (out of scope, flagged for follow-up)
During Defect #18 inventory I noticed the frontend \`useCreateIncidentReport\` mutation sends \`incident_type\` but the backend \`create_incident_report\` requires \`incident_category\`. This is a separate bug that would also block the create path — not fixing in S172 since it's not in the canonical defect list. See \`output/s172/diagnostics/DEFECT_18_DECISION.md\` last section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)