### PR TITLE
fix(S181): store-driven list + populate_s181_fields endpoint + pre-provisioned sentinel

### DIFF
--- a/hrms/api/company_master.py
+++ b/hrms/api/company_master.py
@@ -442,3 +442,484 @@ def retry_provision(company: str) -> dict:
 	from hrms.overrides.company import retry_provision_company
 
 	return retry_provision_company(company)
+
+
+# ============================================================================
+# S181 HOTFIX (2026-04-11) -- store-driven list + one-click populate
+#
+# Ship reality correction after the first production review:
+#
+# 1. list_stores() -- the Company Master list must show ONE ROW PER STORE
+#    (from the S037 register), not one row per Frappe Company. Multiple
+#    stores under the same buyer entity show as duplicate rows -- intentional,
+#    because the operational unit is the store, not the legal entity. Adds
+#    non-store entities (head office, commissary, franchisor, holding cos)
+#    as extra rows at the end so nothing falls off the list.
+#
+# 2. populate_s181_fields() -- one whitelisted call that runs the Phase 3
+#    seed (entity_category, store_ownership_type, mosaic_location_id, GPS,
+#    city, operational_status, pos_system) and Phase 4 TIN backfill, plus
+#    sets first_provision_done=1 for every existing Company that already
+#    has a COA (the 45 pre-S181 entities should not trip the Retry
+#    Provisioning UI). Sam triggers this once from the frontend "Populate
+#    S181 Fields" banner and it completes in seconds.
+#
+# 3. get_store_context(store_name) -- returns (store_name, company_name,
+#    abbr, entity_category) for the detail dialog header so it can render
+#    "Ayala Evo City -- Bebang Mega Inc." instead of just the company name.
+# ============================================================================
+
+
+# S037 register path, resolved relative to the hrms app root
+_S037_RELPATH = (
+	"..",
+	"data",
+	"_CLEANROOM",
+	"2026-03-12-s037-store-buyer-entity-register",
+	"store_buyer_entity_register_2026-03-12.csv",
+)
+
+# Non-store legal entities that don't appear in S037 but should still
+# appear in the list. Category maps to the S181 entity_category field.
+_NON_STORE_ENTITIES: dict[str, str] = {
+	"Bebang Enterprise Inc.": "Head Office",
+	"Bebang Kitchen Inc.": "Commissary",
+	"BEBANG FRANCHISE CORP.": "Franchisor",
+	"Bebang Franchise Corporation": "Franchisor",
+	"BFC": "Franchisor",
+	"Irresistible Infusions Inc.": "Holding Company",
+	"DMD HOLDINGS INC.": "Holding Company",
+	"DMD Holdings Inc": "Holding Company",
+	"Resto Tech Inc": "Head Office",
+}
+
+
+def _load_s037_rows() -> list[dict]:
+	"""Read the S037 register and return the list of rows."""
+	import csv
+	import os
+
+	path = os.path.normpath(os.path.join(frappe.get_app_path("hrms"), *_S037_RELPATH))
+	if not os.path.exists(path):
+		frappe.log_error(
+			title="S181 list_stores: S037 register missing",
+			message=f"Expected at {path}",
+		)
+		return []
+	with open(path, encoding="utf-8-sig") as f:
+		return list(csv.DictReader(f))
+
+
+def _lookup_company_fields(company_names: set[str]) -> dict[str, dict]:
+	"""Bulk-fetch the S181 Company fields for the given set of Company
+	docnames in one query. Returns {docname: row_dict} for fast lookup.
+	"""
+	if not company_names:
+		return {}
+	meta = frappe.get_meta("Company")
+	# Only select fields that actually exist -- defensive against partial
+	# migrate state on fresh environments.
+	fields = [
+		f
+		for f in [
+			"name",
+			"company_name",
+			"abbr",
+			"tax_id",
+			"branch_tin",
+			"bir_rdo_code",
+			"entity_category",
+			"store_ownership_type",
+			"operational_status",
+			"city",
+			"province",
+			"region",
+			"full_address",
+			"mall_or_building",
+			"gps_latitude",
+			"gps_longitude",
+			"mosaic_location_id",
+			"pos_system",
+			"first_provision_done",
+		]
+		if f == "name" or meta.has_field(f)
+	]
+	rows = frappe.get_all(
+		"Company",
+		filters={"name": ["in", list(company_names)]},
+		fields=fields,
+	)
+	return {r["name"]: r for r in rows}
+
+
+def _resolve_company_for_s037_row(
+	row: dict, all_companies: set[str], lower_name_index: dict[str, str]
+) -> str | None:
+	"""Find the Frappe Company docname that corresponds to an S037 row.
+
+	Resolution order:
+	1. `row['buyer_entity_name']` exact match against Company docnames
+	2. `row['buyer_entity_name']` case-insensitive match (handles "Bebang
+	   Mega Inc" vs "BEBANG MEGA INC." variants)
+	3. None (store is mapped in S037 but no Frappe Company exists yet)
+	"""
+	buyer = (row.get("buyer_entity_name") or "").strip()
+	if not buyer:
+		return None
+	if buyer in all_companies:
+		return buyer
+	# Case-insensitive normalized fallback
+	# Normalize: lowercase + strip trailing period
+	key = buyer.lower().rstrip(".").strip()
+	return lower_name_index.get(key)
+
+
+def _company_has_coa(company_name: str) -> bool:
+	"""Return True if this Company already has at least one posting Account
+	on it -- a proxy for "was provisioned by S175 or earlier". Used to
+	decide whether the 'Run First Provisioning' button should show.
+	"""
+	return bool(
+		frappe.db.get_value(
+			"Account",
+			{"company": company_name, "is_group": 0},
+			"name",
+		)
+	)
+
+
+@frappe.whitelist()
+def list_stores(
+	filters: dict | str | None = None,
+	search: str | None = None,
+) -> list[dict]:
+	"""Return one row per store from the S037 register + non-store entities.
+
+	HOTFIX: this is the correct data source for the Company Master list
+	page. `list_companies` (above) returns one row per Frappe Company and
+	hides multi-store entities (e.g. Bebang Mega Inc operates 5 stores --
+	list_companies shows 1 row, list_stores shows 5).
+
+	Row shape per store (driven by S037):
+	  - store_name         : from S037 "store_name" (e.g. "Ayala Evo City")
+	  - company            : resolved Frappe Company docname (e.g. "BEBANG MEGA INC.")
+	  - company_label      : Company.company_name display label
+	  - abbr               : Company.abbr
+	  - store_type         : from S037 (Managed Franchise / JV / etc.)
+	  - row_kind           : "store"
+	  - warehouse_docname  : from S037 (for the detail dialog to link to)
+	  - entity_category    : "Store" (fixed for store rows)
+	  - store_ownership_type, operational_status, city, province, region
+	  - mosaic_location_id
+	  - first_provision_done (from the resolved Company)
+	  - has_coa            : True if the Company already has posting accounts
+	                          (used to hide the "Run First Provisioning" pill)
+
+	Row shape per non-store entity (7 rows):
+	  - store_name         : None
+	  - company            : Frappe Company docname
+	  - company_label      : Company.company_name
+	  - abbr               : Company.abbr
+	  - row_kind           : "non_store"
+	  - entity_category    : from NON_STORE_ENTITIES map (Head Office,
+	                          Commissary, Franchisor, Holding Company)
+	  - first_provision_done, has_coa (same as store rows)
+	"""
+	set_backend_observability_context(
+		module="company", action="list_stores", mutation_type="read"
+	)
+
+	if isinstance(filters, str):
+		import json
+
+		try:
+			filters = json.loads(filters)
+		except Exception:
+			filters = None
+	filters = filters or {}
+
+	# Load S037 + Companies index
+	s037_rows = _load_s037_rows()
+	all_company_names = set(frappe.get_all("Company", pluck="name"))
+	lower_name_index: dict[str, str] = {}
+	for name in all_company_names:
+		key = name.lower().rstrip(".").strip()
+		lower_name_index[key] = name
+
+	# Figure out which Companies we'll need field data for (store rows +
+	# non-store rows), then bulk-fetch in one query.
+	resolved_store_companies: list[tuple[dict, str | None]] = []
+	for s037 in s037_rows:
+		company = _resolve_company_for_s037_row(s037, all_company_names, lower_name_index)
+		resolved_store_companies.append((s037, company))
+	non_store_names = [
+		n for n in _NON_STORE_ENTITIES.keys() if n in all_company_names
+	]
+	needed = {c for _, c in resolved_store_companies if c} | set(non_store_names)
+	company_fields = _lookup_company_fields(needed)
+
+	# Cache has_coa checks so we don't re-query per row
+	has_coa_cache: dict[str, bool] = {}
+
+	def has_coa(c: str) -> bool:
+		if c not in has_coa_cache:
+			has_coa_cache[c] = _company_has_coa(c)
+		return has_coa_cache[c]
+
+	def apply_filters(row: dict) -> bool:
+		if filters.get("entity_category") and row.get("entity_category") != filters["entity_category"]:
+			return False
+		if (
+			filters.get("store_ownership_type")
+			and row.get("store_ownership_type") != filters["store_ownership_type"]
+		):
+			return False
+		if (
+			filters.get("operational_status")
+			and row.get("operational_status") != filters["operational_status"]
+		):
+			return False
+		if filters.get("region") and row.get("region") != filters["region"]:
+			return False
+		if search:
+			needles = [
+				(row.get("store_name") or ""),
+				(row.get("company") or ""),
+				(row.get("company_label") or ""),
+				(row.get("city") or ""),
+			]
+			if not any(search.lower() in (s or "").lower() for s in needles):
+				return False
+		return True
+
+	out: list[dict] = []
+
+	# Store rows (from S037, may produce duplicate company references)
+	for s037, company in resolved_store_companies:
+		store_name = (s037.get("store_name") or "").strip()
+		store_type = (s037.get("store_type") or "").strip()
+		warehouse_docname = (s037.get("warehouse_docname") or "").strip()
+		cf = company_fields.get(company) if company else {}
+		row = {
+			"row_kind": "store",
+			"store_name": store_name,
+			"company": company,
+			"company_label": (cf or {}).get("company_name"),
+			"abbr": (cf or {}).get("abbr"),
+			"warehouse_docname": warehouse_docname or None,
+			"store_type_s037": store_type or None,
+			"entity_category": "Store",
+			# Prefer S037 store_type for store_ownership_type display even
+			# when the Company hasn't been seeded yet (so the filter works).
+			"store_ownership_type": (cf or {}).get("store_ownership_type") or (store_type or None),
+			"operational_status": (cf or {}).get("operational_status"),
+			"city": (cf or {}).get("city"),
+			"province": (cf or {}).get("province"),
+			"region": (cf or {}).get("region"),
+			"mosaic_location_id": (cf or {}).get("mosaic_location_id"),
+			"first_provision_done": (cf or {}).get("first_provision_done"),
+			"has_coa": has_coa(company) if company else False,
+			"company_exists": bool(company),
+		}
+		if apply_filters(row):
+			out.append(row)
+
+	# Non-store entity rows
+	for ns_name, cat in _NON_STORE_ENTITIES.items():
+		if ns_name not in all_company_names:
+			continue
+		cf = company_fields.get(ns_name, {})
+		row = {
+			"row_kind": "non_store",
+			"store_name": None,
+			"company": ns_name,
+			"company_label": cf.get("company_name") or ns_name,
+			"abbr": cf.get("abbr"),
+			"warehouse_docname": None,
+			"store_type_s037": None,
+			"entity_category": cf.get("entity_category") or cat,
+			"store_ownership_type": None,
+			"operational_status": cf.get("operational_status"),
+			"city": cf.get("city"),
+			"province": cf.get("province"),
+			"region": cf.get("region"),
+			"mosaic_location_id": cf.get("mosaic_location_id"),
+			"first_provision_done": cf.get("first_provision_done"),
+			"has_coa": has_coa(ns_name),
+			"company_exists": True,
+		}
+		if apply_filters(row):
+			out.append(row)
+
+	# Sort: store rows by store_name, then non-store rows at the bottom
+	out.sort(key=lambda r: (r["row_kind"] != "store", r.get("store_name") or r.get("company") or ""))
+	return out
+
+
+@frappe.whitelist()
+def get_store_context(store_name: str | None = None, company: str | None = None) -> dict:
+	"""Resolve a store_name (from S037) to its Company context for the
+	detail dialog header. If `company` is passed directly (non-store rows),
+	just returns that Company's display fields.
+
+	Used by the detail dialog top bar so it can show
+	"Ayala Evo City -- Bebang Mega Inc. (BMI2)" instead of just the company
+	name. Returns None for fields that can't be resolved.
+	"""
+	set_backend_observability_context(
+		module="company", action="get_store_context", mutation_type="read"
+	)
+
+	if not store_name and not company:
+		frappe.throw(_("Either store_name or company is required"))
+
+	resolved_company = company
+	warehouse_docname = None
+
+	if store_name and not resolved_company:
+		# Look up via S037
+		for s037 in _load_s037_rows():
+			if (s037.get("store_name") or "").strip() == store_name.strip():
+				buyer = (s037.get("buyer_entity_name") or "").strip()
+				warehouse_docname = (s037.get("warehouse_docname") or "").strip() or None
+				if buyer and frappe.db.exists("Company", buyer):
+					resolved_company = buyer
+					break
+				# Case-insensitive fallback
+				all_names = frappe.get_all("Company", pluck="name")
+				lookup = {n.lower().rstrip(".").strip(): n for n in all_names}
+				key = buyer.lower().rstrip(".").strip()
+				if key in lookup:
+					resolved_company = lookup[key]
+					break
+
+	if not resolved_company:
+		return {
+			"store_name": store_name,
+			"company": None,
+			"company_label": None,
+			"abbr": None,
+			"warehouse_docname": warehouse_docname,
+			"entity_category": None,
+		}
+
+	if not frappe.has_permission("Company", "read", doc=resolved_company):
+		frappe.throw(_("Not permitted to read company {0}").format(resolved_company))
+
+	meta = frappe.get_meta("Company")
+	wanted = [
+		f
+		for f in ("company_name", "abbr", "entity_category", "store_ownership_type")
+		if f == "abbr" or f == "company_name" or meta.has_field(f)
+	]
+	doc_row = frappe.db.get_value("Company", resolved_company, wanted, as_dict=True) or {}
+
+	return {
+		"store_name": store_name,
+		"company": resolved_company,
+		"company_label": doc_row.get("company_name"),
+		"abbr": doc_row.get("abbr"),
+		"warehouse_docname": warehouse_docname,
+		"entity_category": doc_row.get("entity_category"),
+		"store_ownership_type": doc_row.get("store_ownership_type"),
+	}
+
+
+@frappe.whitelist()
+def populate_s181_fields() -> dict:
+	"""One-click populate S181 Custom Fields on all existing Companies.
+
+	Runs INLINE what the Phase 3 seed script and Phase 4 TIN backfill do,
+	plus sets `first_provision_done = 1` on every Company that already
+	has posting accounts (the 45 pre-S181 entities with existing COA from
+	S175 -- they should not show a "Run First Provisioning" button).
+
+	Sam triggers this ONCE from the frontend "Populate S181 Fields" banner
+	after the backend is deployed. Idempotent -- safe to re-run. Skips
+	fields that already have the target value. Does NOT create any new
+	accounts (the existing COA is left alone).
+
+	Permission: requires System Manager or Accounts Manager role.
+	"""
+	set_backend_observability_context(
+		module="company",
+		action="populate_s181_fields",
+		mutation_type="update",
+	)
+
+	# Permission gate -- one-shot migration, tightly scoped
+	user_roles = set(frappe.get_roles())
+	if not user_roles & {"System Manager", "Accounts Manager", "Administrator"}:
+		frappe.throw(_("Only System Manager / Accounts Manager can run populate_s181_fields."))
+
+	# Import the script logic directly so this runs inline without needing
+	# bench execute
+	import importlib.util
+	import os
+
+	scripts_dir = os.path.normpath(
+		os.path.join(frappe.get_app_path("hrms"), "..", "scripts")
+	)
+
+	def load_script(filename: str):
+		spec_path = os.path.join(scripts_dir, filename)
+		spec = importlib.util.spec_from_file_location(filename.replace(".py", ""), spec_path)
+		mod = importlib.util.module_from_spec(spec)
+		spec.loader.exec_module(mod)
+		return mod
+
+	phase3 = load_script("s181_phase_3_seed_company_fields.py")
+	phase4 = load_script("s181_phase_4_branch_tin_backfill.py")
+
+	# --- Phase 3 seed ---
+	company_names = frappe.get_all("Company", pluck="name")
+	p3_planned, p3_unmatched = phase3.plan_updates(company_names)
+	p3_updated, p3_skipped, p3_per_field = phase3.apply_updates(p3_planned)
+
+	# --- Phase 4 TIN backfill ---
+	companies = frappe.get_all("Company", fields=["name", "tax_id"])
+	s037_buyer_map = phase4.load_s037_buyer_map()
+	tin_by_entity = phase4.load_tin_rdo_by_entity()
+	p4_planned, p4_unmatched = phase4.plan_updates(companies, s037_buyer_map, tin_by_entity)
+	p4_updated, p4_skipped, p4_per_field = phase4.apply_updates(p4_planned)
+
+	# --- Pre-existing sentinel fix ---
+	# Every Company that already has at least one posting account was
+	# provisioned by an earlier sprint (S175 etc.) and does not need the
+	# S181 on_update hook to run. Set first_provision_done=1 so the
+	# "Run First Provisioning" pill hides for them.
+	company_meta = frappe.get_meta("Company")
+	if company_meta.has_field("first_provision_done"):
+		pre_provisioned: list[str] = []
+		for cname in company_names:
+			if _company_has_coa(cname) and not frappe.db.get_value(
+				"Company", cname, "first_provision_done"
+			):
+				frappe.db.set_value(
+					"Company", cname, "first_provision_done", 1, update_modified=False
+				)
+				pre_provisioned.append(cname)
+		pre_count = len(pre_provisioned)
+	else:
+		pre_count = 0
+
+	frappe.db.commit()
+
+	return {
+		"ok": True,
+		"phase3": {
+			"updated": p3_updated,
+			"skipped": p3_skipped,
+			"per_field": p3_per_field,
+			"unmatched_count": len(p3_unmatched),
+			"unmatched": p3_unmatched[:10],
+		},
+		"phase4": {
+			"updated": p4_updated,
+			"skipped": p4_skipped,
+			"per_field": p4_per_field,
+			"unmatched_count": len(p4_unmatched),
+			"unmatched": p4_unmatched[:10],
+		},
+		"pre_provisioned_sentinels_set": pre_count,
+	}


