### PR TITLE
S189 T7.2-T7.5: extend Mosaic webhook for order.completed + HMAC auth

### DIFF
--- a/hrms/api/mosaic_webhook.py
+++ b/hrms/api/mosaic_webhook.py
@@ -1,21 +1,22 @@
-"""Mosaic POS webhook receiver -- handles order.cancelled events.
+"""Mosaic POS webhook receiver -- handles order.cancelled and order.completed events.
 
-Per S169 plan: the webhook handler is the ONLY writer of `cancelled_at` and
-`cancellation_reason` columns on pos_orders (along with the nightly verify
-script's tombstone_extras path). The hourly poller never touches these
-columns -- see Design Rationale decision #9 for the full rationale.
+S169: order.cancelled — writes cancelled_at/cancellation_reason on pos_orders
+S189: order.completed — upserts pos_orders + pos_order_items with ingestion_source='webhook'
+      (complements hourly poll sync for real-time BOM consumption; poll remains
+      authoritative for order_status and sums since stores may have unstable internet).
 
-When a cancel event arrives, this handler:
-  1. Parses the JSON body using the canonical BEI pattern (get_data + json.loads)
-  2. Round-trip confirms against Mosaic's GET /api/v1/orders/{id} -- expects 404
-     (Path B auth, per T0.5 outcome: Mosaic webhook docs do not document signing)
-  3. Atomically updates the pos_orders row: cancelled_at + cancellation_reason
-     + order_status='CANCELLED', guarded by WHERE cancelled_at IS NULL
-  4. Returns HTTP 200 on success, HTTP 500 on Supabase failure (so Mosaic retries)
+Auth path:
+  - Optional HMAC check via MOSAIC_WEBHOOK_SECRET env var (if set, verify X-Mosaic-Signature)
+  - Path B fallback: round-trip Mosaic GET /api/v1/orders/{id}
+    * order.cancelled expects HTTP 404
+    * order.completed expects HTTP 200 (order exists)
 
-See docs/plans/2026-04-07-sprint-169-mosaic-order-lifecycle-tombstone-webhook.md
+See docs/plans/2026-04-13-sprint-189-realtime-bom-consumption.md (Phase 7) and
+docs/plans/2026-04-07-sprint-169-mosaic-order-lifecycle-tombstone-webhook.md (Phase 0).
 """
 import csv
+import hashlib
+import hmac
 import json
 import os
 from datetime import datetime, timezone
@@ -25,7 +26,7 @@ import frappe
 import requests
 
 from hrms.utils.sentry import set_backend_observability_context
-from hrms.utils.supabase import supabase_query_sql
+from hrms.utils.supabase import SUPABASE_URL, get_service_key, supabase_query_sql
 
 
 # Production Mosaic base URL per docs/api/MOSAIC_API.md (Section 1).
@@ -49,7 +50,7 @@ def receive():
     """
     # DM-7: observability context MUST be the first meaningful line.
     set_backend_observability_context(
-        module="sync_verification",
+        module="mosaic",
         action="mosaic_webhook_receive",
         mutation_type="update",
     )
@@ -67,6 +68,12 @@ def receive():
         frappe.local.response.http_status_code = 400
         return {"ok": False, "reason": "invalid_json"}
 
+    # S189 T7.2: if MOSAIC_WEBHOOK_SECRET is set, verify HMAC signature before processing.
+    # Falls back to round-trip Path B auth if no secret is configured.
+    if not _verify_hmac_signature(raw_body):
+        frappe.local.response.http_status_code = 401
+        return {"ok": False, "reason": "hmac_signature_invalid"}
+
     event = (payload.get("event") or "").strip()
     data = payload.get("data") or {}
 
@@ -74,31 +81,34 @@ def receive():
     if event == "ping":
         return {"ok": True, "handled": False, "reason": "ping"}
 
-    if event != "order.cancelled":
-        # We only subscribe to order.cancelled. Any other event is a mis-registration.
-        return {"ok": True, "handled": False, "reason": f"ignored event: {event}"}
+    if event == "order.cancelled":
+        return _handle_order_cancelled(data)
+    if event == "order.completed":
+        return _handle_order_completed(data)
 
+    # Any other event is a mis-registration.
+    return {"ok": True, "handled": False, "reason": f"ignored event: {event}"}
+
+
+def _handle_order_cancelled(data: dict) -> dict:
+    """S169: tombstone a cancelled order in pos_orders."""
     order_id = data.get("id")
     if not order_id:
         frappe.local.response.http_status_code = 400
         return {"ok": False, "reason": "missing order id"}
 
-    # Path B auth (T0.5 outcome): Mosaic does not sign webhooks, so verify the
-    # claim by calling GET /api/v1/orders/{id} and only proceeding on HTTP 404.
-    if not _authenticate_webhook(order_id, data):
+    # Path B auth: verify by calling GET /api/v1/orders/{id} — expect 404.
+    if not _authenticate_webhook(order_id, data, expect_status=404):
         frappe.log_error(
             title="Mosaic webhook auth failed",
-            message=f"order_id={order_id} event={event}",
+            message=f"order_id={order_id} event=order.cancelled",
         )
         frappe.local.response.http_status_code = 401
         return {"ok": False, "reason": "round_trip_confirm_failed", "order_id": order_id}
 
-    # Prefer Mosaic's authoritative timestamp; wall-clock fallback only if absent.
     cancelled_at = data.get("cancelled_at") or datetime.now(timezone.utc).isoformat()
     reason = (data.get("cancellation_reason") or "mosaic_webhook_missing_reason")[:500]
 
-    # HIGH 8: wrap Supabase write in try/except. Return 500 on failure so Mosaic
-    # retries instead of silently marking the event delivered.
     try:
         result = supabase_query_sql(
             """
@@ -126,8 +136,6 @@ def receive():
         return {"ok": False, "reason": "supabase_update_failed", "order_id": order_id}
 
     if not result:
-        # Either: (a) already tombstoned by a prior webhook/verify run, or
-        # (b) order_id does not exist in pos_orders. Both are idempotent no-ops.
         return {
             "ok": True,
             "handled": False,
@@ -143,14 +151,58 @@ def receive():
     return {"ok": True, "handled": True, "order_id": order_id}
 
 
-def _authenticate_webhook(order_id, data: dict) -> bool:
+def _handle_order_completed(data: dict) -> dict:
+    """S189 T7.4: upsert a completed order into pos_orders + pos_order_items.
+
+    Idempotent: re-delivery of the same webhook or collision with hourly poll
+    does not create duplicates. Sets ingestion_source='webhook' on pos_orders.
+    """
+    set_backend_observability_context(
+        module="mosaic",
+        action="handle_order_completed",
+        mutation_type="create",
+    )
+
+    order_id = data.get("id")
+    if not order_id:
+        frappe.local.response.http_status_code = 400
+        return {"ok": False, "reason": "missing order id"}
+
+    # Round-trip: fetch full order from Mosaic. Expect HTTP 200.
+    order = _fetch_mosaic_order(order_id, data)
+    if not order:
+        frappe.local.response.http_status_code = 401
+        return {"ok": False, "reason": "round_trip_fetch_failed", "order_id": order_id}
+
+    try:
+        _upsert_completed_order(order)
+    except Exception as e:
+        frappe.log_error(
+            title="Mosaic webhook order.completed upsert failed",
+            message=f"order_id={order_id} error={str(e)[:500]}",
+        )
+        try:
+            import sentry_sdk
+            sentry_sdk.capture_exception(e)
+        except Exception:
+            pass
+        frappe.local.response.http_status_code = 500
+        return {"ok": False, "reason": "supabase_upsert_failed", "order_id": order_id}
+
+    frappe.logger().info(
+        f"S189 mosaic webhook: completed order_id={order_id} "
+        f"loc={order.get('location_id')} date={order.get('business_date')}"
+    )
+    return {"ok": True, "handled": True, "order_id": order_id}
+
+
+def _authenticate_webhook(order_id, data: dict, expect_status: int = 404) -> bool:
     """Path B round-trip confirm.
 
-    Look up the credential row for ``data.location_id`` in the Mosaic CSV,
-    obtain an OAuth token, and call ``GET /api/v1/orders/{order_id}``. Returns
-    True only if Mosaic responds with HTTP 404 (confirming the order really
-    was cancelled). Any other status (200, 401, 500, network error) is treated
-    as auth failure -- the webhook will be rejected and Mosaic will retry.
+    Calls Mosaic GET /api/v1/orders/{order_id} and returns True only if the
+    HTTP status matches ``expect_status``:
+      - expect_status=404 for order.cancelled (order should be gone)
+      - expect_status=200 for order.completed (order should exist)
     """
     location_id = data.get("location_id")
     if not location_id:
@@ -173,7 +225,194 @@ def _authenticate_webhook(order_id, data: dict) -> bool:
     except requests.RequestException:
         return False
 
-    return r.status_code == 404
+    return r.status_code == expect_status
+
+
+def _verify_hmac_signature(raw_body: str) -> bool:
+    """S189 T7.2: optional HMAC signature verification.
+
+    If MOSAIC_WEBHOOK_SECRET is set, verify the ``X-Mosaic-Signature`` header
+    matches HMAC-SHA256(secret, raw_body). If the secret is not set, return
+    True (fall through to Path B round-trip auth).
+    """
+    secret = (os.environ.get("MOSAIC_WEBHOOK_SECRET") or "").strip()
+    if not secret:
+        return True  # No secret configured — skip HMAC, rely on round-trip
+
+    try:
+        provided = frappe.request.headers.get("X-Mosaic-Signature", "") or ""
+    except Exception:
+        return False
+
+    if not provided:
+        return False
+
+    expected = hmac.new(
+        secret.encode("utf-8"),
+        (raw_body or "").encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+    return hmac.compare_digest(expected, provided.strip())
+
+
+def _fetch_mosaic_order(order_id, data: dict) -> dict:
+    """S189 T7.4: round-trip fetch full order payload from Mosaic.
+
+    Returns the order dict on HTTP 200, empty dict on any failure. Used by
+    order.completed handler to get authoritative order data rather than
+    trusting the webhook payload (payloads can be partial).
+    """
+    location_id = data.get("location_id")
+    if not location_id:
+        return {}
+
+    cred = _find_credential(location_id)
+    if not cred:
+        return {}
+
+    token = _ensure_oauth_token(cred)
+    if not token:
+        return {}
+
+    try:
+        r = requests.get(
+            f"{MOSAIC_API_BASE}/api/v1/orders/{order_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=15,
+        )
+    except requests.RequestException:
+        return {}
+
+    if r.status_code != 200:
+        return {}
+
+    try:
+        body = r.json()
+    except (ValueError, TypeError):
+        return {}
+
+    # Mosaic responses may wrap data: {data: {...}} or return the order directly
+    if isinstance(body, dict) and "data" in body and isinstance(body["data"], dict):
+        return body["data"]
+    if isinstance(body, dict):
+        return body
+    return {}
+
+
+def _resolve_channel(order: dict) -> str:
+    """Derive channel from Mosaic service_type_id + service_channel_id.
+
+    Same logic as scripts/sync_pos_to_supabase.py._resolve_channel to keep the
+    webhook + poll paths consistent.
+    """
+    channel_map = {1: "GrabFood", 2: "FoodPanda", 16: "FoodPanda", 19: "WebDelivery"}
+    stype = order.get("service_type_id")
+    if stype == 3:
+        return channel_map.get(order.get("service_channel_id"), "Delivery")
+    if stype in (91, 17):
+        return "POS"
+    if stype is None:
+        return "Unknown"
+    return "POS"
+
+
+def _map_order_row(order: dict) -> dict:
+    """Map a Mosaic order payload to a pos_orders row (same shape as poll sync)."""
+    pb = order.get("price_breakdown") or {}
+    upper_or_none = lambda v: v.upper() if isinstance(v, str) and v else None
+    return {
+        "id": order["id"],
+        "location_id": order["location_id"],
+        "business_date": order["business_date"],
+        "bill_number": order.get("bill_number"),
+        "receipt_number": order.get("receipt_number"),
+        "pax_count": order.get("pax_count"),
+        "service_type_id": order.get("service_type_id"),
+        "service_channel_id": order.get("service_channel_id"),
+        "channel": _resolve_channel(order),
+        "original_gross_sales": pb.get("original_gross_sales", 0),
+        "gross_sales": pb.get("gross_sales", 0),
+        "net_sales": pb.get("net_sales", 0),
+        "vatable_sales": pb.get("vatable_sales", 0),
+        "vat_amount": pb.get("vat_amount", 0),
+        "vat_exempt_sales": pb.get("vat_exempt_sales", 0),
+        "zero_rated_sales": pb.get("zero_rated_sales", 0),
+        "total_discounts": pb.get("total_discounts", 0),
+        "delivery_fee": pb.get("delivery_fee", 0),
+        "payment_status": upper_or_none(order.get("payment_status")),
+        "order_status": upper_or_none(order.get("order_status")),
+        "completed_at": order.get("completed_at"),
+        "billed_at": order.get("billed_at"),
+        "paid_at": order.get("paid_at"),
+        # S189 T7.1: mark this row as webhook-sourced so the reconciliation
+        # views can distinguish webhook vs poll ingestion.
+        "ingestion_source": "webhook",
+    }
+
+
+def _map_order_items(order: dict) -> list[dict]:
+    """Map Mosaic order items to pos_order_items rows."""
+    rows = []
+    for idx, item in enumerate(order.get("items") or []):
+        ipb = item.get("price_breakdown") or {}
+        discount = item.get("discount") or {}
+        rows.append({
+            "order_id": order["id"],
+            "line_number": idx,
+            "product_id": item.get("product_id"),
+            "product_name": item.get("name") or item.get("product_name"),
+            "quantity": item.get("quantity", 1),
+            "unit_price": item.get("price") or item.get("unit_price"),
+            "gross_sales": item.get("gross_sales") or ipb.get("gross_sales", 0),
+            "net_sales": item.get("net_sales") or ipb.get("net_sales", 0),
+            "vatable_sales": item.get("vatable_sales") or ipb.get("vatable_sales", 0),
+            "vat_amount": item.get("vat_amount") or ipb.get("vat_amount", 0),
+            "vat_exempt_sales": item.get("vat_exempt_sales") or ipb.get("vat_exempt_sales", 0),
+            "zero_rated_sales": item.get("zero_rated_sales") or ipb.get("zero_rated_sales", 0),
+            "discount_id": discount.get("id"),
+            "discount_name": discount.get("name"),
+            "discount_amount": discount.get("amount", 0),
+        })
+    return rows
+
+
+def _upsert_completed_order(order: dict) -> None:
+    """S189 T7.4/T7.5: idempotent upsert of order + items via PostgREST.
+
+    Uses PostgREST merge-duplicates Prefer header to deduplicate on primary key.
+    Safe under burst replays (store internet recovers after outage) because:
+      - pos_orders PK is id — duplicate INSERT merges
+      - pos_order_items unique index on (order_id, product_id, line_number)
+      - Supabase triggers use ON CONFLICT ON CONSTRAINT idx_dmc_unique
+        + delta=0 short-circuit, preventing phantom consumption on re-delivery
+    """
+    key = get_service_key()
+    headers = {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Prefer": "resolution=merge-duplicates,return=minimal",
+    }
+
+    order_row = _map_order_row(order)
+    r_order = requests.post(
+        f"{SUPABASE_URL}/rest/v1/pos_orders",
+        headers=headers,
+        json=[order_row],
+        timeout=15,
+    )
+    r_order.raise_for_status()
+
+    item_rows = _map_order_items(order)
+    if item_rows:
+        r_items = requests.post(
+            f"{SUPABASE_URL}/rest/v1/pos_order_items",
+            headers=headers,
+            json=item_rows,
+            timeout=15,
+        )
+        r_items.raise_for_status()
 
 
 def _find_credential(location_id) -> dict:

--- a/scripts/s189_register_webhooks_completed.py
+++ b/scripts/s189_register_webhooks_completed.py
@@ -1,0 +1,236 @@
+"""S189 T7.3 — Register Mosaic webhooks for order.completed events.
+
+Sibling of scripts/s169_register_webhooks.py (which registers order.cancelled).
+Registers a separate webhook for `order.completed` so the handler can create
+pos_orders rows with ingestion_source='webhook' before the hourly poll.
+
+Iterates over UNIQUE credential groups in MOSAIC_POS_API_KEYS.csv (12 groups).
+For each group:
+  1. OAuth client_credentials -> access_token
+  2. GET /api/v1/webhooks (list existing)
+  3. If our URL is already registered with events=["order.completed"], SKIP
+  4. Otherwise POST /api/v1/webhooks with events=["order.completed"]
+  5. Append to MOSAIC_WEBHOOK_REGISTRATIONS.csv
+
+Usage:
+    python scripts/s189_register_webhooks_completed.py [--dry-run] [--group <name>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+
+MOSAIC_BASE_URL = "https://api.mosaic-pos.com"
+MOSAIC_TOKEN_URL = f"{MOSAIC_BASE_URL}/oauth/token"
+MOSAIC_WEBHOOKS_URL = f"{MOSAIC_BASE_URL}/api/v1/webhooks"
+
+WEBHOOK_URL = "https://hq.bebang.ph/api/method/hrms.api.mosaic_webhook.receive"
+WEBHOOK_EVENTS = ["order.completed"]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CREDENTIALS_CSV = REPO_ROOT / "data" / "POS_Extraction" / "MOSAIC_POS_API_KEYS.csv"
+REGISTRATIONS_CSV = REPO_ROOT / "data" / "POS_Extraction" / "MOSAIC_WEBHOOK_REGISTRATIONS.csv"
+
+REGISTRATIONS_HEADERS = [
+    "credential_group",
+    "client_id",
+    "webhook_id",
+    "url",
+    "events",
+    "registered_at",
+]
+
+DEFAULT_HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+    "User-Agent": "BEI-S189-WebhookRegistrar/1.0",
+    "X-Source": "s189",
+}
+
+REQUEST_TIMEOUT = 30
+
+
+def log(msg: str) -> None:
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+
+def load_credential_groups(csv_path: Path) -> list[dict]:
+    """Return list of unique credential groups, deduped by Mosaic Client ID."""
+    groups: dict[str, dict] = {}
+    with open(csv_path, encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            cid = (row.get("Mosaic Client ID") or "").strip()
+            if not cid:
+                continue
+            if cid not in groups:
+                groups[cid] = {
+                    "client_id": cid,
+                    "client_secret": (row.get("Mosaic Client Secret") or "").strip(),
+                    "group_name": (row.get("Credential Group") or "").strip(),
+                    "location_count": 0,
+                }
+            groups[cid]["location_count"] += 1
+    return list(groups.values())
+
+
+def get_access_token(client_id: str, client_secret: str) -> str:
+    r = requests.post(
+        MOSAIC_TOKEN_URL,
+        json={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "grant_type": "client_credentials",
+        },
+        headers=DEFAULT_HEADERS,
+        timeout=REQUEST_TIMEOUT,
+    )
+    r.raise_for_status()
+    payload = r.json()
+    token = payload.get("access_token")
+    if not token:
+        raise RuntimeError(f"OAuth response missing access_token: {payload}")
+    return token
+
+
+def list_webhooks(token: str) -> list[dict]:
+    headers = {**DEFAULT_HEADERS, "Authorization": f"Bearer {token}"}
+    r = requests.get(MOSAIC_WEBHOOKS_URL, headers=headers, timeout=REQUEST_TIMEOUT)
+    r.raise_for_status()
+    body = r.json()
+    if isinstance(body, dict) and "data" in body:
+        return list(body["data"])
+    if isinstance(body, list):
+        return body
+    return []
+
+
+def webhook_already_registered(existing: list[dict]) -> dict | None:
+    """Return existing webhook if our URL+order.completed is already registered."""
+    for hook in existing:
+        url = hook.get("url") or hook.get("endpoint") or ""
+        events = hook.get("events") or hook.get("event_types") or []
+        if url == WEBHOOK_URL and "order.completed" in events:
+            return hook
+    return None
+
+
+def register_webhook(token: str) -> dict:
+    headers = {**DEFAULT_HEADERS, "Authorization": f"Bearer {token}"}
+    r = requests.post(
+        MOSAIC_WEBHOOKS_URL,
+        headers=headers,
+        json={"url": WEBHOOK_URL, "events": WEBHOOK_EVENTS},
+        timeout=REQUEST_TIMEOUT,
+    )
+    r.raise_for_status()
+    body = r.json()
+    if isinstance(body, dict) and "data" in body:
+        return body["data"]
+    return body
+
+
+def ensure_registrations_csv() -> None:
+    if REGISTRATIONS_CSV.exists():
+        return
+    REGISTRATIONS_CSV.parent.mkdir(parents=True, exist_ok=True)
+    with open(REGISTRATIONS_CSV, "w", encoding="utf-8", newline="") as f:
+        csv.writer(f).writerow(REGISTRATIONS_HEADERS)
+
+
+def append_registration(
+    group_name: str,
+    client_id: str,
+    webhook_id: str,
+    url: str,
+    events: list[str],
+) -> None:
+    ensure_registrations_csv()
+    with open(REGISTRATIONS_CSV, "a", encoding="utf-8", newline="") as f:
+        csv.writer(f).writerow(
+            [
+                group_name,
+                client_id,
+                webhook_id,
+                url,
+                "|".join(events),
+                datetime.now(timezone.utc).isoformat(),
+            ]
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Register Mosaic order.completed webhooks")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--group", type=str, default=None)
+    args = parser.parse_args()
+
+    if not CREDENTIALS_CSV.exists():
+        log(f"FATAL: credentials CSV not found at {CREDENTIALS_CSV}")
+        return 2
+
+    groups = load_credential_groups(CREDENTIALS_CSV)
+    if args.group:
+        groups = [g for g in groups if g["group_name"] == args.group]
+        if not groups:
+            log(f"No credential groups match --group {args.group!r}")
+            return 2
+
+    log(f"Loaded {len(groups)} unique credential groups from {CREDENTIALS_CSV.name}")
+    log(f"Webhook URL: {WEBHOOK_URL}")
+    log(f"Events: {WEBHOOK_EVENTS}")
+    if args.dry_run:
+        log("DRY-RUN MODE -- no live API calls will be made")
+
+    registered_new = 0
+    skipped_existing = 0
+    failed = 0
+
+    for group in groups:
+        group_label = f"{group['group_name']} ({group['client_id'][:8]}...)"
+        log(f"--- {group_label} [{group['location_count']} locations]")
+
+        if args.dry_run:
+            log("  [DRY-RUN] would OAuth, list webhooks, register if missing")
+            continue
+
+        try:
+            token = get_access_token(group["client_id"], group["client_secret"])
+            existing = list_webhooks(token)
+            already = webhook_already_registered(existing)
+
+            if already:
+                log(f"  SKIP: webhook already registered (id={already.get('id', '?')})")
+                skipped_existing += 1
+                continue
+
+            result = register_webhook(token)
+            wh_id = result.get("id", "?")
+            log(f"  REGISTERED: webhook_id={wh_id}")
+            append_registration(
+                group_name=group["group_name"],
+                client_id=group["client_id"],
+                webhook_id=str(wh_id),
+                url=WEBHOOK_URL,
+                events=WEBHOOK_EVENTS,
+            )
+            registered_new += 1
+        except Exception as e:
+            log(f"  FAILED: {e}")
+            failed += 1
+
+    log(
+        f"Done. new={registered_new} skipped={skipped_existing} failed={failed}"
+    )
+    return 1 if failed > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Completes the previously-deferred Phase 7 webhook work from S189 #564.

## What ships

### T7.2 — Optional HMAC signature auth
- `MOSAIC_WEBHOOK_SECRET` env var (optional)
- If set: `receive()` verifies `X-Mosaic-Signature` header (HMAC-SHA256) before processing
- If not set: falls back to existing Path B round-trip auth
- Additive — existing `order.cancelled` flow unchanged

### T7.3 — Register `order.completed` webhooks
- `scripts/s189_register_webhooks_completed.py`
- Sibling of `scripts/s169_register_webhooks.py`
- Iterates 12 credential groups in `MOSAIC_POS_API_KEYS.csv`
- Skips if already registered; appends to `MOSAIC_WEBHOOK_REGISTRATIONS.csv`

### T7.4 — Handle `order.completed` in webhook receiver
`hrms/api/mosaic_webhook.py`:
- Refactored `receive()` into `_handle_order_cancelled` and `_handle_order_completed`
- `order.completed` branch: round-trip GET expects HTTP 200 (not 404), fetches authoritative order payload, upserts `pos_orders` with `ingestion_source='webhook'` + `pos_order_items`
- Same schema mapping as `scripts/sync_pos_to_supabase.py` — webhook and poll paths produce identical rows
- DM-7: Sentry context `module="mosaic"`, `action="handle_order_completed"`, `mutation_type="create"`

### T7.5 — Idempotent replay
- `pos_orders` PostgREST upsert with `Prefer=merge-duplicates,return=minimal` on PK `id`
- `pos_order_items` upsert merges on `(order_id, product_id, line_number)`
- Supabase `daily_material_consumption` triggers use `ON CONFLICT ON CONSTRAINT idx_dmc_unique` + `delta=0` short-circuit → no phantom consumption on burst replays when store internet recovers

## Deploy

1. Docker rebuild `skip_build=false, no_cache=true` (Python `.py` changed)
2. (Optional) Add `MOSAIC_WEBHOOK_SECRET` to site config if Mosaic issues a signing secret
3. Run `python scripts/s189_register_webhooks_completed.py --dry-run` then live
4. Monitor via `v_ingestion_reconciliation` view — expect `webhook` row count to start climbing

## Test plan

- [ ] `order.cancelled` still works (regression: `_handle_order_cancelled` unchanged behavior)
- [ ] `order.completed` webhook: test order visible in `pos_orders` within seconds with `ingestion_source='webhook'`
- [ ] Re-delivery of same webhook: no duplicate consumption in `daily_material_consumption`
- [ ] Simulated internet outage → burst replay: no duplicate rows
- [ ] `MOSAIC_WEBHOOK_SECRET` set + bad signature → 401
- [ ] `MOSAIC_WEBHOOK_SECRET` unset → round-trip path still works

Plan: `docs/plans/2026-04-13-sprint-189-realtime-bom-consumption.md`
Depends on: #564 (backend schema + migration SQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)