### PR TITLE
S189 docs: align with Mosaic OpenAPI — 7 events, speculative HMAC, PUT upgrade

### DIFF
--- a/docs/api/MOSAIC_API.md
+++ b/docs/api/MOSAIC_API.md
@@ -1,0 +1,240 @@
+# Mosaic Solutions API Documentation
+
+**Authoritative spec (machine-readable):** `docs/api/MOSAIC_API_OPENAPI_2026-04-14.json`
+(OpenAPI 3.0.3 — use this for any ambiguity; this markdown is a human summary)
+
+**Source:** Google Docs shared by Rajat Verma on Oct 3, 2025
+**Google Doc:** https://docs.google.com/document/d/1KcixaVE1Ez3SgQKt-U74BUq3eLCJ3zZ6JbGM2A956O4
+**Downloaded:** 2026-02-07; OpenAPI JSON received 2026-04-14
+**Also saved at:** `F:\Dropbox\Projects\Dice-Roll-Game-Digital\docs\api\MOSAIC_API.md`
+
+---
+
+## Introduction
+
+The Mosaic API allows your business to seamlessly integrate your website or application with our Point-of-Sale (POS) Systems. All communication between clients and the API is secured using JSON over HTTPS. All timestamps in responses are provided in the ISO-8601 format with UTC timezone unless otherwise specified.
+
+## Environments
+
+| Environment | Base URL | Description |
+|-------------|----------|-------------|
+| Testing/Staging | `https://stg-api.mosaicpos.com` | Use for development and testing |
+| Production | `https://api.mosaic-pos.com` | Use for live production systems |
+
+---
+
+## 1. Authentication
+
+The API uses the **OAuth 2.0 client_credentials** grant type. You must first exchange your `client_id` and `client_secret` for an `access_token`. This token must then be passed in the `Authorization` header of all subsequent requests as a Bearer token.
+
+### 1.1 Create Access Token
+
+**POST** `/oauth/token`
+
+**Request:**
+```json
+{
+  "client_id": "<your-client-id>",
+  "client_secret": "<your-secret-key>",
+  "grant_type": "client_credentials"
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "token_type": "Bearer",
+  "expires_in": 86400,
+  "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9..."
+}
+```
+
+---
+
+## 2. Orders
+
+### 2.1 Get Orders
+
+**GET** `/api/v1/orders`
+
+| Parameter | Required | Description | Example |
+|-----------|----------|-------------|---------|
+| `filter[business_date]` | Yes | Filter orders by business date (Y-m-d) | `2025-09-16` |
+| `page[number]` | No | Page number (min 1) | `1` |
+| `page[size]` | No | Items per page (max 100) | `100` |
+
+**Response (200 OK):**
+```json
+{
+  "data": [
+    {
+      "id": 46231,
+      "location_id": 295,
+      "reference_id": null,
+      "business_date": "2023-02-22",
+      "pax_count": 1,
+      "price_breakdown": {
+        "gross_sales": 1.1,
+        "net_sales": 0.8929,
+        "vatable_sales": 0.8929,
+        "vat_amount": 0.1071,
+        "total_discounts": 0
+      },
+      "billed_at": "2023-02-22T00:37:31.000000Z",
+      "paid_at": "2023-02-22T00:37:38.000000Z",
+      "items": [
+        {
+          "product_id": 30419,
+          "name": "Product Name",
+          "price": 1,
+          "quantity": 1,
+          "net_sales": 0.8929,
+          "modifiers": []
+        }
+      ],
+      "payment_methods": [
+        {
+          "payment_type": "Cash",
+          "paid_amount": 1.1,
+          "returned_amount": 0
+        }
+      ]
+    }
+  ],
+  "meta": { "current_page": 1, "last_page": 1, "total": 2 }
+}
+```
+
+### 2.2 Create Order
+
+**POST** `/api/v1/orders`
+
+```json
+{
+  "location_id": 18,
+  "service_type_id": 3,
+  "business_date": "2025-09-16",
+  "ordered_at": "2025-09-16 13:08:07",
+  "price_breakdown": {
+    "gross_sales": 90, "net_sales": 6, "vatable_sales": 80.36,
+    "vat_amount": 9.64, "vat_exempt_sales": 0, "zero_rated_sales": 0,
+    "total_discounts": 0, "delivery_fee": 0
+  },
+  "items": [
+    {
+      "product_sku": "SUADA",
+      "name": "Iced Kape Sua Da",
+      "price": 75, "quantity": 1,
+      "gross_sales": 90, "net_sales": 10,
+      "vatable_sales": 80.36, "vat_amount": 9.64,
+      "vat_exempt_sales": 0, "zero_rated_sales": 0,
+      "discount_amount": 33,
+      "modifiers": [], "discount": null
+    }
+  ],
+  "payment_details": [
+    { "payment_type": "Cash", "paid_amount": 90, "returned_amount": 10 }
+  ]
+}
+```
+
+### 2.3 Get Order by ID — `GET /api/v1/orders/{id}`
+### 2.4 Get Order by Reference — `GET /api/v1/order_references/{order}`
+### 2.5 Cancel Order — `POST /api/v1/orders/{order_id}/cancel`
+
+---
+
+## 3. Locations and Taxes
+
+### 3.1 Get Locations — `GET /api/v1/locations`
+### 3.2 Update Location — `PUT /api/v1/locations/{id}`
+### 3.3 Get Taxes by Location — `GET /api/v1/locations/{location_id}/taxes`
+
+---
+
+## 4. Catalog Management
+
+### 4.1 Get Product Categories — `GET /api/v1/product_categories`
+### 4.2 Get Product Groups — `GET /api/v1/product_categories/{id}/groups`
+### 4.3 Get Products — `GET /api/v1/products`
+### 4.4 Create Product — `POST /api/v1/products`
+### 4.5 Update Product — `PUT /api/v1/products/{id}`
+### 4.6 Get Modifier Groups — `GET /api/v1/modifier_groups`
+### 4.7 Get Modifiers — `GET /api/v1/modifier_groups/{id}/modifiers`
+
+---
+
+## 5. Service Types — `GET /api/v1/service_types`
+
+## 6. Payments
+
+### 6.1 Get Payment Categories — `GET /api/v1/payment_categories`
+### 6.2 Get Payment Types — `GET /api/v1/payment_types`
+### 6.3 Create Payment Type — `POST /api/v1/payment_types`
+
+## 7. Discounts
+
+### 7.1-7.5 Full CRUD at `/api/v1/discounts` and `/api/v1/discounts/{id}`
+
+See dedicated file: `docs/api/MOSAIC_DISCOUNTS_API.md` (or Dice Roll Game copy)
+
+## 8. Webhooks
+
+Full CRUD at `/api/v1/webhooks` and `/api/v1/webhooks/{id}`:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/v1/webhooks` | List all webhooks for the authenticated credential group |
+| POST | `/api/v1/webhooks` | Create a webhook: `{url, events}` — returns `{data: {id, url, events, created_at, updated_at}}` |
+| PUT | `/api/v1/webhooks/{id}` | Update events or URL for an existing webhook |
+| DELETE | `/api/v1/webhooks/{id}` | Delete a webhook |
+
+### 8.1 Supported Events (7 total, per OpenAPI enum 2026-04-14)
+
+| Event | Trigger | BEI usage |
+|-------|---------|-----------|
+| `order.created` | New order opened | Not used (too early for revenue) |
+| `order.paid` | Payment received | Candidate for future real-time revenue stream |
+| `order.ready` | Kitchen completed | Not used |
+| `order.completed` | Order closed | S189: upsert to `pos_orders` with `ingestion_source='webhook'` |
+| `order.cancelled` | Order voided | S169: tombstone `cancelled_at` on `pos_orders` |
+| `location.created` | Store added | Not used |
+| `location.updated` | Store metadata changed | Not used |
+
+### 8.2 Signature / authentication on inbound webhooks
+
+**The OpenAPI doc does NOT document any signature scheme** (no `signature`, `hmac`, or
+webhook-signing fields in the spec as of 2026-04-14). Our handler
+(`hrms/api/mosaic_webhook.py`) therefore uses Path B "round-trip" auth:
+
+1. Receive webhook payload
+2. Extract `order_id` and `location_id`
+3. OAuth with the credential group for that `location_id`
+4. `GET /api/v1/orders/{order_id}` — expected status depends on event:
+   - `order.cancelled` → expect HTTP 404 (order gone)
+   - `order.completed` → expect HTTP 200 (order exists, fetch authoritative payload)
+5. Only accept the webhook if the round-trip matches
+
+The handler also has an optional SPECULATIVE HMAC check (`MOSAIC_WEBHOOK_SECRET`
+env var) for when/if Mosaic publishes a signing spec in the future — it's
+defensive code that falls through to Path B when no secret is set.
+
+### 8.3 Rate limits, retries, delivery guarantees
+
+**Not documented.** Treat as best-effort; reconcile with poll sync daily via
+`scripts/s189_reconciliation_audit.py`.
+
+### 8.4 Known operational issues (2026-04-14)
+
+- `GET /api/v1/webhooks` returns HTTP 500 for ~11 of 12 BEI credential groups,
+  even with exponential backoff retries. **Do not rely on it as a truth source.**
+  Use our delivery evidence (`v_webhook_coverage` in Supabase) instead.
+- S169 registered 12 `order.cancelled` webhooks 2026-04-07, but 7-day webhook
+  coverage is 0% — Mosaic is not delivering. Investigation ongoing; self-healing
+  re-registration runs daily via `scripts/s189_webhook_registration_reconciler.py`.
+
+---
+
+For complete request/response examples, see:
+- `docs/api/MOSAIC_API_OPENAPI_2026-04-14.json` (machine-readable, authoritative)
+- `F:\Dropbox\Projects\Dice-Roll-Game-Digital\docs\api\MOSAIC_API.md` (mirror)

--- a/docs/api/MOSAIC_API_OPENAPI_2026-04-14.json
+++ b/docs/api/MOSAIC_API_OPENAPI_2026-04-14.json
@@ -1,0 +1,8498 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Mosaic Solutions API Doc",
+    "description": "Mosaic API allows your business to seamlessly integrate your website or app with our POS Systems.\n\nAll requests and responses between clients and the API are JSON over HTTPS.\n\nAll timestamps in responses are in ISO-8601 format with UTC timezone unless otherwise specified.\n",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://stg-api.mosaicpos.com",
+      "description": "Testing"
+    },
+    {
+      "url": "https://api.mosaic-pos.com",
+      "description": "Production"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication",
+      "description": "![Authentication Flow](images/auth_flow.jpg)\n"
+    },
+    {
+      "name": "Orders",
+      "description": ""
+    },
+    {
+      "name": "Locations",
+      "description": ""
+    },
+    {
+      "name": "Product Categories",
+      "description": ""
+    },
+    {
+      "name": "Products",
+      "description": ""
+    },
+    {
+      "name": "Modifier Groups",
+      "description": ""
+    },
+    {
+      "name": "Modifiers",
+      "description": ""
+    },
+    {
+      "name": "Service Types",
+      "description": ""
+    },
+    {
+      "name": "Taxes",
+      "description": ""
+    },
+    {
+      "name": "Payments",
+      "description": ""
+    },
+    {
+      "name": "Discounts",
+      "description": ""
+    },
+    {
+      "name": "Webhook Setup",
+      "description": "Clients can provide a URL where Mosaic can POST to receive webhook notifications.\n\n### Client Requirements\n\n* The client must provide a valid HTTPS endpoint.\n* The endpoint should be capable of handling incoming POST requests with JSON payloads.\n* Clients should acknowledge receipt with any **2xx** response."
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "OAuth": {
+        "type": "oauth2",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "/oauth/token"
+          }
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "OAuth": []
+    }
+  ],
+  "paths": {
+    "/oauth/token": {
+      "post": {
+        "summary": "Create Access Token",
+        "operationId": "createAccessToken",
+        "description": "Authorize a client to access APIs.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "token_type": "Bearer",
+                    "expires_in": 86400,
+                    "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiI5ZTc5YjI5My1hYWZjLTQ1M2UtODczNC0xYWU4MzQ1MTI0MzEiLCJqdGkiOiIxYzg1MWEyNzY0ODJmNDVjY2ZmYWVjNDMzZDk4NmE0YmRkNzFjZTlhZTk5ODJlYmNhMjNkNDVkZmY3ZmI3Y2Q3OWViYTYzOTMzOGVjOWQ3MiIsImlhdCI6MTc0NDY5MTMxNi41OTQ4ODcsIm5iZiI6MTc0NDY5MTMxNi41OTQ4ODksImV4cCI6MTc0NDc3NzcxNi41ODYwMzMsInN1YiI6IiIsInNjb3BlcyI6W119.MY0hzDXfvYEsOdT8tMRoSEJqJtDUIbZjhY9lf9oa6NPhh_R7e1-meAixKqrPaoez_nyact19UsCZ_KVzNo2J3EuA_Pkdd30TqAGN4aWbjbn5fbx_ksuJ7Q0J1Mn05oWl0o3-UcO5nK1IHzIz2kYntxn_S6V_2LZlrMKHo543j60p-9yjM5NRBLsTchsCYSWnquYOliplHSaSxBtZd8czIayoEQ9tLbMWyAraaSO0ezg9L49Fx9MYKw7PmC6PpxSwwlhtAjBo2cVAE7yhx-M8lHNH5PpqP1ywOZGOtz1ve4HbQ2nBVR9SSVmqbn5xRajyijqd0oTCFXZBbt9IoPwam3B7-GJIIkSZxUzSxPvvCLIVLEaFfBh9i9uuWQx1PHekmHDsJZuSopV6AWKwOtmHnvXjNV88jtNUGr8BrdeiBVLLSTGtXwnJ7AMVEtJDB1H2ZGWaxlVGnJ-tTdRzcJazLElqp_xESOpRY24RuICDK-bF_TmnyM8caTrCyRvxAbQCmIfMcUY9XrnH4OJpgbZBMhfL6OMwy14e26dZzt2WAT8ohG6_SIxhfFRkKTjY4paqTvWoMnfwpjibzlWIGMm5mB9Pnr_V0kqcXZ7ld36DTzYVh-zqn4Eu7q6FTYoJydYSJSlxzRmajlLrFG1uK7Jtuione0YHbTQS0osTjjPCKHs"
+                  },
+                  "properties": {
+                    "token_type": {
+                      "type": "string",
+                      "example": "Bearer",
+                      "description": "The type of the token."
+                    },
+                    "expires_in": {
+                      "type": "integer",
+                      "example": 86400,
+                      "description": "The number of seconds before the token expires."
+                    },
+                    "access_token": {
+                      "type": "string",
+                      "example": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiI5ZTc5YjI5My1hYWZjLTQ1M2UtODczNC0xYWU4MzQ1MTI0MzEiLCJqdGkiOiIxYzg1MWEyNzY0ODJmNDVjY2ZmYWVjNDMzZDk4NmE0YmRkNzFjZTlhZTk5ODJlYmNhMjNkNDVkZmY3ZmI3Y2Q3OWViYTYzOTMzOGVjOWQ3MiIsImlhdCI6MTc0NDY5MTMxNi41OTQ4ODcsIm5iZiI6MTc0NDY5MTMxNi41OTQ4ODksImV4cCI6MTc0NDc3NzcxNi41ODYwMzMsInN1YiI6IiIsInNjb3BlcyI6W119.MY0hzDXfvYEsOdT8tMRoSEJqJtDUIbZjhY9lf9oa6NPhh_R7e1-meAixKqrPaoez_nyact19UsCZ_KVzNo2J3EuA_Pkdd30TqAGN4aWbjbn5fbx_ksuJ7Q0J1Mn05oWl0o3-UcO5nK1IHzIz2kYntxn_S6V_2LZlrMKHo543j60p-9yjM5NRBLsTchsCYSWnquYOliplHSaSxBtZd8czIayoEQ9tLbMWyAraaSO0ezg9L49Fx9MYKw7PmC6PpxSwwlhtAjBo2cVAE7yhx-M8lHNH5PpqP1ywOZGOtz1ve4HbQ2nBVR9SSVmqbn5xRajyijqd0oTCFXZBbt9IoPwam3B7-GJIIkSZxUzSxPvvCLIVLEaFfBh9i9uuWQx1PHekmHDsJZuSopV6AWKwOtmHnvXjNV88jtNUGr8BrdeiBVLLSTGtXwnJ7AMVEtJDB1H2ZGWaxlVGnJ-tTdRzcJazLElqp_xESOpRY24RuICDK-bF_TmnyM8caTrCyRvxAbQCmIfMcUY9XrnH4OJpgbZBMhfL6OMwy14e26dZzt2WAT8ohG6_SIxhfFRkKTjY4paqTvWoMnfwpjibzlWIGMm5mB9Pnr_V0kqcXZ7ld36DTzYVh-zqn4Eu7q6FTYoJydYSJSlxzRmajlLrFG1uK7Jtuione0YHbTQS0osTjjPCKHs",
+                      "description": "The token to be passed on API requests as a header."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Authentication"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "client_id": {
+                    "type": "string",
+                    "description": "",
+                    "example": "<your-client-id>"
+                  },
+                  "client_secret": {
+                    "type": "string",
+                    "description": "",
+                    "example": "<your-secret-key>"
+                  },
+                  "grant_type": {
+                    "type": "string",
+                    "description": "",
+                    "example": "client_credentials"
+                  }
+                },
+                "required": [
+                  "client_id",
+                  "client_secret",
+                  "grant_type"
+                ]
+              }
+            }
+          }
+        },
+        "security": [],
+        "": {
+          "summary": "Create Access Token",
+          "operationId": "createAccessToken",
+          "description": "Authorize a client to access APIs.",
+          "parameters": [
+            {
+              "in": "header",
+              "name": "Accept",
+              "schema": {
+                "type": "string",
+                "default": "application/json"
+              },
+              "required": true
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "",
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "type": "object",
+                    "example": {
+                      "token_type": "Bearer",
+                      "expires_in": 86400,
+                      "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiI5ZTc5YjI5My1hYWZjLTQ1M2UtODczNC0xYWU4MzQ1MTI0MzEiLCJqdGkiOiIxYzg1MWEyNzY0ODJmNDVjY2ZmYWVjNDMzZDk4NmE0YmRkNzFjZTlhZTk5ODJlYmNhMjNkNDVkZmY3ZmI3Y2Q3OWViYTYzOTMzOGVjOWQ3MiIsImlhdCI6MTc0NDY5MTMxNi41OTQ4ODcsIm5iZiI6MTc0NDY5MTMxNi41OTQ4ODksImV4cCI6MTc0NDc3NzcxNi41ODYwMzMsInN1YiI6IiIsInNjb3BlcyI6W119.MY0hzDXfvYEsOdT8tMRoSEJqJtDUIbZjhY9lf9oa6NPhh_R7e1-meAixKqrPaoez_nyact19UsCZ_KVzNo2J3EuA_Pkdd30TqAGN4aWbjbn5fbx_ksuJ7Q0J1Mn05oWl0o3-UcO5nK1IHzIz2kYntxn_S6V_2LZlrMKHo543j60p-9yjM5NRBLsTchsCYSWnquYOliplHSaSxBtZd8czIayoEQ9tLbMWyAraaSO0ezg9L49Fx9MYKw7PmC6PpxSwwlhtAjBo2cVAE7yhx-M8lHNH5PpqP1ywOZGOtz1ve4HbQ2nBVR9SSVmqbn5xRajyijqd0oTCFXZBbt9IoPwam3B7-GJIIkSZxUzSxPvvCLIVLEaFfBh9i9uuWQx1PHekmHDsJZuSopV6AWKwOtmHnvXjNV88jtNUGr8BrdeiBVLLSTGtXwnJ7AMVEtJDB1H2ZGWaxlVGnJ-tTdRzcJazLElqp_xESOpRY24RuICDK-bF_TmnyM8caTrCyRvxAbQCmIfMcUY9XrnH4OJpgbZBMhfL6OMwy14e26dZzt2WAT8ohG6_SIxhfFRkKTjY4paqTvWoMnfwpjibzlWIGMm5mB9Pnr_V0kqcXZ7ld36DTzYVh-zqn4Eu7q6FTYoJydYSJSlxzRmajlLrFG1uK7Jtuione0YHbTQS0osTjjPCKHs"
+                    },
+                    "properties": {
+                      "token_type": {
+                        "type": "string",
+                        "example": "Bearer",
+                        "description": "The type of the token."
+                      },
+                      "expires_in": {
+                        "type": "integer",
+                        "example": 86400,
+                        "description": "The number of seconds before the token expires."
+                      },
+                      "access_token": {
+                        "type": "string",
+                        "example": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiI5ZTc5YjI5My1hYWZjLTQ1M2UtODczNC0xYWU4MzQ1MTI0MzEiLCJqdGkiOiIxYzg1MWEyNzY0ODJmNDVjY2ZmYWVjNDMzZDk4NmE0YmRkNzFjZTlhZTk5ODJlYmNhMjNkNDVkZmY3ZmI3Y2Q3OWViYTYzOTMzOGVjOWQ3MiIsImlhdCI6MTc0NDY5MTMxNi41OTQ4ODcsIm5iZiI6MTc0NDY5MTMxNi41OTQ4ODksImV4cCI6MTc0NDc3NzcxNi41ODYwMzMsInN1YiI6IiIsInNjb3BlcyI6W119.MY0hzDXfvYEsOdT8tMRoSEJqJtDUIbZjhY9lf9oa6NPhh_R7e1-meAixKqrPaoez_nyact19UsCZ_KVzNo2J3EuA_Pkdd30TqAGN4aWbjbn5fbx_ksuJ7Q0J1Mn05oWl0o3-UcO5nK1IHzIz2kYntxn_S6V_2LZlrMKHo543j60p-9yjM5NRBLsTchsCYSWnquYOliplHSaSxBtZd8czIayoEQ9tLbMWyAraaSO0ezg9L49Fx9MYKw7PmC6PpxSwwlhtAjBo2cVAE7yhx-M8lHNH5PpqP1ywOZGOtz1ve4HbQ2nBVR9SSVmqbn5xRajyijqd0oTCFXZBbt9IoPwam3B7-GJIIkSZxUzSxPvvCLIVLEaFfBh9i9uuWQx1PHekmHDsJZuSopV6AWKwOtmHnvXjNV88jtNUGr8BrdeiBVLLSTGtXwnJ7AMVEtJDB1H2ZGWaxlVGnJ-tTdRzcJazLElqp_xESOpRY24RuICDK-bF_TmnyM8caTrCyRvxAbQCmIfMcUY9XrnH4OJpgbZBMhfL6OMwy14e26dZzt2WAT8ohG6_SIxhfFRkKTjY4paqTvWoMnfwpjibzlWIGMm5mB9Pnr_V0kqcXZ7ld36DTzYVh-zqn4Eu7q6FTYoJydYSJSlxzRmajlLrFG1uK7Jtuione0YHbTQS0osTjjPCKHs",
+                        "description": "The token to be passed on API requests as a header."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "tags": [
+            "Authentication"
+          ],
+          "requestBody": {
+            "required": true,
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "client_id": {
+                      "type": "string",
+                      "description": "",
+                      "example": "<your-client-id>"
+                    },
+                    "client_secret": {
+                      "type": "string",
+                      "description": "",
+                      "example": "<your-secret-key>"
+                    },
+                    "grant_type": {
+                      "type": "string",
+                      "description": "",
+                      "example": "client_credentials"
+                    }
+                  },
+                  "required": [
+                    "client_id",
+                    "client_secret",
+                    "grant_type"
+                  ]
+                }
+              }
+            }
+          },
+          "security": []
+        }
+      }
+    },
+    "/api/v1/orders": {
+      "get": {
+        "summary": "Get Orders",
+        "operationId": "getOrders",
+        "description": "Get all of the orders.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "filter[business_date]",
+            "description": "Filter orders by business date. Must be a valid date in the format <code>Y-m-d</code>.",
+            "example": "2026-04-13",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Filter orders by business date. Must be a valid date in the format <code>Y-m-d</code>.",
+              "example": "2026-04-13"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[number]",
+            "description": "The current page number of the result set to display. Must be at least 1.",
+            "example": 1,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The current page number of the result set to display. Must be at least 1.",
+              "example": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[size]",
+            "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+            "example": 100,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+              "example": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 46231,
+                        "location_id": 295,
+                        "service_type_id": 1,
+                        "service_channel_id": null,
+                        "reference_id": null,
+                        "business_date": "2023-02-22",
+                        "bill_number": 7690,
+                        "receipt_number": 7674,
+                        "pax_count": 1,
+                        "price_breakdown": {
+                          "original_gross_sales": 1,
+                          "gross_sales": 1.1,
+                          "net_sales": 0.8929,
+                          "vatable_sales": 0.8929,
+                          "vat_amount": 0.1071,
+                          "vat_exempt_sales": 0,
+                          "zero_rated_sales": 0,
+                          "total_discounts": 0,
+                          "delivery_fee": null,
+                          "is_free_delivery": false
+                        },
+                        "fulfillment_option": null,
+                        "payment_status": "PAID",
+                        "order_status": null,
+                        "cancellation_reason": null,
+                        "billed_at": "2023-02-22T00:37:31.000000Z",
+                        "paid_at": "2023-02-22T00:37:38.000000Z",
+                        "completed_at": null,
+                        "cancelled_at": null,
+                        "items": [
+                          {
+                            "product_id": 30419,
+                            "name": "Gsggsg",
+                            "price": 1,
+                            "quantity": 1,
+                            "gross_sales": 1.1,
+                            "net_sales": 0.8929,
+                            "vatable_sales": 0.8929,
+                            "vat_amount": 0.1071,
+                            "vat_exempt_sales": 0,
+                            "zero_rated_sales": 0,
+                            "modifiers": []
+                          }
+                        ],
+                        "taxes": [],
+                        "payment_methods": [
+                          {
+                            "payment_type": "Cash",
+                            "paid_amount": 1.1,
+                            "returned_amount": 0
+                          },
+                          {
+                            "payment_type": "QRPH",
+                            "paid_amount": 332,
+                            "returned_amount": 0
+                          }
+                        ]
+                      },
+                      {
+                        "id": 46231,
+                        "location_id": 295,
+                        "service_type_id": 1,
+                        "service_channel_id": null,
+                        "reference_id": null,
+                        "business_date": "2023-02-22",
+                        "bill_number": 7690,
+                        "receipt_number": 7674,
+                        "pax_count": 1,
+                        "price_breakdown": {
+                          "original_gross_sales": 1,
+                          "gross_sales": 1.1,
+                          "net_sales": 0.8929,
+                          "vatable_sales": 0.8929,
+                          "vat_amount": 0.1071,
+                          "vat_exempt_sales": 0,
+                          "zero_rated_sales": 0,
+                          "total_discounts": 0,
+                          "delivery_fee": null,
+                          "is_free_delivery": false
+                        },
+                        "fulfillment_option": null,
+                        "payment_status": "PAID",
+                        "order_status": null,
+                        "cancellation_reason": null,
+                        "billed_at": "2023-02-22T00:37:31.000000Z",
+                        "paid_at": "2023-02-22T00:37:38.000000Z",
+                        "completed_at": null,
+                        "cancelled_at": null,
+                        "items": [
+                          {
+                            "product_id": 30419,
+                            "name": "Gsggsg",
+                            "price": 1,
+                            "quantity": 1,
+                            "gross_sales": 1.1,
+                            "net_sales": 0.8929,
+                            "vatable_sales": 0.8929,
+                            "vat_amount": 0.1071,
+                            "vat_exempt_sales": 0,
+                            "zero_rated_sales": 0,
+                            "modifiers": []
+                          }
+                        ],
+                        "taxes": [],
+                        "payment_methods": [
+                          {
+                            "payment_type": "Cash",
+                            "paid_amount": 1.1,
+                            "returned_amount": 0
+                          },
+                          {
+                            "payment_type": "QRPH",
+                            "paid_amount": 332,
+                            "returned_amount": 0
+                          }
+                        ]
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 46231,
+                          "location_id": 295,
+                          "service_type_id": 1,
+                          "service_channel_id": null,
+                          "reference_id": null,
+                          "business_date": "2023-02-22",
+                          "bill_number": 7690,
+                          "receipt_number": 7674,
+                          "pax_count": 1,
+                          "price_breakdown": {
+                            "original_gross_sales": 1,
+                            "gross_sales": 1.1,
+                            "net_sales": 0.8929,
+                            "vatable_sales": 0.8929,
+                            "vat_amount": 0.1071,
+                            "vat_exempt_sales": 0,
+                            "zero_rated_sales": 0,
+                            "total_discounts": 0,
+                            "delivery_fee": null,
+                            "is_free_delivery": false
+                          },
+                          "fulfillment_option": null,
+                          "payment_status": "PAID",
+                          "order_status": null,
+                          "cancellation_reason": null,
+                          "billed_at": "2023-02-22T00:37:31.000000Z",
+                          "paid_at": "2023-02-22T00:37:38.000000Z",
+                          "completed_at": null,
+                          "cancelled_at": null,
+                          "items": [
+                            {
+                              "product_id": 30419,
+                              "name": "Gsggsg",
+                              "price": 1,
+                              "quantity": 1,
+                              "gross_sales": 1.1,
+                              "net_sales": 0.8929,
+                              "vatable_sales": 0.8929,
+                              "vat_amount": 0.1071,
+                              "vat_exempt_sales": 0,
+                              "zero_rated_sales": 0,
+                              "modifiers": []
+                            }
+                          ],
+                          "taxes": [],
+                          "payment_methods": [
+                            {
+                              "payment_type": "Cash",
+                              "paid_amount": 1.1,
+                              "returned_amount": 0
+                            },
+                            {
+                              "payment_type": "QRPH",
+                              "paid_amount": 332,
+                              "returned_amount": 0
+                            }
+                          ]
+                        },
+                        {
+                          "id": 46231,
+                          "location_id": 295,
+                          "service_type_id": 1,
+                          "service_channel_id": null,
+                          "reference_id": null,
+                          "business_date": "2023-02-22",
+                          "bill_number": 7690,
+                          "receipt_number": 7674,
+                          "pax_count": 1,
+                          "price_breakdown": {
+                            "original_gross_sales": 1,
+                            "gross_sales": 1.1,
+                            "net_sales": 0.8929,
+                            "vatable_sales": 0.8929,
+                            "vat_amount": 0.1071,
+                            "vat_exempt_sales": 0,
+                            "zero_rated_sales": 0,
+                            "total_discounts": 0,
+                            "delivery_fee": null,
+                            "is_free_delivery": false
+                          },
+                          "fulfillment_option": null,
+                          "payment_status": "PAID",
+                          "order_status": null,
+                          "cancellation_reason": null,
+                          "billed_at": "2023-02-22T00:37:31.000000Z",
+                          "paid_at": "2023-02-22T00:37:38.000000Z",
+                          "completed_at": null,
+                          "cancelled_at": null,
+                          "items": [
+                            {
+                              "product_id": 30419,
+                              "name": "Gsggsg",
+                              "price": 1,
+                              "quantity": 1,
+                              "gross_sales": 1.1,
+                              "net_sales": 0.8929,
+                              "vatable_sales": 0.8929,
+                              "vat_amount": 0.1071,
+                              "vat_exempt_sales": 0,
+                              "zero_rated_sales": 0,
+                              "modifiers": []
+                            }
+                          ],
+                          "taxes": [],
+                          "payment_methods": [
+                            {
+                              "payment_type": "Cash",
+                              "paid_amount": 1.1,
+                              "returned_amount": 0
+                            },
+                            {
+                              "payment_type": "QRPH",
+                              "paid_amount": 332,
+                              "returned_amount": 0
+                            }
+                          ]
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 46231,
+                            "description": "The ID of the order."
+                          },
+                          "location_id": {
+                            "type": "integer",
+                            "example": 295,
+                            "description": "The ID of the location."
+                          },
+                          "service_type_id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The service type of the order."
+                          },
+                          "service_channel_id": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The service channel of the order.",
+                            "nullable": true
+                          },
+                          "reference_id": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The reference ID of the order.",
+                            "nullable": true
+                          },
+                          "business_date": {
+                            "type": "string",
+                            "example": "2023-02-22",
+                            "description": "The business date of the order."
+                          },
+                          "bill_number": {
+                            "type": "integer",
+                            "example": 7690
+                          },
+                          "receipt_number": {
+                            "type": "integer",
+                            "example": 7674
+                          },
+                          "pax_count": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The number of pax."
+                          },
+                          "price_breakdown": {
+                            "type": "object",
+                            "properties": {
+                              "original_gross_sales": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "gross_sales": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "net_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vatable_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vat_amount": {
+                                "type": "number",
+                                "example": 0.1071
+                              },
+                              "vat_exempt_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "zero_rated_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "total_discounts": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "delivery_fee": {
+                                "type": "string",
+                                "example": null
+                              },
+                              "is_free_delivery": {
+                                "type": "boolean",
+                                "example": false
+                              }
+                            },
+                            "required": [
+                              "original_gross_sales",
+                              "gross_sales",
+                              "net_sales",
+                              "vatable_sales",
+                              "vat_amount",
+                              "vat_exempt_sales",
+                              "total_discounts",
+                              "delivery_fee",
+                              "is_free_delivery"
+                            ]
+                          },
+                          "fulfillment_option": {
+                            "type": "string",
+                            "example": null,
+                            "nullable": true
+                          },
+                          "payment_status": {
+                            "type": "string",
+                            "example": "PAID",
+                            "description": "The status of the payment."
+                          },
+                          "order_status": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The status of the order.",
+                            "nullable": true
+                          },
+                          "cancellation_reason": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The status of the order.",
+                            "nullable": true
+                          },
+                          "billed_at": {
+                            "type": "string",
+                            "example": "2023-02-22T00:37:31.000000Z",
+                            "description": "The time when the order was billed.",
+                            "nullable": true
+                          },
+                          "paid_at": {
+                            "type": "string",
+                            "example": "2023-02-22T00:37:38.000000Z",
+                            "description": "The time when the order was paid.",
+                            "nullable": true
+                          },
+                          "completed_at": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The time when the order was completed.",
+                            "nullable": true
+                          },
+                          "cancelled_at": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The time when the order was cancelled.",
+                            "nullable": true
+                          },
+                          "items": {
+                            "type": "array",
+                            "example": [
+                              {
+                                "product_id": 30419,
+                                "name": "Gsggsg",
+                                "price": 1,
+                                "quantity": 1,
+                                "gross_sales": 1.1,
+                                "net_sales": 0.8929,
+                                "vatable_sales": 0.8929,
+                                "vat_amount": 0.1071,
+                                "vat_exempt_sales": 0,
+                                "zero_rated_sales": 0,
+                                "modifiers": []
+                              }
+                            ],
+                            "description": "The products purchased.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "product_id": {
+                                  "type": "integer",
+                                  "example": 30419
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "Gsggsg"
+                                },
+                                "price": {
+                                  "type": "integer",
+                                  "example": 1
+                                },
+                                "quantity": {
+                                  "type": "integer",
+                                  "example": 1
+                                },
+                                "gross_sales": {
+                                  "type": "number",
+                                  "example": 1.1
+                                },
+                                "net_sales": {
+                                  "type": "number",
+                                  "example": 0.8929
+                                },
+                                "vatable_sales": {
+                                  "type": "number",
+                                  "example": 0.8929
+                                },
+                                "vat_amount": {
+                                  "type": "number",
+                                  "example": 0.1071
+                                },
+                                "vat_exempt_sales": {
+                                  "type": "integer",
+                                  "example": 0
+                                },
+                                "zero_rated_sales": {
+                                  "type": "integer",
+                                  "example": 0
+                                },
+                                "modifiers": {
+                                  "type": "array",
+                                  "example": []
+                                }
+                              }
+                            }
+                          },
+                          "taxes": {
+                            "type": "array",
+                            "example": [],
+                            "description": "The taxes applied."
+                          },
+                          "payment_methods": {
+                            "type": "array",
+                            "example": [
+                              {
+                                "payment_type": "Cash",
+                                "paid_amount": 1.1,
+                                "returned_amount": 0
+                              },
+                              {
+                                "payment_type": "QRPH",
+                                "paid_amount": 332,
+                                "returned_amount": 0
+                              }
+                            ],
+                            "description": "The payments made.",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "payment_type": {
+                                  "type": "string",
+                                  "example": "Cash"
+                                },
+                                "paid_amount": {
+                                  "type": "number",
+                                  "example": 1.1
+                                },
+                                "returned_amount": {
+                                  "type": "integer",
+                                  "example": 0
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "location_id",
+                        "service_type_id",
+                        "service_channel_id",
+                        "reference_id",
+                        "business_date",
+                        "bill_number",
+                        "receipt_number",
+                        "pax_count",
+                        "price_breakdown",
+                        "fulfillment_option",
+                        "payment_status",
+                        "order_status",
+                        "cancellation_reason",
+                        "billed_at",
+                        "paid_at",
+                        "completed_at",
+                        "cancelled_at",
+                        "items",
+                        "taxes",
+                        "payment_methods"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orders"
+        ]
+      },
+      "post": {
+        "summary": "Create Order",
+        "operationId": "createOrder",
+        "description": "Create an order.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 46231,
+                      "location_id": 295,
+                      "service_type_id": 1,
+                      "service_channel_id": null,
+                      "reference_id": null,
+                      "business_date": "2023-02-22",
+                      "bill_number": 7690,
+                      "receipt_number": 7674,
+                      "pax_count": 1,
+                      "price_breakdown": {
+                        "original_gross_sales": 1,
+                        "gross_sales": 1.1,
+                        "net_sales": 0.8929,
+                        "vatable_sales": 0.8929,
+                        "vat_amount": 0.1071,
+                        "vat_exempt_sales": 0,
+                        "zero_rated_sales": 0,
+                        "total_discounts": 0,
+                        "delivery_fee": null,
+                        "is_free_delivery": false
+                      },
+                      "fulfillment_option": null,
+                      "payment_status": "PAID",
+                      "order_status": null,
+                      "cancellation_reason": null,
+                      "billed_at": "2023-02-22T00:37:31.000000Z",
+                      "paid_at": "2023-02-22T00:37:38.000000Z",
+                      "completed_at": null,
+                      "cancelled_at": null,
+                      "items": [
+                        {
+                          "product_id": 30419,
+                          "name": "Gsggsg",
+                          "price": 1,
+                          "quantity": 1,
+                          "gross_sales": 1.1,
+                          "net_sales": 0.8929,
+                          "vatable_sales": 0.8929,
+                          "vat_amount": 0.1071,
+                          "vat_exempt_sales": 0,
+                          "zero_rated_sales": 0,
+                          "modifiers": []
+                        }
+                      ],
+                      "taxes": [],
+                      "payment_methods": [
+                        {
+                          "payment_type": "Cash",
+                          "paid_amount": 1.1,
+                          "returned_amount": 0
+                        },
+                        {
+                          "payment_type": "QRPH",
+                          "paid_amount": 332,
+                          "returned_amount": 0
+                        }
+                      ]
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 46231,
+                          "description": "The ID of the order."
+                        },
+                        "location_id": {
+                          "type": "integer",
+                          "example": 295,
+                          "description": "The ID of the location."
+                        },
+                        "service_type_id": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The service type of the order."
+                        },
+                        "service_channel_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The service channel of the order.",
+                          "nullable": true
+                        },
+                        "reference_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The reference ID of the order.",
+                          "nullable": true
+                        },
+                        "business_date": {
+                          "type": "string",
+                          "example": "2023-02-22",
+                          "description": "The business date of the order."
+                        },
+                        "bill_number": {
+                          "type": "integer",
+                          "example": 7690
+                        },
+                        "receipt_number": {
+                          "type": "integer",
+                          "example": 7674
+                        },
+                        "pax_count": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The number of pax."
+                        },
+                        "price_breakdown": {
+                          "type": "object",
+                          "properties": {
+                            "original_gross_sales": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "gross_sales": {
+                              "type": "number",
+                              "example": 1.1
+                            },
+                            "net_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vatable_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vat_amount": {
+                              "type": "number",
+                              "example": 0.1071
+                            },
+                            "vat_exempt_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "zero_rated_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "total_discounts": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "delivery_fee": {
+                              "type": "string",
+                              "example": null
+                            },
+                            "is_free_delivery": {
+                              "type": "boolean",
+                              "example": false
+                            }
+                          },
+                          "required": [
+                            "original_gross_sales",
+                            "gross_sales",
+                            "net_sales",
+                            "vatable_sales",
+                            "vat_amount",
+                            "vat_exempt_sales",
+                            "total_discounts",
+                            "delivery_fee",
+                            "is_free_delivery"
+                          ]
+                        },
+                        "fulfillment_option": {
+                          "type": "string",
+                          "example": null,
+                          "nullable": true
+                        },
+                        "payment_status": {
+                          "type": "string",
+                          "example": "PAID",
+                          "description": "The status of the payment."
+                        },
+                        "order_status": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "cancellation_reason": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "billed_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:31.000000Z",
+                          "description": "The time when the order was billed.",
+                          "nullable": true
+                        },
+                        "paid_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:38.000000Z",
+                          "description": "The time when the order was paid.",
+                          "nullable": true
+                        },
+                        "completed_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was completed.",
+                          "nullable": true
+                        },
+                        "cancelled_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was cancelled.",
+                          "nullable": true
+                        },
+                        "items": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "product_id": 30419,
+                              "name": "Gsggsg",
+                              "price": 1,
+                              "quantity": 1,
+                              "gross_sales": 1.1,
+                              "net_sales": 0.8929,
+                              "vatable_sales": 0.8929,
+                              "vat_amount": 0.1071,
+                              "vat_exempt_sales": 0,
+                              "zero_rated_sales": 0,
+                              "modifiers": []
+                            }
+                          ],
+                          "description": "The products purchased.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "product_id": {
+                                "type": "integer",
+                                "example": 30419
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "Gsggsg"
+                              },
+                              "price": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "gross_sales": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "net_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vatable_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vat_amount": {
+                                "type": "number",
+                                "example": 0.1071
+                              },
+                              "vat_exempt_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "zero_rated_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "modifiers": {
+                                "type": "array",
+                                "example": []
+                              }
+                            }
+                          }
+                        },
+                        "taxes": {
+                          "type": "array",
+                          "example": [],
+                          "description": "The taxes applied."
+                        },
+                        "payment_methods": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "payment_type": "Cash",
+                              "paid_amount": 1.1,
+                              "returned_amount": 0
+                            },
+                            {
+                              "payment_type": "QRPH",
+                              "paid_amount": 332,
+                              "returned_amount": 0
+                            }
+                          ],
+                          "description": "The payments made.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "payment_type": {
+                                "type": "string",
+                                "example": "Cash"
+                              },
+                              "paid_amount": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "returned_amount": {
+                                "type": "integer",
+                                "example": 0
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "location_id",
+                        "service_type_id",
+                        "service_channel_id",
+                        "reference_id",
+                        "business_date",
+                        "bill_number",
+                        "receipt_number",
+                        "pax_count",
+                        "price_breakdown",
+                        "fulfillment_option",
+                        "payment_status",
+                        "order_status",
+                        "cancellation_reason",
+                        "billed_at",
+                        "paid_at",
+                        "completed_at",
+                        "cancelled_at",
+                        "items",
+                        "taxes",
+                        "payment_methods"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orders"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "location_id": {
+                    "type": "integer",
+                    "description": "Must be a valid location ID. This field is required when <code>branch_code</code> is not present.",
+                    "example": 13
+                  },
+                  "branch_code": {
+                    "type": "string",
+                    "description": "Must be a valid branch code. This field is required when <code>location_id</code> is not present.",
+                    "example": "et"
+                  },
+                  "service_type_id": {
+                    "type": "integer",
+                    "description": "Must be a valid service type ID.",
+                    "example": 3,
+                    "nullable": true
+                  },
+                  "service_channel_id": {
+                    "type": "integer",
+                    "description": "Must be a valid service channel ID under the service type.",
+                    "example": 14,
+                    "nullable": true
+                  },
+                  "fulfillment_option": {
+                    "type": "string",
+                    "description": "",
+                    "example": "DELIVERY",
+                    "enum": [
+                      "DELIVERY",
+                      "PICK_UP"
+                    ],
+                    "nullable": true
+                  },
+                  "reference_id": {
+                    "type": "string",
+                    "description": "Must not be greater than 255 characters.",
+                    "example": "iuqdbbypljrlgcgo",
+                    "nullable": true
+                  },
+                  "pax_count": {
+                    "type": "integer",
+                    "description": "The number of guests. Must be at least 1.",
+                    "example": 1,
+                    "nullable": true
+                  },
+                  "business_date": {
+                    "type": "string",
+                    "description": "Must be a valid date in the format <code>Y-m-d</code>.",
+                    "example": "2026-04-13"
+                  },
+                  "ordered_at": {
+                    "type": "string",
+                    "description": "Must be a valid date in the format <code>Y-m-d H:i:s</code>.",
+                    "example": "2026-04-13 02:25:07"
+                  },
+                  "print_kot": {
+                    "type": "boolean",
+                    "description": "Flag if KOT will be printed after order is created.",
+                    "example": false
+                  },
+                  "price_breakdown": {
+                    "type": "object",
+                    "description": "",
+                    "example": [],
+                    "properties": {
+                      "gross_sales": {
+                        "type": "number",
+                        "description": "Must be at least 0.",
+                        "example": 90
+                      },
+                      "net_sales": {
+                        "type": "number",
+                        "description": "Must be at least 0.",
+                        "example": 25
+                      },
+                      "vatable_sales": {
+                        "type": "number",
+                        "description": "Must be at least 0.",
+                        "example": 80.36
+                      },
+                      "vat_amount": {
+                        "type": "number",
+                        "description": "Must be at least 0.",
+                        "example": 9.64
+                      },
+                      "vat_exempt_sales": {
+                        "type": "number",
+                        "description": "Must be at least 0.",
+                        "example": 0
+                      },
+                      "zero_rated_sales": {
+                        "type": "number",
+                        "description": "Must be at least 0.",
+                        "example": 0
+                      },
+                      "total_discounts": {
+                        "type": "number",
+                        "description": "Must be at least 0.",
+                        "example": 3
+                      },
+                      "delivery_fee": {
+                        "type": "number",
+                        "description": "Must be at least 0.",
+                        "example": 0,
+                        "nullable": true
+                      },
+                      "is_free_delivery": {
+                        "type": "boolean",
+                        "description": "Flag if delivery fee is waived.",
+                        "example": false
+                      }
+                    },
+                    "required": [
+                      "gross_sales",
+                      "net_sales",
+                      "vatable_sales",
+                      "vat_amount",
+                      "vat_exempt_sales",
+                      "zero_rated_sales",
+                      "total_discounts"
+                    ]
+                  },
+                  "items": {
+                    "type": "array",
+                    "description": "",
+                    "example": [
+                      []
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "product_id": {
+                          "type": "integer",
+                          "description": "Must be a valid product. This field is required when none of <code>items.*.product_sku</code> and <code>items.*.name</code> are present.",
+                          "example": 13
+                        },
+                        "product_sku": {
+                          "type": "string",
+                          "description": "Must be a valid product. This field is required when none of <code>items.*.product_id</code> and <code>items.*.name</code> are present.",
+                          "example": "SUADA"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "The product name. This field is required when none of <code>items.*.product_id</code> and <code>items.*.product_sku</code> are present. Must not be greater than 191 characters.",
+                          "example": "Iced Kape Sua Da (Vietnamese Latte)"
+                        },
+                        "price": {
+                          "type": "number",
+                          "description": "The product's base price. Must be at least 0.",
+                          "example": 75
+                        },
+                        "quantity": {
+                          "type": "integer",
+                          "description": "Must be at least 1.",
+                          "example": 1
+                        },
+                        "gross_sales": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 90
+                        },
+                        "net_sales": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 29
+                        },
+                        "vatable_sales": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 80.36
+                        },
+                        "vat_amount": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 9.64
+                        },
+                        "vat_exempt_sales": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 0
+                        },
+                        "zero_rated_sales": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 0
+                        },
+                        "discount_amount": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 72
+                        },
+                        "modifiers": {
+                          "type": "array",
+                          "description": "",
+                          "example": null,
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "modifier_id": {
+                                "type": "integer",
+                                "description": "Must be a valid modifier. This field is required when none of <code>items.*.modifiers.*.modifier_sku</code> and <code>items.*.modifiers.*.name</code> are present.",
+                                "example": 13
+                              },
+                              "modifier_sku": {
+                                "type": "string",
+                                "description": "Must be a valid modifier. This field is required when none of <code>items.*.modifiers.*.modifier_id</code> and <code>items.*.modifiers.*.name</code> are present.",
+                                "example": "UPS15"
+                              },
+                              "group": {
+                                "type": "string",
+                                "description": "This field is required when none of <code>items.*.modifiers.*.modifier_id</code> and <code>items.*.modifiers.*.modifier_sku</code> are present. Must not be greater than 100 characters.",
+                                "example": "iuqdbbypljrlgcgo"
+                              },
+                              "type": {
+                                "type": "string",
+                                "description": "This field is required when none of <code>items.*.modifiers.*.modifier_id</code> and <code>items.*.modifiers.*.modifier_sku</code> are present.",
+                                "example": "Forced",
+                                "enum": [
+                                  "Forced",
+                                  "Unforced"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "The modifier name. This field is required when none of <code>items.*.modifiers.*.modifier_id</code> and <code>items.*.modifiers.*.modifier_sku</code> are present. Must not be greater than 100 characters.",
+                                "example": "UPsize"
+                              },
+                              "price": {
+                                "type": "number",
+                                "description": "The modifier's base price. Must be at least 0.",
+                                "example": 15
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "description": "Must be at least 1.",
+                                "example": 1
+                              }
+                            },
+                            "required": [
+                              "price",
+                              "quantity"
+                            ]
+                          }
+                        },
+                        "discount": {
+                          "type": "object",
+                          "description": "The item-level discount info.",
+                          "example": null,
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "Must be a valid discount ID.",
+                              "example": null
+                            },
+                            "name": {
+                              "type": "string",
+                              "description": "Must not be greater than 100 characters.",
+                              "example": "hbfswlbkudwnbszw"
+                            },
+                            "quantity": {
+                              "type": "integer",
+                              "description": "The number of items discounted. Must be at least 1.",
+                              "example": 15
+                            },
+                            "amount": {
+                              "type": "number",
+                              "description": "The amount discounted. Must be at least 0.",
+                              "example": 77
+                            },
+                            "first_name": {
+                              "type": "string",
+                              "description": "The customer's first name. Must not be greater than 191 characters.",
+                              "example": "lqenrdxtykuguxfb"
+                            },
+                            "last_name": {
+                              "type": "string",
+                              "description": "The customer's last name. Must not be greater than 191 characters.",
+                              "example": "sfixuershecqszhp"
+                            },
+                            "reference_number": {
+                              "type": "string",
+                              "description": "The customer's reference/ID number. Must not be greater than 191 characters.",
+                              "example": "anhkovypnsyqipgf"
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "price",
+                        "quantity",
+                        "gross_sales",
+                        "net_sales",
+                        "vatable_sales",
+                        "vat_amount",
+                        "vat_exempt_sales",
+                        "zero_rated_sales"
+                      ]
+                    }
+                  },
+                  "taxes": {
+                    "type": "array",
+                    "description": "The breakdown of taxes and other charges.",
+                    "example": null,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Must be a valid tax name.",
+                          "example": "VAT"
+                        },
+                        "amount": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 75
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "amount"
+                      ]
+                    }
+                  },
+                  "payment_details": {
+                    "type": "array",
+                    "description": "",
+                    "example": [
+                      []
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "payment_type": {
+                          "type": "string",
+                          "description": "Must be a valid payment type.",
+                          "example": "Cash"
+                        },
+                        "paid_amount": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 90
+                        },
+                        "returned_amount": {
+                          "type": "number",
+                          "description": "Must be at least 0.",
+                          "example": 10
+                        }
+                      },
+                      "required": [
+                        "payment_type",
+                        "paid_amount",
+                        "returned_amount"
+                      ]
+                    }
+                  },
+                  "customer_info": {
+                    "type": "object",
+                    "description": "The customer's info.",
+                    "example": null,
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "",
+                        "example": "Mr. Grayson Sawayn Sr.",
+                        "nullable": true
+                      },
+                      "address": {
+                        "type": "string",
+                        "description": "",
+                        "example": "97103 Cruickshank Summit Apt. 620 South Bessieside, PA 41226-6380",
+                        "nullable": true
+                      },
+                      "business_style": {
+                        "type": "string",
+                        "description": "",
+                        "example": "Feest, Sauer and Trantow",
+                        "nullable": true
+                      },
+                      "tin": {
+                        "type": "string",
+                        "description": "",
+                        "example": "212-204-664-046",
+                        "nullable": true
+                      },
+                      "sales_invoice_number": {
+                        "type": "string",
+                        "description": "",
+                        "example": "00000000001491758537",
+                        "nullable": true
+                      }
+                    }
+                  },
+                  "discount": {
+                    "type": "object",
+                    "description": "The order-level discount info.",
+                    "example": null,
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "Must be a valid discount ID.",
+                        "example": null
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "Must not be greater than 100 characters.",
+                        "example": "qiuqdbbypljrlgcg"
+                      },
+                      "amount": {
+                        "type": "number",
+                        "description": "The amount discounted. Must be at least 0.",
+                        "example": 49
+                      },
+                      "first_name": {
+                        "type": "string",
+                        "description": "The customer's first name. Must not be greater than 191 characters.",
+                        "example": "hbfswlbkudwnbszw"
+                      },
+                      "last_name": {
+                        "type": "string",
+                        "description": "The customer's last name. Must not be greater than 191 characters.",
+                        "example": "ewlqenrdxtykugux"
+                      },
+                      "reference_number": {
+                        "type": "string",
+                        "description": "The customer's reference/ID number. Must not be greater than 191 characters.",
+                        "example": "fbsfixuershecqsz"
+                      }
+                    }
+                  }
+                },
+                "required": [
+                  "business_date",
+                  "ordered_at",
+                  "items",
+                  "payment_details"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/order_references/{order}": {
+      "get": {
+        "summary": "Get Order by Reference",
+        "operationId": "getOrderByReference",
+        "description": "Get an order by reference number.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 46231,
+                      "location_id": 295,
+                      "service_type_id": 1,
+                      "service_channel_id": null,
+                      "reference_id": null,
+                      "business_date": "2023-02-22",
+                      "bill_number": 7690,
+                      "receipt_number": 7674,
+                      "pax_count": 1,
+                      "price_breakdown": {
+                        "original_gross_sales": 1,
+                        "gross_sales": 1.1,
+                        "net_sales": 0.8929,
+                        "vatable_sales": 0.8929,
+                        "vat_amount": 0.1071,
+                        "vat_exempt_sales": 0,
+                        "zero_rated_sales": 0,
+                        "total_discounts": 0,
+                        "delivery_fee": null,
+                        "is_free_delivery": false
+                      },
+                      "fulfillment_option": null,
+                      "payment_status": "PAID",
+                      "order_status": null,
+                      "cancellation_reason": null,
+                      "billed_at": "2023-02-22T00:37:31.000000Z",
+                      "paid_at": "2023-02-22T00:37:38.000000Z",
+                      "completed_at": null,
+                      "cancelled_at": null,
+                      "items": [
+                        {
+                          "product_id": 30419,
+                          "name": "Gsggsg",
+                          "price": 1,
+                          "quantity": 1,
+                          "gross_sales": 1.1,
+                          "net_sales": 0.8929,
+                          "vatable_sales": 0.8929,
+                          "vat_amount": 0.1071,
+                          "vat_exempt_sales": 0,
+                          "zero_rated_sales": 0,
+                          "modifiers": []
+                        }
+                      ],
+                      "taxes": [],
+                      "payment_methods": [
+                        {
+                          "payment_type": "Cash",
+                          "paid_amount": 1.1,
+                          "returned_amount": 0
+                        },
+                        {
+                          "payment_type": "QRPH",
+                          "paid_amount": 332,
+                          "returned_amount": 0
+                        }
+                      ]
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 46231,
+                          "description": "The ID of the order."
+                        },
+                        "location_id": {
+                          "type": "integer",
+                          "example": 295,
+                          "description": "The ID of the location."
+                        },
+                        "service_type_id": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The service type of the order."
+                        },
+                        "service_channel_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The service channel of the order.",
+                          "nullable": true
+                        },
+                        "reference_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The reference ID of the order.",
+                          "nullable": true
+                        },
+                        "business_date": {
+                          "type": "string",
+                          "example": "2023-02-22",
+                          "description": "The business date of the order."
+                        },
+                        "bill_number": {
+                          "type": "integer",
+                          "example": 7690
+                        },
+                        "receipt_number": {
+                          "type": "integer",
+                          "example": 7674
+                        },
+                        "pax_count": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The number of pax."
+                        },
+                        "price_breakdown": {
+                          "type": "object",
+                          "properties": {
+                            "original_gross_sales": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "gross_sales": {
+                              "type": "number",
+                              "example": 1.1
+                            },
+                            "net_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vatable_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vat_amount": {
+                              "type": "number",
+                              "example": 0.1071
+                            },
+                            "vat_exempt_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "zero_rated_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "total_discounts": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "delivery_fee": {
+                              "type": "string",
+                              "example": null
+                            },
+                            "is_free_delivery": {
+                              "type": "boolean",
+                              "example": false
+                            }
+                          },
+                          "required": [
+                            "original_gross_sales",
+                            "gross_sales",
+                            "net_sales",
+                            "vatable_sales",
+                            "vat_amount",
+                            "vat_exempt_sales",
+                            "total_discounts",
+                            "delivery_fee",
+                            "is_free_delivery"
+                          ]
+                        },
+                        "fulfillment_option": {
+                          "type": "string",
+                          "example": null,
+                          "nullable": true
+                        },
+                        "payment_status": {
+                          "type": "string",
+                          "example": "PAID",
+                          "description": "The status of the payment."
+                        },
+                        "order_status": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "cancellation_reason": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "billed_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:31.000000Z",
+                          "description": "The time when the order was billed.",
+                          "nullable": true
+                        },
+                        "paid_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:38.000000Z",
+                          "description": "The time when the order was paid.",
+                          "nullable": true
+                        },
+                        "completed_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was completed.",
+                          "nullable": true
+                        },
+                        "cancelled_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was cancelled.",
+                          "nullable": true
+                        },
+                        "items": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "product_id": 30419,
+                              "name": "Gsggsg",
+                              "price": 1,
+                              "quantity": 1,
+                              "gross_sales": 1.1,
+                              "net_sales": 0.8929,
+                              "vatable_sales": 0.8929,
+                              "vat_amount": 0.1071,
+                              "vat_exempt_sales": 0,
+                              "zero_rated_sales": 0,
+                              "modifiers": []
+                            }
+                          ],
+                          "description": "The products purchased.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "product_id": {
+                                "type": "integer",
+                                "example": 30419
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "Gsggsg"
+                              },
+                              "price": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "gross_sales": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "net_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vatable_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vat_amount": {
+                                "type": "number",
+                                "example": 0.1071
+                              },
+                              "vat_exempt_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "zero_rated_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "modifiers": {
+                                "type": "array",
+                                "example": []
+                              }
+                            }
+                          }
+                        },
+                        "taxes": {
+                          "type": "array",
+                          "example": [],
+                          "description": "The taxes applied."
+                        },
+                        "payment_methods": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "payment_type": "Cash",
+                              "paid_amount": 1.1,
+                              "returned_amount": 0
+                            },
+                            {
+                              "payment_type": "QRPH",
+                              "paid_amount": 332,
+                              "returned_amount": 0
+                            }
+                          ],
+                          "description": "The payments made.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "payment_type": {
+                                "type": "string",
+                                "example": "Cash"
+                              },
+                              "paid_amount": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "returned_amount": {
+                                "type": "integer",
+                                "example": 0
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "location_id",
+                        "service_type_id",
+                        "service_channel_id",
+                        "reference_id",
+                        "business_date",
+                        "bill_number",
+                        "receipt_number",
+                        "pax_count",
+                        "price_breakdown",
+                        "fulfillment_option",
+                        "payment_status",
+                        "order_status",
+                        "cancellation_reason",
+                        "billed_at",
+                        "paid_at",
+                        "completed_at",
+                        "cancelled_at",
+                        "items",
+                        "taxes",
+                        "payment_methods"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orders"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "order",
+          "description": "The reference number of the order.",
+          "example": "REF-123456",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/api/v1/orders/{id}": {
+      "get": {
+        "summary": "Get Order",
+        "operationId": "getOrder",
+        "description": "Get an order by ID.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 46231,
+                      "location_id": 295,
+                      "service_type_id": 1,
+                      "service_channel_id": null,
+                      "reference_id": null,
+                      "business_date": "2023-02-22",
+                      "bill_number": 7690,
+                      "receipt_number": 7674,
+                      "pax_count": 1,
+                      "price_breakdown": {
+                        "original_gross_sales": 1,
+                        "gross_sales": 1.1,
+                        "net_sales": 0.8929,
+                        "vatable_sales": 0.8929,
+                        "vat_amount": 0.1071,
+                        "vat_exempt_sales": 0,
+                        "zero_rated_sales": 0,
+                        "total_discounts": 0,
+                        "delivery_fee": null,
+                        "is_free_delivery": false
+                      },
+                      "fulfillment_option": null,
+                      "payment_status": "PAID",
+                      "order_status": null,
+                      "cancellation_reason": null,
+                      "billed_at": "2023-02-22T00:37:31.000000Z",
+                      "paid_at": "2023-02-22T00:37:38.000000Z",
+                      "completed_at": null,
+                      "cancelled_at": null,
+                      "items": [
+                        {
+                          "product_id": 30419,
+                          "name": "Gsggsg",
+                          "price": 1,
+                          "quantity": 1,
+                          "gross_sales": 1.1,
+                          "net_sales": 0.8929,
+                          "vatable_sales": 0.8929,
+                          "vat_amount": 0.1071,
+                          "vat_exempt_sales": 0,
+                          "zero_rated_sales": 0,
+                          "modifiers": []
+                        }
+                      ],
+                      "taxes": [],
+                      "payment_methods": [
+                        {
+                          "payment_type": "Cash",
+                          "paid_amount": 1.1,
+                          "returned_amount": 0
+                        },
+                        {
+                          "payment_type": "QRPH",
+                          "paid_amount": 332,
+                          "returned_amount": 0
+                        }
+                      ]
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 46231,
+                          "description": "The ID of the order."
+                        },
+                        "location_id": {
+                          "type": "integer",
+                          "example": 295,
+                          "description": "The ID of the location."
+                        },
+                        "service_type_id": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The service type of the order."
+                        },
+                        "service_channel_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The service channel of the order.",
+                          "nullable": true
+                        },
+                        "reference_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The reference ID of the order.",
+                          "nullable": true
+                        },
+                        "business_date": {
+                          "type": "string",
+                          "example": "2023-02-22",
+                          "description": "The business date of the order."
+                        },
+                        "bill_number": {
+                          "type": "integer",
+                          "example": 7690
+                        },
+                        "receipt_number": {
+                          "type": "integer",
+                          "example": 7674
+                        },
+                        "pax_count": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The number of pax."
+                        },
+                        "price_breakdown": {
+                          "type": "object",
+                          "properties": {
+                            "original_gross_sales": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "gross_sales": {
+                              "type": "number",
+                              "example": 1.1
+                            },
+                            "net_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vatable_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vat_amount": {
+                              "type": "number",
+                              "example": 0.1071
+                            },
+                            "vat_exempt_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "zero_rated_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "total_discounts": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "delivery_fee": {
+                              "type": "string",
+                              "example": null
+                            },
+                            "is_free_delivery": {
+                              "type": "boolean",
+                              "example": false
+                            }
+                          },
+                          "required": [
+                            "original_gross_sales",
+                            "gross_sales",
+                            "net_sales",
+                            "vatable_sales",
+                            "vat_amount",
+                            "vat_exempt_sales",
+                            "total_discounts",
+                            "delivery_fee",
+                            "is_free_delivery"
+                          ]
+                        },
+                        "fulfillment_option": {
+                          "type": "string",
+                          "example": null,
+                          "nullable": true
+                        },
+                        "payment_status": {
+                          "type": "string",
+                          "example": "PAID",
+                          "description": "The status of the payment."
+                        },
+                        "order_status": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "cancellation_reason": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "billed_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:31.000000Z",
+                          "description": "The time when the order was billed.",
+                          "nullable": true
+                        },
+                        "paid_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:38.000000Z",
+                          "description": "The time when the order was paid.",
+                          "nullable": true
+                        },
+                        "completed_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was completed.",
+                          "nullable": true
+                        },
+                        "cancelled_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was cancelled.",
+                          "nullable": true
+                        },
+                        "items": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "product_id": 30419,
+                              "name": "Gsggsg",
+                              "price": 1,
+                              "quantity": 1,
+                              "gross_sales": 1.1,
+                              "net_sales": 0.8929,
+                              "vatable_sales": 0.8929,
+                              "vat_amount": 0.1071,
+                              "vat_exempt_sales": 0,
+                              "zero_rated_sales": 0,
+                              "modifiers": []
+                            }
+                          ],
+                          "description": "The products purchased.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "product_id": {
+                                "type": "integer",
+                                "example": 30419
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "Gsggsg"
+                              },
+                              "price": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "gross_sales": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "net_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vatable_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vat_amount": {
+                                "type": "number",
+                                "example": 0.1071
+                              },
+                              "vat_exempt_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "zero_rated_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "modifiers": {
+                                "type": "array",
+                                "example": []
+                              }
+                            }
+                          }
+                        },
+                        "taxes": {
+                          "type": "array",
+                          "example": [],
+                          "description": "The taxes applied."
+                        },
+                        "payment_methods": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "payment_type": "Cash",
+                              "paid_amount": 1.1,
+                              "returned_amount": 0
+                            },
+                            {
+                              "payment_type": "QRPH",
+                              "paid_amount": 332,
+                              "returned_amount": 0
+                            }
+                          ],
+                          "description": "The payments made.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "payment_type": {
+                                "type": "string",
+                                "example": "Cash"
+                              },
+                              "paid_amount": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "returned_amount": {
+                                "type": "integer",
+                                "example": 0
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "location_id",
+                        "service_type_id",
+                        "service_channel_id",
+                        "reference_id",
+                        "business_date",
+                        "bill_number",
+                        "receipt_number",
+                        "pax_count",
+                        "price_breakdown",
+                        "fulfillment_option",
+                        "payment_status",
+                        "order_status",
+                        "cancellation_reason",
+                        "billed_at",
+                        "paid_at",
+                        "completed_at",
+                        "cancelled_at",
+                        "items",
+                        "taxes",
+                        "payment_methods"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orders"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "description": "The ID of the order.",
+          "example": 123456,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/orders/{order_id}/cancel": {
+      "post": {
+        "summary": "Cancel Order",
+        "operationId": "cancelOrder",
+        "description": "Tag the specified order as cancelled.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 46231,
+                      "location_id": 295,
+                      "service_type_id": 1,
+                      "service_channel_id": null,
+                      "reference_id": null,
+                      "business_date": "2023-02-22",
+                      "bill_number": 7690,
+                      "receipt_number": 7674,
+                      "pax_count": 1,
+                      "price_breakdown": {
+                        "original_gross_sales": 1,
+                        "gross_sales": 1.1,
+                        "net_sales": 0.8929,
+                        "vatable_sales": 0.8929,
+                        "vat_amount": 0.1071,
+                        "vat_exempt_sales": 0,
+                        "zero_rated_sales": 0,
+                        "total_discounts": 0,
+                        "delivery_fee": null,
+                        "is_free_delivery": false
+                      },
+                      "fulfillment_option": null,
+                      "payment_status": "PAID",
+                      "order_status": null,
+                      "cancellation_reason": null,
+                      "billed_at": "2023-02-22T00:37:31.000000Z",
+                      "paid_at": "2023-02-22T00:37:38.000000Z",
+                      "completed_at": null,
+                      "cancelled_at": null,
+                      "items": [
+                        {
+                          "product_id": 30419,
+                          "name": "Gsggsg",
+                          "price": 1,
+                          "quantity": 1,
+                          "gross_sales": 1.1,
+                          "net_sales": 0.8929,
+                          "vatable_sales": 0.8929,
+                          "vat_amount": 0.1071,
+                          "vat_exempt_sales": 0,
+                          "zero_rated_sales": 0,
+                          "modifiers": []
+                        }
+                      ],
+                      "taxes": [],
+                      "payment_methods": [
+                        {
+                          "payment_type": "Cash",
+                          "paid_amount": 1.1,
+                          "returned_amount": 0
+                        },
+                        {
+                          "payment_type": "QRPH",
+                          "paid_amount": 332,
+                          "returned_amount": 0
+                        }
+                      ]
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 46231,
+                          "description": "The ID of the order."
+                        },
+                        "location_id": {
+                          "type": "integer",
+                          "example": 295,
+                          "description": "The ID of the location."
+                        },
+                        "service_type_id": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The service type of the order."
+                        },
+                        "service_channel_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The service channel of the order.",
+                          "nullable": true
+                        },
+                        "reference_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The reference ID of the order.",
+                          "nullable": true
+                        },
+                        "business_date": {
+                          "type": "string",
+                          "example": "2023-02-22",
+                          "description": "The business date of the order."
+                        },
+                        "bill_number": {
+                          "type": "integer",
+                          "example": 7690
+                        },
+                        "receipt_number": {
+                          "type": "integer",
+                          "example": 7674
+                        },
+                        "pax_count": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The number of pax."
+                        },
+                        "price_breakdown": {
+                          "type": "object",
+                          "properties": {
+                            "original_gross_sales": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "gross_sales": {
+                              "type": "number",
+                              "example": 1.1
+                            },
+                            "net_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vatable_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vat_amount": {
+                              "type": "number",
+                              "example": 0.1071
+                            },
+                            "vat_exempt_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "zero_rated_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "total_discounts": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "delivery_fee": {
+                              "type": "string",
+                              "example": null
+                            },
+                            "is_free_delivery": {
+                              "type": "boolean",
+                              "example": false
+                            }
+                          },
+                          "required": [
+                            "original_gross_sales",
+                            "gross_sales",
+                            "net_sales",
+                            "vatable_sales",
+                            "vat_amount",
+                            "vat_exempt_sales",
+                            "total_discounts",
+                            "delivery_fee",
+                            "is_free_delivery"
+                          ]
+                        },
+                        "fulfillment_option": {
+                          "type": "string",
+                          "example": null,
+                          "nullable": true
+                        },
+                        "payment_status": {
+                          "type": "string",
+                          "example": "PAID",
+                          "description": "The status of the payment."
+                        },
+                        "order_status": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "cancellation_reason": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "billed_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:31.000000Z",
+                          "description": "The time when the order was billed.",
+                          "nullable": true
+                        },
+                        "paid_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:38.000000Z",
+                          "description": "The time when the order was paid.",
+                          "nullable": true
+                        },
+                        "completed_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was completed.",
+                          "nullable": true
+                        },
+                        "cancelled_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was cancelled.",
+                          "nullable": true
+                        },
+                        "items": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "product_id": 30419,
+                              "name": "Gsggsg",
+                              "price": 1,
+                              "quantity": 1,
+                              "gross_sales": 1.1,
+                              "net_sales": 0.8929,
+                              "vatable_sales": 0.8929,
+                              "vat_amount": 0.1071,
+                              "vat_exempt_sales": 0,
+                              "zero_rated_sales": 0,
+                              "modifiers": []
+                            }
+                          ],
+                          "description": "The products purchased.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "product_id": {
+                                "type": "integer",
+                                "example": 30419
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "Gsggsg"
+                              },
+                              "price": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "gross_sales": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "net_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vatable_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vat_amount": {
+                                "type": "number",
+                                "example": 0.1071
+                              },
+                              "vat_exempt_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "zero_rated_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "modifiers": {
+                                "type": "array",
+                                "example": []
+                              }
+                            }
+                          }
+                        },
+                        "taxes": {
+                          "type": "array",
+                          "example": [],
+                          "description": "The taxes applied."
+                        },
+                        "payment_methods": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "payment_type": "Cash",
+                              "paid_amount": 1.1,
+                              "returned_amount": 0
+                            },
+                            {
+                              "payment_type": "QRPH",
+                              "paid_amount": 332,
+                              "returned_amount": 0
+                            }
+                          ],
+                          "description": "The payments made.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "payment_type": {
+                                "type": "string",
+                                "example": "Cash"
+                              },
+                              "paid_amount": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "returned_amount": {
+                                "type": "integer",
+                                "example": 0
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "location_id",
+                        "service_type_id",
+                        "service_channel_id",
+                        "reference_id",
+                        "business_date",
+                        "bill_number",
+                        "receipt_number",
+                        "pax_count",
+                        "price_breakdown",
+                        "fulfillment_option",
+                        "payment_status",
+                        "order_status",
+                        "cancellation_reason",
+                        "billed_at",
+                        "paid_at",
+                        "completed_at",
+                        "cancelled_at",
+                        "items",
+                        "taxes",
+                        "payment_methods"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orders"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "description": "The reason why the order is to be cancelled. Must not be greater than 255 characters.",
+                    "example": "Items are unavailable"
+                  }
+                },
+                "required": [
+                  "reason"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "order_id",
+          "description": "The ID of the order.",
+          "example": 46231,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/orders/{order_id}/complete": {
+      "post": {
+        "summary": "Complete Order",
+        "operationId": "completeOrder",
+        "description": "Tag the specified order as completed.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 46231,
+                      "location_id": 295,
+                      "service_type_id": 1,
+                      "service_channel_id": null,
+                      "reference_id": null,
+                      "business_date": "2023-02-22",
+                      "bill_number": 7690,
+                      "receipt_number": 7674,
+                      "pax_count": 1,
+                      "price_breakdown": {
+                        "original_gross_sales": 1,
+                        "gross_sales": 1.1,
+                        "net_sales": 0.8929,
+                        "vatable_sales": 0.8929,
+                        "vat_amount": 0.1071,
+                        "vat_exempt_sales": 0,
+                        "zero_rated_sales": 0,
+                        "total_discounts": 0,
+                        "delivery_fee": null,
+                        "is_free_delivery": false
+                      },
+                      "fulfillment_option": null,
+                      "payment_status": "PAID",
+                      "order_status": null,
+                      "cancellation_reason": null,
+                      "billed_at": "2023-02-22T00:37:31.000000Z",
+                      "paid_at": "2023-02-22T00:37:38.000000Z",
+                      "completed_at": null,
+                      "cancelled_at": null,
+                      "items": [
+                        {
+                          "product_id": 30419,
+                          "name": "Gsggsg",
+                          "price": 1,
+                          "quantity": 1,
+                          "gross_sales": 1.1,
+                          "net_sales": 0.8929,
+                          "vatable_sales": 0.8929,
+                          "vat_amount": 0.1071,
+                          "vat_exempt_sales": 0,
+                          "zero_rated_sales": 0,
+                          "modifiers": []
+                        }
+                      ],
+                      "taxes": [],
+                      "payment_methods": [
+                        {
+                          "payment_type": "Cash",
+                          "paid_amount": 1.1,
+                          "returned_amount": 0
+                        },
+                        {
+                          "payment_type": "QRPH",
+                          "paid_amount": 332,
+                          "returned_amount": 0
+                        }
+                      ]
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 46231,
+                          "description": "The ID of the order."
+                        },
+                        "location_id": {
+                          "type": "integer",
+                          "example": 295,
+                          "description": "The ID of the location."
+                        },
+                        "service_type_id": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The service type of the order."
+                        },
+                        "service_channel_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The service channel of the order.",
+                          "nullable": true
+                        },
+                        "reference_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The reference ID of the order.",
+                          "nullable": true
+                        },
+                        "business_date": {
+                          "type": "string",
+                          "example": "2023-02-22",
+                          "description": "The business date of the order."
+                        },
+                        "bill_number": {
+                          "type": "integer",
+                          "example": 7690
+                        },
+                        "receipt_number": {
+                          "type": "integer",
+                          "example": 7674
+                        },
+                        "pax_count": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The number of pax."
+                        },
+                        "price_breakdown": {
+                          "type": "object",
+                          "properties": {
+                            "original_gross_sales": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "gross_sales": {
+                              "type": "number",
+                              "example": 1.1
+                            },
+                            "net_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vatable_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vat_amount": {
+                              "type": "number",
+                              "example": 0.1071
+                            },
+                            "vat_exempt_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "zero_rated_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "total_discounts": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "delivery_fee": {
+                              "type": "string",
+                              "example": null
+                            },
+                            "is_free_delivery": {
+                              "type": "boolean",
+                              "example": false
+                            }
+                          },
+                          "required": [
+                            "original_gross_sales",
+                            "gross_sales",
+                            "net_sales",
+                            "vatable_sales",
+                            "vat_amount",
+                            "vat_exempt_sales",
+                            "total_discounts",
+                            "delivery_fee",
+                            "is_free_delivery"
+                          ]
+                        },
+                        "fulfillment_option": {
+                          "type": "string",
+                          "example": null,
+                          "nullable": true
+                        },
+                        "payment_status": {
+                          "type": "string",
+                          "example": "PAID",
+                          "description": "The status of the payment."
+                        },
+                        "order_status": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "cancellation_reason": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "billed_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:31.000000Z",
+                          "description": "The time when the order was billed.",
+                          "nullable": true
+                        },
+                        "paid_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:38.000000Z",
+                          "description": "The time when the order was paid.",
+                          "nullable": true
+                        },
+                        "completed_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was completed.",
+                          "nullable": true
+                        },
+                        "cancelled_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was cancelled.",
+                          "nullable": true
+                        },
+                        "items": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "product_id": 30419,
+                              "name": "Gsggsg",
+                              "price": 1,
+                              "quantity": 1,
+                              "gross_sales": 1.1,
+                              "net_sales": 0.8929,
+                              "vatable_sales": 0.8929,
+                              "vat_amount": 0.1071,
+                              "vat_exempt_sales": 0,
+                              "zero_rated_sales": 0,
+                              "modifiers": []
+                            }
+                          ],
+                          "description": "The products purchased.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "product_id": {
+                                "type": "integer",
+                                "example": 30419
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "Gsggsg"
+                              },
+                              "price": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "gross_sales": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "net_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vatable_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vat_amount": {
+                                "type": "number",
+                                "example": 0.1071
+                              },
+                              "vat_exempt_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "zero_rated_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "modifiers": {
+                                "type": "array",
+                                "example": []
+                              }
+                            }
+                          }
+                        },
+                        "taxes": {
+                          "type": "array",
+                          "example": [],
+                          "description": "The taxes applied."
+                        },
+                        "payment_methods": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "payment_type": "Cash",
+                              "paid_amount": 1.1,
+                              "returned_amount": 0
+                            },
+                            {
+                              "payment_type": "QRPH",
+                              "paid_amount": 332,
+                              "returned_amount": 0
+                            }
+                          ],
+                          "description": "The payments made.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "payment_type": {
+                                "type": "string",
+                                "example": "Cash"
+                              },
+                              "paid_amount": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "returned_amount": {
+                                "type": "integer",
+                                "example": 0
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "location_id",
+                        "service_type_id",
+                        "service_channel_id",
+                        "reference_id",
+                        "business_date",
+                        "bill_number",
+                        "receipt_number",
+                        "pax_count",
+                        "price_breakdown",
+                        "fulfillment_option",
+                        "payment_status",
+                        "order_status",
+                        "cancellation_reason",
+                        "billed_at",
+                        "paid_at",
+                        "completed_at",
+                        "cancelled_at",
+                        "items",
+                        "taxes",
+                        "payment_methods"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orders"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "order_id",
+          "description": "The ID of the order.",
+          "example": 46231,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/orders/{order_id}/ready": {
+      "post": {
+        "summary": "Tag Order as Ready",
+        "operationId": "tagOrderAsReady",
+        "description": "Tag the specified order as ready.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 46231,
+                      "location_id": 295,
+                      "service_type_id": 1,
+                      "service_channel_id": null,
+                      "reference_id": null,
+                      "business_date": "2023-02-22",
+                      "bill_number": 7690,
+                      "receipt_number": 7674,
+                      "pax_count": 1,
+                      "price_breakdown": {
+                        "original_gross_sales": 1,
+                        "gross_sales": 1.1,
+                        "net_sales": 0.8929,
+                        "vatable_sales": 0.8929,
+                        "vat_amount": 0.1071,
+                        "vat_exempt_sales": 0,
+                        "zero_rated_sales": 0,
+                        "total_discounts": 0,
+                        "delivery_fee": null,
+                        "is_free_delivery": false
+                      },
+                      "fulfillment_option": null,
+                      "payment_status": "PAID",
+                      "order_status": null,
+                      "cancellation_reason": null,
+                      "billed_at": "2023-02-22T00:37:31.000000Z",
+                      "paid_at": "2023-02-22T00:37:38.000000Z",
+                      "completed_at": null,
+                      "cancelled_at": null,
+                      "items": [
+                        {
+                          "product_id": 30419,
+                          "name": "Gsggsg",
+                          "price": 1,
+                          "quantity": 1,
+                          "gross_sales": 1.1,
+                          "net_sales": 0.8929,
+                          "vatable_sales": 0.8929,
+                          "vat_amount": 0.1071,
+                          "vat_exempt_sales": 0,
+                          "zero_rated_sales": 0,
+                          "modifiers": []
+                        }
+                      ],
+                      "taxes": [],
+                      "payment_methods": [
+                        {
+                          "payment_type": "Cash",
+                          "paid_amount": 1.1,
+                          "returned_amount": 0
+                        },
+                        {
+                          "payment_type": "QRPH",
+                          "paid_amount": 332,
+                          "returned_amount": 0
+                        }
+                      ]
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 46231,
+                          "description": "The ID of the order."
+                        },
+                        "location_id": {
+                          "type": "integer",
+                          "example": 295,
+                          "description": "The ID of the location."
+                        },
+                        "service_type_id": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The service type of the order."
+                        },
+                        "service_channel_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The service channel of the order.",
+                          "nullable": true
+                        },
+                        "reference_id": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The reference ID of the order.",
+                          "nullable": true
+                        },
+                        "business_date": {
+                          "type": "string",
+                          "example": "2023-02-22",
+                          "description": "The business date of the order."
+                        },
+                        "bill_number": {
+                          "type": "integer",
+                          "example": 7690
+                        },
+                        "receipt_number": {
+                          "type": "integer",
+                          "example": 7674
+                        },
+                        "pax_count": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The number of pax."
+                        },
+                        "price_breakdown": {
+                          "type": "object",
+                          "properties": {
+                            "original_gross_sales": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "gross_sales": {
+                              "type": "number",
+                              "example": 1.1
+                            },
+                            "net_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vatable_sales": {
+                              "type": "number",
+                              "example": 0.8929
+                            },
+                            "vat_amount": {
+                              "type": "number",
+                              "example": 0.1071
+                            },
+                            "vat_exempt_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "zero_rated_sales": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "total_discounts": {
+                              "type": "integer",
+                              "example": 0
+                            },
+                            "delivery_fee": {
+                              "type": "string",
+                              "example": null
+                            },
+                            "is_free_delivery": {
+                              "type": "boolean",
+                              "example": false
+                            }
+                          },
+                          "required": [
+                            "original_gross_sales",
+                            "gross_sales",
+                            "net_sales",
+                            "vatable_sales",
+                            "vat_amount",
+                            "vat_exempt_sales",
+                            "total_discounts",
+                            "delivery_fee",
+                            "is_free_delivery"
+                          ]
+                        },
+                        "fulfillment_option": {
+                          "type": "string",
+                          "example": null,
+                          "nullable": true
+                        },
+                        "payment_status": {
+                          "type": "string",
+                          "example": "PAID",
+                          "description": "The status of the payment."
+                        },
+                        "order_status": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "cancellation_reason": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The status of the order.",
+                          "nullable": true
+                        },
+                        "billed_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:31.000000Z",
+                          "description": "The time when the order was billed.",
+                          "nullable": true
+                        },
+                        "paid_at": {
+                          "type": "string",
+                          "example": "2023-02-22T00:37:38.000000Z",
+                          "description": "The time when the order was paid.",
+                          "nullable": true
+                        },
+                        "completed_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was completed.",
+                          "nullable": true
+                        },
+                        "cancelled_at": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The time when the order was cancelled.",
+                          "nullable": true
+                        },
+                        "items": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "product_id": 30419,
+                              "name": "Gsggsg",
+                              "price": 1,
+                              "quantity": 1,
+                              "gross_sales": 1.1,
+                              "net_sales": 0.8929,
+                              "vatable_sales": 0.8929,
+                              "vat_amount": 0.1071,
+                              "vat_exempt_sales": 0,
+                              "zero_rated_sales": 0,
+                              "modifiers": []
+                            }
+                          ],
+                          "description": "The products purchased.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "product_id": {
+                                "type": "integer",
+                                "example": 30419
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "Gsggsg"
+                              },
+                              "price": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "quantity": {
+                                "type": "integer",
+                                "example": 1
+                              },
+                              "gross_sales": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "net_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vatable_sales": {
+                                "type": "number",
+                                "example": 0.8929
+                              },
+                              "vat_amount": {
+                                "type": "number",
+                                "example": 0.1071
+                              },
+                              "vat_exempt_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "zero_rated_sales": {
+                                "type": "integer",
+                                "example": 0
+                              },
+                              "modifiers": {
+                                "type": "array",
+                                "example": []
+                              }
+                            }
+                          }
+                        },
+                        "taxes": {
+                          "type": "array",
+                          "example": [],
+                          "description": "The taxes applied."
+                        },
+                        "payment_methods": {
+                          "type": "array",
+                          "example": [
+                            {
+                              "payment_type": "Cash",
+                              "paid_amount": 1.1,
+                              "returned_amount": 0
+                            },
+                            {
+                              "payment_type": "QRPH",
+                              "paid_amount": 332,
+                              "returned_amount": 0
+                            }
+                          ],
+                          "description": "The payments made.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "payment_type": {
+                                "type": "string",
+                                "example": "Cash"
+                              },
+                              "paid_amount": {
+                                "type": "number",
+                                "example": 1.1
+                              },
+                              "returned_amount": {
+                                "type": "integer",
+                                "example": 0
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "location_id",
+                        "service_type_id",
+                        "service_channel_id",
+                        "reference_id",
+                        "business_date",
+                        "bill_number",
+                        "receipt_number",
+                        "pax_count",
+                        "price_breakdown",
+                        "fulfillment_option",
+                        "payment_status",
+                        "order_status",
+                        "cancellation_reason",
+                        "billed_at",
+                        "paid_at",
+                        "completed_at",
+                        "cancelled_at",
+                        "items",
+                        "taxes",
+                        "payment_methods"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Orders"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "order_id",
+          "description": "The ID of the order.",
+          "example": 46231,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/locations": {
+      "get": {
+        "summary": "Get Locations",
+        "operationId": "getLocations",
+        "description": "Get the locations.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "filter[branch_code]",
+            "description": "Filter locations by branch code. Comma-separated values are allowed.",
+            "example": "PCPHBKU43792",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter locations by branch code. Comma-separated values are allowed.",
+              "example": "PCPHBKU43792"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[number]",
+            "description": "The current page number of the result set to display. Must be at least 1.",
+            "example": 1,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The current page number of the result set to display. Must be at least 1.",
+              "example": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[size]",
+            "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+            "example": 100,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+              "example": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "Oberbrunner, Corkery and Bednar",
+                        "alias": null,
+                        "branch_code": "PCPHYPL07603",
+                        "address": "52341 Danny Roads Kertzmannton, MD 14524-6405",
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Quitzon Ltd",
+                        "alias": null,
+                        "branch_code": "PCPHEWL87933",
+                        "address": "79155 Jenkins Spurs Apt. 780 Effertztown, OH 31285",
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z"
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "Oberbrunner, Corkery and Bednar",
+                          "alias": null,
+                          "branch_code": "PCPHYPL07603",
+                          "address": "52341 Danny Roads Kertzmannton, MD 14524-6405",
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z"
+                        },
+                        {
+                          "id": 2,
+                          "name": "Quitzon Ltd",
+                          "alias": null,
+                          "branch_code": "PCPHEWL87933",
+                          "address": "79155 Jenkins Spurs Apt. 780 Effertztown, OH 31285",
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The ID of the location."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Oberbrunner, Corkery and Bednar",
+                            "description": "The name of the location."
+                          },
+                          "alias": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The alias for the location."
+                          },
+                          "branch_code": {
+                            "type": "string",
+                            "example": "PCPHYPL07603",
+                            "description": "The branch code of the location."
+                          },
+                          "address": {
+                            "type": "string",
+                            "example": "52341 Danny Roads Kertzmannton, MD 14524-6405",
+                            "description": "The address of the location."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z",
+                            "description": "The time when the location was created in ISO-8601 format with UTC timezone."
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z",
+                            "description": "The time when the location was last updated in ISO-8601 format with UTC timezone."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "alias",
+                        "branch_code",
+                        "address",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Locations"
+        ]
+      }
+    },
+    "/api/v1/locations/{id}": {
+      "put": {
+        "summary": "Update Location",
+        "operationId": "updateLocation",
+        "description": "Update the alias or branch code of the specified location.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 3,
+                      "name": "Oberbrunner, Corkery and Bednar",
+                      "alias": null,
+                      "branch_code": "PCPHYPL07603",
+                      "address": "52341 Danny Roads Kertzmannton, MD 14524-6405",
+                      "created_at": "2026-04-12T18:25:07.000000Z",
+                      "updated_at": "2026-04-12T18:25:07.000000Z"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 3,
+                          "description": "The ID of the location."
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Oberbrunner, Corkery and Bednar",
+                          "description": "The name of the location."
+                        },
+                        "alias": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The alias for the location."
+                        },
+                        "branch_code": {
+                          "type": "string",
+                          "example": "PCPHYPL07603",
+                          "description": "The branch code of the location."
+                        },
+                        "address": {
+                          "type": "string",
+                          "example": "52341 Danny Roads Kertzmannton, MD 14524-6405",
+                          "description": "The address of the location."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:07.000000Z",
+                          "description": "The time when the location was created in ISO-8601 format with UTC timezone."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:07.000000Z",
+                          "description": "The time when the location was last updated in ISO-8601 format with UTC timezone."
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "alias",
+                        "branch_code",
+                        "address",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Locations"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "alias": {
+                    "type": "string",
+                    "description": "The alias for the location. Must not be greater than 191 characters.",
+                    "example": "Berge-Jacobi",
+                    "nullable": true
+                  },
+                  "branch_code": {
+                    "type": "string",
+                    "description": "The branch code of the location. Must not be greater than 191 characters.",
+                    "example": "PCPHDWN78269",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "description": "The ID of the location.",
+          "example": 2,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/locations/{location_id}/taxes": {
+      "get": {
+        "summary": "Get Taxes",
+        "operationId": "getTaxes",
+        "description": "Get all the taxes of the specified location.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "VAT",
+                        "type": "Tax Inclusive",
+                        "is_service_charge": true,
+                        "is_net_based": false,
+                        "is_applied_after_discount": false,
+                        "is_service_based": false
+                      },
+                      {
+                        "id": 2,
+                        "name": "Srv Charge",
+                        "type": "Tax Inclusive",
+                        "is_service_charge": false,
+                        "is_net_based": false,
+                        "is_applied_after_discount": false,
+                        "is_service_based": true,
+                        "service_types": []
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "VAT",
+                          "type": "Tax Inclusive",
+                          "is_service_charge": true,
+                          "is_net_based": false,
+                          "is_applied_after_discount": false,
+                          "is_service_based": false
+                        },
+                        {
+                          "id": 2,
+                          "name": "Srv Charge",
+                          "type": "Tax Inclusive",
+                          "is_service_charge": false,
+                          "is_net_based": false,
+                          "is_applied_after_discount": false,
+                          "is_service_based": true,
+                          "service_types": []
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The ID of the tax."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "VAT",
+                            "description": "The name of the tax."
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "Tax Inclusive",
+                            "description": "The type of tax."
+                          },
+                          "is_service_charge": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Flag if this tax is considered as service charge."
+                          },
+                          "is_net_based": {
+                            "type": "boolean",
+                            "example": false,
+                            "description": "Flag if price to be taxed are VAT inclusive."
+                          },
+                          "is_applied_after_discount": {
+                            "type": "boolean",
+                            "example": false,
+                            "description": "Flag if this tax is applied after discounts."
+                          },
+                          "is_service_based": {
+                            "type": "boolean",
+                            "example": false,
+                            "description": "Flag if tax is only applied on specific service types."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "type",
+                        "is_service_charge",
+                        "is_net_based",
+                        "is_applied_after_discount",
+                        "is_service_based"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Locations"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "location_id",
+          "description": "The ID of the location.",
+          "example": 2,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/product_categories": {
+      "get": {
+        "summary": "Get Categories",
+        "operationId": "getCategories",
+        "description": "Get all of the product categories.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "In",
+                        "is_non_taxable": false,
+                        "has_promos": false,
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Et",
+                        "is_non_taxable": false,
+                        "has_promos": false,
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z"
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "In",
+                          "is_non_taxable": false,
+                          "has_promos": false,
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z"
+                        },
+                        {
+                          "id": 2,
+                          "name": "Et",
+                          "is_non_taxable": false,
+                          "has_promos": false,
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The ID of the category."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "In",
+                            "description": "The name of the category."
+                          },
+                          "is_non_taxable": {
+                            "type": "boolean",
+                            "example": false,
+                            "description": "Flag to determine if category is non-taxable."
+                          },
+                          "has_promos": {
+                            "type": "boolean",
+                            "example": false,
+                            "description": "Flag to determine if category has any associated promos."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the category was created in ISO-8601 format with UTC timezone."
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the category was last updated in ISO-8601 format with UTC timezone."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "is_non_taxable",
+                        "has_promos",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Product Categories"
+        ]
+      }
+    },
+    "/api/v1/product_categories/{product_category_id}/groups": {
+      "get": {
+        "summary": "Get Groups",
+        "operationId": "getGroups",
+        "description": "Get all of the product groups under the specified category.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "In Dolor",
+                        "sort_order": 1,
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z",
+                        "subgroups": [
+                          {
+                            "id": 1,
+                            "name": "Aut Debitis",
+                            "created_at": "2026-04-12T18:25:08.000000Z",
+                            "updated_at": "2026-04-12T18:25:08.000000Z"
+                          },
+                          {
+                            "id": 2,
+                            "name": "Dolorum",
+                            "created_at": "2026-04-12T18:25:08.000000Z",
+                            "updated_at": "2026-04-12T18:25:08.000000Z"
+                          },
+                          {
+                            "id": 3,
+                            "name": "Eos Repudiandae",
+                            "created_at": "2026-04-12T18:25:08.000000Z",
+                            "updated_at": "2026-04-12T18:25:08.000000Z"
+                          }
+                        ]
+                      },
+                      {
+                        "id": 2,
+                        "name": "Velit Repellendus",
+                        "sort_order": 2,
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z",
+                        "subgroups": [
+                          {
+                            "id": 4,
+                            "name": "Eligendi",
+                            "created_at": "2026-04-12T18:25:08.000000Z",
+                            "updated_at": "2026-04-12T18:25:08.000000Z"
+                          },
+                          {
+                            "id": 5,
+                            "name": "Autem Amet",
+                            "created_at": "2026-04-12T18:25:08.000000Z",
+                            "updated_at": "2026-04-12T18:25:08.000000Z"
+                          },
+                          {
+                            "id": 6,
+                            "name": "Consectetur",
+                            "created_at": "2026-04-12T18:25:08.000000Z",
+                            "updated_at": "2026-04-12T18:25:08.000000Z"
+                          }
+                        ]
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "In Dolor",
+                          "sort_order": 1,
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z",
+                          "subgroups": [
+                            {
+                              "id": 1,
+                              "name": "Aut Debitis",
+                              "created_at": "2026-04-12T18:25:08.000000Z",
+                              "updated_at": "2026-04-12T18:25:08.000000Z"
+                            },
+                            {
+                              "id": 2,
+                              "name": "Dolorum",
+                              "created_at": "2026-04-12T18:25:08.000000Z",
+                              "updated_at": "2026-04-12T18:25:08.000000Z"
+                            },
+                            {
+                              "id": 3,
+                              "name": "Eos Repudiandae",
+                              "created_at": "2026-04-12T18:25:08.000000Z",
+                              "updated_at": "2026-04-12T18:25:08.000000Z"
+                            }
+                          ]
+                        },
+                        {
+                          "id": 2,
+                          "name": "Velit Repellendus",
+                          "sort_order": 2,
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z",
+                          "subgroups": [
+                            {
+                              "id": 4,
+                              "name": "Eligendi",
+                              "created_at": "2026-04-12T18:25:08.000000Z",
+                              "updated_at": "2026-04-12T18:25:08.000000Z"
+                            },
+                            {
+                              "id": 5,
+                              "name": "Autem Amet",
+                              "created_at": "2026-04-12T18:25:08.000000Z",
+                              "updated_at": "2026-04-12T18:25:08.000000Z"
+                            },
+                            {
+                              "id": 6,
+                              "name": "Consectetur",
+                              "created_at": "2026-04-12T18:25:08.000000Z",
+                              "updated_at": "2026-04-12T18:25:08.000000Z"
+                            }
+                          ]
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The ID of the group."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "In Dolor",
+                            "description": "The name of the group."
+                          },
+                          "sort_order": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The sorting order of the group."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the group was created in ISO-8601 format with UTC timezone."
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the group was last updated in ISO-8601 format with UTC timezone."
+                          },
+                          "subgroups": {
+                            "type": "array",
+                            "example": [
+                              {
+                                "id": 1,
+                                "name": "Aut Debitis",
+                                "created_at": "2026-04-12T18:25:08.000000Z",
+                                "updated_at": "2026-04-12T18:25:08.000000Z"
+                              },
+                              {
+                                "id": 2,
+                                "name": "Dolorum",
+                                "created_at": "2026-04-12T18:25:08.000000Z",
+                                "updated_at": "2026-04-12T18:25:08.000000Z"
+                              },
+                              {
+                                "id": 3,
+                                "name": "Eos Repudiandae",
+                                "created_at": "2026-04-12T18:25:08.000000Z",
+                                "updated_at": "2026-04-12T18:25:08.000000Z"
+                              }
+                            ],
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "example": 1
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "Aut Debitis"
+                                },
+                                "created_at": {
+                                  "type": "string",
+                                  "example": "2026-04-12T18:25:08.000000Z"
+                                },
+                                "updated_at": {
+                                  "type": "string",
+                                  "example": "2026-04-12T18:25:08.000000Z"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "sort_order",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Product Categories"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "product_category_id",
+          "description": "The ID of the product category.",
+          "example": 1,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/products": {
+      "get": {
+        "summary": "Get Products",
+        "operationId": "getProducts",
+        "description": "Get all of the products.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "filter[sku]",
+            "description": "Filter products by SKU. Comma-separated values are allowed.",
+            "example": "PRDLBKUD",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter products by SKU. Comma-separated values are allowed.",
+              "example": "PRDLBKUD"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[number]",
+            "description": "The current page number of the result set to display. Must be at least 1.",
+            "example": 1,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The current page number of the result set to display. Must be at least 1.",
+              "example": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[size]",
+            "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+            "example": 100,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+              "example": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "Et Quia Quibusdam",
+                        "sku": "QDBBYPLJ",
+                        "description": null,
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Expedita Iusto Ut",
+                        "sku": "CGOHBFSW",
+                        "description": null,
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z"
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "Et Quia Quibusdam",
+                          "sku": "QDBBYPLJ",
+                          "description": null,
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z"
+                        },
+                        {
+                          "id": 2,
+                          "name": "Expedita Iusto Ut",
+                          "sku": "CGOHBFSW",
+                          "description": null,
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The ID of the product."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Et Quia Quibusdam",
+                            "description": "The name of the product."
+                          },
+                          "sku": {
+                            "type": "string",
+                            "example": "QDBBYPLJ",
+                            "description": "The SKU of the product."
+                          },
+                          "description": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The description of the product."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the product was created."
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the product was last updated."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "sku",
+                        "description",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Products"
+        ]
+      },
+      "post": {
+        "summary": "Create Product",
+        "operationId": "createProduct",
+        "description": "",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 3,
+                      "name": "Quis Consectetur Fugit",
+                      "sku": "QSZHPANH",
+                      "description": null,
+                      "created_at": "2026-04-12T18:25:08.000000Z",
+                      "updated_at": "2026-04-12T18:25:08.000000Z"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 3,
+                          "description": "The ID of the product."
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Quis Consectetur Fugit",
+                          "description": "The name of the product."
+                        },
+                        "sku": {
+                          "type": "string",
+                          "example": "QSZHPANH",
+                          "description": "The SKU of the product."
+                        },
+                        "description": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The description of the product."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:08.000000Z",
+                          "description": "The time when the product was created."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:08.000000Z",
+                          "description": "The time when the product was last updated."
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "sku",
+                        "description",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Products"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "group_id": {
+                    "type": "string",
+                    "description": "Must be a valid product group ID.",
+                    "example": 5372
+                  },
+                  "subgroup_id": {
+                    "type": "string",
+                    "description": "Must be a valid product sub-group ID.",
+                    "example": null,
+                    "nullable": true
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the product. Must not be greater than 191 characters.",
+                    "example": "Iced Kape Sua Da"
+                  },
+                  "sku": {
+                    "type": "string",
+                    "description": "The SKU of the product. Must not be greater than 191 characters.",
+                    "example": "SUADA",
+                    "nullable": true
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The description of the product. Must not be greater than 65535 characters.",
+                    "example": "A strong blend of rich espresso with leche condensada, over ice.",
+                    "nullable": true
+                  },
+                  "price": {
+                    "type": "number",
+                    "description": "The base price of the product. Must be at least 0.",
+                    "example": 75
+                  },
+                  "modifiers": {
+                    "type": "array",
+                    "description": "Any modifiers of the product.",
+                    "example": [
+                      {
+                        "name": "Size",
+                        "type": "Forced",
+                        "required_quantity": 1,
+                        "options": [
+                          {
+                            "name": "Regular",
+                            "code": "REG",
+                            "price": 0
+                          },
+                          {
+                            "name": "UPsize",
+                            "code": "UP",
+                            "price": 15
+                          }
+                        ]
+                      },
+                      {
+                        "name": "Add-ons",
+                        "type": "Unforced",
+                        "options": [
+                          {
+                            "name": "Boba Pearls",
+                            "code": "REG",
+                            "price": 20
+                          }
+                        ]
+                      }
+                    ],
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "description": "Must not be greater than 191 characters.",
+                          "example": "qiuqdbbypljrlgcg"
+                        },
+                        "type": {
+                          "type": "string",
+                          "description": "",
+                          "example": "Forced",
+                          "enum": [
+                            "Forced",
+                            "Unforced"
+                          ]
+                        },
+                        "required_quantity": {
+                          "type": "integer",
+                          "description": "This field is required when <code>modifiers.*.type</code> is <code>Forced</code>. Must be at least 1.",
+                          "example": 49
+                        },
+                        "options": {
+                          "type": "array",
+                          "description": "",
+                          "example": null,
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Must not be greater than 191 characters.",
+                                "example": "hbfswlbkudwnbszw"
+                              },
+                              "code": {
+                                "type": "string",
+                                "description": "Must not be greater than 13 characters.",
+                                "example": "ewlqenrdx"
+                              },
+                              "sku": {
+                                "type": "string",
+                                "description": "Must not be greater than 191 characters.",
+                                "example": "tykuguxfbsfixuer",
+                                "nullable": true
+                              },
+                              "price": {
+                                "type": "number",
+                                "description": "Must be at least 0.",
+                                "example": 65
+                              }
+                            },
+                            "required": [
+                              "name",
+                              "code",
+                              "price"
+                            ]
+                          }
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "type"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "group_id",
+                  "name",
+                  "price"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "summary": "Bulk Update Products",
+        "operationId": "bulkUpdateProducts",
+        "description": "Update the names or SKUs of the specified products.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 4,
+                        "name": "Id Blanditiis Eum",
+                        "sku": "RLGCGOHB",
+                        "description": null,
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z"
+                      },
+                      {
+                        "id": 5,
+                        "name": "Quia Quisquam Eos",
+                        "sku": "LBKUDWNB",
+                        "description": null,
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z"
+                      }
+                    ]
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 4,
+                          "name": "Id Blanditiis Eum",
+                          "sku": "RLGCGOHB",
+                          "description": null,
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z"
+                        },
+                        {
+                          "id": 5,
+                          "name": "Quia Quisquam Eos",
+                          "sku": "LBKUDWNB",
+                          "description": null,
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 4,
+                            "description": "The ID of the product."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Id Blanditiis Eum",
+                            "description": "The name of the product."
+                          },
+                          "sku": {
+                            "type": "string",
+                            "example": "RLGCGOHB",
+                            "description": "The SKU of the product."
+                          },
+                          "description": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The description of the product."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the product was created."
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the product was last updated."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "sku",
+                        "description",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Products"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "description": "The products to update.",
+                "example": [
+                  {
+                    "id": 13,
+                    "name": "et",
+                    "sku": "et",
+                    "description": "Quia quibusdam facilis ratione illo architecto non."
+                  }
+                ],
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "The ID of the product.",
+                      "example": 13
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the product.",
+                      "example": "et"
+                    },
+                    "sku": {
+                      "type": "string",
+                      "description": "The SKU of the product.",
+                      "example": "et",
+                      "nullable": true
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "The product description.",
+                      "example": "Quia quibusdam facilis ratione illo architecto non.",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/products/{id}": {
+      "put": {
+        "summary": "Update Product",
+        "operationId": "updateProduct",
+        "description": "Update the specified product.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 6,
+                      "name": "Et Quia Quibusdam",
+                      "sku": "QDBBYPLJ",
+                      "description": null,
+                      "created_at": "2026-04-12T18:25:08.000000Z",
+                      "updated_at": "2026-04-12T18:25:08.000000Z"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 6,
+                          "description": "The ID of the product."
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Et Quia Quibusdam",
+                          "description": "The name of the product."
+                        },
+                        "sku": {
+                          "type": "string",
+                          "example": "QDBBYPLJ",
+                          "description": "The SKU of the product."
+                        },
+                        "description": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The description of the product."
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:08.000000Z",
+                          "description": "The time when the product was created."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:08.000000Z",
+                          "description": "The time when the product was last updated."
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "sku",
+                        "description",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Products"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the product. Must not be greater than 191 characters.",
+                    "example": "Iced Kape Sua Da (Vietnamese Latte)"
+                  },
+                  "sku": {
+                    "type": "string",
+                    "description": "The SKU of the product. Must not be greater than 191 characters.",
+                    "example": "KAPESUADA",
+                    "nullable": true
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The product description. Must not be greater than 65535 characters.",
+                    "example": "A strong blend of rich espresso with leche condensada, over ice.",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "description": "The ID of the product.",
+          "example": 13,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/products/{product_id}/modifier_groups": {
+      "get": {
+        "summary": "Get Modifiers Groups",
+        "operationId": "getModifiersGroups",
+        "description": "Get the modifiers groups of the specified product.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 7415,
+                        "name": "Size Option",
+                        "type": "Forced",
+                        "required_quantity": 1,
+                        "created_at": "2025-05-20T01:53:53.000000Z",
+                        "updated_at": "2025-05-20T01:53:53.000000Z",
+                        "options": [
+                          {
+                            "id": 21431,
+                            "name": "Regular",
+                            "code": null,
+                            "sku": null,
+                            "created_at": "2025-05-20T01:53:53.000000Z",
+                            "updated_at": "2025-05-20T01:53:53.000000Z"
+                          },
+                          {
+                            "id": 21432,
+                            "name": "UPsize",
+                            "code": null,
+                            "sku": null,
+                            "created_at": "2025-05-20T01:53:53.000000Z",
+                            "updated_at": "2025-05-20T01:53:53.000000Z"
+                          }
+                        ]
+                      },
+                      {
+                        "id": 7416,
+                        "name": "Taste Preference",
+                        "type": "Forced",
+                        "required_quantity": 1,
+                        "created_at": "2025-05-20T01:53:53.000000Z",
+                        "updated_at": "2025-05-20T01:53:53.000000Z",
+                        "options": [
+                          {
+                            "id": 21433,
+                            "name": "Less Sweet",
+                            "code": null,
+                            "sku": null,
+                            "created_at": "2025-05-20T01:53:53.000000Z",
+                            "updated_at": "2025-05-20T01:53:53.000000Z"
+                          },
+                          {
+                            "id": 21434,
+                            "name": "Original PICKUP Recipe",
+                            "code": null,
+                            "sku": null,
+                            "created_at": "2025-05-20T01:53:53.000000Z",
+                            "updated_at": "2025-05-20T01:53:53.000000Z"
+                          },
+                          {
+                            "id": 21435,
+                            "name": "Sweeter",
+                            "code": null,
+                            "sku": null,
+                            "created_at": "2025-05-20T01:53:53.000000Z",
+                            "updated_at": "2025-05-20T01:53:53.000000Z"
+                          }
+                        ]
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 7415,
+                          "name": "Size Option",
+                          "type": "Forced",
+                          "required_quantity": 1,
+                          "created_at": "2025-05-20T01:53:53.000000Z",
+                          "updated_at": "2025-05-20T01:53:53.000000Z",
+                          "options": [
+                            {
+                              "id": 21431,
+                              "name": "Regular",
+                              "code": null,
+                              "sku": null,
+                              "created_at": "2025-05-20T01:53:53.000000Z",
+                              "updated_at": "2025-05-20T01:53:53.000000Z"
+                            },
+                            {
+                              "id": 21432,
+                              "name": "UPsize",
+                              "code": null,
+                              "sku": null,
+                              "created_at": "2025-05-20T01:53:53.000000Z",
+                              "updated_at": "2025-05-20T01:53:53.000000Z"
+                            }
+                          ]
+                        },
+                        {
+                          "id": 7416,
+                          "name": "Taste Preference",
+                          "type": "Forced",
+                          "required_quantity": 1,
+                          "created_at": "2025-05-20T01:53:53.000000Z",
+                          "updated_at": "2025-05-20T01:53:53.000000Z",
+                          "options": [
+                            {
+                              "id": 21433,
+                              "name": "Less Sweet",
+                              "code": null,
+                              "sku": null,
+                              "created_at": "2025-05-20T01:53:53.000000Z",
+                              "updated_at": "2025-05-20T01:53:53.000000Z"
+                            },
+                            {
+                              "id": 21434,
+                              "name": "Original PICKUP Recipe",
+                              "code": null,
+                              "sku": null,
+                              "created_at": "2025-05-20T01:53:53.000000Z",
+                              "updated_at": "2025-05-20T01:53:53.000000Z"
+                            },
+                            {
+                              "id": 21435,
+                              "name": "Sweeter",
+                              "code": null,
+                              "sku": null,
+                              "created_at": "2025-05-20T01:53:53.000000Z",
+                              "updated_at": "2025-05-20T01:53:53.000000Z"
+                            }
+                          ]
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 7415
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Size Option"
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "Forced"
+                          },
+                          "required_quantity": {
+                            "type": "integer",
+                            "example": 1
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2025-05-20T01:53:53.000000Z"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2025-05-20T01:53:53.000000Z"
+                          },
+                          "options": {
+                            "type": "array",
+                            "example": [
+                              {
+                                "id": 21431,
+                                "name": "Regular",
+                                "code": null,
+                                "sku": null,
+                                "created_at": "2025-05-20T01:53:53.000000Z",
+                                "updated_at": "2025-05-20T01:53:53.000000Z"
+                              },
+                              {
+                                "id": 21432,
+                                "name": "UPsize",
+                                "code": null,
+                                "sku": null,
+                                "created_at": "2025-05-20T01:53:53.000000Z",
+                                "updated_at": "2025-05-20T01:53:53.000000Z"
+                              }
+                            ],
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "integer",
+                                  "example": 21431
+                                },
+                                "name": {
+                                  "type": "string",
+                                  "example": "Regular"
+                                },
+                                "code": {
+                                  "type": "string",
+                                  "example": null,
+                                  "nullable": true
+                                },
+                                "sku": {
+                                  "type": "string",
+                                  "example": null,
+                                  "nullable": true
+                                },
+                                "created_at": {
+                                  "type": "string",
+                                  "example": "2025-05-20T01:53:53.000000Z"
+                                },
+                                "updated_at": {
+                                  "type": "string",
+                                  "example": "2025-05-20T01:53:53.000000Z"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Products"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "product_id",
+          "description": "The ID of the product.",
+          "example": 13,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/modifier_groups": {
+      "get": {
+        "summary": "Get Modifier Groups",
+        "operationId": "getModifierGroups",
+        "description": "Get all of the modifiers groups.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "page[number]",
+            "description": "The current page number of the result set to display. Must be at least 1.",
+            "example": 1,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The current page number of the result set to display. Must be at least 1.",
+              "example": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[size]",
+            "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+            "example": 100,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+              "example": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "Et Quia Quibusdam",
+                        "type": "Unforced",
+                        "required_quantity": null,
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z",
+                        "options": []
+                      },
+                      {
+                        "id": 2,
+                        "name": "Architecto Non Id",
+                        "type": "Forced",
+                        "required_quantity": 4,
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z",
+                        "options": []
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "Et Quia Quibusdam",
+                          "type": "Unforced",
+                          "required_quantity": null,
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z",
+                          "options": []
+                        },
+                        {
+                          "id": 2,
+                          "name": "Architecto Non Id",
+                          "type": "Forced",
+                          "required_quantity": 4,
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z",
+                          "options": []
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The ID of the modifier group."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Et Quia Quibusdam",
+                            "description": "The name of the modifier group."
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "Unforced",
+                            "description": "The type of modifier group."
+                          },
+                          "required_quantity": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The number of options required to be selected."
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z",
+                            "description": "The time when the modifier was created in ISO-8601 format with UTC timezone."
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z",
+                            "description": "The time when the modifier was last updated in ISO-8601 format with UTC timezone."
+                          },
+                          "options": {
+                            "type": "array",
+                            "example": [],
+                            "description": "The modifier group options."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "type",
+                        "required_quantity",
+                        "created_at",
+                        "updated_at",
+                        "options"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Modifier Groups"
+        ]
+      }
+    },
+    "/api/v1/modifier_groups/{modifier_group_id}/modifiers": {
+      "get": {
+        "summary": "Get Modifiers",
+        "operationId": "getModifiers",
+        "description": "Get all of the modifiers of the specified group.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "Odio Veritatis In",
+                        "code": "OVI",
+                        "sku": "UDWNBSZW",
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Neque Nulla Dignissimos",
+                        "code": "NND",
+                        "sku": "QENRDXTY",
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z"
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "Odio Veritatis In",
+                          "code": "OVI",
+                          "sku": "UDWNBSZW",
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z"
+                        },
+                        {
+                          "id": 2,
+                          "name": "Neque Nulla Dignissimos",
+                          "code": "NND",
+                          "sku": "QENRDXTY",
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Odio Veritatis In"
+                          },
+                          "code": {
+                            "type": "string",
+                            "example": "OVI"
+                          },
+                          "sku": {
+                            "type": "string",
+                            "example": "UDWNBSZW"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Modifier Groups"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "modifier_group_id",
+          "description": "The ID of the modifier group.",
+          "example": 1,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/modifiers": {
+      "get": {
+        "summary": "Get Modifiers",
+        "operationId": "getModifiers",
+        "description": "Get all of the modifiers.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "filter[sku]",
+            "description": "Filter modifiers by SKU. Comma-separated values are allowed.",
+            "example": "LBKUDWNB",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Filter modifiers by SKU. Comma-separated values are allowed.",
+              "example": "LBKUDWNB"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[number]",
+            "description": "The current page number of the result set to display. Must be at least 1.",
+            "example": 1,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The current page number of the result set to display. Must be at least 1.",
+              "example": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[size]",
+            "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+            "example": 100,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+              "example": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 3,
+                        "name": "Est Ut Distinctio",
+                        "code": "EUD",
+                        "sku": "IHGPNALF",
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z"
+                      },
+                      {
+                        "id": 4,
+                        "name": "In Quaerat Dicta",
+                        "code": "IQD",
+                        "sku": "VIUMAVQZ",
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z"
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 3,
+                          "name": "Est Ut Distinctio",
+                          "code": "EUD",
+                          "sku": "IHGPNALF",
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z"
+                        },
+                        {
+                          "id": 4,
+                          "name": "In Quaerat Dicta",
+                          "code": "IQD",
+                          "sku": "VIUMAVQZ",
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 3
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Est Ut Distinctio"
+                          },
+                          "code": {
+                            "type": "string",
+                            "example": "EUD"
+                          },
+                          "sku": {
+                            "type": "string",
+                            "example": "IHGPNALF"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Modifiers"
+        ]
+      },
+      "put": {
+        "summary": "Bulk Update Modifiers",
+        "operationId": "bulkUpdateModifiers",
+        "description": "Update the specified modifiers.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 5,
+                        "name": "Quia Quibusdam Facilis",
+                        "code": "QQF",
+                        "sku": "DBBYPLJR",
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z"
+                      },
+                      {
+                        "id": 6,
+                        "name": "Iusto Ut Vitae",
+                        "code": "IUV",
+                        "sku": "GOHBFSWL",
+                        "created_at": "2026-04-12T18:25:07.000000Z",
+                        "updated_at": "2026-04-12T18:25:07.000000Z"
+                      }
+                    ]
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 5,
+                          "name": "Quia Quibusdam Facilis",
+                          "code": "QQF",
+                          "sku": "DBBYPLJR",
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z"
+                        },
+                        {
+                          "id": 6,
+                          "name": "Iusto Ut Vitae",
+                          "code": "IUV",
+                          "sku": "GOHBFSWL",
+                          "created_at": "2026-04-12T18:25:07.000000Z",
+                          "updated_at": "2026-04-12T18:25:07.000000Z"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 5
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Quia Quibusdam Facilis"
+                          },
+                          "code": {
+                            "type": "string",
+                            "example": "QQF"
+                          },
+                          "sku": {
+                            "type": "string",
+                            "example": "DBBYPLJR"
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z"
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:07.000000Z"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Modifiers"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "description": "The modifiers to update.",
+                "example": [
+                  {
+                    "id": 13,
+                    "name": "et",
+                    "code": "et",
+                    "sku": "et"
+                  }
+                ],
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "description": "The ID of the modifier.",
+                      "example": 13
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The name of the modifier.",
+                      "example": "et"
+                    },
+                    "code": {
+                      "type": "string",
+                      "description": "The code of the modifier.",
+                      "example": "et",
+                      "nullable": true
+                    },
+                    "sku": {
+                      "type": "string",
+                      "description": "The SKU of the modifier.",
+                      "example": "et",
+                      "nullable": true
+                    }
+                  },
+                  "required": [
+                    "id"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/modifiers/{id}": {
+      "put": {
+        "summary": "Update Modifier",
+        "operationId": "updateModifier",
+        "description": "Update the specified modifier.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 7,
+                      "name": "Facilis Ratione Illo",
+                      "code": "FRI",
+                      "sku": "BYPLJRLG",
+                      "created_at": "2026-04-12T18:25:07.000000Z",
+                      "updated_at": "2026-04-12T18:25:07.000000Z"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 7
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Facilis Ratione Illo"
+                        },
+                        "code": {
+                          "type": "string",
+                          "example": "FRI"
+                        },
+                        "sku": {
+                          "type": "string",
+                          "example": "BYPLJRLG"
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:07.000000Z"
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:07.000000Z"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Modifiers"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the modifier. Must not be greater than 191 characters.",
+                    "example": "Regular"
+                  },
+                  "code": {
+                    "type": "string",
+                    "description": "The code for the modifier. Must not be greater than 13 characters.",
+                    "example": "REG",
+                    "nullable": true
+                  },
+                  "sku": {
+                    "type": "string",
+                    "description": "The SKU of the modifier. Must not be greater than 191 characters.",
+                    "example": "SZREG",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "description": "The ID of the modifier.",
+          "example": 1,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/service_types": {
+      "get": {
+        "summary": "Get Service Types",
+        "operationId": "getServiceTypes",
+        "description": "",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "page[number]",
+            "description": "The current page number of the result set to display. Must be at least 1.",
+            "example": 1,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The current page number of the result set to display. Must be at least 1.",
+              "example": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[size]",
+            "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+            "example": 100,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+              "example": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "Dine-in"
+                      },
+                      {
+                        "id": 1,
+                        "name": "Dine-in"
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "Dine-in"
+                        },
+                        {
+                          "id": 1,
+                          "name": "Dine-in"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Dine-in"
+                          }
+                        }
+                      }
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Service Types"
+        ]
+      }
+    },
+    "/api/v1/taxes": {
+      "get": {
+        "summary": "Get Taxes",
+        "operationId": "getTaxes",
+        "description": "Get all the taxes.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "page[number]",
+            "description": "The current page number of the result set to display. Must be at least 1.",
+            "example": 1,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The current page number of the result set to display. Must be at least 1.",
+              "example": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[size]",
+            "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+            "example": 100,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+              "example": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 3,
+                        "name": "VAT",
+                        "type": "Tax Exclusive",
+                        "is_service_charge": false,
+                        "is_net_based": false,
+                        "is_applied_after_discount": true,
+                        "is_service_based": true,
+                        "service_types": []
+                      },
+                      {
+                        "id": 4,
+                        "name": "Service Charge",
+                        "type": "Tax Exclusive",
+                        "is_service_charge": true,
+                        "is_net_based": true,
+                        "is_applied_after_discount": true,
+                        "is_service_based": true,
+                        "service_types": []
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 3,
+                          "name": "VAT",
+                          "type": "Tax Exclusive",
+                          "is_service_charge": false,
+                          "is_net_based": false,
+                          "is_applied_after_discount": true,
+                          "is_service_based": true,
+                          "service_types": []
+                        },
+                        {
+                          "id": 4,
+                          "name": "Service Charge",
+                          "type": "Tax Exclusive",
+                          "is_service_charge": true,
+                          "is_net_based": true,
+                          "is_applied_after_discount": true,
+                          "is_service_based": true,
+                          "service_types": []
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 3,
+                            "description": "The ID of the tax."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "VAT",
+                            "description": "The name of the tax."
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "Tax Exclusive",
+                            "description": "The type of tax."
+                          },
+                          "is_service_charge": {
+                            "type": "boolean",
+                            "example": false,
+                            "description": "Flag if this tax is considered as service charge."
+                          },
+                          "is_net_based": {
+                            "type": "boolean",
+                            "example": false,
+                            "description": "Flag if price to be taxed are VAT inclusive."
+                          },
+                          "is_applied_after_discount": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Flag if this tax is applied after discounts."
+                          },
+                          "is_service_based": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Flag if tax is only applied on specific service types."
+                          },
+                          "service_types": {
+                            "type": "array",
+                            "example": [],
+                            "description": "The applicable service types."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "type",
+                        "is_service_charge",
+                        "is_net_based",
+                        "is_applied_after_discount",
+                        "is_service_based",
+                        "service_types"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Taxes"
+        ]
+      }
+    },
+    "/api/v1/payment_categories": {
+      "get": {
+        "summary": "Get Payment Categories",
+        "operationId": "getPaymentCategories",
+        "description": "Get all of the payment categories.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "Grab Food"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Cash"
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "Grab Food"
+                        },
+                        {
+                          "id": 2,
+                          "name": "Cash"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The ID of the payment category."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Grab Food",
+                            "description": "The name of the payment category."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Payments"
+        ]
+      }
+    },
+    "/api/v1/payment_types": {
+      "get": {
+        "summary": "Get Payment Types",
+        "operationId": "getPaymentTypes",
+        "description": "Get all of the payment types.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "Veritatis In",
+                        "type": "epayment",
+                        "receipt_print_quantity": 2,
+                        "will_open_cash_drawer": true,
+                        "category": {
+                          "id": 67,
+                          "name": "Gift Certificate/GC"
+                        }
+                      },
+                      {
+                        "id": 2,
+                        "name": "Quae Impedit",
+                        "type": "mosaicpay_qrph",
+                        "receipt_print_quantity": 1,
+                        "will_open_cash_drawer": false,
+                        "category": {
+                          "id": 57,
+                          "name": "Epayment"
+                        }
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "Veritatis In",
+                          "type": "epayment",
+                          "receipt_print_quantity": 2,
+                          "will_open_cash_drawer": true,
+                          "category": {
+                            "id": 67,
+                            "name": "Gift Certificate/GC"
+                          }
+                        },
+                        {
+                          "id": 2,
+                          "name": "Quae Impedit",
+                          "type": "mosaicpay_qrph",
+                          "receipt_print_quantity": 1,
+                          "will_open_cash_drawer": false,
+                          "category": {
+                            "id": 57,
+                            "name": "Epayment"
+                          }
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The ID of the payment."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Veritatis In",
+                            "description": "The name of the payment."
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "epayment",
+                            "description": "The type of the payment.",
+                            "enum": [
+                              "cash",
+                              "card",
+                              "check",
+                              "voucher",
+                              "comp",
+                              "epayment",
+                              "mosaicpay_qrph"
+                            ]
+                          },
+                          "receipt_print_quantity": {
+                            "type": "integer",
+                            "example": 2,
+                            "description": "The number of receipts to be printed."
+                          },
+                          "will_open_cash_drawer": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Flag if cash drawer will open."
+                          },
+                          "category": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "example": 67,
+                                "description": "The ID of the payment category."
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "Gift Certificate/GC",
+                                "description": "The name of the payment category."
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "name"
+                            ],
+                            "description": "The payment category.",
+                            "nullable": true
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "type",
+                        "receipt_print_quantity",
+                        "will_open_cash_drawer",
+                        "category"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Payments"
+        ]
+      },
+      "post": {
+        "summary": "Create Payment Type",
+        "operationId": "createPaymentType",
+        "description": "Create a payment type.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 3,
+                      "name": "Quibusdam",
+                      "type": "comp",
+                      "receipt_print_quantity": 1,
+                      "will_open_cash_drawer": true,
+                      "category": {
+                        "id": 110,
+                        "name": "Cash"
+                      }
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 3,
+                          "description": "The ID of the payment."
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Quibusdam",
+                          "description": "The name of the payment."
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "comp",
+                          "description": "The type of the payment.",
+                          "enum": [
+                            "cash",
+                            "card",
+                            "check",
+                            "voucher",
+                            "comp",
+                            "epayment",
+                            "mosaicpay_qrph"
+                          ]
+                        },
+                        "receipt_print_quantity": {
+                          "type": "integer",
+                          "example": 1,
+                          "description": "The number of receipts to be printed."
+                        },
+                        "will_open_cash_drawer": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if cash drawer will open."
+                        },
+                        "category": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "example": 110,
+                              "description": "The ID of the payment category."
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Cash",
+                              "description": "The name of the payment category."
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "name"
+                          ],
+                          "description": "The payment category.",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "type",
+                        "receipt_print_quantity",
+                        "will_open_cash_drawer",
+                        "category"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Payments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "category_id": {
+                    "type": "integer",
+                    "description": "The <code>id</code> of an existing record in the payment_categories table.",
+                    "example": 13
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the payment. Must not be greater than 191 characters.",
+                    "example": "GCash"
+                  },
+                  "type": {
+                    "type": "string",
+                    "description": "The type of payment.",
+                    "example": "cash",
+                    "enum": [
+                      "cash",
+                      "card",
+                      "check",
+                      "voucher",
+                      "comp",
+                      "epayment",
+                      "mosaicpay_qrph"
+                    ]
+                  },
+                  "receipt_print_quantity": {
+                    "type": "integer",
+                    "description": "The number of receipts to be printed. Must be at least 1. Must not be greater than 2.",
+                    "example": 1
+                  },
+                  "will_open_cash_drawer": {
+                    "type": "boolean",
+                    "description": "Flag if cash drawer will open.",
+                    "example": true
+                  }
+                },
+                "required": [
+                  "category_id",
+                  "name",
+                  "type",
+                  "receipt_print_quantity",
+                  "will_open_cash_drawer"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/discounts": {
+      "get": {
+        "summary": "Get Discounts",
+        "operationId": "getDiscounts",
+        "description": "Get all of the discounts.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          },
+          {
+            "in": "query",
+            "name": "page[number]",
+            "description": "The current page number of the result set to display. Must be at least 1.",
+            "example": 1,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The current page number of the result set to display. Must be at least 1.",
+              "example": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page[size]",
+            "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+            "example": 100,
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "description": "The number of items to include per page in the result set. Must be at least 1. Must not be greater than 100.",
+              "example": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": 1,
+                        "name": "Senior Citizen Discount",
+                        "type": "PERCENTAGE",
+                        "rate": 80,
+                        "amount": null,
+                        "ceiling_discount_amount": null,
+                        "is_ceiling_discount_per_line_item": false,
+                        "is_applied_on_net": true,
+                        "is_service_based": false,
+                        "applied_after_service_charge": true,
+                        "has_customer_details": true,
+                        "is_passcode_required": true,
+                        "starts_at": "2026-04-12T16:00:00.000000Z",
+                        "ends_at": "2026-06-12T16:00:00.000000Z"
+                      },
+                      {
+                        "id": 2,
+                        "name": "Senior Citizen Discount",
+                        "type": "FIXED",
+                        "rate": null,
+                        "amount": 100,
+                        "ceiling_discount_amount": null,
+                        "is_ceiling_discount_per_line_item": false,
+                        "is_applied_on_net": true,
+                        "is_service_based": false,
+                        "applied_after_service_charge": true,
+                        "has_customer_details": true,
+                        "is_passcode_required": true,
+                        "starts_at": "2026-04-12T16:00:00.000000Z",
+                        "ends_at": "2026-09-12T16:00:00.000000Z"
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": 1,
+                          "name": "Senior Citizen Discount",
+                          "type": "PERCENTAGE",
+                          "rate": 80,
+                          "amount": null,
+                          "ceiling_discount_amount": null,
+                          "is_ceiling_discount_per_line_item": false,
+                          "is_applied_on_net": true,
+                          "is_service_based": false,
+                          "applied_after_service_charge": true,
+                          "has_customer_details": true,
+                          "is_passcode_required": true,
+                          "starts_at": "2026-04-12T16:00:00.000000Z",
+                          "ends_at": "2026-06-12T16:00:00.000000Z"
+                        },
+                        {
+                          "id": 2,
+                          "name": "Senior Citizen Discount",
+                          "type": "FIXED",
+                          "rate": null,
+                          "amount": 100,
+                          "ceiling_discount_amount": null,
+                          "is_ceiling_discount_per_line_item": false,
+                          "is_applied_on_net": true,
+                          "is_service_based": false,
+                          "applied_after_service_charge": true,
+                          "has_customer_details": true,
+                          "is_passcode_required": true,
+                          "starts_at": "2026-04-12T16:00:00.000000Z",
+                          "ends_at": "2026-09-12T16:00:00.000000Z"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "example": 1,
+                            "description": "The ID of the discount."
+                          },
+                          "name": {
+                            "type": "string",
+                            "example": "Senior Citizen Discount",
+                            "description": "The name of the discount."
+                          },
+                          "type": {
+                            "type": "string",
+                            "example": "PERCENTAGE",
+                            "description": "The type of discount.",
+                            "enum": [
+                              "FIXED",
+                              "PERCENTAGE"
+                            ]
+                          },
+                          "rate": {
+                            "type": "integer",
+                            "example": 80,
+                            "description": "The percentage rate applied.",
+                            "nullable": true
+                          },
+                          "amount": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The fixed amount of discount.",
+                            "nullable": true
+                          },
+                          "ceiling_discount_amount": {
+                            "type": "string",
+                            "example": null,
+                            "description": "The maximum allowable discount."
+                          },
+                          "is_ceiling_discount_per_line_item": {
+                            "type": "boolean",
+                            "example": false,
+                            "description": "Flag if ceiling discount is applied per line item."
+                          },
+                          "is_applied_on_net": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Flag if discount is applied on net price (without VAT)."
+                          },
+                          "is_service_based": {
+                            "type": "boolean",
+                            "example": false,
+                            "description": "Flag if discount is only applied to service charge."
+                          },
+                          "applied_after_service_charge": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Flag if discount is applied after service charge."
+                          },
+                          "has_customer_details": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Flag if discount needs customer details (e.g ID number)."
+                          },
+                          "is_passcode_required": {
+                            "type": "boolean",
+                            "example": true,
+                            "description": "Flag if passcode is required before applying discount on POS."
+                          },
+                          "starts_at": {
+                            "type": "string",
+                            "example": "2026-04-12T16:00:00.000000Z",
+                            "description": "The time when the discount is available."
+                          },
+                          "ends_at": {
+                            "type": "string",
+                            "example": "2026-06-12T16:00:00.000000Z",
+                            "description": "The time when the discount expires."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "type",
+                        "rate",
+                        "amount",
+                        "ceiling_discount_amount",
+                        "is_ceiling_discount_per_line_item",
+                        "is_applied_on_net",
+                        "is_service_based",
+                        "applied_after_service_charge",
+                        "has_customer_details",
+                        "is_passcode_required",
+                        "starts_at",
+                        "ends_at"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Discounts"
+        ]
+      },
+      "post": {
+        "summary": "Create Discount",
+        "operationId": "createDiscount",
+        "description": "Create a discount.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 3,
+                      "name": "Senior Citizen Discount",
+                      "type": "PERCENTAGE",
+                      "rate": 80,
+                      "amount": null,
+                      "ceiling_discount_amount": null,
+                      "is_ceiling_discount_per_line_item": false,
+                      "is_applied_on_net": true,
+                      "is_service_based": false,
+                      "applied_after_service_charge": true,
+                      "has_customer_details": true,
+                      "is_passcode_required": true,
+                      "starts_at": "2026-04-12T16:00:00.000000Z",
+                      "ends_at": "2026-06-12T16:00:00.000000Z"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 3,
+                          "description": "The ID of the discount."
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Senior Citizen Discount",
+                          "description": "The name of the discount."
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "PERCENTAGE",
+                          "description": "The type of discount.",
+                          "enum": [
+                            "FIXED",
+                            "PERCENTAGE"
+                          ]
+                        },
+                        "rate": {
+                          "type": "integer",
+                          "example": 80,
+                          "description": "The percentage rate applied.",
+                          "nullable": true
+                        },
+                        "amount": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The fixed amount of discount.",
+                          "nullable": true
+                        },
+                        "ceiling_discount_amount": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The maximum allowable discount."
+                        },
+                        "is_ceiling_discount_per_line_item": {
+                          "type": "boolean",
+                          "example": false,
+                          "description": "Flag if ceiling discount is applied per line item."
+                        },
+                        "is_applied_on_net": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if discount is applied on net price (without VAT)."
+                        },
+                        "is_service_based": {
+                          "type": "boolean",
+                          "example": false,
+                          "description": "Flag if discount is only applied to service charge."
+                        },
+                        "applied_after_service_charge": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if discount is applied after service charge."
+                        },
+                        "has_customer_details": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if discount needs customer details (e.g ID number)."
+                        },
+                        "is_passcode_required": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if passcode is required before applying discount on POS."
+                        },
+                        "starts_at": {
+                          "type": "string",
+                          "example": "2026-04-12T16:00:00.000000Z",
+                          "description": "The time when the discount is available."
+                        },
+                        "ends_at": {
+                          "type": "string",
+                          "example": "2026-06-12T16:00:00.000000Z",
+                          "description": "The time when the discount expires."
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "type",
+                        "rate",
+                        "amount",
+                        "ceiling_discount_amount",
+                        "is_ceiling_discount_per_line_item",
+                        "is_applied_on_net",
+                        "is_service_based",
+                        "applied_after_service_charge",
+                        "has_customer_details",
+                        "is_passcode_required",
+                        "starts_at",
+                        "ends_at"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Discounts"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "The type of discount.",
+                    "example": "FIXED",
+                    "enum": [
+                      "FIXED",
+                      "PERCENTAGE"
+                    ]
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the discount. Must not be greater than 191 characters.",
+                    "example": "Payday Discount"
+                  },
+                  "rate": {
+                    "type": "number",
+                    "description": "The percentage rate applied. This field is required when <code>type</code> is <code>PERCENTAGE</code>. Must be at least 0. Must not be greater than 100.",
+                    "example": 10
+                  },
+                  "amount": {
+                    "type": "number",
+                    "description": "The fixed amount of discount. This field is required when <code>type</code> is <code>FIXED</code>. Must be at least 0.",
+                    "example": 100
+                  },
+                  "ceiling_discount_amount": {
+                    "type": "number",
+                    "description": "The maximum allowable discount. Omit or pass `null` for non-capped discounts. Must be at least 0.",
+                    "example": 500,
+                    "nullable": true
+                  },
+                  "is_ceiling_discount_per_line_item": {
+                    "type": "boolean",
+                    "description": "Flag if ceiling discount is applied per line item.",
+                    "example": false
+                  },
+                  "is_applied_on_net": {
+                    "type": "boolean",
+                    "description": "Flag if discount is applied on net price (without VAT).",
+                    "example": false
+                  },
+                  "is_service_based": {
+                    "type": "boolean",
+                    "description": "Flag if discount is only applied to service charge.",
+                    "example": true
+                  },
+                  "applied_after_service_charge": {
+                    "type": "boolean",
+                    "description": "Flag if discount is applied after service charge.",
+                    "example": false
+                  },
+                  "has_customer_details": {
+                    "type": "boolean",
+                    "description": "Flag if discount needs customer details (e.g ID number).",
+                    "example": false
+                  },
+                  "is_passcode_required": {
+                    "type": "boolean",
+                    "description": "Flag if passcode is required before applying discount on POS.",
+                    "example": false
+                  },
+                  "starts_at": {
+                    "type": "string",
+                    "description": "The time when the discount is available. Must be a valid date in the format <code>Y-m-d H:i:s</code>.",
+                    "example": "2026-04-13 00:00:00"
+                  },
+                  "ends_at": {
+                    "type": "string",
+                    "description": "The time when the discount expires. Omit or pass `null` for non-expiring discounts. Must be a valid date in the format <code>Y-m-d H:i:s</code>. Must be a date after <code>starts_at</code>.",
+                    "example": "2026-08-13 00:00:00",
+                    "nullable": true
+                  }
+                },
+                "required": [
+                  "type",
+                  "name",
+                  "starts_at"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/discounts/{id}": {
+      "get": {
+        "summary": "Get Discount",
+        "operationId": "getDiscount",
+        "description": "Get the discount by ID.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 4,
+                      "name": "Senior Citizen Discount",
+                      "type": "PERCENTAGE",
+                      "rate": 40,
+                      "amount": null,
+                      "ceiling_discount_amount": 100,
+                      "is_ceiling_discount_per_line_item": false,
+                      "is_applied_on_net": true,
+                      "is_service_based": false,
+                      "applied_after_service_charge": true,
+                      "has_customer_details": true,
+                      "is_passcode_required": true,
+                      "starts_at": "2026-04-12T16:00:00.000000Z",
+                      "ends_at": "2026-12-12T16:00:00.000000Z"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 4,
+                          "description": "The ID of the discount."
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Senior Citizen Discount",
+                          "description": "The name of the discount."
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "PERCENTAGE",
+                          "description": "The type of discount.",
+                          "enum": [
+                            "FIXED",
+                            "PERCENTAGE"
+                          ]
+                        },
+                        "rate": {
+                          "type": "integer",
+                          "example": 40,
+                          "description": "The percentage rate applied.",
+                          "nullable": true
+                        },
+                        "amount": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The fixed amount of discount.",
+                          "nullable": true
+                        },
+                        "ceiling_discount_amount": {
+                          "type": "integer",
+                          "example": 100,
+                          "description": "The maximum allowable discount."
+                        },
+                        "is_ceiling_discount_per_line_item": {
+                          "type": "boolean",
+                          "example": false,
+                          "description": "Flag if ceiling discount is applied per line item."
+                        },
+                        "is_applied_on_net": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if discount is applied on net price (without VAT)."
+                        },
+                        "is_service_based": {
+                          "type": "boolean",
+                          "example": false,
+                          "description": "Flag if discount is only applied to service charge."
+                        },
+                        "applied_after_service_charge": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if discount is applied after service charge."
+                        },
+                        "has_customer_details": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if discount needs customer details (e.g ID number)."
+                        },
+                        "is_passcode_required": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if passcode is required before applying discount on POS."
+                        },
+                        "starts_at": {
+                          "type": "string",
+                          "example": "2026-04-12T16:00:00.000000Z",
+                          "description": "The time when the discount is available."
+                        },
+                        "ends_at": {
+                          "type": "string",
+                          "example": "2026-12-12T16:00:00.000000Z",
+                          "description": "The time when the discount expires."
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "type",
+                        "rate",
+                        "amount",
+                        "ceiling_discount_amount",
+                        "is_ceiling_discount_per_line_item",
+                        "is_applied_on_net",
+                        "is_service_based",
+                        "applied_after_service_charge",
+                        "has_customer_details",
+                        "is_passcode_required",
+                        "starts_at",
+                        "ends_at"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Discounts"
+        ]
+      },
+      "put": {
+        "summary": "Update Discount",
+        "operationId": "updateDiscount",
+        "description": "Update a specified discount.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": 5,
+                      "name": "Senior Citizen Discount",
+                      "type": "PERCENTAGE",
+                      "rate": 80,
+                      "amount": null,
+                      "ceiling_discount_amount": null,
+                      "is_ceiling_discount_per_line_item": false,
+                      "is_applied_on_net": true,
+                      "is_service_based": false,
+                      "applied_after_service_charge": true,
+                      "has_customer_details": true,
+                      "is_passcode_required": true,
+                      "starts_at": "2026-04-12T16:00:00.000000Z",
+                      "ends_at": "2026-06-12T16:00:00.000000Z"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 5,
+                          "description": "The ID of the discount."
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Senior Citizen Discount",
+                          "description": "The name of the discount."
+                        },
+                        "type": {
+                          "type": "string",
+                          "example": "PERCENTAGE",
+                          "description": "The type of discount.",
+                          "enum": [
+                            "FIXED",
+                            "PERCENTAGE"
+                          ]
+                        },
+                        "rate": {
+                          "type": "integer",
+                          "example": 80,
+                          "description": "The percentage rate applied.",
+                          "nullable": true
+                        },
+                        "amount": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The fixed amount of discount.",
+                          "nullable": true
+                        },
+                        "ceiling_discount_amount": {
+                          "type": "string",
+                          "example": null,
+                          "description": "The maximum allowable discount."
+                        },
+                        "is_ceiling_discount_per_line_item": {
+                          "type": "boolean",
+                          "example": false,
+                          "description": "Flag if ceiling discount is applied per line item."
+                        },
+                        "is_applied_on_net": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if discount is applied on net price (without VAT)."
+                        },
+                        "is_service_based": {
+                          "type": "boolean",
+                          "example": false,
+                          "description": "Flag if discount is only applied to service charge."
+                        },
+                        "applied_after_service_charge": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if discount is applied after service charge."
+                        },
+                        "has_customer_details": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if discount needs customer details (e.g ID number)."
+                        },
+                        "is_passcode_required": {
+                          "type": "boolean",
+                          "example": true,
+                          "description": "Flag if passcode is required before applying discount on POS."
+                        },
+                        "starts_at": {
+                          "type": "string",
+                          "example": "2026-04-12T16:00:00.000000Z",
+                          "description": "The time when the discount is available."
+                        },
+                        "ends_at": {
+                          "type": "string",
+                          "example": "2026-06-12T16:00:00.000000Z",
+                          "description": "The time when the discount expires."
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "type",
+                        "rate",
+                        "amount",
+                        "ceiling_discount_amount",
+                        "is_ceiling_discount_per_line_item",
+                        "is_applied_on_net",
+                        "is_service_based",
+                        "applied_after_service_charge",
+                        "has_customer_details",
+                        "is_passcode_required",
+                        "starts_at",
+                        "ends_at"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Discounts"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "The type of discount.",
+                    "example": "FIXED",
+                    "enum": [
+                      "FIXED",
+                      "PERCENTAGE"
+                    ]
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the discount. Must not be greater than 191 characters.",
+                    "example": "Payday Discount"
+                  },
+                  "rate": {
+                    "type": "number",
+                    "description": "The percentage rate applied. This field is required when <code>type</code> is <code>PERCENTAGE</code>. Must be at least 0. Must not be greater than 100.",
+                    "example": 10
+                  },
+                  "amount": {
+                    "type": "number",
+                    "description": "The fixed amount of discount. This field is required when <code>type</code> is <code>FIXED</code>. Must be at least 0.",
+                    "example": 100
+                  },
+                  "ceiling_discount_amount": {
+                    "type": "number",
+                    "description": "The maximum allowable discount. Omit or pass `null` for non-capped discounts. Must be at least 0.",
+                    "example": 500,
+                    "nullable": true
+                  },
+                  "is_ceiling_discount_per_line_item": {
+                    "type": "boolean",
+                    "description": "Flag if ceiling discount is applied per line item.",
+                    "example": false
+                  },
+                  "is_applied_on_net": {
+                    "type": "boolean",
+                    "description": "Flag if discount is applied on net price (without VAT).",
+                    "example": false
+                  },
+                  "is_service_based": {
+                    "type": "boolean",
+                    "description": "Flag if discount is only applied to service charge.",
+                    "example": false
+                  },
+                  "applied_after_service_charge": {
+                    "type": "boolean",
+                    "description": "Flag if discount is applied after service charge.",
+                    "example": false
+                  },
+                  "has_customer_details": {
+                    "type": "boolean",
+                    "description": "Flag if discount needs customer details (e.g ID number).",
+                    "example": false
+                  },
+                  "is_passcode_required": {
+                    "type": "boolean",
+                    "description": "Flag if passcode is required before applying discount on POS.",
+                    "example": false
+                  },
+                  "starts_at": {
+                    "type": "string",
+                    "description": "The time when the discount is available. Must be a valid date in the format <code>Y-m-d H:i:s</code>.",
+                    "example": "2026-04-13 00:00:00"
+                  },
+                  "ends_at": {
+                    "type": "string",
+                    "description": "The time when the discount expires. Omit or pass `null` for non-expiring discounts. Must be a valid date in the format <code>Y-m-d H:i:s</code>. Must be a date after <code>starts_at</code>.",
+                    "example": "2026-08-13 00:00:00",
+                    "nullable": true
+                  }
+                },
+                "required": [
+                  "type",
+                  "name",
+                  "starts_at"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Discount",
+        "operationId": "deleteDiscount",
+        "description": "Delete the specified discount.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Discounts"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "description": "The ID of the discount.",
+          "example": 13,
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/api/v1/webhooks": {
+      "get": {
+        "summary": "Get Webhooks",
+        "operationId": "getWebhooks",
+        "description": "Get all the webhooks.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": [
+                      {
+                        "id": "67429494-7816-388c-9088-cf3412e03741",
+                        "url": "https://www.sawayn.com/cupiditate-quae-impedit-aut-debitis-neque-nulla-dignissimos",
+                        "events": [
+                          "order.ready"
+                        ],
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z"
+                      },
+                      {
+                        "id": "12147e72-e483-3a18-b29d-a714edc261c0",
+                        "url": "https://rowe.org/repellendus-ut-dolor-saepe-non-quae.html",
+                        "events": [
+                          "order.ready"
+                        ],
+                        "created_at": "2026-04-12T18:25:08.000000Z",
+                        "updated_at": "2026-04-12T18:25:08.000000Z"
+                      }
+                    ],
+                    "meta": {
+                      "current_page": 1,
+                      "last_page": 1,
+                      "per_page": 100,
+                      "total": 2
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "example": [
+                        {
+                          "id": "67429494-7816-388c-9088-cf3412e03741",
+                          "url": "https://www.sawayn.com/cupiditate-quae-impedit-aut-debitis-neque-nulla-dignissimos",
+                          "events": [
+                            "order.ready"
+                          ],
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z"
+                        },
+                        {
+                          "id": "12147e72-e483-3a18-b29d-a714edc261c0",
+                          "url": "https://rowe.org/repellendus-ut-dolor-saepe-non-quae.html",
+                          "events": [
+                            "order.ready"
+                          ],
+                          "created_at": "2026-04-12T18:25:08.000000Z",
+                          "updated_at": "2026-04-12T18:25:08.000000Z"
+                        }
+                      ],
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "example": "67429494-7816-388c-9088-cf3412e03741",
+                            "description": "The ID of the webhook."
+                          },
+                          "url": {
+                            "type": "string",
+                            "example": "https://www.sawayn.com/cupiditate-quae-impedit-aut-debitis-neque-nulla-dignissimos",
+                            "description": "The URL where to send the events."
+                          },
+                          "events": {
+                            "type": "array",
+                            "example": [
+                              "order.ready"
+                            ],
+                            "description": "The events to subscribe to.",
+                            "enum": [
+                              "order.cancelled",
+                              "order.completed",
+                              "order.created",
+                              "order.paid",
+                              "order.ready",
+                              "location.created",
+                              "location.updated"
+                            ],
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "created_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the webhook was created in ISO-8601 format with UTC timezone."
+                          },
+                          "updated_at": {
+                            "type": "string",
+                            "example": "2026-04-12T18:25:08.000000Z",
+                            "description": "The time when the webhook was last updated in ISO-8601 format with UTC timezone."
+                          }
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "url",
+                        "events",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    },
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "current_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "last_page": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "per_page": {
+                          "type": "integer",
+                          "example": 100
+                        },
+                        "total": {
+                          "type": "integer",
+                          "example": 2
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Webhook Setup"
+        ]
+      },
+      "post": {
+        "summary": "Create Webhook",
+        "operationId": "createWebhook",
+        "description": "Create a webhook.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": "99bb52ab-a25b-345d-bef2-9717aa293b9a",
+                      "url": "http://www.boehm.com/ad-eaque-quia-quisquam-eos-odio-veritatis",
+                      "events": [
+                        "order.created"
+                      ],
+                      "created_at": "2026-04-12T18:25:08.000000Z",
+                      "updated_at": "2026-04-12T18:25:08.000000Z"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "99bb52ab-a25b-345d-bef2-9717aa293b9a",
+                          "description": "The ID of the webhook."
+                        },
+                        "url": {
+                          "type": "string",
+                          "example": "http://www.boehm.com/ad-eaque-quia-quisquam-eos-odio-veritatis",
+                          "description": "The URL where to send the events."
+                        },
+                        "events": {
+                          "type": "array",
+                          "example": [
+                            "order.created"
+                          ],
+                          "description": "The events to subscribe to.",
+                          "enum": [
+                            "order.cancelled",
+                            "order.completed",
+                            "order.created",
+                            "order.paid",
+                            "order.ready",
+                            "location.created",
+                            "location.updated"
+                          ],
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:08.000000Z",
+                          "description": "The time when the webhook was created in ISO-8601 format with UTC timezone."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:08.000000Z",
+                          "description": "The time when the webhook was last updated in ISO-8601 format with UTC timezone."
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "url",
+                        "events",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Webhook Setup"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "The URL where to send the events. Must be a valid URL.",
+                    "example": "http://hammes.info/ratione-illo-architecto-non-id-blanditiis-eum"
+                  },
+                  "events": {
+                    "type": "array",
+                    "description": "The events to subscribe to.",
+                    "example": [
+                      "order.cancelled"
+                    ],
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "order.cancelled",
+                        "order.completed",
+                        "order.created",
+                        "order.paid",
+                        "order.ready",
+                        "location.created",
+                        "location.updated"
+                      ]
+                    }
+                  }
+                },
+                "required": [
+                  "url",
+                  "events"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/webhooks/{id}": {
+      "put": {
+        "summary": "Update Webhook",
+        "operationId": "updateWebhook",
+        "description": "Update the URL or subscribed events of the specified webhook.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "data": {
+                      "id": "457f7347-9e77-3304-86a9-2e2c8c6457a7",
+                      "url": "http://www.boehm.com/ad-eaque-quia-quisquam-eos-odio-veritatis",
+                      "events": [
+                        "order.created"
+                      ],
+                      "created_at": "2026-04-12T18:25:08.000000Z",
+                      "updated_at": "2026-04-12T18:25:08.000000Z"
+                    }
+                  },
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "example": "457f7347-9e77-3304-86a9-2e2c8c6457a7",
+                          "description": "The ID of the webhook."
+                        },
+                        "url": {
+                          "type": "string",
+                          "example": "http://www.boehm.com/ad-eaque-quia-quisquam-eos-odio-veritatis",
+                          "description": "The URL where to send the events."
+                        },
+                        "events": {
+                          "type": "array",
+                          "example": [
+                            "order.created"
+                          ],
+                          "description": "The events to subscribe to.",
+                          "enum": [
+                            "order.cancelled",
+                            "order.completed",
+                            "order.created",
+                            "order.paid",
+                            "order.ready",
+                            "location.created",
+                            "location.updated"
+                          ],
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "created_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:08.000000Z",
+                          "description": "The time when the webhook was created in ISO-8601 format with UTC timezone."
+                        },
+                        "updated_at": {
+                          "type": "string",
+                          "example": "2026-04-12T18:25:08.000000Z",
+                          "description": "The time when the webhook was last updated in ISO-8601 format with UTC timezone."
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "url",
+                        "events",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Webhook Setup"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "description": "The URL where to send the events. Must be a valid URL.",
+                    "example": "http://hammes.info/ratione-illo-architecto-non-id-blanditiis-eum"
+                  },
+                  "events": {
+                    "type": "array",
+                    "description": "The events to subscribe to.",
+                    "example": [
+                      "order.completed"
+                    ],
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "order.cancelled",
+                        "order.completed",
+                        "order.created",
+                        "order.paid",
+                        "order.ready",
+                        "location.created",
+                        "location.updated"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete Webhook",
+        "operationId": "deleteWebhook",
+        "description": "Delete the specified webhook.",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Accept",
+            "schema": {
+              "type": "string",
+              "default": "application/json"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Webhook Setup"
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "id",
+          "description": "The ID of the webhook.",
+          "example": "01969e52-a9c6-71e4-8135-d64846061cbd",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/runbooks/S189_BOM_CONSUMPTION.md
+++ b/docs/runbooks/S189_BOM_CONSUMPTION.md
@@ -2,6 +2,7 @@
 
 **Last updated:** 2026-04-14
 **Sprint plan:** `docs/plans/2026-04-13-sprint-189-realtime-bom-consumption.md`
+**Mosaic API spec (authoritative):** `docs/api/MOSAIC_API_OPENAPI_2026-04-14.json` — always check this first for any Mosaic endpoint ambiguity; the markdown summary at `docs/api/MOSAIC_API.md` is derived from it.
 
 ## Purpose
 

--- a/hrms/api/mosaic_webhook.py
+++ b/hrms/api/mosaic_webhook.py
@@ -6,10 +6,18 @@ S189: order.completed — upserts pos_orders + pos_order_items with ingestion_so
       authoritative for order_status and sums since stores may have unstable internet).
 
 Auth path:
-  - Optional HMAC check via MOSAIC_WEBHOOK_SECRET env var (if set, verify X-Mosaic-Signature)
-  - Path B fallback: round-trip Mosaic GET /api/v1/orders/{id}
+  - Optional HMAC check via MOSAIC_WEBHOOK_SECRET env var (SPECULATIVE:
+    Mosaic's public OpenAPI doc does not document webhook signing as of
+    2026-04-14; this code is defensive for if/when they add it).
+    See docs/api/MOSAIC_API_OPENAPI_2026-04-14.json — no 'signature', 'hmac',
+    or webhook-signing entries exist in the spec.
+  - Path B (actually used): round-trip Mosaic GET /api/v1/orders/{id}
     * order.cancelled expects HTTP 404
     * order.completed expects HTTP 200 (order exists)
+
+Supported events per Mosaic OpenAPI spec (docs/api/MOSAIC_API_OPENAPI_2026-04-14.json):
+  order.created, order.completed, order.cancelled, order.paid, order.ready,
+  location.created, location.updated
 
 See docs/plans/2026-04-13-sprint-189-realtime-bom-consumption.md (Phase 7) and
 docs/plans/2026-04-07-sprint-169-mosaic-order-lifecycle-tombstone-webhook.md (Phase 0).
@@ -68,8 +76,11 @@ def receive():
         frappe.local.response.http_status_code = 400
         return {"ok": False, "reason": "invalid_json"}
 
-    # S189 T7.2: if MOSAIC_WEBHOOK_SECRET is set, verify HMAC signature before processing.
-    # Falls back to round-trip Path B auth if no secret is configured.
+    # SPECULATIVE HMAC check: Mosaic's public OpenAPI spec does NOT document a
+    # signature scheme (verified 2026-04-14 against docs/api/MOSAIC_API_OPENAPI_2026-04-14.json).
+    # This branch only runs if someone sets MOSAIC_WEBHOOK_SECRET — meaning they've
+    # received a signing secret out-of-band from Mosaic. Without the env var,
+    # verify() returns True and we fall through to Path B round-trip auth.
     if not _verify_hmac_signature(raw_body):
         frappe.local.response.http_status_code = 401
         return {"ok": False, "reason": "hmac_signature_invalid"}
@@ -229,11 +240,20 @@ def _authenticate_webhook(order_id, data: dict, expect_status: int = 404) -> boo
 
 
 def _verify_hmac_signature(raw_body: str) -> bool:
-    """S189 T7.2: optional HMAC signature verification.
+    """SPECULATIVE: Optional HMAC signature verification.
 
-    If MOSAIC_WEBHOOK_SECRET is set, verify the ``X-Mosaic-Signature`` header
-    matches HMAC-SHA256(secret, raw_body). If the secret is not set, return
-    True (fall through to Path B round-trip auth).
+    Mosaic's public OpenAPI spec (docs/api/MOSAIC_API_OPENAPI_2026-04-14.json)
+    does NOT document any webhook signing. This function exists for forward
+    compatibility: if Mosaic later publishes a signing spec and issues us a
+    secret, setting MOSAIC_WEBHOOK_SECRET env var activates verification.
+
+    Current behavior:
+      - MOSAIC_WEBHOOK_SECRET unset → returns True, falls through to Path B
+      - MOSAIC_WEBHOOK_SECRET set → expects X-Mosaic-Signature header to
+        match HMAC-SHA256(secret, raw_body). Missing/mismatch → 401.
+
+    The header name ``X-Mosaic-Signature`` is a guess. When Mosaic actually
+    documents signing, update both the header name and the HMAC scheme here.
     """
     secret = (os.environ.get("MOSAIC_WEBHOOK_SECRET") or "").strip()
     if not secret:

--- a/scripts/s189_webhook_registration_reconciler.py
+++ b/scripts/s189_webhook_registration_reconciler.py
@@ -70,8 +70,81 @@ def oauth(client_id: str, client_secret: str, attempts: int = 3) -> str | None:
     return None
 
 
+def _try_list_webhooks(token: str) -> list[dict] | None:
+    """GET /api/v1/webhooks — per Mosaic OpenAPI doc (docs/api/MOSAIC_API_OPENAPI_2026-04-14.json).
+
+    Returns the list of webhooks or None if Mosaic returned 5xx (known flaky).
+    """
+    try:
+        r = requests.get(
+            f"{MOSAIC_BASE}/api/v1/webhooks",
+            headers={**DEFAULT_HEADERS, "Authorization": f"Bearer {token}"},
+            timeout=20,
+        )
+    except requests.RequestException:
+        return None
+    if not r.ok:
+        return None
+    try:
+        body = r.json()
+    except (ValueError, TypeError):
+        return None
+    hooks = body.get("data", body) if isinstance(body, dict) else body
+    return hooks if isinstance(hooks, list) else None
+
+
+def _update_webhook(token: str, webhook_id: str, events: list[str]) -> tuple[bool, str, dict | None]:
+    """PUT /api/v1/webhooks/{id} — update events for an existing registration."""
+    try:
+        r = requests.put(
+            f"{MOSAIC_BASE}/api/v1/webhooks/{webhook_id}",
+            headers={**DEFAULT_HEADERS, "Authorization": f"Bearer {token}"},
+            json={"url": WEBHOOK_URL, "events": events},
+            timeout=30,
+        )
+    except requests.RequestException as e:
+        return False, f"network_error: {e}", None
+    if r.ok:
+        try:
+            body = r.json()
+            data = body.get("data", body) if isinstance(body, dict) else body
+            return True, "updated", data
+        except (ValueError, TypeError):
+            return True, "updated_but_body_unparseable", None
+    return False, f"put_http_{r.status_code}: {(r.text or '')[:200]}", None
+
+
 def register(token: str, events: list[str]) -> tuple[bool, str, dict | None]:
-    """POST webhook registration. Returns (ok, reason, body)."""
+    """Reconcile webhook registration for our URL.
+
+    Per Mosaic OpenAPI (docs/api/MOSAIC_API_OPENAPI_2026-04-14.json):
+      - POST /api/v1/webhooks creates {url, events}
+      - PUT  /api/v1/webhooks/{id} updates events for existing registration
+      - GET  /api/v1/webhooks lists (known flaky — 500 for ~11/12 groups)
+
+    Strategy: try GET first. If it works:
+      - Our URL absent → POST to create
+      - Our URL present with matching events → already_registered (no-op)
+      - Our URL present with different events → PUT to update
+    If GET fails (most common case due to Mosaic 500s): fall through to POST
+    and rely on Mosaic's duplicate-URL handling (409/422 swallowed as
+    already_registered).
+    """
+    existing = _try_list_webhooks(token)
+    if existing is not None:
+        matching = [h for h in existing if (h.get("url") or "") == WEBHOOK_URL]
+        if matching:
+            current_events = set(matching[0].get("events") or matching[0].get("event_types") or [])
+            wanted = set(events)
+            if wanted.issubset(current_events):
+                return True, "already_registered", matching[0]
+            # Registration exists but doesn't cover all our events → PUT to update
+            webhook_id = matching[0].get("id")
+            if webhook_id:
+                union = sorted(current_events | wanted)
+                return _update_webhook(token, str(webhook_id), union)
+        # No matching registration → POST below
+
     try:
         r = requests.post(
             f"{MOSAIC_BASE}/api/v1/webhooks",


### PR DESCRIPTION
## Purpose

You shared the Mosaic OpenAPI 3.0.3 spec (`Mosaic Solutions API Doc.json`, 336 KB). Auditing my earlier S189 work against it uncovered 3 issues I had inferred wrong from existing code + error messages instead of docs.

## What I got wrong → fixed here

### 1. HMAC signature scheme was speculative
- #565 shipped `MOSAIC_WEBHOOK_SECRET` + `X-Mosaic-Signature` HMAC verification
- Spec has **zero** signature/hmac/signing entries (grep confirmed)
- Fix: marked docstrings + comments clearly as **SPECULATIVE**; header name flagged as a guess; code still safe (falls through when secret unset, which it will be)

### 2. Using 2 of 7 supported events
The enum in the spec has 7 events. We use 2. Full taxonomy documented:
| Event | BEI usage |
|-------|-----------|
| `order.created` | Not used (too early for revenue) |
| `order.paid` | **Candidate for future real-time revenue stream** |
| `order.ready` | Not used |
| `order.completed` | S189 (#565): upsert `pos_orders` with `ingestion_source='webhook'` |
| `order.cancelled` | S169: tombstone `cancelled_at` |
| `location.created` | Not used |
| `location.updated` | Not used |

### 3. Reconciler was POST-only
- Spec documents `PUT /api/v1/webhooks/{id}` for updates
- `scripts/s189_webhook_registration_reconciler.py` now:
  1. Try `GET /api/v1/webhooks` (spec-documented)
  2. If our URL present with subset events → no-op (already_registered)
  3. If our URL present with different events → `PUT` to union events
  4. If our URL absent → `POST` to create
  5. If GET returns 5xx (common Mosaic flake) → fall back to POST + swallow duplicate errors

No behavioral regression: the POST fallback path matches the old code exactly.

## Files

| File | Change |
|------|--------|
| `docs/api/MOSAIC_API_OPENAPI_2026-04-14.json` | NEW — 336 KB authoritative spec, saved so we stop inferring |
| `docs/api/MOSAIC_API.md` | Expanded §8 Webhooks: events table, signature/auth explanation, rate limits, known operational issues |
| `docs/runbooks/S189_BOM_CONSUMPTION.md` | Now cites OpenAPI JSON as source of truth |
| `hrms/api/mosaic_webhook.py` | HMAC code marked SPECULATIVE in module docstring, receive() comment, and `_verify_hmac_signature` docstring |
| `scripts/s189_webhook_registration_reconciler.py` | Added `_try_list_webhooks` + `_update_webhook` helpers; rewrote `register()` with GET → PUT/POST strategy; PostgreSQL-safe fallback preserved |

## Test plan

- [x] `python -c "import ast; ast.parse(...)"` — both Python files parse
- [x] Fallback path identical when GET returns 5xx → reconciler still works on flaky Mosaic
- [ ] After merge, next scheduled reconciler run (3 AM PHT) will attempt GET first; check logs for "updated" vs "registered" vs "already_registered" outcomes

## Sustainability hook

Filed alongside the existing runbook rule: **when Mosaic docs are ambiguous, check `docs/api/MOSAIC_API_OPENAPI_2026-04-14.json` first** — stop inferring from error messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)