### PR TITLE
fix(S184): GPS sync API key — check env vars + better error message

### DIFF
--- a/hrms/api/company_master.py
+++ b/hrms/api/company_master.py
@@ -1712,11 +1712,20 @@ def populate_s181_fields() -> dict:
 
 def _s184_fetch_superadmin_stores() -> list[dict]:
 	"""Fetch store list from Superadmin API. Returns [] on failure."""
+	import os
 	import requests
 
-	api_key = frappe.conf.get("superadmin_stores_api_key") or ""
+	# Try multiple sources for the API key:
+	# 1. Frappe site_config.json
+	# 2. Environment variable (set by Docker/Doppler)
+	# 3. Doppler CLI fallback (local dev only)
+	api_key = (
+		frappe.conf.get("superadmin_stores_api_key")
+		or os.environ.get("SUPERADMIN_STORES_API_KEY")
+		or os.environ.get("SUPERADMIN_API_KEY")
+		or ""
+	)
 	if not api_key:
-		# Try Doppler fallback (local dev only)
 		import subprocess
 		import sys
 
@@ -1733,7 +1742,13 @@ def _s184_fetch_superadmin_stores() -> list[dict]:
 			pass
 
 	if not api_key:
-		frappe.log_error(title="S184 GPS sync", message="SUPERADMIN_STORES_API_KEY not available")
+		frappe.log_error(
+			title="S184 GPS sync: no API key",
+			message="Checked: frappe.conf.superadmin_stores_api_key, "
+			"env SUPERADMIN_STORES_API_KEY, env SUPERADMIN_API_KEY, doppler CLI. "
+			"None available. Add the key to site_config.json: "
+			'bench set-config superadmin_stores_api_key "bebang_..."',
+		)
 		return []
 
 	try:


### PR DESCRIPTION
## Summary

GPS sync was silently returning 0 stores because the Superadmin API key wasn't available on the server. The function only checked `frappe.conf` and Doppler CLI — neither works inside Docker.

### Root Cause
`_s184_fetch_superadmin_stores()` tried:
1. `frappe.conf.get("superadmin_stores_api_key")` — not in site_config.json
2. `doppler` CLI — not installed in Docker container

Both failed silently, returning `[]`. GPS sync skipped all stores.

### Fix
Now checks 4 sources in order:
1. `frappe.conf.superadmin_stores_api_key` (site_config.json)
2. `os.environ["SUPERADMIN_STORES_API_KEY"]` (Docker env / Doppler injection)
3. `os.environ["SUPERADMIN_API_KEY"]` (alternate name)
4. `doppler` CLI fallback (local dev only)

If all fail, logs a detailed error with the fix command.

### Action After Merge
Either:
- **Option A:** `bench set-config superadmin_stores_api_key "bebang_ZNb..."` on the server
- **Option B:** Add `SUPERADMIN_STORES_API_KEY` to Docker env vars

Then re-run "Populate S181 Fields" — GPS will populate for all 48 stores.

## Test plan
- [ ] Deploy + add API key via bench set-config or env var
- [ ] Re-run populate
- [ ] Verify GPS on all 48 stores

🤖 Generated with [Claude Code](https://claude.com/claude-code)