### PR TITLE
fix(S182): _effective_end_day ignores dead channels for per-store drill-down

### DIFF
--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -1341,7 +1341,18 @@ def _effective_end_day(requested_end_day: date, freshness: dict[str, Any]) -> da
 	]
 	if not core_sales_dates:
 		return requested_end_day
-	return min(requested_end_day, min(core_sales_dates))
+	# S182 fix (2026-04-11): ignore "dead" channels for the current scope —
+	# channels whose max business_date is more than 7 days behind the newest
+	# channel have not been syncing for this scope and clamping by them
+	# collapses per-store drill-down windows where one particular store has
+	# never had web orders (so web_max is ancient). For the fleet-wide Sales
+	# Dashboard view both channels are typically within 1 day of each other
+	# so this filter is a no-op and the old `min(pos, web)` semantics still
+	# apply. Only per-store drill-downs see a behavior change, and for them
+	# the old behavior was wrong.
+	newest = max(core_sales_dates)
+	relevant_dates = [d for d in core_sales_dates if (newest - d).days <= 7]
+	return min(requested_end_day, min(relevant_dates))
 
 
 def _effective_discount_end_day(sales_effective_end_day: date, freshness: dict[str, Any]) -> date:


### PR DESCRIPTION
## Hotfix #2 for S182 (per-store page shows zeros)

### Symptom
After #540 + #542 deployed, the dedicated per-store page shows all zeros for specific stores that the Leaderboard shows with real sales in the same window.

See Sam's screenshot: [Megaworld Venice Grand Canal dynamic page] shows \`₱0 / 0 / 0 / ₱0.00\` across all KPI tiles with an empty Daily Signals table, while the Leaderboard shows the same store with non-zero net sales in every per-channel column.

### Root cause
\`_effective_end_day\` computes:

\`\`\`python
min(requested_end_day, min(pos_max_business_date, web_max_business_date))
\`\`\`

For the fleet-wide Sales Dashboard view this is correct: both channels are typically within 1 day of each other so the inner \`min()\` picks yesterday and avoids showing today's partial-sync data.

For a per-store drill-down scope, the freshness object is computed **for one location_id**. If that particular store never had recent web orders (or had one old web order years ago and then stopped), its \`web_max_business_date\` is ancient (e.g., \`2024-01-01\`) while \`pos_max\` is current (\`2026-04-10\`). \`min(pos, web)\` then collapses to the ancient date, and

\`\`\`python
sales_rows = _query_daily_rows(start_day=2026-04-01, effective_end=2024-01-01, [location_id])
\`\`\`

returns an empty list because \`effective_end < start_day\`, which is exactly the empty-rows branch at \`_build_dashboard_overview_payload:2840-2842\`. All zeros propagate up.

The store shows in the Leaderboard because fleet-wide \`web_max\` is recent (some store had a web order yesterday), so the clamp is fine for the all-stores path. This bug was latent — the dynamic per-store page is the first UI surface to exercise single-store overview fetches.

### Fix
Filter out channels whose max business_date is more than 7 days behind the newest channel before taking the min. This means:

- **Fleet view** with \`pos_max=2026-04-11\` and \`web_max=2026-04-10\` → gap 1 day, both kept, \`min()\` result unchanged (backward compatible)
- **Per-store view** with \`pos_max=2026-04-11\` and \`web_max=2024-01-01\` → gap 828 days, web channel dropped as \"dead for this scope\", clamp uses \`pos_max\` only, window no longer collapses

7 days is a defensible buffer: POS and web should always be within a few days of each other during normal operation. A gap larger than that means the channel is not syncing for this specific scope.

### Scope
- Only \`hrms/api/sales_dashboard.py\` — one function (\`_effective_end_day\`)
- No workflow changes
- Backward compatible for fleet view
- \`ast.parse(...)\` → OK

### Branch rule
Created from current \`origin/production\` per the \"every new fix = new branch\" rule — #540 and #542 are both merged so pushing to either would be blocked by the hook and stranded on cleanup.

### Deploy notes
Python source change, still requires full rebuild:

\`\`\`
skip_build=false
no_cache=true
\`\`\`

### Post-deploy smoke test
Open \`/dashboard/analytics/sales/stores/<location_id>?start=2026-04-01&end=2026-04-11\` for any store that shows non-zero sales on the Leaderboard (e.g., the Megaworld Venice Grand Canal row from the screenshot). The per-store page should now show matching KPIs and daily rows instead of all zeros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)