### PR TITLE
fix(S172 Phase 8 followup): true root cause for #8 + 2 collateral defects (Pass 3)

### DIFF
--- a/hrms/api/disciplinary.py
+++ b/hrms/api/disciplinary.py
@@ -7,7 +7,7 @@ per Philippine DOLE requirements.
 import frappe
 from frappe import _
 from frappe.rate_limiter import rate_limit
-from frappe.utils import getdate, add_days, today
+from frappe.utils import getdate, add_days, today, formatdate
 from hrms.utils.api_helpers import (
     _get_employee_or_throw,
     _get_employee_details,
@@ -106,8 +106,20 @@ def create_incident_report(data=None, **kwargs):
     ir.insert(ignore_permissions=True)
     frappe.db.commit()
 
-    # Notify HR
-    _notify_hr_of_incident(ir)
+    # S172 Phase 8 fix: notification failures MUST NOT kill the API response.
+    # The IR has already been committed above — if email/notify blows up, log
+    # it (Sentry picks up frappe.log_error automatically) and return success so
+    # the frontend sees the created record. Previously an AttributeError from
+    # `frappe.format_date` (the wrong import) was raised after commit, the
+    # client got HTTP 500, and the IR was orphaned in "persisted-but-unseen"
+    # state — which RT-S172-05 caught.
+    try:
+        _notify_hr_of_incident(ir)
+    except Exception:
+        frappe.log_error(
+            title=f"S172: IR notify failed for {ir.name}",
+            message=frappe.get_traceback(),
+        )
 
     return {
         "message": _("Incident report created successfully"),
@@ -146,7 +158,7 @@ def _notify_hr_of_incident(ir):
                 employee=ir.employee,
                 reported_by_name=ir.reported_by_name,
                 category=ir.incident_category,
-                incident_date=frappe.format_date(ir.incident_date),
+                incident_date=formatdate(ir.incident_date),
                 recommended_action=ir.recommended_action or "Not specified",
                 report_id=ir.name,
             ),
@@ -361,9 +373,9 @@ def _notify_employee_of_nte(nte, ir):
         Please respond via my.bebang.ph.
         """).format(
             employee_name=nte.employee_name,
-            incident_date=frappe.format_date(ir.incident_date),
+            incident_date=formatdate(ir.incident_date),
             category=ir.incident_category,
-            deadline=frappe.format_date(nte.response_deadline),
+            deadline=formatdate(nte.response_deadline),
             charges=nte.charges,
         ),
         reference_doctype="BEI Notice to Explain",
@@ -443,7 +455,7 @@ def _notify_hr_of_nte_response(nte):
                 employee_name=nte.employee_name,
                 employee=nte.employee,
                 nte_name=nte.name,
-                response_date=frappe.format_date(nte.response_date),
+                response_date=formatdate(nte.response_date),
             ),
             reference_doctype="BEI Notice to Explain",
             reference_name=nte.name,
@@ -536,7 +548,7 @@ def _notify_employee_of_nod(nod, nte):
         You have the right to appeal this decision within 5 days via my.bebang.ph.
         """).format(
             employee_name=nod.employee_name,
-            decision_date=frappe.format_date(nod.decision_date),
+            decision_date=formatdate(nod.decision_date),
             penalty=nod.penalty,
             suspension_info=(f"<strong>Suspension Days:</strong> {nod.suspension_days}<br>"
                            if nod.penalty == "Suspension" else ""),
@@ -632,7 +644,7 @@ def _notify_hr_of_appeal(appeal, nod):
                 employee_name=appeal.employee_name,
                 employee=appeal.employee,
                 penalty=nod.penalty,
-                appeal_date=frappe.format_date(appeal.appeal_date),
+                appeal_date=formatdate(appeal.appeal_date),
                 appeal_id=appeal.name,
             ),
             reference_doctype="BEI Employee Appeal",

--- a/hrms/api/overtime_request.py
+++ b/hrms/api/overtime_request.py
@@ -44,8 +44,18 @@ def create_overtime_request(
         mutation_type="create",
     )
 
