### PR TITLE
🚨 fix(S176 hotfix #12): mgmt token fallback + deploy workflow injection

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -167,6 +167,7 @@ jobs:
           SENTRY_DSN="__SENTRY_DSN__"
           SUPABASE_URL="__SUPABASE_URL__"
           SUPABASE_KEY="__SUPABASE_KEY__"
+          SUPABASE_MGMT_TOKEN="__SUPABASE_MGMT_TOKEN__"
           MIN_FREE_KB=6291456
 
           echo "💾 Root disk before deploy:"
@@ -207,6 +208,10 @@ jobs:
             if [ -n "$SUPABASE_URL" ]; then
               ENV_ARGS="$ENV_ARGS --env-rm SUPABASE_URL --env-rm SUPABASE_SERVICE_ROLE_KEY"
               ENV_ARGS="$ENV_ARGS --env-add SUPABASE_URL=$SUPABASE_URL --env-add SUPABASE_SERVICE_ROLE_KEY=$SUPABASE_KEY"
+            fi
+            if [ -n "$SUPABASE_MGMT_TOKEN" ]; then
+              ENV_ARGS="$ENV_ARGS --env-rm SUPABASE_MGMT_TOKEN"
+              ENV_ARGS="$ENV_ARGS --env-add SUPABASE_MGMT_TOKEN=$SUPABASE_MGMT_TOKEN"
             fi
             docker service update --detach=true --update-failure-action=rollback --image $DEPLOY_IMAGE $ENV_ARGS $SVC
             echo "  ↳ $SVC update dispatched"
@@ -250,6 +255,7 @@ jobs:
           DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__SENTRY_DSN__/${{ secrets.SENTRY_DSN }}}"
           DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__SUPABASE_URL__/${{ env.SUPABASE_URL }}}"
           DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__SUPABASE_KEY__/${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}}"
+          DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__SUPABASE_MGMT_TOKEN__/${{ secrets.SUPABASE_MGMT_TOKEN }}}"
           DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__GHCR_TOKEN__/${{ secrets.GITHUB_TOKEN }}}"
           DEPLOY_SCRIPT="${DEPLOY_SCRIPT//__GHCR_USER__/${{ github.actor }}}"
 

--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -216,6 +216,15 @@ def _get_supabase_project_id() -> str:
 	)
 
 
+class SupabaseMgmtTokenMissing(RuntimeError):
+	"""Raised when SUPABASE_MGMT_TOKEN is not configured.
+
+	Callers catch this specifically to fall back to a slower PostgREST
+	pagination path so the dashboard still works (just more slowly) in
+	environments where the Mgmt token hasn't been provisioned yet.
+	"""
+
+
 def _supabase_query_sql(sql: str) -> list[dict[str, Any]]:
 	"""S176 hotfix #11: execute SQL via Supabase Management API.
 
@@ -237,7 +246,7 @@ def _supabase_query_sql(sql: str) -> list[dict[str, Any]]:
 	"""
 	token = _get_supabase_mgmt_token()
 	if not token:
