### PR TITLE
fix(S172 Phase 8): unblock L3 retest — 3 regressions + 1 new defect

### DIFF
--- a/hrms/api/disciplinary.py
+++ b/hrms/api/disciplinary.py
@@ -20,12 +20,22 @@ from hrms.utils.sentry import set_backend_observability_context
 
 @frappe.whitelist()
 @rate_limit(limit=10, seconds=60)
-def create_incident_report(data):
+def create_incident_report(data=None, **kwargs):
     """File new incident report.
 
-    Args:
-        data: JSON string with fields: employee, incident_date, incident_category,
-              description, store, recommended_action, witnesses
+    Accepts either shape (S172 Phase 8 fix for the RT-S172-05 new defect):
+    - Legacy: `data` kwarg (JSON string or dict) — used by internal callers
+      and the original contract.
+    - Frontend: flat kwargs (`employee`, `incident_date`, `incident_type`, ...)
+      — this is what `useCreateIncidentReport` in bei-tasks actually sends,
+      because Frappe's `frappe.api.handle` unwraps the JSON POST body into
+      individual keyword arguments. Before this fix the positional `data`
+      parameter was never populated, raising `TypeError: missing 1 required
+      positional argument: 'data'` on every frontend call.
+
+    Args (via either shape):
+        employee, incident_date, incident_category (or alias incident_type),
+        description, store, recommended_action, witnesses, severity
 
     Returns:
         Created incident report name
@@ -42,6 +52,14 @@ def create_incident_report(data):
 
     if isinstance(data, str):
         data = json.loads(data)
+    if data is None:
+        # Frontend calls land here — Frappe unwrapped the JSON body into kwargs.
+        data = kwargs
+    elif isinstance(data, dict) and kwargs:
+        # Defensive merge in case a caller sends both shapes.
+        merged = dict(data)
+        merged.update(kwargs)
+        data = merged
 
     # S172 Defect #24 fix: accept both incident_type (frontend field name) and
     # incident_category (backend field name). The frontend `useCreateIncidentReport`

--- a/hrms/api/payroll_compensation.py
+++ b/hrms/api/payroll_compensation.py
@@ -524,6 +524,23 @@ def update_compensation(
 
 	employee_list = bulk_employees or [employee]
 
+	# S172 Phase 8 fix (Defect #16 unblock): when the originator is already an
+	# HR Manager, the dual-control flow should skip the HR Manager stage and
+	# send the request directly to Accounts Manager for final approval. An HR
+	# Manager approving their own submission would defeat dual control; the
+	# real second set of eyes in this case is the Accounts Manager. Without
+	# this auto-advance, HR-originated comp changes got stranded at
+	# "Pending HR Manager" because Finance's queue filters on
+	# "Pending Accounts Manager" and never saw them — which is the exact failure
+	# mode RT-S172-02 reproduced (the SSA-creation savepoint fix in
+	# approve_compensation_change was never reached).
+	submitter_roles = frappe.get_roles(frappe.session.user)
+	initial_status = (
+		"Pending Accounts Manager"
+		if ("HR Manager" in submitter_roles or "System Manager" in submitter_roles)
+		else "Pending HR Manager"
+	)
+
 	created = []
 	for emp_id in employee_list:
 		if not frappe.db.exists("Employee", emp_id):
@@ -575,8 +592,15 @@ def update_compensation(
 				"new_value": new_value,
 				"effective_date": effective_date,
 				"reason": reason,
-				"status": "Pending HR Manager",
+				"status": initial_status,
 				"requested_by": frappe.session.user,
+				# When an HR Manager originates, their submission IS the HR-stage
+				# sign-off — record it so the audit trail is complete.
+				"hr_reviewer": (
+					frappe.session.user
+					if initial_status == "Pending Accounts Manager"
+					else None
+				),
 			}
 		)
 		doc.insert(ignore_permissions=True)

--- a/hrms/overrides/employee_master.py
+++ b/hrms/overrides/employee_master.py
@@ -23,7 +23,18 @@ class EmployeeMaster(Employee):
 				self.set_employee_name()
 				self.name = self.employee_name
 
-		self.employee = self.name
+		# S172 Phase 8 fix (Defect #8 root cause): upstream hrms unconditionally
+		# overwrote `self.employee` with `self.name` (HR-EMP-NNNNN), which clobbered
+		# the BEI-EMP-YYYY-NNNNN business ID that create_employee_direct sets on
+		# the payload. Because `generate_bei_employee_id` reads
+		# `SELECT MAX(employee) WHERE employee LIKE 'BEI-EMP-YYYY-%'`, every row
+		# ended up with employee = HR-EMP-NNNNN and the generator kept returning the
+		# same stale maximum (e.g. BEI-EMP-2026-00004) forever.
+		#
+		# Preserve the BEI business ID when the caller explicitly set it; fall back
+		# to the upstream behaviour (employee = name) only when no BEI ID was set.
+		if not (self.employee or "").startswith("BEI-EMP-"):
+			self.employee = self.name
 
 
 def validate_onboarding_process(doc, method=None):


### PR DESCRIPTION
## Summary

Phase 8 L3 retest (scenarios RT-S172-01..08) exposed that three S172 fixes did not fully close on production and revealed one new backend bug. All four are root-caused and fixed without removing any feature.

## Diagnosis and fixes

### Defect #8 — duplicate BEI employee_id (RT-S172-07 FAIL)
- **Symptom:** Two consecutive `create_employee_direct` calls returned the same `employee_id = BEI-EMP-2026-00004`.
- **Root cause:** \`hrms/overrides/employee_master.py::EmployeeMaster.autoname()\` unconditionally executes \`self.employee = self.name\`, clobbering the BEI-EMP-YYYY-NNNNN business ID set by \`create_employee_direct\` with the HR-EMP-NNNNN primary key. \`generate_bei_employee_id\` reads \`MAX(employee LIKE 'BEI-EMP-YYYY-%')\`, so every row held \`employee = HR-EMP-NNNNN\` and the generator kept returning the same stale max forever.
- **Fix:** Preserve the BEI ID when the caller set it; keep the upstream default otherwise.

### Defect #16 — comp change stranded at Pending HR Manager (RT-S172-02 FAIL)
- **Symptom:** After HR submitted a comp change and Finance tried to approve, the BCC was nowhere in Finance's queue and no SSA was created.
- **Root cause:** \`update_compensation\` creates every BCC at \`"Pending HR Manager"\`. When HR is the submitter there is no one above them at HR stage, so the BCC sits forever. Finance's queue filters on \`"Pending Accounts Manager"\` and never saw it — the savepoint-wrapped activation in \`approve_compensation_change\` (the earlier #16 fix) was never reached.
- **Fix:** When the submitter already holds HR Manager (or System Manager) role, auto-advance the BCC to \`"Pending Accounts Manager"\` and record \`hr_reviewer\` for the audit trail. Dual control is preserved — Finance remains the second set of eyes.

### Defect RT-S172-05 NEW — create_incident_report TypeError
- **Symptom:** Every frontend submit of a new incident report returned HTTP 500 \`TypeError: create_incident_report() missing 1 required positional argument: 'data'\`.
- **Root cause:** The function signature was \`def create_incident_report(data):\`. Frappe's \`frappe.api.handle\` unwraps the JSON POST body into individual kwargs, so the positional \`data\` was never populated.
- **Fix:** Accept both shapes — legacy \`data=\` (string or dict) and flat kwargs. Backwards-compatible; the #18 Branch fallback and #24 \`incident_type\`→\`incident_category\` alias still apply.

## Files

- \`hrms/overrides/employee_master.py\` — +13/-1
- \`hrms/api/payroll_compensation.py\` — +25/-1
- \`hrms/api/disciplinary.py\` — +21/-4

## Companion PR

bei-tasks: fix for Defect #19 (\`/overtime/apply\` Access Restricted) — the parent HR layout's \`HR_ADMIN\` guard still caught Crew because the self-service whitelist did not include \`/overtime/apply\`.

## Test plan

- [ ] Deploy hrms
- [ ] Re-run RT-S172-02 → expect SSA created, BCC Approved
- [ ] Re-run RT-S172-05 → expect IR created with incident_category=Attendance, severity=Minor, store=employee.branch
- [ ] Re-run RT-S172-07 → expect two distinct employee_ids matching \`^BEI-EMP-\d{4}-\d{5}$\`

## Evidence

\`output/l3/s172/retest/AUDIT_REPORT.md\` (NO-GO under previous state)
\`output/l3/s172/retest/RT-S172-{02,05,07}/evidence.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)