### PR TITLE
fix(pcf): resolve COA codes via account_number column (DEFECT-009 follow-up)

### DIFF
--- a/hrms/api/pcf.py
+++ b/hrms/api/pcf.py
@@ -1030,20 +1030,41 @@ def _get_replenishment_source_account(company: str):
 def _resolve_coa_code_to_account(code: str, company: str) -> str | None:
     """
     DEFECT-009 fix: Map a naked GL code (e.g. "6010100") to a full Account
-    DocType name (e.g. "6010100 - Representation & Entertainment - BEI") for
-    the given company. Returns None if no match.
+    DocType name (e.g. "REPRESENTATION & ENTERTAINMENT-OTHERS - Bebang
+    Enterprise Inc.") for the given company. Returns None if no match.
 
     The classifier returns naked codes from Liezel's training data; the
     batch approve flow validates against tabAccount link, which fails on
     a bare code. Resolve once at classify-time so approve always succeeds.
+
+    Lookup strategy: BEI's Chart of Accounts stores the GL code in the
+    `account_number` column, NOT in the name. Account names look like
+    "REPRESENTATION & ENTERTAINMENT-OTHERS - Bebang Enterprise Inc.".
+    First-pass tried `name LIKE '{code} - %'` and never matched anything.
+    Correct query: filter by `account_number` (and disabled=0).
     """
     if not code or not company:
         return None
-    # Prefer non-group leaf accounts whose name starts with the code + " - "
     rows = frappe.db.sql(
         """
         SELECT name FROM `tabAccount`
-        WHERE company=%s AND is_group=0 AND name LIKE %s
+        WHERE company=%s
+          AND is_group=0
+          AND COALESCE(disabled, 0) = 0
+          AND account_number=%s
+        ORDER BY name LIMIT 1
+        """,
+        (company, str(code)),
+        as_dict=False,
+    )
+    if rows:
+        return rows[0][0]
+    # Fallback: legacy CoA layouts where the code IS in the name prefix
+    rows = frappe.db.sql(
+        """
+        SELECT name FROM `tabAccount`
+        WHERE company=%s AND is_group=0 AND COALESCE(disabled, 0) = 0
+          AND name LIKE %s
         ORDER BY name LIMIT 1
         """,
         (company, f"{code} - %"),


### PR DESCRIPTION
## Summary
PR #510 introduced \`_resolve_coa_code_to_account()\` with a \`name LIKE '{code} - %'\` query, assuming BEI Account names start with the GL code prefix. **They don't.** Verified by direct SSM probe — every code (6010100, 6006001, 6006003, 6010003, 6004005) returned None in production. The fix in #510 deployed but did nothing.

## Ground truth (verified via SSM)
\`\`\`
Code 6010100: name='REPRESENTATION & ENTERTAINMENT-OTHERS - Bebang Enterprise Inc.', account_number='6010100'
Code 6006001: name='STORE SUPPLIES - Bebang Enterprise Inc.', account_number='6006001'
Code 6006003: name='OFFICE SUPPLIES - Bebang Enterprise Inc.', account_number='6006003'
\`\`\`

The GL code is in \`tabAccount.account_number\`, not embedded in the \`name\` prefix.

## Fix
Query by \`account_number=code\` first (canonical BEI CoA layout). Keep the legacy LIKE-on-name path as a fallback for any CoA where the code IS prefixed in the name. Adds \`disabled=0\` filter.

## Test plan
- [ ] Deploy backend → SSM probe \`_resolve_coa_code_to_account('6010100','Bebang Enterprise Inc.')\` → expect \`'REPRESENTATION & ENTERTAINMENT-OTHERS - Bebang Enterprise Inc.'\`
- [ ] Run S167 Phase 2 + 3.2a + 3.2b end-to-end without the SSM workaround → approve_batch_with_coa returns 200 OK without LinkValidationError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)