### PR TITLE
fix(S188): switch to workbook CSV + fix 5 unresolved stores

### DIFF
--- a/hrms/api/company_master.py
+++ b/hrms/api/company_master.py
@@ -496,7 +496,7 @@ def retry_provision(company: str) -> dict:
 # never cloned by GitHub Actions when it builds the bench image, so
 # `_load_s037_rows()` returned an empty list and the entire feature
 # silently produced 0 store rows. L3 testing caught this on first run.
-_S037_RELPATH = ("data_seed", "store_buyer_entity_register_2026-03-12.csv")
+_S037_RELPATH = ("data_seed", "store_entity_mapping_2026-04-13.csv")
 
 # Non-store legal entities that don't appear in S037 but should still
 # appear in the list. Category maps to the S181 entity_category field.
@@ -1186,7 +1186,7 @@ def populate_s181_fields() -> dict:
 			if _set(company_name, "store_ownership_type", ownership):
 				p3_per_field["store_ownership_type"] = p3_per_field.get("store_ownership_type", 0) + 1
 				changed = True
-			active = (s037.get("active_fulfillment_status") or "").strip().lower()
+			active = (s037.get("active_status") or s037.get("active_fulfillment_status") or "").strip().lower()
 			status = "Active" if active == "active" else "Temporarily Closed"
 			if _set(company_name, "operational_status", status):
 				p3_per_field["operational_status"] = p3_per_field.get("operational_status", 0) + 1