### PR DESCRIPTION
## Summary

Post-merge production review (2026-04-11) of the S181 Company Master page surfaced four UX defects. This hotfix addresses all of them on the backend side with an additive API layer — zero schema changes, zero modifications to existing methods. The matching frontend hotfix is on `Bebang-Enterprise-Inc/BEI-Tasks` branch `fix/s181-store-list` and must deploy **after** this PR is merged + deployed.

## Defects addressed

### 1. List showed one row per Frappe Company instead of one row per store

48 stores map to only 38 unique buyer entities. My original `list_companies` endpoint returned one row per `tabCompany`, so multi-store buyer entities were silently collapsed:

| Buyer entity | Stores it operates |
|---|---|
| Bebang Mega Inc | 5 stores (Ayala Evo City, Ayala Vermosa, Robinsons Gen. Trias, Robinsons Imus, SM Tanza) |
| Bebang Enterprise Inc. | 4 stores (Robinsons Antipolo, SM Manila, SM Megamall, SM Southmall) |
| Bebang SM Marikina Inc. | 2 stores (SM Marikina, Sta. Lucia East Grand Mall) |
| TAJ Food Corp | 2 stores (D'Verde Calamba, SM Caloocan) |
| Tungsten Capital Holdings OPC | 2 stores (Robinsons Galleria South, SM Sangandaan) |

10 stores were effectively hidden behind shared rows. The operational unit for this page is the store, not the legal entity.

**Fix:** new `hrms.api.company_master.list_stores()` endpoint. Reads the S037 register (`data/_CLEANROOM/2026-03-12-s037-store-buyer-entity-register/store_buyer_entity_register_2026-03-12.csv`), returns one row per store (~48), joined with the resolved Frappe Company's S181 fields, plus the 7 non-store entities (head office, commissary, franchisor, holding companies) at the end. Multi-store buyer entities now appear as duplicate rows — intentional and marked with `row_kind: "store"` and a unique `store_name`.

Each row carries `has_coa: boolean` (true if the Company already has posting accounts from an earlier sprint like S175). The frontend uses this to hide the "Run First Provisioning" pill on the 45 pre-existing companies.

### 2. All fields blank because Phase 3 seed was never run

I deferred Task 3.2 (execute seed via SSM) as "deploy-time operator action" and *assumed* it had run when Sam confirmed "deployed". He only ran `bench migrate`, so `entity_category` / `store_ownership_type` / `mosaic_location_id` / GPS / `city` are NULL on every existing Company. The list renders em dashes everywhere. **This is a verification failure on my side — I should have queried a sample row instead of trusting my own deferral.**

**Fix:** new `hrms.api.company_master.populate_s181_fields()` whitelisted endpoint that runs the Phase 3 seed + Phase 4 TIN backfill **inline** (imports the script modules directly — no `bench execute`, no SSH), plus sets `first_provision_done = 1` on every Company that already has posting accounts. Sam triggers it **once** from the frontend banner and gets per-field mutation counts back in the response. Idempotent, safe to re-run.

Permission gate: `System Manager` / `Accounts Manager` / `Administrator`.

### 3. "Retry Provisioning" pill showed on every row

All 45 pre-S181 Companies have `first_provision_done = 0` because the `on_update` hook has never fired for them (they haven't been saved since S181 deployed). But they already have complete COAs from S175, so the pill is both meaningless and alarming.

**Fix:** `populate_s181_fields()` sets `first_provision_done = 1` on every Company whose COA already exists (the proxy for "was provisioned by an earlier sprint"). After one click on the banner, the pill disappears on those 45 rows and only shows on *genuinely* half-provisioned new companies. The frontend *also* consumes the new `has_coa` field in the list row so it can hide the pill client-side even before `populate_s181_fields` runs — defense in depth.

### 4. Detail dialog header showed only the company name

With 10 stores sharing buyer entities, "Bebang Mega Inc" in the header doesn't tell the operator which of the 5 stores they're looking at.

**Fix:** new `hrms.api.company_master.get_store_context(store_name)` endpoint. Resolves an S037 store name to its full context (store_name + company docname + company_label + abbr + warehouse_docname + entity_category + store_ownership_type). The frontend detail dialog top bar now shows "Ayala Evo City" as the primary label with "BEBANG MEGA INC. (BMI2)" as secondary.

## New methods in `hrms/api/company_master.py`

| Method | Purpose | Permission |
|---|---|---|
| `list_stores(filters, search)` | Store-driven list (48 stores + 7 non-store) with filter + search + `has_coa` per row | Read (general) |
| `get_store_context(store_name, company)` | Resolve S037 store_name → Company context for the dialog header | Read Company (specific) |
| `populate_s181_fields()` | One-click: Phase 3 seed + Phase 4 TIN backfill + mark pre-provisioned sentinels | System Manager / Accounts Manager / Administrator |

### New helpers (module-private)

- `_load_s037_rows()` — reads the S037 CSV via `frappe.get_app_path` relative lookup
- `_lookup_company_fields(names)` — bulk-fetches S181 fields for a set of Company docnames in one query (used by `list_stores` to avoid N+1)
- `_resolve_company_for_s037_row(row)` — matches S037 `buyer_entity_name` → Frappe Company docname, with case-insensitive fallback for variants like "Bebang Mega Inc" vs "BEBANG MEGA INC."
- `_company_has_coa(name)` — `EXISTS` check for posting accounts on a Company
- `_NON_STORE_ENTITIES` — curated `{docname: category}` map for the 7 head office / commissary / franchisor / holding Companies

## Existing methods untouched

`list_companies`, `get_company`, `update_company_section`, `upsert_compliance_document`, `delete_compliance_document`, `upsert_adms_device`, `delete_adms_device`, `retry_provision` — all unchanged. `list_companies` is left alive for backwards compatibility; the frontend hotfix switches to `list_stores` but nothing else in the codebase calls `list_companies`.

## Sentry DM-7

All three new endpoints call `set_backend_observability_context(module="company", action=..., mutation_type=...)` as their first meaningful line, matching the existing pattern in this module. Private underscore-prefixed helpers do not, per the DM-7 rule.

## Verification before commit

- `py_compile hrms/api/company_master.py`: OK
- 11 `@frappe.whitelist` methods (was 8, added `list_stores` + `get_store_context` + `populate_s181_fields`)
- No changes to existing method signatures — pure additive layer
- No schema changes

## Deploy notes

1. Merge this PR to `production`
2. Deploy hrms (the new endpoints become callable via the `/api/frappe/api/method/hrms.api.company_master.*` proxy — no bench migrate needed, no new Custom Fields, no new DocTypes)
3. Merge the matching frontend hotfix PR on `Bebang-Enterprise-Inc/BEI-Tasks` (branch `fix/s181-store-list`) — Vercel will auto-deploy
4. Open `https://my.bebang.ph/dashboard/bd/companies` as `test.admin` or your CEO account
5. The amber "Populate S181 Fields" banner will be at the top. Click it once. Wait ~5-15 seconds. Expect a green success banner with:
   - Phase 3 seed: ~35-40 companies updated (entity_category / store_ownership_type / mosaic_location_id / GPS / city / operational_status / pos_system)
   - Phase 4 TIN backfill: ~30+ companies updated (branch_tin / bir_rdo_code)
   - ~45 pre-provisioned sentinels set
6. List refreshes. Every store row now shows populated Category / Ownership / Status / City / Mosaic ID columns. Bebang Mega Inc appears as 5 store rows (Ayala Evo City, Ayala Vermosa, Robinsons Gen. Trias, Robinsons Imus, SM Tanza). The "Run First Provisioning" pill disappears on the 45 pre-existing rows.
7. Click any store row. The detail dialog opens with the store name as the primary header.

## Test plan

- [ ] `/dashboard/bd/companies` loads with the amber "Populate S181 Fields" banner at the top (before populate ran)
- [ ] Click the banner button → backend `populate_s181_fields` returns `{ok: true, phase3: {...}, phase4: {...}, pre_provisioned_sentinels_set: N}`
- [ ] Green success banner shows per-phase mutation counts
- [ ] List refreshes automatically and fields are populated on every row
- [ ] Search "Bebang Mega" → returns 5 rows (5 stores)
- [ ] Search "Ayala" → returns ~4 rows (Ayala Evo City, Ayala Fairview Terraces, Ayala Market! Market!, Ayala Solenad 2, Ayala UP Town Center, Ayala Vermosa)
- [ ] Filter Entity Category = Store → ~48 rows
- [ ] Filter + Store Ownership = Managed Franchise → smaller subset
- [ ] Click "Ayala Evo City" → dialog opens with "Ayala Evo City" as primary label, "BEBANG MEGA INC. (BMI2)" as secondary
- [ ] Click "Ayala Vermosa" → dialog opens with "Ayala Vermosa" as primary label, same "BEBANG MEGA INC. (BMI2)" secondary (shared company)
- [ ] "Run First Provisioning" pill does NOT appear on any pre-existing company row
- [ ] Green "Provisioned" badge appears on every pre-existing row's Provisioning column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
