### PR TITLE
fix(pcf): flatten create_pcf_fund response so normalizer sees data (DEFECT-017)

### DIFF
--- a/hrms/api/pcf.py
+++ b/hrms/api/pcf.py
@@ -1287,17 +1287,25 @@ def create_pcf_fund(
     pcf.insert(ignore_permissions=True)
     frappe.db.commit()
 
+    # DEFECT-017: flatten fund fields at the top level so the frontend
+    # normalizer (which reads message.name / message.fund_type) sees real
+    # values. The nested `pcf` block is retained for any older consumers.
+    payload = {
+        "name": pcf.name,
+        "fund_type": pcf.fund_type,
+        "fund_label": pcf.fund_label,
+        "store": pcf.store,
+        "department": pcf.department,
+        "fund_amount": pcf.fund_amount,
+        "threshold_percentage": pcf.threshold_percentage,
+        "custodian": pcf.custodian,
+        "is_enabled": pcf.is_enabled,
+    }
     return {
         "success": True,
         "message": f"PCF fund created: {pcf.fund_label}",
-        "pcf": {
-            "name": pcf.name,
-            "fund_type": pcf.fund_type,
-            "fund_label": pcf.fund_label,
-            "store": pcf.store,
-            "department": pcf.department,
-            "fund_amount": pcf.fund_amount,
-        },
+        "pcf": payload,
+        **payload,
     }
 
 


### PR DESCRIPTION
## Summary
Fixes S167 **DEFECT-017**: \`create_pcf_fund()\` returned fund data nested under \`message.pcf.{name,fund_type,...}\`, but the bei-tasks frontend normalizer reads \`message.name\` / \`message.fund_type\`. The fund WAS created on the backend but the UI saw an empty \`{name:"",fund_type:""}\` payload and rendered a confusing "no data" state.

## Fix
Returns fund fields at **both** the top level (flat) and the nested \`pcf\` block (retained for any older consumers already reading the nested path). Also includes \`threshold_percentage\`, \`custodian\`, \`is_enabled\` so the UI has everything it needs in a single call, avoiding a follow-up fetch.

## Test plan
- [ ] Deploy backend → open PCF admin as sam → click "Create Department Fund" → pick a dept → Save → verify the modal closes and the new fund card immediately shows the right label/amount without a blank "created but no data" state.
- [ ] Verify the fund is also returned correctly in the nested path for any old clients: response should be \`{success:true, pcf:{name,...}, name, fund_type, ...}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)