### PR TITLE
fix(S186): accept name param in get_supplier_overview

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -7800,11 +7800,13 @@ def get_supplier_grid(
 
 
 @frappe.whitelist()
-def get_supplier_overview(supplier):
+def get_supplier_overview(name=None, supplier=None):
     """Single-call supplier detail — identity, metrics, items, POs, GRs, invoices, monthly spend.
 
     Returns everything the Supplier Overview page needs in one round-trip.
     All metrics are computed live via SQL (not from stored DocType fields).
+
+    Accepts `name` (from proxy :name param) or `supplier` for direct calls.
     """
     from hrms.utils.sentry import set_backend_observability_context
     set_backend_observability_context(module="procurement", action="get_supplier_overview")
@@ -7814,6 +7816,8 @@ def get_supplier_overview(supplier):
         _("You do not have permission to view the Supplier Hub."),
     )
 
+    # Accept either `name` (proxy convention) or `supplier` (direct call)
+    supplier = name or supplier
     if not supplier:
         frappe.throw(_("Supplier is required."))
 


### PR DESCRIPTION
## Summary
The API proxy sends `:name` URL params as `name=...` to Frappe. `get_supplier_overview` expected a `supplier` param, so every detail page click resulted in "Supplier not found".

Now accepts both `name` (from proxy) and `supplier` (for direct API calls).

## Test plan
- [ ] Click any supplier row in the grid → overview loads correctly
- [ ] Direct API call with `?supplier=SUP-001` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)