-		raise RuntimeError("SUPABASE_MGMT_TOKEN is not configured")
+		raise SupabaseMgmtTokenMissing("SUPABASE_MGMT_TOKEN is not configured")
 	project_id = _get_supabase_project_id()
 	url = f"https://api.supabase.com/v1/projects/{project_id}/database/query"
 	response = requests.post(
@@ -859,7 +868,33 @@ def _get_mosaic_channel_split(
 		  AND location_id IN ({loc_csv})
 		GROUP BY channel_key
 	"""
-	rows = _supabase_query_sql(sql)
+	try:
+		rows = _supabase_query_sql(sql)
+	except SupabaseMgmtTokenMissing:
+		# S176 hotfix #12: PostgREST fallback when Mgmt token missing.
+		frappe.log_error(
+			"Sales Dashboard perf degraded: SUPABASE_MGMT_TOKEN missing; falling back to slow PostgREST.",
+			"Sales Dashboard perf fallback",
+		)
+		params: list[tuple[str, Any]] = [
+			("select", "channel,gross_sales,net_sales"),
+			("payment_status", "eq.PAID"),
+			("business_date", f"gte.{start_day.isoformat()}"),
+			("business_date", f"lte.{end_day.isoformat()}"),
+			("location_id", f"in.({_location_scope_key(location_ids)})"),
+		]
+		raw_rows = _supabase_get_all("v_pos_orders_live", params, page_size=1000)
+		agg: dict[str, dict[str, float]] = {}
+		for raw in raw_rows:
+			key = str(raw.get("channel") or "unknown").lower()
+			bucket = agg.setdefault(key, {"gross": 0.0, "net_wo_vat": 0.0, "orders": 0})
+			bucket["gross"] += _to_float(raw.get("gross_sales"))
+			bucket["net_wo_vat"] += _to_float(raw.get("net_sales"))
+			bucket["orders"] += 1
+		for bucket in agg.values():
+			bucket["gross"] = _round_half_up(bucket["gross"])
+			bucket["net_wo_vat"] = _round_half_up(bucket["net_wo_vat"])
+		return agg
 	split: dict[str, dict[str, float]] = {}
 	for row in rows:
 		key = str(row.get("channel_key") or "unknown")
@@ -1024,16 +1059,45 @@ def _get_channel_cups_from_mosaic(
 		  AND o.channel IN ('FoodPanda', 'GrabFood')
 		GROUP BY channel_key
 	"""
-	rows = _supabase_query_sql(sql)
-	fp_cups = 0
-	gf_cups = 0
-	for r in rows:
-		ck = str(r.get("channel_key") or "")
-		cups = _to_int(r.get("cups"))
-		if ck == "foodpanda":
-			fp_cups = cups
-		elif ck == "grabfood":
-			gf_cups = cups
+	try:
+		rows = _supabase_query_sql(sql)
+		fp_cups = 0
+		gf_cups = 0
+		for r in rows:
+			ck = str(r.get("channel_key") or "")
+			cups = _to_int(r.get("cups"))
+			if ck == "foodpanda":
+				fp_cups = cups
+			elif ck == "grabfood":
+				gf_cups = cups
+	except SupabaseMgmtTokenMissing:
+		def _ids(channel: str) -> list[int]:
+			p: list[tuple[str, Any]] = [
+				("select", "id"),
+				("channel", f"eq.{channel}"),
+				("payment_status", "eq.PAID"),
+				("business_date", f"gte.{start_day.isoformat()}"),
+				("business_date", f"lte.{end_day.isoformat()}"),
+				("location_id", f"in.({_location_scope_key(location_ids)})"),
+			]
+			return [int(r["id"]) for r in _supabase_get_all("pos_orders", p, page_size=1000) if r.get("id")]
+
+		def _sum_cups(order_ids: list[int]) -> int:
+			if not order_ids:
+				return 0
+			total = 0
+			for chunk in [order_ids[i:i+500] for i in range(0, len(order_ids), 500)]:
+				id_list = ",".join(str(oid) for oid in chunk)
+				p: list[tuple[str, Any]] = [
+					("select", "quantity"),
+					("order_id", f"in.({id_list})"),
+				]
+				rows_fb = _supabase_get_all("pos_order_items", p, page_size=1000)
+				total += sum(int(r.get("quantity") or 0) for r in rows_fb)
+			return total
+
+		fp_cups = _sum_cups(_ids("FoodPanda"))
+		gf_cups = _sum_cups(_ids("GrabFood"))
 	return {
 		"foodpanda_cups": fp_cups,
 		"grabfood_cups": gf_cups,
@@ -1752,7 +1816,24 @@ def _get_mosaic_channel_split_per_day(
 		  AND location_id IN ({loc_csv})
 		GROUP BY business_date, channel_key
 	"""
-	rows = _supabase_query_sql(sql)
+	try:
+		rows = _supabase_query_sql(sql)
+	except SupabaseMgmtTokenMissing:
+		params: list[tuple[str, Any]] = [
+			("select", "business_date,channel,net_sales"),
+			("payment_status", "eq.PAID"),
+			("business_date", f"gte.{start_day.isoformat()}"),
+			("business_date", f"lte.{end_day.isoformat()}"),
+			("location_id", f"in.({_location_scope_key(location_ids)})"),
+		]
+		raw_rows = _supabase_get_all("v_pos_orders_live", params, page_size=1000)
+		per_day_fb: dict[str, dict[str, float]] = {}
+		for raw in raw_rows:
+			day = str(raw.get("business_date"))
+			ch = str(raw.get("channel") or "unknown").lower()
+			day_bucket = per_day_fb.setdefault(day, {})
+			day_bucket[ch] = day_bucket.get(ch, 0.0) + _to_float(raw.get("net_sales"))
+		return per_day_fb
 	per_day: dict[str, dict[str, float]] = {}
 	for r in rows:
 		day = str(r.get("biz_date"))


### PR DESCRIPTION
## CRITICAL — Sales Dashboard is currently broken in production

Hotfix #11 (PR #536) added a dependency on \`SUPABASE_MGMT_TOKEN\` but the token was never injected into the Frappe Docker Swarm services by the deploy workflow. Dashboard now fails with:

\`\`\`
SUPABASE_MGMT_TOKEN is not configured
\`\`\`

This PR fixes both the immediate failure (fallback) and the root cause (workflow).

## Part 1 — Graceful fallback in \`sales_dashboard.py\`

- **New \`SupabaseMgmtTokenMissing\` exception class** — subclass of RuntimeError, raised specifically when the env var is missing
- **\`_supabase_query_sql\`** raises the new exception instead of generic RuntimeError
- **Three hot helpers catch it and fall back to PostgREST pagination:**
  - \`_get_mosaic_channel_split\`
  - \`_get_mosaic_channel_split_per_day\`
  - \`_get_channel_cups_from_mosaic\`
- **Frappe error log** fires once so the degraded state shows up in Sentry
- **Dashboard keeps working** immediately after deploy regardless of whether the env var propagated successfully

| Env var state | Path | 14-day load time |
|---|---|---|
| Missing (current production) | PostgREST pagination | ~45s (same as pre-#11) |
| Configured (after #12 deploys) | Mgmt SQL GROUP BY | ~2-3s |

No more "dashboard fails entirely" state.

## Part 2 — Deploy workflow injection

Three additive changes to \`.github/workflows/build-and-deploy.yml\`, all matching the existing \`SUPABASE_SERVICE_ROLE_KEY\` pattern on lines 207-210 and 252:

1. **Placeholder declaration** (line 170): \`SUPABASE_MGMT_TOKEN="__SUPABASE_MGMT_TOKEN__"\`

2. **ENV_ARGS injection block** (lines 211-214):
   \`\`\`bash
   if [ -n "\$SUPABASE_MGMT_TOKEN" ]; then
     ENV_ARGS="\$ENV_ARGS --env-rm SUPABASE_MGMT_TOKEN"
     ENV_ARGS="\$ENV_ARGS --env-add SUPABASE_MGMT_TOKEN=\$SUPABASE_MGMT_TOKEN"
   fi
   \`\`\`

3. **GitHub secret substitution** (line 258):
   \`\`\`bash
   DEPLOY_SCRIPT="\${DEPLOY_SCRIPT//__SUPABASE_MGMT_TOKEN__/\${{ secrets.SUPABASE_MGMT_TOKEN }}}"
   \`\`\`

The \`SUPABASE_MGMT_TOKEN\` secret is **already in GitHub Actions** — it's used by \`daily-pos-sync.yml\` line 35. This PR just propagates it into the Frappe container at deploy time. No new secrets to provision.

## Why this is permanent (not Path 2 or Path 3)

| Path | Permanent? | Why |
|---|---|---|
| Path 1 (this PR) | ✅ YES | Every deploy re-injects via \`--env-add\`; survives container restarts, Swarm failovers, EC2 replacement |
| Path 2 (fallback only) | ❌ NO | Dashboard permanently stuck at 45s for 14-day / 502 for 30-day |
| Path 3 (manual SSM) | ❌ NO | Lives only in current Swarm spec; wiped by any \`stack rm\`; no git history, no audit trail |

## Risk assessment

- **Additive only** — no existing env vars changed, no image build logic touched
- **Same pattern** as \`SUPABASE_SERVICE_ROLE_KEY\` which has been working since S165
- **Fallback safety net** — if the token propagation somehow fails, Part 1 catches it and the dashboard still works (just slowly)
- **No architectural changes** — no new services, no schema changes, no new dependencies
- **Token scope is read-only SQL** (the Mgmt API SQL endpoint uses the same token as the sync workflows already use)

## Test plan after merge

- [ ] Build + deploy completes green
- [ ] Dashboard loads for 1-day window → should match hotfix #10 values
- [ ] Dashboard loads for 14-day default window → should complete in **~3s** (was 45s or failing)
- [ ] Dashboard loads for 30-day window → should complete in **~3s** (was 502 gateway timeout)
- [ ] Sentry shows NO "Sales Dashboard perf fallback" error (if it does, the env var injection failed and we're on the slow path)
- [ ] All values match ground truth: Apr 10 single-day = ₱4,105,897, 14-day = ₱50,985,887

Approved by Sam (CEO) 2026-04-11 after Path 1 vs 2 vs 3 analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)