### PR TITLE
fix: SC/PWD discounts show PHP 0 — PostgREST filter excludes NULL discount_bir_category rows

### DIFF
--- a/hrms/api/discount_abuse.py
+++ b/hrms/api/discount_abuse.py
@@ -1220,7 +1220,15 @@ def _query_discount_item_rows_for_orders(
 			("order", "order_id.asc,line_number.asc"),
 		]
 		if categories:
-			params.append(("discount_bir_category", f"in.({','.join(sorted(categories))})"))
+			# S176 hotfix #5 2026-04-10: include NULL discount_bir_category rows.
+			# Mosaic populates discount_name (e.g. "Senior Citizen Discount", "PWD")
+			# but leaves discount_bir_category as NULL for all rows. The Python-side
+			# _canonical_discount_category() classifier handles the name->category
+			# mapping, but it never sees the rows if PostgREST filters them out here.
+			# The OR filter fetches rows where the column matches OR is NULL, letting
+			# the downstream Python classifier do name-based fallback.
+			cat_list = ",".join(sorted(categories))
+			params.append(("or", f"(discount_bir_category.in.({cat_list}),discount_bir_category.is.null)"))
 		rows = _supabase_get_all("pos_order_items", params)
 		for row in rows:
 			order_id = int(row.get("order_id") or 0)


### PR DESCRIPTION
## Defect

Every store in the **Highest Discount Stores** ranking shows:
\`\`\`
SC ₱0 • PWD ₱0
\`\`\`
despite real SC/PWD discount data existing in the database.

## Investigation (raw Supabase, 2026-03-27 to 2026-04-09)

| discount_bir_category | discount_name | rows | total discount |
|---|---|---|---|
| **NULL** | Senior Citizen Discount | 24,575 | ₱950,632.82 |
| **NULL** | PWD | 10,528 | ₱400,666.08 |

**ALL 35,417 discount rows have \`discount_bir_category = NULL\`.** Mosaic populates \`discount_name\` but never sets the category column.

## Root cause

\`_query_discount_item_rows_for_orders()\` at line 1222 sends this PostgREST filter:

\`\`\`
discount_bir_category=in.(SC,PWD)
\`\`\`

NULL does not match an \`in.()\` filter in PostgREST. Every discount row is excluded. The downstream Python classifier (\`_canonical_discount_category\`) that maps \`"Senior Citizen Discount" → SC\` and \`"PWD" → PWD\` via name fallback never sees any rows.

## Fix

Change the PostgREST filter to:
\`\`\`
or=(discount_bir_category.in.(SC,PWD),discount_bir_category.is.null)
\`\`\`

This lets NULL-category rows through. The Python classifier handles the name-to-category mapping correctly.

## Expected post-fix values (across all 45 stores, 2026-03-27..2026-04-09)

\`\`\`
SC discount total:  ₱950,632.82  (was ₱0)
PWD discount total: ₱400,666.08  (was ₱0)
\`\`\`

Per-store values will now show real amounts instead of ₱0.

## Also fixed this session

**Apr 1 NULL-channel orders:** Applied SQL UPDATE on 7,222 \`pos_orders\` rows with \`channel=NULL\` on 2026-04-01, mapping \`service_type_id=91/17 → POS\` and \`service_type_id=3 → Delivery\` (same logic as \`_resolve_channel\` in \`sync_pos_to_supabase.py\`). Apr 1 POS sales restored from ₱259K → ₱2,794K.

### Diff
- 1 file: \`hrms/api/discount_abuse.py\` (+9 / -1)
- \`py_compile\` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)