### PR TITLE
fix(pcf): guard replenishment source account lookup against missing BEI Settings

### DIFF
--- a/hrms/api/pcf.py
+++ b/hrms/api/pcf.py
@@ -1009,15 +1009,21 @@ def _get_account_by_number(company: str, account_number: str):
 
 
 def _get_replenishment_source_account(company: str):
-    if frappe.db.has_column("tabBEI Settings", "pcf_replenishment_source_account"):
-        source = frappe.db.get_single_value("BEI Settings", "pcf_replenishment_source_account")
-        if source:
-            return source
+    try:
+        if frappe.db.has_column("tabBEI Settings", "pcf_replenishment_source_account"):
+            source = frappe.db.get_single_value("BEI Settings", "pcf_replenishment_source_account")
+            if source:
+                return source
+    except Exception:
+        pass  # BEI Settings DocType may not exist yet
 
-    if frappe.db.has_column("tabCompany", "default_cash_account"):
-        source = frappe.db.get_value("Company", company, "default_cash_account")
-        if source:
-            return source
+    try:
+        if frappe.db.has_column("tabCompany", "default_cash_account"):
+            source = frappe.db.get_value("Company", company, "default_cash_account")
+            if source:
+                return source
+    except Exception:
+        pass
 
     return None
 


### PR DESCRIPTION
## Summary
- `_get_replenishment_source_account()` crashes with `ProgrammingError` when `tabBEI Settings` table doesn't exist
- `has_column()` throws instead of returning False for missing tables
- Wrapped both `has_column` checks in try/except so the function falls through to `Company.default_cash_account`

## Found During
S177 L3 testing — `request_replenishment` called on approved batch BEI-PCF-2026-00009 (₱879). The function crashed at line 1012 before reaching the Company fallback.

## Test plan
- [ ] Deploy, then rerun `scripts/s177r_test_replenishment.py` via SSM
- [ ] Verify JE created with Company default cash account as source
- [ ] Verify batch.replenishment_requested = 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)