### PR TITLE
fix(S176 hotfix): pos_orders has no net_sales_without_vat column

### DIFF
--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -746,8 +746,11 @@ def _get_grabfood_channel_totals(
 			"grabfood_orders": 0,
 			"grabfood_avg_ticket": 0.0,
 		}
+	# S176 hotfix 2026-04-09: pos_orders does NOT have a net_sales_without_vat column
+	# (that lives only in the daily_store_metrics materialized view). Derive it as
+	# net_sales - vat_amount using columns that actually exist on pos_orders.
 	params: list[tuple[str, Any]] = [
-		("select", "gross_sales,net_sales,net_sales_without_vat"),
+		("select", "gross_sales,net_sales,vat_amount"),
 		("channel", "eq.GrabFood"),
 		("payment_status", "eq.PAID"),
 		("business_date", f"gte.{start_day.isoformat()}"),
@@ -756,7 +759,9 @@ def _get_grabfood_channel_totals(
 	]
 	rows = _supabase_get_all("pos_orders", params, page_size=1000)
 	gross_total = sum(_to_float(row.get("gross_sales")) for row in rows)
-	net_wo_vat_total = sum(_to_float(row.get("net_sales_without_vat")) for row in rows)
+	net_wo_vat_total = sum(
+		_to_float(row.get("net_sales")) - _to_float(row.get("vat_amount")) for row in rows
+	)
 	order_count = len(rows)
 	avg_ticket = _round_half_up(gross_total / order_count) if order_count else 0.0
 	return {


### PR DESCRIPTION
## Blocker in production

S176 (hrms#519) shipped a new `_get_grabfood_channel_totals()` helper that
selects `net_sales_without_vat` from `pos_orders`. That column does **not**
exist on the raw `pos_orders` table — it only lives on the `daily_store_metrics`
materialized view.

Result: the Sales Dashboard endpoint now errors:
\`\`\`
column pos_orders.net_sales_without_vat does not exist
\`\`\`

The dashboard fails to load for all users.

## Fix

Change the PostgREST \`select\` list to columns that actually exist:
\`gross_sales,net_sales,vat_amount\`. Derive net-without-VAT in Python as
\`sum(net_sales - vat_amount)\`.

This matches the BEI standard formula and does **not** divide by 1.12
(which would break SC/PWD-exempt rows per MEMORY.md lesson #24).

## Diff
- 1 file: \`hrms/api/sales_dashboard.py\`
- +7 / -2 lines, single helper function
- No schema change, no new endpoint, no cache change
- \`py_compile\` → exit 0

## Why it wasn't caught pre-merge
The pre-execution audit (\`output/s176/pre_execution_audit/AUDIT_SUMMARY.md\`)
enumerated the \`daily_store_metrics\` view columns and erroneously assumed the
same column names applied to the underlying \`pos_orders\` table. The raw table
only stores \`gross_sales\`, \`net_sales\`, \`vatable_sales\`, \`vat_amount\`,
\`vat_exempt_sales\`, \`zero_rated_sales\` (per \`scripts/sync_pos_to_supabase.py\`
line 392-398). No existing function in \`sales_dashboard.py\` ever selected from
\`pos_orders\` directly before S176, so the mismatch slipped through.

## New branch per CLAUDE.md rule
\`s176-analytics-ia-restructure\` was merged (hrms#519) and is dead — this fix
lives on a fresh branch created from current \`origin/production\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)