### PR TITLE
fix(pcf): resolve AI classifier naked COA codes to full Account names (DEFECT-009)

### DIFF
--- a/hrms/api/pcf.py
+++ b/hrms/api/pcf.py
@@ -1027,6 +1027,31 @@ def _get_replenishment_source_account(company: str):
 # ============================================================
 
 
+def _resolve_coa_code_to_account(code: str, company: str) -> str | None:
+    """
+    DEFECT-009 fix: Map a naked GL code (e.g. "6010100") to a full Account
+    DocType name (e.g. "6010100 - Representation & Entertainment - BEI") for
+    the given company. Returns None if no match.
+
+    The classifier returns naked codes from Liezel's training data; the
+    batch approve flow validates against tabAccount link, which fails on
+    a bare code. Resolve once at classify-time so approve always succeeds.
+    """
+    if not code or not company:
+        return None
+    # Prefer non-group leaf accounts whose name starts with the code + " - "
+    rows = frappe.db.sql(
+        """
+        SELECT name FROM `tabAccount`
+        WHERE company=%s AND is_group=0 AND name LIKE %s
+        ORDER BY name LIMIT 1
+        """,
+        (company, f"{code} - %"),
+        as_dict=False,
+    )
+    return rows[0][0] if rows else None
+
+
 @frappe.whitelist()
 def classify_batch_items(batch_name: str):
     """
@@ -1039,6 +1064,14 @@ def classify_batch_items(batch_name: str):
     Returns:
         Classification results per item
     """
+    from hrms.utils.sentry import set_backend_observability_context
+    set_backend_observability_context(
+        module="pcf",
+        action="classify_batch_items",
+        mutation_type="update",
+        extras={"batch_name": batch_name},
+    )
+
     batch = frappe.get_doc("BEI PCF Batch", batch_name)
     from hrms.api.expense_classifier import classify_expense, COA_LABELS
 
@@ -1051,9 +1084,19 @@ def classify_batch_items(batch_name: str):
                 amount=flt(item.amount),
             )
 
-            suggested_coa = classification.get("coa")
-            suggested_label = COA_LABELS.get(suggested_coa, "") if suggested_coa else ""
+            suggested_code = classification.get("coa")
+            suggested_label = COA_LABELS.get(suggested_code, "") if suggested_code else ""
             confidence = flt(classification.get("confidence", 0))
+
+            # DEFECT-009: classifier returns naked GL codes like "6010100";
+            # resolve to the full Account DocType name so later approve
+            # calls don't hit LinkValidationError. Store the resolved name
+            # in suggested_coa (Link field), and keep the raw code on the
+            # label for diagnostics if resolution fails.
+            suggested_coa = _resolve_coa_code_to_account(suggested_code, batch.company) if suggested_code else None
+            if suggested_code and not suggested_coa:
+                # Lookup failed - leave suggested_coa empty, surface via label
+                suggested_label = f"{suggested_label} (unresolved: {suggested_code})" if suggested_label else f"Unresolved: {suggested_code}"
 
             # Update batch item
             frappe.db.set_value(


### PR DESCRIPTION
## Summary
Fixes S167 **DEFECT-009**: `classify_batch_items` in \`hrms/api/pcf.py\` was storing naked GL codes (e.g. \`6010100\`) in \`tabBEI PCF Batch Item.suggested_coa\`, which is a **Link field** to \`tabAccount\`. The actual Account name is \`"6010100 - Representation & Entertainment - BEI"\` — so the subsequent \`approve_batch_with_coa\` call always failed with LinkValidationError on items classified to Representation & Entertainment.

This was the blocker for Phase 3.2b in S167 REDO; the workaround was SSM-clearing \`suggested_coa\` before every approve attempt. This PR fixes it properly.

## Fix
- New helper \`_resolve_coa_code_to_account(code, company)\` — does a \`LIKE "{code} - %"\` lookup against \`tabAccount\` filtered by company + \`is_group=0\`, returning the full leaf Account name.
- Called once per item in \`classify_batch_items\` before \`db.set_value\`. If the lookup fails (e.g. code not in the target company's CoA), \`suggested_coa\` is left empty and the unresolved code is surfaced in \`suggested_coa_label\` for visibility.
- Adds \`set_backend_observability_context()\` per core governance rule (`.claude/rules/sentry-observability.md`).

## Test plan
- [ ] Deploy + rerun S167 Phase 3 flow on a fresh HR batch: click "Run AI Classification" → verify \`tabBEI PCF Batch Item.suggested_coa\` contains a full Account name (not a 7-digit code) → click "Approve with COA" and confirm 200 OK without LinkValidationError.
- [ ] Fallback path: classify a description that maps to a code not in the company's CoA → verify \`suggested_coa\` is empty and \`suggested_coa_label\` contains the unresolved-code marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)