--- a/hrms/data_seed/bir_entity_register_2026-04-13.csv
+++ b/hrms/data_seed/bir_entity_register_2026-04-13.csv
@@ -1,0 +1,55 @@
+entity_name,type,store_purpose,tin,rdo_code,vat_status
+Bebang Enterprise Inc.,Corporation,Head Office,647-243-690-00000,041,VAT Registered
+Bebang Kitchen Inc,Corporation,Commissary,010-880-681-00001,041,VAT Registered
+Resto Tech Inc,Corporation,Head Office,655-821-050-00000,041,VAT Registered
+Irresistible Infusions Inc,Corporation,Head Office,634-954-873-00000,041,VAT Registered
+Bebang Shaw Inc,Corporation,Commissary,651-116-069-00000,041,VAT Registered
+Bebang Enterprise Inc.,Corporation,SM Megamall,647-243-690-00001,041,VAT Registered
+Bebang Market Market Inc.,Corporation,Ayala Market! Market!,656-572-595-00001,044,VAT Registered
+Bebang Enterprise Inc.,Corporation,SM Manila,647-243-690-00002,033,VAT Registered
+Bebang Enterprise Inc.,Corporation,SM Southmall,647-243-690-00004,53A,VAT Registered
+Bebang FTE Inc.,Corporation,Ayala Fairview Terraces,663-440-106-00001,028,VAT Registered
+Bebang North Edsa Inc.,Corporation,SM North EDSA,663-447-579-00001,038,VAT Registered
+Bebang SMV Inc.,Corporation,SM Valenzuela,665-313-198-00001,024,VAT Registered
+Bebang LCT Inc,Corporation,Lucky China Town,665-462-689-00001,030,VAT Registered
+Bebang Enterprise Inc.,Corporation,Robinsons Place Antipolo,647-243-690-00005,045,VAT Registered
+Bebang Starmall Alabang Inc.,Corporation,The Terminal Exchange,670-277-140-00001,53B,VAT Registered
+Bebang Grand Central Inc.,Corporation,SM Grand Central,010-880-753-00001,027,VAT Registered
+Bebang SM Marikina Inc.,Corporation,SM Marikina,670-282-332-00001,045,VAT Registered
+Bebang Paseo Inc,Corporation,Paseo Center,010-880-720-00001,050,VAT Registered
+Bebang PITX Inc,Corporation,PITX Terminal,010-880-712-00001,052,VAT Registered
+Bebang SMEO Inc,Corporation,SM East Ortigas,665-312-808-00001,043,VAT Registered
+Bebang Venice Grand Canal Inc.,Corporation,Venice Grand Canal,010-880-690-00001,044,VAT Registered
+Bebang Festival Inc.,Corporation,Festival Mall Alabang,672-618-586-00001,53B,VAT Registered
+Bebang SMOA Inc.,Corporation,SM Mall of Asia,665-459-236-00001,051,VAT Registered
+Bebang BF Homes Inc.,Corporation,BF Homes Paranaque (Aguirre Ave.),673-762-767-00000,052,VAT Registered
+JL TRADE OPC,Corporation,SM San Jose Del Monte,775-842-763-00003,25B,VAT Registered
+Bebang Mega Inc,Corporation,SM Tanza,010-885-436-00001,054B,VAT Registered
+Tungsten Capital Holdings OPC,Corporation,SM Sangandaan,679-843-234-00001,027,VAT Registered
+Bebang Marilao Inc,Corporation,SM Marilao,675-267-457-00001,025B,VAT Registered
+Bebang SM Bicutan Inc.,Corporation,SM Bicutan,010-887-661-00001,052,VAT Registered
+TAJ Food Corp,Corporation,SM Caloocan,681-325-053-00001,027,VAT Registered
+Bebang Mega Inc,Corporation,Robinsons Place Imus,010-885-436-00002,54A,VAT Registered
+Bebang UP Town Center Inc.,Corporation,Ayala UP Town Center,675-270-405-00001,039,VAT Registered
+Bebang Mega Inc,Corporation,Ayala Evo City,010-885-436-00004,54B,VAT Registered
+Bebang Mega Inc,Corporation,Ayala Vermosa,010-885-436-00005,54A,VAT Registered
+Bebang Mega Inc,Corporation,Robinsons Place Gen. Trias,010-885-436-00003,54B,VAT Registered
+Bebang SMM Inc.,Corporation,SM Center Pulilan,662-567-267-00001,25A,VAT Registered
+HFFM Solenad Food Services Inc.,Corporation,Ayala Solenad 2,681-476-808-00001,057,VAT Registered
+Bebang SM Marikina Inc.,Corporation,Sta. Lucia East Grand Mall,670-282-332-00002,046,VAT Registered
+Tungsten Capital Holdings OPC,Corporation,Robinsons Galleria South,679-843-234-00002,057,VAT Registered
+Halo-Halo Terminal Food Corp.,Corporation,NAIA T3 (Departure),690-528-808-00000,051,VAT Registered
+DMD Holdings Inc,Corporation,Uptown Mall,649-154-841-00001,044,VAT Registered
+Red Taldawa Foods OPC,Corporation,SM Clark,687-525-727-00007,21A,VAT Registered
+B Cubed Ventures Corp.,Corporation,Tomas Morato (CTTM Square),682-574-745-00001,039,VAT Registered
+Tricern Food Corp.,Corporation,Vista Mall Taguig,010-038-108-00005,044,VAT Registered
+Tungsten Capital Holdings OPC,Corporation,Food Express (Gateway Mall),679-843-234-00003,040,VAT Registered
+Freeze Delight Inc.,Corporation,Robinsons Place Dasmarinas,697-636-476-00001,54A,VAT Registered
+Day Ones Food and Drink Establishments Corp.,Corporation,SM Taytay,010-939-944-00001,046,VAT Registered
+TAJ Food Corp,Corporation,D'Verde Calamba,681-325-053-00002,056,VAT Registered
+BEIFranchise Food OPC,Corporation,Ortigas Greenhills,688-721-280-00001,042,VAT Registered
+BB Estancia Food Corp.,Corporation,Ortigas Estancia,693-136-289-00001,043,VAT Registered
+Sweet Harmony Food Corp,Corporation,SM Sta. Rosa,691-378-334-00000,057,VAT Registered
+DLS Dessert Craft Inc.,Corporation,Ever Gotesco Commonwealth,671-219-097-00001,028,VAT Registered
+Tastecartel Corp.,Corporation,The Grid,672-270-879-00001,049,VAT Registered
+Perpetual Food Corp,Corporation,Xetromall Montalban,698-838-619-00000,045,VAT Registered

