### PR TITLE
fix(S184): map last 3 unmatched Superadmin stores — all 48 covered

### DIFF
--- a/hrms/api/company_master.py
+++ b/hrms/api/company_master.py
@@ -1614,7 +1614,7 @@ def populate_s181_fields() -> dict:
 			# Untagged companies Sam identified
 			"TASTECARTEL CORP.": "The Grid - Rockwell",
 			"JL TRADE OPC": "SM SJDM",
-			"DLS Dessert Craft Inc.": "Ever Gotesco Commonwealth",
+			"DLS Dessert Craft Inc.": "Ever Commonwealth",
 			# Companies whose S037 buyer differs from Frappe name
 			"BEBANG BF HOMES INC.": "BF Homes",
 			"BEBANG FT INC.": "Ayala Malls Fairview Terraces",
@@ -1626,6 +1626,9 @@ def populate_s181_fields() -> dict:
 			"BEBANG MARKET MARKET INC.": "Ayala Market Market",
 			"BEBANG SMM INC.": "SM  Manila",
 			"BEBANG SMOA INC.": "SM Mall Of Asia",
+			"BEIFRANCHISE FOOD OPC": "Ortigas Land Greenhills",
+			"TAJ FOOD CORP.": "D'Verde Calamba",
+			"Bebang Kitchen Inc.": "Shaw BLVD",
 		}
 
 		for company_name in all_company_names:


### PR DESCRIPTION
## Summary

PR #554 mapped 45/48 Superadmin API stores. This fixes the remaining 3:

| Frappe Company | Superadmin Store | Fix |
|---|---|---|
| DLS Dessert Craft Inc. | Ever Commonwealth | Was mapped to "Ever Gotesco Commonwealth" (wrong SA name) |
| BEIFRANCHISE FOOD OPC | Ortigas Land Greenhills | SA has "Land" prefix, S037 doesn't |
| TAJ FOOD CORP. | D'Verde Calamba | Apostrophe handling in name matching |
| Bebang Kitchen Inc. | Shaw BLVD | Commissary GPS |

**All 48 Superadmin API stores now have a Frappe company mapping.** After deploy + re-run populate, every store gets GPS.

## Test plan
- [ ] Deploy + re-run "Populate S181 Fields"
- [ ] Verify GPS on DLS Dessert Craft, BEIFRANCHISE FOOD, TAJ FOOD CORP, Bebang Kitchen

🤖 Generated with [Claude Code](https://claude.com/claude-code)