-    # Permission gate
-    frappe.has_permission("BEI Overtime Request", "create", throw=True)
+    # S172 Phase 8 fix (RT-S172-04 collateral): the previous gate was
+    # `frappe.has_permission("BEI Overtime Request", "create", throw=True)`,
+    # but Crew users do NOT have the DocPerm `create` on BEI Overtime Request
+    # (and giving it would open direct Desk inserts outside this API). The
+    # entire point of this endpoint is to let any authenticated employee file
+    # their own OT via self-service — the insert below already runs with
+    # `ignore_permissions=True`, the employee is resolved server-side (no
+    # client-supplied ID means no spoofing), and @frappe.whitelist() enforces
+    # authentication. So the proper gate is "the caller must have a linked
+    # Employee record", which we already enforce immediately below.
+    if frappe.session.user == "Guest":
+        frappe.throw(_("Please sign in to file overtime."), frappe.PermissionError)
 
     # Resolve current user → employee
     employee = frappe.db.get_value(

--- a/hrms/overrides/employee_master.py
+++ b/hrms/overrides/employee_master.py
@@ -23,18 +23,33 @@ class EmployeeMaster(Employee):
 				self.set_employee_name()
 				self.name = self.employee_name
 
-		# S172 Phase 8 fix (Defect #8 root cause): upstream hrms unconditionally
-		# overwrote `self.employee` with `self.name` (HR-EMP-NNNNN), which clobbered
-		# the BEI-EMP-YYYY-NNNNN business ID that create_employee_direct sets on
-		# the payload. Because `generate_bei_employee_id` reads
-		# `SELECT MAX(employee) WHERE employee LIKE 'BEI-EMP-YYYY-%'`, every row
-		# ended up with employee = HR-EMP-NNNNN and the generator kept returning the
-		# same stale maximum (e.g. BEI-EMP-2026-00004) forever.
-		#
-		# Preserve the BEI business ID when the caller explicitly set it; fall back
-		# to the upstream behaviour (employee = name) only when no BEI ID was set.
+		# S172 Phase 8 fix (Defect #8 root cause, autoname leg):
+		# Preserve the BEI-EMP-YYYY-NNNNN business ID when the caller explicitly
+		# set it via create_employee_direct. See validate() for the durable leg.
 		if not (self.employee or "").startswith("BEI-EMP-"):
 			self.employee = self.name
+
+	def validate(self):
+		# S172 Phase 8 fix (Defect #8 TRUE root cause):
+		# Upstream `erpnext.setup.doctype.employee.employee.Employee.validate()`
+		# contains `self.employee = self.name` at line 125 which runs AFTER our
+		# autoname() override and AFTER every subsequent save, unconditionally
+		# clobbering the BEI-EMP-YYYY-NNNNN business ID back to HR-EMP-NNNNN.
+		#
+		# Because generate_bei_employee_id reads
+		# `SELECT MAX(employee) WHERE employee LIKE 'BEI-EMP-YYYY-%'`, this made
+		# the generator stuck on the same stale maximum (BEI-EMP-2026-00004) for
+		# every create call — no row ever actually persisted with
+		# employee = BEI-EMP-*, so MAX never moved forward.
+		#
+		# Strategy: snapshot the BEI id before calling super().validate(), then
+		# restore it after. This is durable across both create and update flows,
+		# since validate() runs on every save, not just insert.
+		saved_employee = (self.employee or "")
+		is_bei_id = saved_employee.startswith("BEI-EMP-")
+		super().validate()
+		if is_bei_id and self.employee != saved_employee:
+			self.employee = saved_employee
 
 
 def validate_onboarding_process(doc, method=None):


### PR DESCRIPTION
## Summary

Phase 8 Pass 3 L3 retest (post #518 + #371 deploy) surfaced that 3 issues still weren't fully fixed. This PR lands the TRUE root cause for each — no symptomatic patches.

## What Pass 3 found

| Scenario | Pass 3 verdict | Root cause |
|---|---|---|
| RT-S172-07 | Defect #8 **still regressing** — both employee_ids = BEI-EMP-2026-00004 | Upstream \`erpnext.setup.doctype.employee.Employee.validate()\` runs \`self.employee = self.name\` AFTER our autoname override, clobbering the BEI id |
| RT-S172-05 | NEW COLLATERAL — create_incident_report HTTP 500 post-commit | \`_notify_hr_of_incident\` called \`frappe.format_date\` which doesn't exist; real name is \`frappe.utils.formatdate\` |
| RT-S172-04 | NEW COLLATERAL — 403 PermissionError | \`frappe.has_permission("BEI Overtime Request", "create", throw=True)\` rejected Crew users because they don't hold the DocPerm; endpoint is self-service so the gate was dead wrong |

## Fixes

### 1. \`hrms/overrides/employee_master.py\` — validate() override
Snapshot the BEI id before \`super().validate()\`, restore after. Durable across both insert and subsequent saves since \`validate()\` runs on every save.

\`\`\`python
def validate(self):
    saved_employee = (self.employee or "")
    is_bei_id = saved_employee.startswith("BEI-EMP-")
    super().validate()
    if is_bei_id and self.employee != saved_employee:
        self.employee = saved_employee
\`\`\`

### 2. \`hrms/api/disciplinary.py\` — correct function name + defensive notify wrap
- Import \`formatdate\` from \`frappe.utils\` and replace all 6 call sites.
- Wrap \`_notify_hr_of_incident(ir)\` in try/except so future notify failures log via \`frappe.log_error\` (Sentry picks it up) but don't poison the API response. The IR is already committed before notify runs — returning 500 afterwards leaves the row orphaned in "persisted-but-unseen" state, which is exactly what RT-S172-05 caught.

### 3. \`hrms/api/overtime_request.py\` — replace broken DocPerm gate
Remove \`frappe.has_permission("BEI Overtime Request", "create", throw=True)\` and replace with a simple Guest-blocking check. The insert already runs with \`ignore_permissions=True\`, employee is resolved server-side (no spoofing), and \`@frappe.whitelist()\` enforces auth. The existing \`if not employee: throw(...)\` still ensures the caller has a linked Employee record.

## Features preserved

- Upstream \`employee = name\` default still applies for non-BEI callers
- HR notification still fires on IR creation (just no longer blocks the response on failure)
- Self-service OT filing still requires authentication + linked Employee; no ID spoofing possible

## Test plan

After deploy, re-run:
- [ ] RT-S172-07 → two distinct \`employee_id\` matching \`^BEI-EMP-\d{4}-\d{5}$\`
- [ ] RT-S172-05 → IR created with HTTP 200, SSM row present with store/incident_category/severity populated
- [ ] RT-S172-04 → OT submit without attendance returns HTTP 417 with "attendance correction" message (not 403)

## Evidence

- \`output/l3/s172/retest/RT-S172-07/evidence.json\` (Pass 3)
- \`output/l3/s172/retest/RT-S172-05/evidence.json\` (Pass 3)
- \`output/l3/s172/retest/RT-S172-04/evidence.json\` (Pass 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)