### PR TITLE
fix(S182): use SUPABASE_DAILY_VIEW constant for per-store website SQL

### DIFF
--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -1127,12 +1127,18 @@ def _get_store_website_split_map(
 	end_day: date,
 	location_ids: list[int],
 ) -> dict[int, dict[str, float]]:
-	"""S182: per-store website non-COD + COD net sales from `daily_store_metrics` MV.
+	"""S182: per-store website non-COD + COD net sales from the daily store MV.
 
 	Website channels do NOT exist in `v_pos_orders_live` (per `sales_dashboard.py:849`
 	docstring) — they are sourced from the MV. The MV columns are
 	`website_non_cod_net_sales_without_vat` and `web_cod_net_sales_without_vat`
 	(verified at `output/s182/mv_column_verification.md`).
+
+	**Relation name:** `public.sales_dashboard_daily_store_metrics` — NOT
+	`public.daily_store_metrics`. The original Phase B helper used the shorthand
+	from the docstring at line ~831 which does not match the real relation name.
+	Fix landed post-PR#540 deploy when L3 smoke surfaced
+	`SQL error at FROM public.daily_store_metrics`.
 
 	Returns: { location_id: { website_non_cod, website_cod } } with both keys present.
 	Zero-fill stores with no rows.
@@ -1145,7 +1151,7 @@ def _get_store_website_split_map(
 			location_id,
 			SUM(website_non_cod_net_sales_without_vat)::numeric(14,2) AS web_non_cod,
 			SUM(web_cod_net_sales_without_vat)::numeric(14,2) AS web_cod
-		FROM public.daily_store_metrics
+		FROM public.{SUPABASE_DAILY_VIEW}
 		WHERE business_date >= '{start_day.isoformat()}'
 		  AND business_date <= '{end_day.isoformat()}'
 		  AND location_id IN ({loc_csv})
@@ -1164,7 +1170,7 @@ def _get_store_website_split_map(
 			("business_date", f"lte.{end_day.isoformat()}"),
 			("location_id", f"in.({_location_scope_key(location_ids)})"),
 		]
-		raw_rows = _supabase_get_all("daily_store_metrics", params, page_size=1000)
+		raw_rows = _supabase_get_all(SUPABASE_DAILY_VIEW, params, page_size=1000)
 		acc: dict[int, dict[str, float]] = {}
 		for raw in raw_rows:
 			lid = _to_int(raw.get("location_id"))


### PR DESCRIPTION
## Hotfix for S182 Phase B (PR #540 deploy)

### Symptom
After #540 deployed, the Sales Dashboard shows:

> **Dashboard load failed**
> `\t\tFROM public.daily_store_metrics\n  ^\n`

### Root cause
Phase B's new \`_get_store_website_split_map\` helper wrote SQL against
\`public.daily_store_metrics\` — that relation does not exist. The real
relation name is \`public.sales_dashboard_daily_store_metrics\`, stored in
the \`SUPABASE_DAILY_VIEW\` constant at line 42 and used by all existing
PostgREST call sites.

The mistake came from the docstring at line ~831 which describes \"the
materialized view daily_store_metrics\" as shorthand for the concept, not
the Postgres relation name. The Phase B implementation trusted the
docstring instead of the actual constant.

### Fix
- SQL now interpolates \`public.{SUPABASE_DAILY_VIEW}\` so the helper tracks
  whatever the canonical view name is today (and any future rename)
- PostgREST fallback arg also uses \`SUPABASE_DAILY_VIEW\` instead of the
  bare wrong literal — both the fast path and the fallback were broken in
  the same way
- Docstring updated with the real relation name + a pointer to this fix
  trail so nobody else copies the shorthand

### Scope
- Only \`hrms/api/sales_dashboard.py\` (one function, one SQL string, one
  fallback arg, one docstring)
- \`python -c \"import ast; ast.parse(...)\"\` → OK
- No workflows, no other helpers

### Branch rule
Created from current \`origin/production\` per the **\"every new fix =
new branch\"** rule — PR #540 is already merged so pushing back to
\`s182-store-rankings-per-channel\` is blocked by the PreToolUse hook
(and would be lost on cleanup anyway).

### Deploy notes
This is still a new Python symbol change path (SQL string literal
change), so the same rule applies: dispatch \`build-and-deploy.yml\`
with \`skip_build=false, no_cache=true\`. A cached deploy will ship
the broken SQL again.

### Post-deploy smoke test
\`\`\`bash
bench --site hq.bebang.ph execute hrms.api.sales_dashboard.get_sales_dashboard_store_rankings \
  --kwargs '{\"start_date\":\"2026-04-10\",\"end_date\":\"2026-04-10\",\"stores\":null}'
\`\`\`
Should return with per-store \`channel_mix\` dicts populated (non-zero
website_non_cod / website_cod on stores that had web orders in the
window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)