### PR TITLE
fix(S188): resolve 3 stores to per-store companies (billing TIN fix)

### DIFF
--- a/hrms/api/company_master.py
+++ b/hrms/api/company_master.py
@@ -602,6 +602,10 @@ def _resolve_company_for_s037_row(
 		"Sta. Lucia East Grand Mall": "Bebang SM Marikina Inc. - Sta Lucia",
 		"D'Verde Calamba": "TAJ Food Corp. - DVerde Calamba",
 		"Food Express (Gateway Mall)": "Tungsten Capital - Gateway Mall",
+		# Existing per-store companies (pre-S188, now re-parented)
+		"SM Caloocan": "BEBANG SM CALOOCAN",
+		"SM Sangandaan": "BEBANG SM SANGANDAAN",
+		"Robinsons Galleria South": "BEBANG ROBINSONS GALLERIA SOUTH",
 	}
 	if store_name and store_name in _STORE_TO_CHILD:
 		child = _STORE_TO_CHILD[store_name]


### PR DESCRIPTION
## Summary

3 stores resolved to the wrong company (parent group instead of per-store child), causing wrong branch_tin for BKI billing:

| Store | Before (wrong) | After (correct) | Correct Branch TIN |
|---|---|---|---|
| SM Caloocan | TAJ FOOD CORP. (00002) | BEBANG SM CALOOCAN | 681-325-053-00001 |
| SM Sangandaan | TUNGSTEN (00003) | BEBANG SM SANGANDAAN | 679-843-234-00001 |
| Robinsons Galleria South | TUNGSTEN (00003) | BEBANG ROBINSONS GALLERIA SOUTH | 679-843-234-00002 |

After deploy: **49/49 stores billing ready** with correct TIN.

## Test plan
- [ ] list_stores → SM Caloocan shows BEBANG SM CALOOCAN
- [ ] get_bki_billing("BEBANG SM CALOOCAN") returns correct entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)