--- a/hrms/data_seed/company_register_2026-04-13.csv
+++ b/hrms/data_seed/company_register_2026-04-13.csv
@@ -1,0 +1,41 @@
+frappe_company_name,abbr,company_type,parent_company,bir_entity_name,tin,rdo_code,vat_status
+Irresistible Infusions Inc.,III,Holding Company,(standalone),Irresistible Infusions Inc.,634-954-873-00000,041,VAT Registered
+Bebang Enterprise Inc.,BEI,Head Office,Irresistible Infusions Inc.,Bebang Enterprise Inc.,647-243-690-00000,041,VAT Registered
+Bebang Kitchen Inc.,BKI,Commissary,Irresistible Infusions Inc.,Bebang Kitchen Inc,010-880-681-00001,041,VAT Registered
+BEBANG FRANCHISE CORP.,BFC,Franchisor,(standalone),BEBANG FRANCHISE CORP.,672-618-804-00000,044,VAT Registered
+DMD HOLDINGS INC.,DHI,Holdings,(standalone),DMD Holdings Inc,649-154-841-00000,041,VAT Registered
+TUNGSTEN CAPITAL HOLDINGS OPC,BAG,Store Corporation,(standalone),TUNGSTEN CAPITAL HOLDINGS OPC,679-843-234-00000,044,VAT Registered
+HFFM SOLENAD FOOD SERVICES INC.,BAS,Store Corporation,(standalone),HFFM SOLENAD FOOD SERVICES INC.,681-476-808-00000,034,VAT Registered
+BEBANG BF HOMES INC.,BBHI,Store Corporation,(standalone),Bebang BF Homes Inc.,673-762-767-00000,052,VAT Registered
+TAJ FOOD CORP.,BDV,Store Corporation,(standalone),TAJ Food Corp.,681-325-053-00000,042,VAT Registered
+DLS Dessert Craft Inc.,BEGC,Store Corporation,(standalone),DLS Dessert Craft Inc.,671-219-097-00000,RDO,
+BEBANG FESTIVAL INC.,BFI,Store Corporation,(standalone),Bebang Festival Inc.,672-618-586-00000,044,VAT Registered
+BEBANG FT INC.,BFI2,Store Corporation,(standalone),Bebang FT Inc.,663-440-106-00000,044,VAT Registered
+BEBANG GRAND CENTRAL INC.,BGCI,Store Corporation,(standalone),Bebang Grand Central Inc.,010-880-753-00000,044,VAT Registered
+BEBANG LCT INC.,BLI,Store Corporation,(standalone),Bebang LCT Inc,665-462-689-00000,044,VAT Registered
+BEBANG MARILAO INC.,BMI,Store Corporation,(standalone),Bebang Marilao Inc,675-267-457-00000,044,VAT Registered
+BEBANG MARKET MARKET INC.,BMMI,Store Corporation,(standalone),Bebang Market Market Inc.,656-572-595-00000,044,VAT Registered
+BEBANG MEGA INC.,BMI2,Store Corporation,(standalone),Bebang Mega Inc,010-885-436-00000,044,VAT Registered
+BEBANG NORTH EDSA INC.,BNEI,Store Corporation,(standalone),Bebang North Edsa,663-447-579-00000,044,VAT Registered
+BEBANG PASEO INC.,BPI,Store Corporation,(standalone),Bebang Paseo Inc,010-880-720-00000,044,VAT Registered
+BEBANG PITX INC.,BPI2,Store Corporation,(standalone),Bebang PITX Inc,010-880-712-00000,044,VAT Registered
+BEBANG SM BICUTAN INC.,BSBI,Store Corporation,(standalone),Bebang SM Bicutan Inc.,010-887-661-00000,044,VAT Registered
+RED TALDAWA FOODS OPC,BSC2,Store Corporation,(standalone),RED TALDAWA FOODS OPC,687-525-727-00000,21B,VAT Registered
+BEBANG SM MARIKINA INC.,BSMI,Store Corporation,(standalone),Bebang SM Marikina Inc.,670-282-332-00000,044,VAT Registered
+JL TRADE OPC,BSS2,Store Corporation,(standalone),JL TRADE OPC,775-842-763-00000,045,VAT Registered
+DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.,BST,Store Corporation,(standalone),DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.,010-939-944-00000,049,VAT Registered
+BEBANG SMEO INC.,BSI,Store Corporation,(standalone),Bebang SMEO Inc,665-312-808-00000,044,VAT Registered
+BEBANG SMM INC.,BSI2,Store Corporation,(standalone),Bebang SMM Inc.,662-567-267-00000,044,VAT Registered
+BEBANG SMOA INC.,BSI3,Store Corporation,(standalone),Bebang SMOA Inc.,665-459-236-00000,044,VAT Registered
+BEBANG SMV INC.,BSI4,Store Corporation,(standalone),Bebang SMV Inc.,665-313-198-00000,044,VAT Registered
+BEBANG STARMALL ALABANG INC.,BSAI,Store Corporation,(standalone),Bebang Starmall Alabang Inc.,670-277-140-00000,044,VAT Registered
+TASTECARTEL CORP.,BTGF,Store Corporation,(standalone),TASTECARTEL CORP.,672-270-879-00000,040,VAT Registered
+B CUBED VENTURES CORP.,BTM,Store Corporation,(standalone),B CUBED VENTURES CORP.,682-574-745-00000,039,VAT Registered
+BEBANG UP TOWN CENTER INC.,BUTC,Store Corporation,(standalone),Bebang UP Town Center Inc.,675-270-405-00000,044,VAT Registered
+BEBANG VENICE GRAND CANAL INC.,BVGC,Store Corporation,(standalone),Bebang Venice Grand Canal Inc.,010-880-690-00000,044,VAT Registered
+TRICERN FOOD CORP.,BV,Store Corporation,(standalone),TRICERN FOOD CORP.,010-038-108-00000,53A,VAT Registered
+SWEET HARMONY FOOD CORP.,,Store Corporation,(standalone),SWEET HARMONY FOOD CORP.,691-378-334-00000,057,VAT Registered
+HALO-HALO TERMINAL FOOD CORP.,,Store Corporation,(standalone),HALO-HALO TERMINAL FOOD CORP.,690-528-808-00000,051,VAT Registered
+BEIFRANCHISE FOOD OPC,,Store Corporation,(standalone),BEIFRANCHISE FOOD OPC,688-721-280-00000,028,VAT Registered
+BB ESTANCIA FOOD CORP.,,Store Corporation,(standalone),BB ESTANCIA FOOD CORP.,693-136-289-00000,043,VAT Registered
+PERPETUAL FOOD CORP.,,Store Corporation,(standalone),PERPETUAL FOOD CORP.,698-838-619-00000,045,VAT Registered

