### PR TITLE
fix(S176 hotfix #2): override foodpanda_sales with direct pos_orders query

### DIFF
--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -772,6 +772,55 @@ def _get_grabfood_channel_totals(
 	}
 
 
+def _get_foodpanda_channel_totals(
+	start_day: date,
+	end_day: date,
+	location_ids: list[int],
+) -> dict[str, Any]:
+	"""S176 hotfix 2026-04-09: FoodPanda direct-aggregation parallel to GrabFood.
+
+	Background: the sales_dashboard_daily_store_metrics view's foodpanda_subtotal
+	column is sourced from the legacy foodpanda_orders Google Sheet ingest, which
+	was halted 2026-03-31. For every day from 2026-04-01 onward the view returns
+	0.00 while the real FoodPanda data lives in pos_orders.channel='FoodPanda'.
+
+	This mirrors _get_grabfood_channel_totals — same columns, same derivation
+	(net_wo_vat = net_sales - vat_amount), same zero-default on empty result.
+
+	Returns keys: foodpanda_sales, foodpanda_sales_without_vat, foodpanda_orders,
+	foodpanda_avg_ticket. These OVERRIDE the stale values injected by
+	_aggregate_sales() from the view.
+	"""
+	if not location_ids:
+		return {
+			"foodpanda_sales": 0.0,
+			"foodpanda_sales_without_vat": 0.0,
+			"foodpanda_orders": 0,
+			"foodpanda_avg_ticket": 0.0,
+		}
+	params: list[tuple[str, Any]] = [
+		("select", "gross_sales,net_sales,vat_amount"),
+		("channel", "eq.FoodPanda"),
+		("payment_status", "eq.PAID"),
+		("business_date", f"gte.{start_day.isoformat()}"),
+		("business_date", f"lte.{end_day.isoformat()}"),
+		("location_id", f"in.({_location_scope_key(location_ids)})"),
+	]
+	rows = _supabase_get_all("pos_orders", params, page_size=1000)
+	gross_total = sum(_to_float(row.get("gross_sales")) for row in rows)
+	net_wo_vat_total = sum(
+		_to_float(row.get("net_sales")) - _to_float(row.get("vat_amount")) for row in rows
+	)
+	order_count = len(rows)
+	avg_ticket = _round_half_up(gross_total / order_count) if order_count else 0.0
+	return {
+		"foodpanda_sales": _round_half_up(gross_total),
+		"foodpanda_sales_without_vat": _round_half_up(net_wo_vat_total),
+		"foodpanda_orders": order_count,
+		"foodpanda_avg_ticket": avg_ticket,
+	}
+
+
 def _build_data_quality_warnings(start_day: date, end_day: date, freshness: dict[str, Any]) -> list[str]:
 	warnings: list[str] = []
 	foodpanda_cups_max = freshness.get("foodpanda_cups_max_business_date")
@@ -2012,6 +2061,8 @@ def _build_dashboard_summary_payload(
 		summary = _aggregate_sales(sales_rows)
 		# S176 DD-14 Option A: inject real GrabFood totals from pos_orders direct query.
 		summary.update(_get_grabfood_channel_totals(start_day, effective_end, selected_location_ids))
+		# S176 hotfix 2026-04-09: override FoodPanda totals (view is stale post-2026-03-31).
+		summary.update(_get_foodpanda_channel_totals(start_day, effective_end, selected_location_ids))
 		projection_window_rows = [
 			row for row in sales_rows if str(row.get("business_date")) <= discount_effective_end.isoformat()
 		]
@@ -2104,6 +2155,8 @@ def _build_dashboard_overview_payload(
 		summary = _aggregate_sales(sales_rows)
 		# S176 DD-14 Option A: inject real GrabFood totals from pos_orders direct query.
 		summary.update(_get_grabfood_channel_totals(start_day, effective_end, selected_location_ids))
+		# S176 hotfix 2026-04-09: override FoodPanda totals (view is stale post-2026-03-31).
+		summary.update(_get_foodpanda_channel_totals(start_day, effective_end, selected_location_ids))
 		mode_state = _build_mode_state(view_mode, start_day, effective_end, scope)
 		projection_window_rows = [
 			row for row in sales_rows if str(row.get("business_date")) <= discount_effective_end.isoformat()


### PR DESCRIPTION
## Data accuracy defect found during post-deploy validation

Running a full Supabase cross-check against the deployed Sales Dashboard
(after hrms#519 + hrms#520 shipped) surfaced a significant FoodPanda
under-count.

### Numbers (window: 2026-03-20 to 2026-04-09, all 45 BEI stores)

| Source | Gross | Net w/o VAT | Orders |
|---|---|---|---|
| Live \`get_sales_dashboard_summary\` | **PHP 9,510,332.00** | PHP 8,491,367.96 | — |
| Raw \`pos_orders.channel='FoodPanda' AND payment_status='PAID'\` | **PHP 12,346,234.84** | PHP 9,703,227.36 | 19,260 |
| **Under-count** | **PHP 2,835,902.84** | PHP 1,211,859.40 | — |

### Root cause

The \`sales_dashboard_daily_store_metrics\` view joins against the legacy
\`foodpanda_orders\` Google Sheet ingest, which was **halted 2026-03-31**
per S171. Per-day breakdown from the view:

| Date | view.foodpanda_subtotal |
|---|---|
| 2026-03-27..2026-03-31 | real values (716K - 1.1M/day) |
| **2026-04-01 onward** | **0.00 every day** |

Same dates, raw \`pos_orders.channel='FoodPanda'\`:

| Date | pos_orders real total |
|---|---|
| 2026-04-01 | 255,367.56 |
| 2026-04-02 | 619,889.68 |
| ... | ... |
| 2026-04-09 | 978,551.70 |

The real FoodPanda data for 2026-04-01..2026-04-09 is in \`pos_orders\` via
the Mosaic sync (S165), but \`_aggregate_sales\` reads from the stale view
which has zero for those days.

### Why S176 didn't catch this

The plan's DD-10 scoped only the **freshness tile date key**, not the
**dollar aggregation**. The new \`_get_grabfood_channel_totals\` helper added
by DD-14 worked around the same problem for GrabFood (view has no
\`grabfood_*\` columns at all), but the symmetric FoodPanda fix was not in
scope — the plan assumed FoodPanda totals were still accurate via the view.
Pre-merge filesystem greps can't detect stale MV data.

## Fix

Same pattern as \`_get_grabfood_channel_totals\`:

1. New private helper \`_get_foodpanda_channel_totals(start_day, end_day, location_ids)\`
   queries \`pos_orders WHERE channel='FoodPanda' AND payment_status='PAID'\`
   via \`_supabase_get_all\`. Selects \`gross_sales, net_sales, vat_amount\`.
   Derives \`net_wo_vat = sum(net_sales - vat_amount)\`.
2. Inject \`summary.update(_get_foodpanda_channel_totals(...))\` in BOTH
   \`_build_dashboard_summary_payload\` and \`_build_dashboard_overview_payload\`
   RIGHT AFTER the grabfood update. This **overrides** the stale view values
   injected by \`_aggregate_sales\`.
3. \`_build_channel_mix\` picks up the corrected values automatically because
   it reads from \`summary['foodpanda_sales']\` / \`foodpanda_sales_without_vat\`.

### Diff
- 1 file: \`hrms/api/sales_dashboard.py\`
- +53 / -0 lines
- No schema change. No new endpoint. Same protected-surface boundaries as S176.
- \`py_compile\` -> exit 0

### Post-merge validation plan
After this PR deploys, I'll re-run \`output/s176/validation/validate_live.py\`
which will add FoodPanda assertions. Expected post-fix values:

\`\`\`
foodpanda_sales            = 12,346,234.84  (up from 9,510,332.00)
foodpanda_sales_without_vat = 9,703,227.36  (up from 8,491,367.96)
\`\`\`

## New branch per CLAUDE.md rule
Both prior S176 branches are merged and dead. This is a fresh branch from
current \`origin/production\` (includes hotfix #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)