### PR TITLE
fix(S184): map last 3 unmatched Superadmin stores — all 48 covered

### DIFF
--- a/hrms/api/company_master.py
+++ b/hrms/api/company_master.py
@@ -1614,7 +1614,7 @@ def populate_s181_fields() -> dict:
 			# Untagged companies Sam identified
 			"TASTECARTEL CORP.": "The Grid - Rockwell",
 			"JL TRADE OPC": "SM SJDM",
-			"DLS Dessert Craft Inc.": "Ever Gotesco Commonwealth",
+			"DLS Dessert Craft Inc.": "Ever Commonwealth",
 			# Companies whose S037 buyer differs from Frappe name
 			"BEBANG BF HOMES INC.": "BF Homes",
 			"BEBANG FT INC.": "Ayala Malls Fairview Terraces",
@@ -1626,6 +1626,9 @@ def populate_s181_fields() -> dict:
 			"BEBANG MARKET MARKET INC.": "Ayala Market Market",
 			"BEBANG SMM INC.": "SM  Manila",
 			"BEBANG SMOA INC.": "SM Mall Of Asia",
+			"BEIFRANCHISE FOOD OPC": "Ortigas Land Greenhills",
+			"TAJ FOOD CORP.": "D'Verde Calamba",
+			"Bebang Kitchen Inc.": "Shaw BLVD",
 		}
 
 		for company_name in all_company_names:


### PR DESCRIPTION
## Summary
- Fix Ever Gotesco Commonwealth → Ever Commonwealth (correct SA API name)
- Add BEIFRANCHISE FOOD OPC → Ortigas Land Greenhills
- Add TAJ FOOD CORP. → D'Verde Calamba
- Add Bebang Kitchen Inc. → Shaw BLVD (commissary)

Recreated from closed PR #555 whose branch was accidentally deleted during cleanup.

## Test plan
- [ ] Deploy and re-run `populate_s181_fields` — all 48 SA stores should map
- [ ] Only JV and Managed Franchise should remain without GPS (junk companies to delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)