--- a/hrms/data_seed/store_entity_mapping_2026-04-13.csv
+++ b/hrms/data_seed/store_entity_mapping_2026-04-13.csv
@@ -1,0 +1,50 @@
+store_name,buyer_entity_name,store_type,warehouse_docname,billing_policy,active_status
+Ayala Evo City,Bebang Mega Inc,Managed Franchise,Ayala Evo - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Ayala Fairview Terraces,Bebang FTE Inc.,JV,Ayala Malls Fairview Terraces - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Ayala Market! Market!,Bebang Market Market Inc.,JV,Ayala Market Market - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Ayala Solenad 2,HFFM Solenad Food Services Inc.,Managed Franchise,Ayala Solenad - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Ayala UP Town Center,Bebang UP Town Center Inc.,JV,Ayala UPTC - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Ayala Vermosa,Bebang Mega Inc,Managed Franchise,Ayala Vermosa - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+BF Homes Paranaque (Aguirre Ave.),Bebang BF Homes Inc.,JV,BF Homes - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+D'Verde Calamba,TAJ Food Corp,Managed Franchise,D'verde Laguna - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Ever Gotesco Commonwealth,DLS Dessert Craft Inc.,Full Franchise,Ever Commonwealth - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY__PROVISIONAL_ENTITY_HOLD,active_with_billing_hold
+Festival Mall Alabang,Bebang Festival Inc.,JV,Festival Mall Alabang - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Food Express (Gateway Mall),Tungsten Capital Holdings OPC,Managed Franchise,Araneta Gateway - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Lucky China Town,Bebang LCT Inc,JV,Lucky Chinatown - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+NAIA T3 (Departure),Halo-Halo Terminal Food Corp.,Managed Franchise,NAIA T3 - BKI,BKI_TO_STORE_INTERCOMPANY,active
+Ortigas Estancia,BB Estancia Food Corp.,Managed Franchise,,BKI_TO_STORE_INTERCOMPANY,active
+Ortigas Greenhills,BEIFranchise Food OPC,Managed Franchise,Greenhills Ortigas - BKI,BKI_TO_STORE_INTERCOMPANY,active
+PITX Terminal,Bebang PITX Inc,JV,Megawide PITX - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Paseo Center,Bebang Paseo Inc,JV,,BKI_TO_STORE_INTERCOMPANY,active
+Robinsons Galleria South,Tungsten Capital Holdings OPC,Managed Franchise,Robisons Galleria South - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Robinsons Place Antipolo,Bebang Enterprise Inc.,JV,Robinsons Antipolo - Bebang Enterprise Inc.,BKI_TO_BEI_INTERCOMPANY_WITH_STORE_ALLOCATION,active
+Robinsons Place Dasmarinas,Freeze Delight Inc.,Managed Franchise,,BKI_TO_STORE_INTERCOMPANY,excluded
+Robinsons Place Gen. Trias,Bebang Mega Inc,Managed Franchise,,BKI_TO_STORE_INTERCOMPANY,active
+Robinsons Place Imus,Bebang Mega Inc,Managed Franchise,,BKI_TO_STORE_INTERCOMPANY,active
+SM Bicutan,Bebang SM Bicutan Inc.,JV,SM Bicutan - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Caloocan,TAJ Food Corp,Managed Franchise,SM Caloocan - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Center Pulilan,Bebang SMM Inc.,Managed Franchise,SM Pulilan - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Clark,Red Taldawa Foods OPC,Managed Franchise,SM Clark - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM East Ortigas,Bebang SMEO Inc,JV,SM East Ortigas - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Grand Central,Bebang Grand Central Inc.,JV,SM Grand Central - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Mall of Asia,Bebang SMOA Inc.,JV,SM Mall Of Asia - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Manila,Bebang Enterprise Inc.,JV,SM  Manila - Bebang Enterprise Inc.,BKI_TO_BEI_INTERCOMPANY_WITH_STORE_ALLOCATION,active
+SM Marikina,Bebang SM Marikina Inc.,JV,SM Marikina - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Marilao,Bebang Marilao Inc,JV,SM Marilao - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Megamall,Bebang Enterprise Inc.,JV,SM Megamall - Bebang Enterprise Inc.,BKI_TO_BEI_INTERCOMPANY_WITH_STORE_ALLOCATION,active
+SM North EDSA,Bebang North Edsa Inc.,JV,SM North EDSA - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM San Jose Del Monte,Legacy77 Food Corp,Managed Franchise,SJDM - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Sangandaan,Tungsten Capital Holdings OPC,Managed Franchise,SM Sangandaan - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Southmall,Bebang Enterprise Inc.,JV,SM Southmall - Bebang Enterprise Inc.,BKI_TO_BEI_INTERCOMPANY_WITH_STORE_ALLOCATION,active
+SM Sta. Rosa,Sweet Harmony Food Corp,Managed Franchise,SM Sta. Rosa - BKI,BKI_TO_STORE_INTERCOMPANY,active
+SM Tanza,Bebang Mega Inc,Managed Franchise,SM Tanza - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+SM Taytay,Day Ones Food and Drink Establishments Corp.,Managed Franchise,SM Taytay - BKI,BKI_TO_STORE_INTERCOMPANY,active
+SM Valenzuela,Bebang SMV Inc.,JV,SM Valenzuela - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Sta. Lucia East Grand Mall,Bebang SM Marikina Inc.,JV,Sta. Lucia East Grand Mall - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+The Grid - Rockwell,TASTECARTEL CORP.,Full Franchise,The Grid - Rockwell - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY__PROVISIONAL_ENTITY_HOLD,active_with_billing_hold
+The Terminal Exchange,Bebang Starmall Alabang Inc.,JV,The Terminal - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Tomas Morato (CTTM Square),B Cubed Ventures Corp.,Managed Franchise,CTTM Tomas Morato - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Uptown Mall,DMD Holdings Inc,Managed Franchise,Up Town Mall BGC - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Venice Grand Canal,Bebang Venice Grand Canal Inc.,JV,Megaworld Venice Grand Canal - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Vista Mall Taguig,Tricern Food Corp.,Managed Franchise,Vista Mall Taguig - Bebang Enterprise Inc.,BKI_TO_STORE_INTERCOMPANY,active
+Xentromall Montalban,Perpetual Food Corp.,Managed Franchise,,,


### PR DESCRIPTION
## Summary

Fixes 5 stores showing no company in list_stores after S188 deploy.

**Root cause:** list_stores read the old S037 CSV (March 12) which had wrong buyer entity names for 5 stores. The new workbook CSV (April 13) has correct names.

**Changes:**
- `_S037_RELPATH` → `store_entity_mapping_2026-04-13.csv`
- `active_fulfillment_status` → `active_status` column compatibility
- 3 new workbook CSVs added to data_seed

**SSM changes already applied (not in this PR):**
- BEBANG MEGA, TAJ, TUNGSTEN → entity_category = "Holding Company"
- LEGACY77, JV, Managed Franchise → entity_category = "Archived"
- JL TRADE OPC → branch_tin = 775-842-763-00003

## Test plan
- [ ] Deploy + open Company Master
- [ ] Verify all 49 stores show a company (no blank Company column)
- [ ] Verify Ayala Fairview → BEBANG FT INC.
- [ ] Verify The Grid → TASTECARTEL CORP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)