### PR TITLE
feat(S193): supplier status guard — block PO/Invoice/RFP for Blacklisted + Pending Verification suppliers

### DIFF
--- a/docs/plans/2026-04-14-sprint-191-foodpanda-unified-source.md
+++ b/docs/plans/2026-04-14-sprint-191-foodpanda-unified-source.md
@@ -1,0 +1,474 @@
+---
+sprint_id: S191
+sprint_name: "FoodPanda Unified Source — Per-Store Rolling Cutover Fix"
+branch: s191-foodpanda-unified-source
+repos:
+  - BEI-ERP (hrms — backend only)
+branches:
+  hrms: s191-foodpanda-unified-source
+depends_on: [S176]
+status: PLANNED
+planned_date: 2026-04-14
+amended_date: 2026-04-14
+amendment_version: v2
+owner: sam@bebang.ph
+signoff_authority: single-owner
+estimated_units: 42
+hard_unit_ceiling: 55
+session_scope: single-agent-single-session
+plan_file: docs/plans/2026-04-14-sprint-191-foodpanda-unified-source.md
+registry_row: |
+  | `S191` | Sprint 191 | `s191-foodpanda-unified-source` (hrms) | — | PLANNED 2026-04-14 — FoodPanda Unified Source: fix missing ₱17M+ March FP sales. |
+completed_date: null
+execution_summary: null
+---
+
+# S191 — FoodPanda Unified Source (Per-Store Rolling Cutover Fix)
+
+## Amendment Log
+
+**v2 (2026-04-14):** Applied 12 audit-driven amendments across 3 domain audits (backend, architecture, cold-start). No scope removed. All improvements strengthen correctness, regression safety, and rollback posture. Unit budget raised 28 → 42 to reflect 5 new tasks (0.4 dedup, 0.5 caller inventory, 2.5 outer cache bump, 3.6 daily-series double-count fix, 3.7 sales_row_metrics fix, 3.8 _build_comparisons fix, 3.9 export_sales_dashboard_detail verify, 4.3 rollback runbook, 4.4 sam pre-deploy notice) — each was a HIDDEN gap that would have caused corrupt success.
+
+| ID | Fix | Location |
+|---|---|---|
+| B-1 | Remove `foodpanda_vat_deducted_sales` add-back in `_aggregate_daily_series` → stops daily-series ₱17M double-count | Task 3.6 |
+| B-2 | Preserve `float`-per-channel return shape in `_get_store_channel_split_map` + `_get_mosaic_channel_split_per_day` → prevents leaderboard dict-vs-float corruption | Tasks 3.2, 3.5 |
+| B-3 | Replace `fp_bucket = split.pop("foodpanda"` (not just add new line) → prevents silent revert | Task 2.1 |
+| B-4 | Verify `export_sales_dashboard_detail` picks up unified FP + L3-191-13 | Task 3.9 |
+| B-5 | Bump outer cache prefix `overview` → `overview_s191` → invalidates pre-deploy cached payloads | Task 2.5 |
+| B-6 | `order_id` dedup check in Phase 0 + `DISTINCT ON (order_id)` if dupes found | Tasks 0.4, 1.1 |
+| B-7 | L3 thresholds labeled NET (₱18M) not gross (₱20M) | L3-191-01/05 |
+| B-8 | PostgREST fallback uses `ilike.delivered` (not `eq.delivered`) + refuses > 45-day ranges | Task 1.2 |
+| B-9 | Variance thresholds on GROSS not net; ₱2M total / ₱150K single-day (raised) | Task 0.3, HARD BLOCKER 0-1 |
+| B-10 | Fix `_sales_row_metrics` to use unified FP | Task 3.7 + L3-191-15 |
+| B-11 | Fix `_build_comparisons` to use unified FP for baselines | Task 3.8 + L3-191-14 |
+| B-12 | Completeness guard: Mosaic-wins only when ≥ 50% of legacy rows/gross | Task 1.1 |
+
+**v1 (2026-04-14):** Initial plan.
+
+## Executive Summary
+
+Sam (CEO) reported on 2026-04-14 that March FoodPanda sales in the Analytics dashboard show **₱4,465,227** (Mosaic-only) instead of the actual **~₱21.7M** (legacy Google Sheet + Mosaic combined). Investigation confirmed the `foodpanda_orders` Google Sheet table still has 50,525 delivered orders for Feb 1 – Mar 31 (~₱31.2M total), but the S176 `_apply_mosaic_channel_split` logic **overwrites** the legacy FoodPanda totals with Mosaic-only data, dropping ~₱17M of pre-cutover legacy sales from every Analytics surface.
+
+**Additional complication (CEO clarification 2026-04-14):** The FoodPanda cutover from Google Sheet to Mosaic POS API **happened per store over ~1 week** in late March, not on a single global date. The current `_FOODPANDA_MOSAIC_START = 2026-03-27` constant is fundamentally wrong — each store has its own cutover moment.
+
+**Fix:** Replace the global-date cutover with a **per-(location_id, business_date) FULL OUTER JOIN** of the two sources. Mosaic wins when both have data for a given store-day (authoritative post-cutover). Legacy Google Sheet fills any store-day without Mosaic data. Zero loss, zero double-count, regardless of when each store transitioned.
+
+**Scope:** Backend-only (no frontend changes, no new API endpoints, no schema changes). Three existing functions in `hrms/api/sales_dashboard.py` get updated:
+1. `_get_mosaic_channel_split()` (line 825) — headline Channel Mix donut
+2. `_get_store_channel_split_map()` (line 1049) — per-store channel mix on Leaderboard / Store Detail
+3. `_get_mosaic_channel_split_per_day()` (line 1962) — daily time-series chart
+
+**Out of scope:** GrabFood (CEO confirmed BEI was not selling on GrabFood pre-April; post-April rollout is still incomplete). Do NOT touch GrabFood logic in this sprint.
+
+**Total: 28 units, 5 phases.** Single-agent single-session, backend-only.
+
+---
+
+## Design Rationale (For Cold-Start Agents)
+
+### Why this exists
+
+Two CEO directives on 2026-04-14:
+
+1. "Our FoodPanda sales for March were 20m+ not 4.4 million" — Analytics dashboard is under-reporting by ~₱17M
+2. "Not all stores were transitioned from the manual sheet to POS in the same date, it happened over 1 week. so how to make sure nothing is missing or lost?" — rejects any global-date cutover fix
+
+Verified numbers from Supabase (2026-04-14 audit):
+
+| Period | Legacy `foodpanda_orders` (Google Sheet) | Mosaic `pos_orders` WHERE channel=FoodPanda |
+|---|---|---|
+| Feb 2026 | 16,188 orders / ₱9.5M subtotal | 0 |
+| Mar 2026 | 34,337 orders / ₱21.7M subtotal | 8,477 orders / ₱4.7M net |
+| Apr 2026 | 0 (frozen Mar 31) | 16,583 orders / ₱9.5M net |
+| **Total** | **50,525 orders / ₱31.2M** | 25,060 orders / ₱14.2M |
+
+Dashboard currently shows Mosaic-only for March → ₱4.4M instead of ₱21.7M. For Feb it shows ₱0 because `_apply_mosaic_channel_split` zeroes out legacy too.
+
+### Why per-(store, day) FULL OUTER JOIN (not a global cutover date)
+
+The CEO explicitly rejected any global cutover date because the FoodPanda-to-Mosaic transition happened per store over ~1 week. A global date either:
+- Drops late-transitioning stores' legacy data (if cutover is too early)
+- Double-counts early-transitioning stores' Mosaic data (if cutover is too late)
+
+A per-store cutover date would work but requires tracking the transition date per store — fragile and manually maintained.
+
+**The union-at-cell-grain approach eliminates the problem:**
+```sql
+WITH fp_mosaic AS (
+    SELECT location_id, business_date, SUM(gross_sales) gross, SUM(net_sales) net, COUNT(*) orders
+    FROM v_pos_orders_live
+    WHERE channel = 'FoodPanda' AND payment_status = 'PAID'
+      AND business_date BETWEEN $start AND $end
+      AND location_id IN ($locations)
+    GROUP BY 1, 2
+),
+fp_legacy AS (
+    SELECT location_id, business_date, SUM(subtotal) gross, SUM(subtotal / 1.12) net, COUNT(*) orders
+    FROM foodpanda_orders
+    WHERE LOWER(order_status) = 'delivered'
+      AND business_date BETWEEN $start AND $end
+      AND location_id IN ($locations)
+    GROUP BY 1, 2
+)
+SELECT
+    COALESCE(m.location_id, l.location_id) AS location_id,
+    COALESCE(m.business_date, l.business_date) AS business_date,
+    COALESCE(m.gross, l.gross) AS gross,  -- Mosaic wins when both exist
+    COALESCE(m.net, l.net) AS net,
+    COALESCE(m.orders, l.orders) AS orders,
+    CASE WHEN m.gross IS NOT NULL THEN 'mosaic' ELSE 'legacy_sheet' END AS source
+FROM fp_mosaic m
+FULL OUTER JOIN fp_legacy l
+    ON m.location_id = l.location_id AND m.business_date = l.business_date
+```
+
+**Result per (store, day):**
+
+| Mosaic has data | Legacy has data | Result | Source |
+|---|---|---|---|
+| Yes | No | Mosaic | Post-cutover for this store |
+| No | Yes | Legacy | Pre-cutover for this store |
+| Yes | Yes | Mosaic | Overlap period — Mosaic is authoritative |
+| No | No | — | Store had no FP sales that day (skip row) |
+
+No loss. No double-count. Works for any transition pattern.
+
+### Why Mosaic wins on overlap
+
+Two reasons:
+1. **Mosaic is the authoritative post-cutover source** — once a store is on Mosaic, the Google Sheet is redundant (may be stale or incomplete). If both sources have data for the same (store, day), Mosaic is the newer reality.
+2. **S176 hotfix #10 established this precedent** — the current code already prefers Mosaic on overlap dates (2026-03-26 to 2026-03-31) to avoid double-count. This sprint extends that preference to the per-store level.
+
+### Why the gross/net computation differs between sources
+
+| Source | Gross | Net (without VAT) |
+|---|---|---|
+| Mosaic `v_pos_orders_live` | `gross_sales` column (already computed) | `net_sales` column (already net of VAT) |
+| Legacy `foodpanda_orders` | `subtotal` column | `subtotal / 1.12` (derived — FoodPanda doesn't expose VAT separately) |
+
+This asymmetry is a known limitation of the legacy Google Sheet schema. Use `subtotal / 1.12` for net to match the existing MV logic (`sales_dashboard_daily_store_metrics.foodpanda_vat_deducted_sales` uses this formula — see MV definition line confirmed 2026-04-14).
+
+### Known limitations
+
+- **Legacy sheet is frozen at 2026-03-31** — after that date, only Mosaic has data. The JOIN handles this naturally (legacy side returns no rows for April+).
+- **FoodPanda VAT imputation** — legacy net is `subtotal / 1.12`. If a FoodPanda order was VAT-exempt (e.g., senior discount), this formula slightly overstates VAT. Acceptable: the legacy sheet never tracked VAT exemptions individually; this is the baseline we're preserving.
+- **Store closure days** — if a store had zero FP sales on a day, no row appears in either source. The FULL OUTER JOIN correctly produces no result for that (store, day) pair. Time-series aggregation must handle missing days via existing `COALESCE(fp.gross, 0)` patterns in the MV-consuming code.
+- **GrabFood is out of scope** — do NOT apply this pattern to GrabFood. Per CEO: "ignore Grabfood because we were not selling on Grabfood pre april and we're not fully on Grab Food in all our stores yet." The existing Mosaic-only GrabFood logic stays unchanged.
+
+### Source references (verified 2026-04-14)
+
+- **Bug location:** `hrms/api/sales_dashboard.py:960-961` — `_apply_mosaic_channel_split` overwrites `summary["foodpanda_sales"]` with `fp_bucket` (Mosaic-only)
+- **Current Mosaic-only helper:** `hrms/api/sales_dashboard.py:825-907` — `_get_mosaic_channel_split` queries `v_pos_orders_live` only
+- **Per-store variant (also broken):** `hrms/api/sales_dashboard.py:1049` — `_get_store_channel_split_map`
+- **Per-day variant (also broken):** `hrms/api/sales_dashboard.py:1962` — `_get_mosaic_channel_split_per_day`
+- **Legacy table schema:** `foodpanda_orders` columns = `order_id`, `fp_restaurant_code`, `location_id` (int), `delivery_type`, `payment_type`, `payment_method`, `is_pro_order`, `order_status` (use `LOWER(order_status) = 'delivered'` filter), `order_received_at`, `accepted_at`, `delivered_at`, `cancelled_at`, `subtotal` (numeric — use this for gross), `packaging_charges`, `tax_charge`, `business_date` (date)
+- **Mosaic table schema:** `v_pos_orders_live` columns = `location_id`, `business_date`, `channel` (text — filter `= 'FoodPanda'`), `payment_status` (filter `= 'PAID'`), `gross_sales`, `net_sales` (already net of VAT per CRITICAL comment at line 844), `vat_amount`
+- **MV reference:** `sales_dashboard_daily_store_metrics` view definition confirms `foodpanda_subtotal` comes from legacy and uses `subtotal / 1.12` for net
+- **Cutover constant to REMOVE/DEPRECATE:** `_FOODPANDA_MOSAIC_START = date(2026, 3, 27)` at `sales_dashboard.py:31`. Keep the constant in code but mark it as `# DEPRECATED S191: per-(store,day) JOIN replaces global date. Constant retained for the freshness warning at line 1296.`
+- **SQL execution helper:** `_supabase_query_sql(sql: str)` at `sales_dashboard.py:229` — Mgmt API, single round-trip, handles the FULL OUTER JOIN in one call
+- **PostgREST fallback pattern:** `_supabase_get_all(resource, params, page_size)` — used when `SupabaseMgmtTokenMissing`; see `_get_mosaic_channel_split` line 874-898 for the pattern
+- **Cache pattern:** `_cache_get_or_set(cache_key, builder, 300)` with `_sales_dashboard_cache_key(prefix, location_ids, start_day=..., end_day=...)` — existing 300s TTL
+
+---
+
+## Agent Boot Sequence
+
+1. **Read this plan fully.**
+2. **Create backend branch:**
+   ```bash
+   cd F:/Dropbox/Projects/BEI-ERP
+   git fetch origin production && git checkout -b s191-foodpanda-unified-source origin/production
+   ```
+3. **Read the bug site:** `hrms/api/sales_dashboard.py:825-1030` (existing `_get_mosaic_channel_split` + `_apply_mosaic_channel_split`).
+4. **Read the two other variants:** `_get_store_channel_split_map` (line 1049+) and `_get_mosaic_channel_split_per_day` (line 1962+).
+5. **Read the S176 hotfix comment block** at `_apply_mosaic_channel_split` (lines 916-945) to understand why the overwrite exists.
+6. **Do not touch GrabFood logic.** CEO directive — GrabFood stays Mosaic-only.
+7. **Do not modify frontend code.** Backend-only sprint.
+
+---
+
+## Execution Authority
+
+This sprint is intended for autonomous end-to-end execution.
+Do not stop for progress-only updates.
+Only pause for items listed in the Autonomous Execution Contract `stop_only_for` section.
+
+---
+
+## Requirements Regression Checklist
+
+- [ ] Does the FoodPanda source logic use a FULL OUTER JOIN of `v_pos_orders_live` (Mosaic) and `foodpanda_orders` (legacy) at the (`location_id`, `business_date`) grain?
+- [ ] When both Mosaic and legacy have data for the same (store, day), does Mosaic win? (HARD BLOCKER — CEO preference)
+- [ ] When only legacy has data for a (store, day), is it preserved and included in totals?
+- [ ] When only Mosaic has data for a (store, day), is it preserved and included in totals?
+- [ ] Is the legacy net computed as `subtotal / 1.12` (matching existing MV logic)?
+- [ ] Does the filter exclude non-delivered legacy orders: `LOWER(order_status) = 'delivered'`?
+- [ ] Does the filter exclude unpaid Mosaic orders: `payment_status = 'PAID'`?
+- [ ] Does the FoodPanda bucket in the result dict have the same shape as other buckets (`{"gross": float, "net_wo_vat": float, "orders": int}`)?
+- [ ] Is GrabFood logic completely untouched? (HARD BLOCKER — CEO directive)
+- [ ] Are all three functions updated consistently (`_get_mosaic_channel_split`, `_get_store_channel_split_map`, `_get_mosaic_channel_split_per_day`)?
+- [ ] Does the cache key distinguish the new unified FP totals from the old Mosaic-only totals so post-deploy cache is invalidated?
+- [ ] Does the verification baseline script confirm March 2026 FoodPanda ≥ ₱20M after the fix?
+- [ ] Does every new/modified `@frappe.whitelist()` endpoint call `set_backend_observability_context()`? (Already present — verify only)
+- [ ] Is the `_FOODPANDA_MOSAIC_START` constant still referenced by the freshness warning at line 1296? (Keep but mark deprecated)
+
+**[AMENDED v2 — audit-driven checks; all 12 amendments surfaced here]:**
+
+- [ ] **(B-1)** Was `+ _to_float(row.get("foodpanda_vat_deducted_sales"))` REMOVED from `_aggregate_daily_series` at line ~2061? `grep -c "foodpanda_vat_deducted_sales"` count is LOWER than pre-S191 baseline by exactly 1?
+- [ ] **(B-2)** Do `_get_store_channel_split_map` and `_get_mosaic_channel_split_per_day` PRESERVE the `float`-per-channel return shape (NOT nested dict)? Consumer at line ~2502 still receives float?
+- [ ] **(B-3)** Was `fp_bucket = split.pop("foodpanda"` pattern DELETED from `_apply_mosaic_channel_split`? Replaced with `split.pop("foodpanda", None)` on one line + `fp_bucket = fp_unified` on the next?
+- [ ] **(B-4)** Is `export_sales_dashboard_detail` (line ~3261) verified to use unified FP via the fixed `_get_mosaic_channel_split_per_day` / `_aggregate_daily_series`? L3-191-13 added?
+- [ ] **(B-5)** Was the outer cache key prefix bumped from `"overview"` to `"overview_s191"` in `_build_dashboard_overview_payload`? Any other FP-touching cache prefixes also bumped?
+- [ ] **(B-6)** Did Task 0.4 dedup check run? If dupes found, does the legacy CTE use `DISTINCT ON (order_id)`?
+- [ ] **(B-7)** Are L3 thresholds correctly labeled as NET (≥ ₱18M net, not ₱20M gross)? Phase 2.6 smoke test uses ≥ ₱18M?
+- [ ] **(B-8)** Does the PostgREST fallback use `ilike.delivered` (case-insensitive) NOT `eq.delivered`? Does it refuse date ranges > 45 days without Mgmt token?
+- [ ] **(B-9)** Phase 0 variance thresholds measure GROSS (not net), and are raised to ₱2M total / ₱150K single-store-day?
+- [ ] **(B-10)** Was `_sales_row_metrics` (line ~2644) updated to use `_get_unified_foodpanda_totals`?
+- [ ] **(B-11)** Was `_build_comparisons` (line ~1760) updated to override `prev["foodpanda_sales"]` / `prev["foodpanda_sales_without_vat"]` with unified values? AND recompute prev totals?
+- [ ] **(B-12)** Does `_get_unified_foodpanda_totals` include the completeness guard (`mosaic wins only when mosaic_orders >= 0.5 * legacy_orders OR mosaic_gross >= 0.5 * legacy_gross`)? Emits `source = 'legacy_partial_mosaic'` for the partial-sync case?
+
+---
+
+## Surface Ownership Matrix
+
+| Owner | Owned file globs |
+|---|---|
+| S191 backend | `hrms/api/sales_dashboard.py` — ONLY these functions: `_get_mosaic_channel_split` (lines 825-907), `_get_store_channel_split_map` (line 1049+), `_get_mosaic_channel_split_per_day` (line 1962+). May touch `_apply_mosaic_channel_split` (lines 910-1027) ONLY if the JOIN is implemented as a new helper function returning the same `fp_bucket` shape. |
+
+**Protected surfaces (do not touch):**
+- `hrms/api/sales_dashboard.py` — all other functions (S176 channel split infrastructure, S182 store rankings, S183 product analytics, S185 comparison logic, S187 leaderboard)
+- `.github/workflows/*`
+- `bei-tasks/**/*` — no frontend changes
+- `lib/roles.ts` — no RBAC changes
+- GrabFood logic everywhere — do not touch (CEO directive)
+- WebDelivery logic — do not touch (out of scope)
+- POS (pickup) logic — do not touch (already correct)
+
+---
+
+## Phase Budget Contract
+
+| Phase | Name | Est. Units | Hard Cap |
+|---|---|---|---|
+| Phase 0 | Branch setup + baseline audit + dedup check + duplicate caller inventory | 5 | 7 |
+| Phase 1 | Unified helper `_get_unified_foodpanda_totals` (with completeness guard + dedup) | 8 | 10 |
+| Phase 2 | Wire into `_get_mosaic_channel_split` + fix `_apply_mosaic_channel_split` + bump outer cache prefix | 7 | 9 |
+| Phase 3 | Wire into `_get_store_channel_split_map` + `_get_mosaic_channel_split_per_day` + FIX `_aggregate_daily_series` double-count + fix `_sales_row_metrics` + fix `_build_comparisons` + fix `export_sales_dashboard_detail` | 14 | 18 |
+| Phase 4 | Verification + data audit + PR + closeout + rollback runbook | 8 | 11 |
+| **Total** | | **42** | **55** |
+
+---
+
+## Phase Table
+
+### Phase 0 — Branch setup + baseline audit (3 units)
+
+**Goal:** Establish the ground-truth baseline for March 2026 FoodPanda so we can verify the fix. If Mosaic + legacy don't reconcile reasonably, we have a data quality issue to investigate BEFORE changing code.
+
+| # | Task | MUST_MODIFY / Evidence |
+|---|---|---|
+| 0.1 | Create branch (see boot sequence) | `git branch --show-current` = `s191-foodpanda-unified-source` |
+| 0.2 | Record base SHA in `output/s191/BASELINE.md` | File exists |
+| 0.3 | **Run baseline audit SQL.** Query Supabase via `_supabase_query_sql` (or direct boto3 SSM if running locally): for each (location_id, business_date) in Feb-April 2026, compute legacy FP gross, Mosaic FP gross, overlap flag, and per-store first-Mosaic-day / last-legacy-day. Write results to `output/s191/baseline_audit.csv`. Also write a summary `output/s191/BASELINE_SUMMARY.md` with: total stores, total overlap-days, total GROSS variance (sum of abs(mosaic_gross - legacy_gross) on overlap days), total NET variance (same for net — expected to be higher due to `subtotal/1.12` approximation), per-store transition pattern. **HARD BLOCKER 0-1 (AMENDED v2):** Measure variance on GROSS only (not net) — legacy net is `subtotal/1.12` which systematically differs from Mosaic's exact VAT by up to 8%. If total GROSS overlap variance > ₱2M OR any single-store single-day GROSS variance > ₱150K (raised from ₱50K to account for high-volume stores like Trinoma/SM North), STOP and surface to user. If NET variance is 5-10% higher than GROSS variance, that's the VAT methodology gap — document it, proceed. | `output/s191/baseline_audit.csv` exists with ≥100 rows; `output/s191/BASELINE_SUMMARY.md` has 8 metrics (6 original + gross-vs-net variance split) |
+| 0.4 | **[AMENDED v2 — audit fix B-6] Dedup check on `foodpanda_orders.order_id`.** Query: `SELECT order_id, COUNT(*) AS dupes FROM public.foodpanda_orders WHERE LOWER(order_status) = 'delivered' AND business_date BETWEEN '2026-02-01' AND '2026-03-31' GROUP BY order_id HAVING COUNT(*) > 1 LIMIT 100`. Write result count + sample to `output/s191/baseline_dedup_check.md`. **HARD BLOCKER 0-2:** If >10 duplicate `order_id` rows found, the FULL OUTER JOIN's legacy CTE MUST use `SELECT DISTINCT ON (order_id) ... ORDER BY order_id, synced_at DESC` subquery before the SUM aggregation. This prevents phantom revenue. If 0 duplicates: proceed with straight SUM, document the check result. | `output/s191/baseline_dedup_check.md` exists; if dupes found, Phase 1.1 SQL includes `DISTINCT ON (order_id)` |
+| 0.5 | **[AMENDED v2 — audit fix B-4/B-10] Caller inventory.** `grep -n "foodpanda_vat_deducted_sales\|foodpanda_subtotal\|_get_mosaic_channel_split\|_get_mosaic_channel_split_per_day\|_get_store_channel_split_map" hrms/api/sales_dashboard.py` and write every call site to `output/s191/foodpanda_call_sites_audit.md`. Explicitly enumerate: `_aggregate_daily_series` (line ~2061), `_sales_row_metrics` (line ~2644), `_build_comparisons` (via `_aggregate_sales`), `export_sales_dashboard_detail` (line ~3261), `_apply_mosaic_channel_split` (line 910), `_build_dashboard_overview_payload`. **HARD BLOCKER 0-3:** If the inventory finds a call site NOT covered in Phase 2 or Phase 3 tasks, STOP and add it to scope. This caller inventory is the freeze-list — every site must be addressed. | `output/s191/foodpanda_call_sites_audit.md` exists with ≥6 call sites enumerated; cross-referenced to Phase 2/3 tasks |
+
+**HARD BLOCKER 0-1 (AMENDED v2):** Do not proceed to Phase 1 until the baseline audit confirms: (a) total March FoodPanda GROSS is ≥ ₱20M when unioned (legacy ₱21.7M gross + Mosaic ₱4.7M with overlap dedup → expected ~₱21.7M unified), (b) GROSS overlap variance is reasonable (<₱2M total across all stores, <₱150K single-store-day), (c) dedup check in Task 0.4 shows either zero dupes OR the SQL has been amended with `DISTINCT ON (order_id)`, (d) caller inventory in Task 0.5 matches the Phase 2/3 scope exactly. If ANY fails, surface to user with the numbers and stop.
+
+### Phase 1 — Unified helper `_get_unified_foodpanda_totals` (6 units)
+
+**Goal:** Build a single reusable helper that returns unified FoodPanda totals per (store, day). All three consumer functions will call this.
+
+| # | Task | MUST_MODIFY / Evidence |
+|---|---|---|
+| 1.1 | **Create `_get_unified_foodpanda_totals(start_day, end_day, location_ids)`** in `hrms/api/sales_dashboard.py` — place it immediately after `_get_mosaic_channel_split` (around line 908). Returns `dict[int, dict[str, dict]]` keyed by `location_id` → `business_date_isoformat` → `{"gross": float, "net_wo_vat": float, "orders": int, "source": str}`. **[AMENDED v2 — audit fix B-2]** The return shape is NESTED DICT by design — but it is for INTERNAL use by the helpers that consume it. The consumers (`_get_store_channel_split_map`, `_get_mosaic_channel_split_per_day`) must CONVERT to their existing float-per-channel shape before exposing to callers. See Phase 3 tasks for the conversion rules. Uses the FULL OUTER JOIN SQL from the Design Rationale section. **[AMENDED v2 — audit fix B-6]** If Task 0.4 found `order_id` dupes, the legacy CTE must use `SELECT DISTINCT ON (order_id) ... FROM public.foodpanda_orders WHERE ... ORDER BY order_id, synced_at DESC` wrapped in a subquery before the SUM. **[AMENDED v2 — audit fix B-12]** Add per-(store,day) completeness guard: if both Mosaic and legacy have rows for the same (store, day), pick Mosaic ONLY WHEN `mosaic_orders >= legacy_orders * 0.5 OR mosaic_gross >= legacy_gross * 0.5`. Otherwise, prefer legacy (interpret as Mosaic had a partial sync). Emit `source = 'mosaic'`, `'legacy'`, or `'legacy_partial_mosaic'` accordingly. Wrapped in `_cache_get_or_set` with 300s TTL and cache key `_sales_dashboard_cache_key("fp_unified_v2", location_ids, start_day=start_day, end_day=end_day)`. **HARD BLOCKER 1-1:** The cache key prefix MUST be `"fp_unified_v2"` (not `"foodpanda"` or `"fp_unified"`) to invalidate both the old Mosaic-only cache AND any pre-completeness-guard cache post-deploy. | `grep -c "_get_unified_foodpanda_totals" hrms/api/sales_dashboard.py` ≥ 1; `grep -c "FULL OUTER JOIN" hrms/api/sales_dashboard.py` ≥ 1; `grep -c "fp_unified_v2" hrms/api/sales_dashboard.py` ≥ 1; `grep -c "legacy_partial_mosaic" hrms/api/sales_dashboard.py` ≥ 1 |
+| 1.2 | **[AMENDED v2 — audit fix B-8] Add PostgREST fallback inside `_get_unified_foodpanda_totals` with explicit implementation.** On `SupabaseMgmtTokenMissing`: (a) Mosaic fetch via `_supabase_get_all("v_pos_orders_live", params=[("select", "location_id,business_date,gross_sales,net_sales"), ("channel", "eq.FoodPanda"), ("payment_status", "eq.PAID"), ("business_date", f"gte.{start_day.isoformat()}"), ("business_date", f"lte.{end_day.isoformat()}"), ("location_id", f"in.({_location_scope_key(location_ids)})")], page_size=5000)`. (b) Legacy fetch via `_supabase_get_all("foodpanda_orders", params=[("select", "order_id,location_id,business_date,subtotal,synced_at"), ("order_status", "ilike.delivered")` — **IMPORTANT: PostgREST does NOT support `LOWER()` in filters. Use `ilike.delivered` (case-insensitive) NOT `eq.delivered` — legacy data has mixed case**`, ("business_date", f"gte.{start_day.isoformat()}"), ("business_date", f"lte.{end_day.isoformat()}"), ("location_id", f"in.({_location_scope_key(location_ids)})")], page_size=5000)`. (c) Python merge implementing FULL OUTER JOIN semantics with Mosaic-wins-on-overlap + completeness guard (same logic as SQL). (d) Python dedup if Task 0.4 flagged dupes: keep row with latest `synced_at` per `order_id`. Log `frappe.log_error("Sales Dashboard perf degraded: SUPABASE_MGMT_TOKEN missing; FP unified fallback", "Sales Dashboard perf fallback")`. **HARD BLOCKER 1-2:** For 60+ day windows (e.g., Feb 1 – Apr 14), the PostgREST fallback may exceed 10s. Add a sentinel check: `if (end_day - start_day).days > 45 and not MGMT_TOKEN: raise RuntimeError("FP unified: Mgmt API required for ranges > 45 days")`. | `grep -c "SupabaseMgmtTokenMissing" hrms/api/sales_dashboard.py` in FP section ≥ 1; `grep -c "ilike.delivered" hrms/api/sales_dashboard.py` ≥ 1 |
+| 1.3 | **Add `_get_unified_foodpanda_totals_aggregate(start_day, end_day, location_ids)`** — sibling helper returning a single aggregated bucket `{"gross": float, "net_wo_vat": float, "orders": int}` summed across all stores and days. This is what `_apply_mosaic_channel_split` needs for the headline. Implemented as a trivial wrapper over `_get_unified_foodpanda_totals`. | `grep -c "_get_unified_foodpanda_totals_aggregate" hrms/api/sales_dashboard.py` ≥ 1 |
+| 1.4 | **Python parse check.** `python -c "import ast; ast.parse(open('hrms/api/sales_dashboard.py').read())"` → PARSE OK. | Parse clean |
+
+**HARD BLOCKER 1-1:** Cache key prefix change is non-negotiable. Using `"fp_unified"` (not `"foodpanda"` or `"mosaic_split"`) ensures any cached bucket from the old Mosaic-only logic is bypassed post-deploy. Without this, users hit stale cached results for up to 300s after deploy and the fix appears to not work.
+
+**HARD BLOCKER 1-2:** Do NOT touch GrabFood logic. `_get_mosaic_channel_split` will continue to return the correct Mosaic-only GrabFood bucket. Only the FoodPanda bucket is overridden by `_get_unified_foodpanda_totals_aggregate`. (Source: CEO directive 2026-04-14 — "ignore Grabfood")
+
+### Phase 2 — Wire into `_get_mosaic_channel_split` + fix `_apply_mosaic_channel_split` (6 units)
+
+**Goal:** The headline Channel Mix donut on the main Sales Analytics page now shows correct March FoodPanda (~₱21.7M not ₱4.4M).
+
+| # | Task | MUST_MODIFY / Evidence |
+|---|---|---|
+| 2.1 | **Modify `_apply_mosaic_channel_split`** (line 910+): after the line `split = _get_mosaic_channel_split(start_day, end_day, location_ids)`, add: `fp_unified = _get_unified_foodpanda_totals_aggregate(start_day, end_day, location_ids)`. Then **REPLACE** the existing line `fp_bucket = split.pop("foodpanda", {"gross": 0.0, "net_wo_vat": 0.0, "orders": 0})` at line 948 with: `split.pop("foodpanda", None)  # discard Mosaic-only FP — now using unified source` on one line, then `fp_bucket = fp_unified` on the next line. The `split.pop("foodpanda", None)` call is MANDATORY — it removes the Mosaic FP from `split` so the "other" rollup at line 952-954 doesn't accidentally include it. **[AMENDED v2 — audit fix B-3] HARD BLOCKER 2-2:** The verification script MUST assert that `fp_bucket = split.pop("foodpanda"` pattern is GONE (replaced with `split.pop("foodpanda", None)` + `fp_bucket = fp_unified`). If the agent leaves the old `fp_bucket = split.pop(...)` line AND adds the new `fp_bucket = fp_unified` after it, the old assignment is overwritten but the READER would be confused — worse, if the new line comes FIRST, the old assignment silently reverts the fix. The verify script checks: `grep -c "fp_bucket = split.pop" hrms/api/sales_dashboard.py` MUST be 0 AND `grep -c "fp_bucket = fp_unified" hrms/api/sales_dashboard.py` MUST be 1. | `grep -c "_get_unified_foodpanda_totals_aggregate" hrms/api/sales_dashboard.py` in `_apply_mosaic_channel_split` section ≥ 1; `grep -c "fp_bucket = split.pop" hrms/api/sales_dashboard.py` == 0; `grep -c "fp_bucket = fp_unified" hrms/api/sales_dashboard.py` ≥ 1 |
+| 2.2 | **Keep GrabFood bucket untouched.** Line 949: `gf_bucket = split.pop("grabfood", ...)` stays as-is. Do NOT introduce any unified GrabFood logic. **HARD BLOCKER 2-1:** If the diff shows any change to `gf_bucket`, `grabfood_sales`, `grabfood_orders`, or `grabfood_avg_ticket`, revert it immediately. (Source: CEO directive 2026-04-14) | `git diff hrms/api/sales_dashboard.py \| grep -c "grabfood"` in diff = 0 for code changes (comments OK) |
+| 2.3 | **Keep `summary["foodpanda_orders"]` aligned with `fp_bucket["orders"]`.** Line 962 already does `summary["foodpanda_orders"] = fp_bucket["orders"]`. After task 2.1, `fp_bucket["orders"]` now reflects unified count. Verify no other code assumes `foodpanda_orders` is Mosaic-only. | `grep -n "foodpanda_orders" hrms/api/sales_dashboard.py` reviewed; no stale assumption |
+| 2.4 | **Update the deprecation comment on `_FOODPANDA_MOSAIC_START`.** At line 31, change the comment to: `# S191 2026-04-14: DEPRECATED as cutover date. Per-(store,day) FULL OUTER JOIN in _get_unified_foodpanda_totals replaces global date. Constant retained ONLY for the freshness warning at line ~1296 that tells users about the historical source split.` | `grep -c "DEPRECATED" hrms/api/sales_dashboard.py` near line 31 ≥ 1 |
+| 2.5 | **[AMENDED v2 — audit fix B-5] Bump outer cache key prefixes to force invalidation post-deploy.** In `_build_dashboard_overview_payload` (~line 2839), change the cache key prefix from `"overview"` to `"overview_s191"`. Similarly find any other outer cache key prefixes that wrap the summary/channel-split result (search `_sales_dashboard_cache_key\("(overview\|summary\|channel_mix\|rankings\|export)` in sales_dashboard.py). For EACH outer prefix that wraps FP-related data, append `_s191`. This ensures users do NOT see stale pre-fix cached results for up to 300s after deploy. Precedent: S176 DD-21 used `"freshness_v2"` for exactly this reason at line ~743. List all changed prefixes in `output/s191/cache_prefix_changes.md`. | `grep -c "overview_s191" hrms/api/sales_dashboard.py` ≥ 1; `output/s191/cache_prefix_changes.md` lists all prefix bumps |
+| 2.6 | **Python parse + smoke test locally.** Start `/local-frappe`, call `get_sales_dashboard_overview` with `start_date=2026-03-01, end_date=2026-03-31`, inspect `response["summary"]["foodpanda_sales_without_vat"]`. **[AMENDED v2 — audit fix B-7] MUST be ≥ ₱18M (net, not gross). Note: the dashboard displays `foodpanda_sales_without_vat` which is the NET (VAT-deducted) amount. Legacy March gross was ₱21.7M; net ≈ `21.7M / 1.12` = ₱19.4M. With the completeness guard possibly picking legacy over partial Mosaic for some overlap days, the final net lands ~₱18-19.4M.** Also inspect `response["summary"]["foodpanda_orders"]` — MUST be ≥ 30,000 (legacy had 34,337). Write result to `output/s191/phase2_local_smoke.json`. | `output/s191/phase2_local_smoke.json` exists; foodpanda_sales_without_vat ≥ 18000000; foodpanda_orders ≥ 30000 |
+
+### Phase 3 — Wire into `_get_store_channel_split_map` + `_get_mosaic_channel_split_per_day` (7 units)
+
+**Goal:** Per-store Channel Mix on Store Leaderboard + Store Detail Dialog shows correct FP totals. Daily time-series chart shows correct FP totals.
+
+| # | Task | MUST_MODIFY / Evidence |
+|---|---|---|
+| 3.1 | **Read `_get_store_channel_split_map`** (line 1049+) to understand the per-store return shape: `dict[location_id, dict[channel_key, {"gross", "net_wo_vat", "orders"}]]`. | Mental model |
+| 3.2 | **[AMENDED v2 — audit fix B-2] Read `_get_store_channel_split_map` return shape CAREFULLY** (lines ~1109-1122). Current shape is `dict[int, dict[str, float]]` — each channel key maps to a single `float` (gross), NOT a nested `{gross, net_wo_vat, orders}` dict. The consumer at line 2502 does `float(mosaic.get("foodpanda", 0.0))` — putting a dict there silently corrupts the FP number in the leaderboard channel_mix. **Modify the function** to preserve the existing float-per-channel shape: after the Mosaic-only SQL, call `fp_unified_by_store = _get_unified_foodpanda_totals(start_day, end_day, location_ids)`. For each `location_id`, sum all its business_date entries to get `total_gross` (single float). Then **override** `result[location_id]["foodpanda"]` with `total_gross` (keeping the float shape). Stores not in `fp_unified_by_store` get `0.0`. If the caller needs `net_wo_vat` or `orders`, create a PARALLEL per-store map (e.g., `_get_unified_foodpanda_per_store_full`) returning the nested dict — but do NOT change the existing function's return type. | `grep -c "_get_unified_foodpanda_totals" hrms/api/sales_dashboard.py` ≥ 2; verify shape by reading `_get_store_channel_split_map` return statement and confirming `float` type preserved |
+| 3.3 | **Do NOT override POS, GrabFood, WebDelivery, or other_mosaic per-store buckets.** These stay Mosaic-only. **HARD BLOCKER 3-1:** Only `result[location_id]["foodpanda"]` is overridden. | Diff reviewed: only foodpanda key overridden |
+| 3.4 | **Read `_get_mosaic_channel_split_per_day`** (line 1962+) to understand the daily return shape. **[AMENDED v2 — audit fix B-2]** Per audit finding: the return is `dict[date_iso, dict[channel_key, float]]` (float, NOT nested dict). Same care as Task 3.2. | Mental model |
+| 3.5 | **[AMENDED v2 — audit fix B-2] Modify `_get_mosaic_channel_split_per_day`** preserving the existing float-per-channel return shape. After the Mosaic-only SQL, call `fp_unified = _get_unified_foodpanda_totals(start_day, end_day, location_ids)`. Aggregate across all stores per day: `fp_by_day: dict[date_iso, float]` where the float is gross sum. For each day in the return dict, **override** `result[date_iso]["foodpanda"]` with `fp_by_day.get(date_iso, 0.0)` (float, not dict). | `grep -c "_get_unified_foodpanda_totals" hrms/api/sales_dashboard.py` ≥ 3 |
+| 3.6 | **[AMENDED v2 — audit fix B-1 / F-01] CRITICAL: Fix `_aggregate_daily_series` double-count at line ~2061.** After Phase 3.5 fixes `_get_mosaic_channel_split_per_day` to return UNIFIED FP data (including pre-cutover legacy), the existing code at line 2061 — `superadmin_delivery_wo_vat += _to_float(row.get("foodpanda_vat_deducted_sales"))` — adds the MV's legacy FP on TOP of the already-included unified FP. Result: Feb/March delivery totals DOUBLE-COUNTED by ~₱17M. **REMOVE the `+ _to_float(row.get("foodpanda_vat_deducted_sales"))` term** from the `superadmin_delivery_wo_vat` accumulator at line 2061. Replace with a comment: `# S191: legacy foodpanda_vat_deducted_sales no longer added here — unified FP totals from _get_mosaic_channel_split_per_day already include legacy.` | `grep -c "foodpanda_vat_deducted_sales" hrms/api/sales_dashboard.py` count REDUCES by 1 vs baseline; comment `S191.*unified FP totals` present near line 2061 |
+| 3.7 | **[AMENDED v2 — audit fix B-10 / F-09] Fix `_sales_row_metrics` at line ~2644.** This helper uses `foodpanda_vat_deducted_sales` from MV rows. Since `_sales_row_metrics` feeds store-detail delivery panels via the MV (not via `_get_unified_foodpanda_totals`), leaving it unchanged creates inconsistency with the unified Channel Mix. **Modify `_sales_row_metrics`** to call `_get_unified_foodpanda_totals` for the (location_id, business_date) of its input row and override `foodpanda_vat_deducted_sales` with the unified `net_wo_vat` (or 0 if no unified data). If per-row calls are too expensive, cache the unified map at the caller level and pass it in. Document the chosen approach in the function docstring. | `grep -c "_get_unified_foodpanda_totals" hrms/api/sales_dashboard.py` ≥ 4 (Task 3.2, 3.5, 3.7 + helpers) |
+| 3.8 | **[AMENDED v2 — audit fix B-11 / F-08] Fix `_build_comparisons` to use unified FP for baseline periods.** Currently calls `_aggregate_sales(prev_rows)` on MV-only rows (no unified FP). Result: current-period FP shows unified ~₱21.7M March, while comparison baseline (Feb) shows MV-only FP → apples-to-oranges delta. **Modify `_build_comparisons`** (line ~1760): after the `_aggregate_sales(prev_rows)` call, call `prev_fp_unified = _get_unified_foodpanda_totals_aggregate(prev_start, prev_end, location_ids)`. **Override** `prev["foodpanda_sales"]` with `prev_fp_unified["gross"]` and `prev["foodpanda_sales_without_vat"]` with `prev_fp_unified["net_wo_vat"]`. Also recompute `prev["total_gross_sales"]` and `prev["total_net_sales_without_vat"]` to reflect the corrected FP (subtract the old MV FP, add unified FP). Do same for `last_year` baseline. | `grep -c "_get_unified_foodpanda_totals_aggregate" hrms/api/sales_dashboard.py` ≥ 2 (Phase 2.1 + Task 3.8) |
+| 3.9 | **[AMENDED v2 — audit fix B-4 / F-03] Fix `export_sales_dashboard_detail` CSV export at line ~3261.** This endpoint calls `_get_mosaic_channel_split_per_day` and `_aggregate_daily_series`. After Tasks 3.5 + 3.6, the export automatically picks up unified FP with no double-count. **Verify** by reading the endpoint body: confirm no inline FP aggregation that bypasses the fixed helpers. If inline FP SQL exists (unlikely but possible), refactor to use `_get_unified_foodpanda_totals`. Add an L3 scenario (L3-191-13 below) that downloads the CSV for March and asserts the FoodPanda column sum is ≥ ₱18M. | Endpoint body read; no inline FP SQL; L3-191-13 added to the L3 table |
+| 3.10 | **Verify no other FoodPanda aggregation path exists.** `grep -n "channel.*FoodPanda\|foodpanda_orders\|foodpanda_vat_deducted_sales\|foodpanda_subtotal" hrms/api/sales_dashboard.py` — every hit must either be: (a) the new unified helper, (b) a DELIBERATELY preserved MV reference for audit/freshness purposes, or (c) the deprecated `_FOODPANDA_MOSAIC_START` warning text. No stale Mosaic-only FP queries allowed. Cross-reference against `output/s191/foodpanda_call_sites_audit.md` from Task 0.5. Append `output/s191/foodpanda_call_sites_audit_POST_FIX.md` showing every call site's resolution. | `output/s191/foodpanda_call_sites_audit_POST_FIX.md` exists; every call site from Task 0.5 is accounted for |
+| 3.11 | **Python parse check.** `ast.parse` → OK. | Parse clean |
+
+**HARD BLOCKER 3-1:** Only the `foodpanda` key is overridden in all three functions. POS/GrabFood/WebDelivery/other_mosaic/web_non_cod/web_cod all stay exactly as before. If the diff shows changes to any non-FoodPanda channel key, revert.
+
+### Phase 4 — Verification + data audit + PR + closeout (6 units)
+
+| # | Task | MUST_MODIFY / Evidence |
+|---|---|---|
+| 4.1 | **[AMENDED v2 — all audit fixes] Verification script.** Create `output/s191/verify_s191.py` with grep + AST assertions for ALL Phase 1-3 patterns, including: (a) `fp_bucket = split.pop` count == 0 (Task 2.1), (b) `fp_bucket = fp_unified` count == 1, (c) `fp_unified_v2` cache prefix (Task 1.1), (d) `overview_s191` outer cache prefix (Task 2.5), (e) `ilike.delivered` for PostgREST fallback (Task 1.2), (f) `legacy_partial_mosaic` completeness guard marker (Task 1.1), (g) `_get_unified_foodpanda_totals` called ≥ 4 times (Tasks 3.2, 3.5, 3.7 + helpers), (h) `_get_unified_foodpanda_totals_aggregate` called ≥ 2 times (Phase 2.1 + Task 3.8), (i) `foodpanda_vat_deducted_sales` count REDUCED by 1 vs baseline (Task 3.6 removed one call site), (j) Sentry `set_backend_observability_context` count UNCHANGED at 5 (pre-S191 baseline — amended from original "≥ 4"), (k) GrabFood anti-regression: `grep -c grabfood hrms/api/sales_dashboard.py` MUST EQUAL 28 (pre-S191 count — audit confirmed exact number). Also include a post-deploy data probe (commented example) showing how to hit the staged endpoint and confirm March FP ≥ ₱18M NET. Run → PASS. | File exists, exits 0; all 11 assertion categories encoded |
+| 4.2 | **Re-run baseline audit SQL post-fix (local):** confirm March FP unified ≈ legacy (₱21.7M GROSS) on pre-cutover days + Mosaic (₱4.7M) on post-cutover days, with no double-count in the overlap window. Also confirm `_aggregate_daily_series` total delivery for Feb/March is NOT inflated by ₱17M (Task 3.6 fix verified). Write `output/s191/post_fix_reconciliation.md` comparing pre-fix vs post-fix numbers across: headline summary, per-store map, per-day series, daily series delivery total, CSV export. | Reconciliation file exists with 5-way before/after comparison |
+| 4.3 | **[AMENDED v2 — audit fix F-12] Write rollback runbook.** `output/s191/ROLLBACK_RUNBOOK.md` documents: (a) `GH_TOKEN="" gh pr merge --undo` or revert commit + redeploy steps, (b) cache invalidation: even on rollback, the new `overview_s191` / `fp_unified_v2` cache keys will naturally expire in 300s and new writes use old `overview` prefix again, (c) no schema changes to undo, (d) success criterion: March FP back to ₱4.4M (Mosaic-only pre-S191 value) within 5 min of rollback deploy. | `output/s191/ROLLBACK_RUNBOOK.md` exists with 4 named sections |
+| 4.4 | **[AMENDED v2 — audit fix F-10] Pre-deploy notification to Sam.** Write `output/s191/SAM_PRE_DEPLOY_NOTICE.md` explicitly stating: "After S191 deploys, Feb 2026 FP goes from ₱0 → ~₱8.5M net, March FP goes from ₱4.4M → ~₱19.4M net. Downstream reports (Apex P&L, board decks, commission calcs) that used the old numbers will show new numbers. This is visibility restoration, not revenue fabrication. If any scheduled report needs the old number, pull it from `output/s191/post_fix_reconciliation.md` before the deploy day." Surface to Sam in the PR description. | `output/s191/SAM_PRE_DEPLOY_NOTICE.md` exists; linked in PR description |
+| 4.5 | **Push branch, create PR.** hrms → production. `GH_TOKEN=""` prefix. PR title: `fix(S191): unified FoodPanda source — recover ₱17M+ pre-cutover March sales`. PR body includes links to baseline_audit, post_fix_reconciliation, rollback_runbook, sam_pre_deploy_notice. | PR number recorded |
+| 4.6 | **Update plan YAML** to `status: DEPLOYED` + update `SPRINT_REGISTRY.md` with PR number. `git add -f docs/plans/`. | Plan + registry updated |
+| 4.7 | **Generate L3 handoff prompt** with the specific assertions listed below (L3 Workflow Scenarios table now has 13 scenarios including CSV export). L3 runs in a fresh session after deploy. Explicitly note: **wait ≥ 5 minutes after deploy before running L3** to allow any pre-deploy cached responses to expire (audit fix W-2). | Handoff prompt output with ≥5 min wait note |
+| 4.8 | **Verify Sentry instrumentation on existing endpoints is still present AND unchanged in count.** **[AMENDED v2 — audit fix W-3]** `grep -c "set_backend_observability_context" hrms/api/sales_dashboard.py` MUST EQUAL 5 (pre-S191 baseline — amended from original "≥ 4"). No new instrumentation required since no new `@frappe.whitelist()` endpoints are introduced. If count changes, Sentry context was accidentally added/removed — revert. | `grep -c "set_backend_observability_context" hrms/api/sales_dashboard.py` == 5 |
+
+---
+
+## Zero-Skip Enforcement
+
+Every task in the phase table MUST be implemented. The agent is FORBIDDEN from:
+- Skipping a task silently
+- Marking partial work as "done"
+- Replacing a task with a simpler version without user approval
+- Saying "deferred to next sprint"
+- Implementing happy path only, skipping edge cases (e.g., stores with only legacy data, stores with only Mosaic data, stores with both — all three cases must be tested)
+- Combining tasks and dropping features
+- **Touching GrabFood logic** (CEO directive — GrabFood is explicitly out of scope)
+- **Introducing frontend changes** (backend-only sprint)
+
+**Phase Completion Checklist:** After each phase, write `output/s191/phase_N_completion.md` with task-by-task status. If any task is skipped/partial, STOP and notify user.
+
+### Verification Script (MANDATORY)
+
+Create `output/s191/verify_s191.py`. Runs after every phase AND at closeout. PR cannot be created until PASS.
+
+The script checks:
+- Phase 1 patterns: `_get_unified_foodpanda_totals`, `_get_unified_foodpanda_totals_aggregate`, `FULL OUTER JOIN`, `fp_unified`, cache key prefix `fp_unified`, fallback path for `SupabaseMgmtTokenMissing`
+- Phase 2 patterns: `_get_unified_foodpanda_totals_aggregate` called in `_apply_mosaic_channel_split`; `DEPRECATED` comment on `_FOODPANDA_MOSAIC_START`
+- Phase 3 patterns: `_get_unified_foodpanda_totals` called in BOTH `_get_store_channel_split_map` AND `_get_mosaic_channel_split_per_day`
+- Anti-regression: `grep -c "grabfood" hrms/api/sales_dashboard.py` unchanged (count must equal pre-S191 count)
+- Protected surfaces: no workflow files modified, no frontend files modified
+- Python AST parses cleanly
+
+---
+
+## L3 Workflow Scenarios
+
+| ID | User | Action | Expected Outcome | Failure Means |
+|---|---|---|---|---|
+| L3-191-01 | sam@bebang.ph | Load Sales Analytics with date range 2026-03-01 to 2026-03-31 | Channel Mix donut shows FoodPanda ≥ **₱18M net** (dashboard shows net_without_vat; legacy gross ₱21.7M ÷ 1.12 ≈ ₱19.4M; completeness-guard edge cases → floor at ₱18M). NOT ₱4.4M (pre-fix). | Unified source not wired to headline |
+| L3-191-02 | sam@bebang.ph | Same 1-month range, check FoodPanda order count | Orders shown ≥ 30,000 (legacy had 34,337; completeness guard may exclude a few cutover days) | Orders field not using unified |
+| L3-191-03 | sam@bebang.ph | Load Sales Analytics with date range 2026-02-01 to 2026-02-28 | Channel Mix donut shows FoodPanda ≥ **₱8M net** (legacy gross ₱9.5M ÷ 1.12 ≈ ₱8.5M net) | Feb legacy data dropped |
+| L3-191-04 | sam@bebang.ph | Load Sales Analytics with date range 2026-04-01 to 2026-04-12 | FoodPanda matches Mosaic-only (~₱9.5M net), NO double-count (Apr legacy is frozen ₱0) | Post-cutover double-count regression |
+| L3-191-05 | sam@bebang.ph | Load Store Leaderboard, 2026-03-01 to 2026-03-31 | Per-store FoodPanda column sum across all stores ≥ **₱18M net** | Per-store helper not wired |
+| L3-191-06 | sam@bebang.ph | Open any store's detail dialog, 2026-03-01 to 2026-03-31 | FoodPanda sales on the dialog match the leaderboard cell for that store (consistency check — no dict-vs-float shape regression) | Per-store inconsistency / return-shape corruption |
+| L3-191-07 | sam@bebang.ph | Daily time-series chart, 2026-03-01 to 2026-03-31 | FoodPanda daily line is non-zero for dates before Mar 27 (pre-cutover days). **Total delivery line is NOT inflated by ₱17M vs pre-fix** (Task 3.6 double-count fix verified) | Per-day helper not wired OR daily-series double-count |
+| L3-191-08 | sam@bebang.ph | Daily time-series chart, 2026-03-25 to 2026-03-31 (overlap zone) | No FoodPanda spike indicating double-count — daily values reasonable (~₱500K-₱1.5M/day) | Mosaic-preferred overlap logic broken OR completeness guard inverted |
+| L3-191-09 | sam@bebang.ph | Check GrabFood Channel Mix bucket for 2026-03-01 to 2026-03-31 | Still ₱0 (unchanged from before — CEO said leave GrabFood alone) | GrabFood regression (should NOT have changed) |
+| L3-191-10 | sam@bebang.ph | Check Pickup (POS) Channel Mix bucket, any date range | Unchanged from pre-S191 values | POS regression |
+| L3-191-11 | sam@bebang.ph | Product Analytics page, 2026-03-01 to 2026-03-31 | Products fetched OK (this sprint does not touch product analytics; regression check only) | Unintended coupling broken |
+| L3-191-12 | sam@bebang.ph | Sales Analytics with 2026-03-25 to 2026-04-05 (spans overlap + both sides) | Total FoodPanda ≥ ₱8M net, daily series smooth across cutover — no cliff, no spike | Union logic broken at overlap |
+| **L3-191-13** | **sam@bebang.ph** | **[AMENDED v2 — audit fix B-4] Click "Export CSV" on Store Leaderboard, 2026-03-01 to 2026-03-31** | **Downloaded CSV's FoodPanda column sum across all rows ≥ ₱18M net. NOT ₱4.4M.** | **`export_sales_dashboard_detail` not wired to unified FP** |
+| **L3-191-14** | **sam@bebang.ph** | **[AMENDED v2 — audit fix B-11] Sales Analytics with 2026-03-01 to 2026-03-31 — check comparison panel (vs prior period / vs last year)** | **Comparison baseline uses unified FP. Feb baseline shows ~₱8M FP (not ₱0). Period-over-period delta is consistent apples-to-apples.** | **`_build_comparisons` not using unified FP — apples-to-oranges** |
+| **L3-191-15** | **sam@bebang.ph** | **[AMENDED v2 — audit fix B-10] Open any store's detail dialog (uses `_sales_row_metrics`) for 2026-02-15** | **FoodPanda delivery number on the per-day panel matches the unified FP for that (store, day). Not 0, not MV-only.** | **`_sales_row_metrics` not using unified FP** |
+
+**[AMENDED v2 — audit fix W-2] POST-DEPLOY WAIT NOTE:** L3 MUST begin at least 5 minutes after the deploy completes. Outer cache keys were bumped (Task 2.5) but any in-flight cached responses from BEFORE the deploy can still serve until their 300s TTL expires. Running L3 immediately post-deploy can surface false FAILs from stale cache.
+
+**Evidence files required before closeout (per S092 rule):**
+- `output/l3/s191/form_submissions.json` (empty array — no form submissions in this sprint, all page loads)
+- `output/l3/s191/api_mutations.json` (empty array — read-only)
+- `output/l3/s191/state_verification.json` (contains the 12 scenarios above with pass/fail + the actual ₱ amounts read from API responses)
+- `output/l3/s191/screenshots/` (one screenshot per scenario showing the actual dashboard state)
+
+---
+
+## Autonomous Execution Contract
+
+- **completion_condition:**
+  - All 5 phases marked DONE in `output/s191/phase_N_completion.md`
+  - `output/s191/verify_s191.py` exits 0
+  - `output/s191/BASELINE_SUMMARY.md` shows overlap variance within acceptable bounds (HARD BLOCKER 0-1)
+  - `output/s191/post_fix_reconciliation.md` confirms March FP ≥ ₱20M post-fix
+  - 1 PR created (hrms only — no frontend, no bei-tasks PR)
+  - Plan YAML updated to DEPLOYED, SPRINT_REGISTRY.md updated with PR number
+- **stop_only_for:**
+  - Missing credentials/access
+  - HARD BLOCKER 0-1 triggered (overlap variance > ₱1M or single-store single-day variance > ₱50K) — surface to user
+  - Direct conflict on `sales_dashboard.py` with a newer sprint
+  - Repeated (3x) technical failure with no progress after grounded research
+  - Baseline audit reveals that March FP unified total is < ₱15M OR > ₱35M — data integrity issue, surface to user before shipping
+- **continue_without_pause_through:** `execute → pr_creation → closeout`
+- **blocker_policy:**
+  - programmatic → fix and continue
+  - repeated failure x3 → grounded research, continue
+  - business-data/policy → pause
+  - verify_s191.py FAIL → fix and re-run immediately
+- **signoff_authority:** single-owner (sam@bebang.ph)
+- **canonical_closeout_artifacts:**
+  - `output/s191/BASELINE.md` — base SHA
+  - `output/s191/BASELINE_SUMMARY.md` — pre-fix audit summary (8 metrics incl. gross-vs-net variance split)
+  - `output/s191/baseline_audit.csv` — per-(store,day) source audit
+  - `output/s191/baseline_dedup_check.md` — **[v2]** `order_id` dedup result (Task 0.4)
+  - `output/s191/foodpanda_call_sites_audit.md` — **[v2]** Task 0.5 pre-fix caller inventory
+  - `output/s191/foodpanda_call_sites_audit_POST_FIX.md` — **[v2]** Task 3.10 post-fix caller resolution
+  - `output/s191/cache_prefix_changes.md` — **[v2]** Task 2.5 outer cache bumps
+  - `output/s191/phase_0..4_completion.md`
+  - `output/s191/phase2_local_smoke.json` — Phase 2.6 local test (net ≥ ₱18M, orders ≥ 30K)
+  - `output/s191/post_fix_reconciliation.md` — 5-way before/after numbers (summary, per-store, per-day, daily-series delivery, CSV export)
+  - `output/s191/ROLLBACK_RUNBOOK.md` — **[v2]** Task 4.3 rollback plan
+  - `output/s191/SAM_PRE_DEPLOY_NOTICE.md` — **[v2]** Task 4.4 downstream impact notice
+  - `output/s191/verify_s191.py` + `verify_output.txt`
+  - `docs/plans/2026-04-14-sprint-191-foodpanda-unified-source.md`
+  - `docs/plans/SPRINT_REGISTRY.md`
+
+---
+
+## Ground-Truth Lock
+
+- **evidence_sources:**
+  - `hrms/api/sales_dashboard.py:825-907` — proves `_get_mosaic_channel_split` is Mosaic-only (no legacy JOIN)
+  - `hrms/api/sales_dashboard.py:948, 960-962` — proves `_apply_mosaic_channel_split` overwrites `summary["foodpanda_sales"]` with Mosaic-only bucket
+  - `hrms/api/sales_dashboard.py:31` — `_FOODPANDA_MOSAIC_START = date(2026, 3, 27)` — the broken global cutover
+  - Supabase `foodpanda_orders` schema audit 2026-04-14 — columns confirmed via `information_schema.columns` query
+  - Supabase baseline numbers 2026-04-14: legacy Feb=16,188 orders/₱9.5M, legacy Mar=34,337 orders/₱21.7M, Mosaic Mar=8,477 orders/₱4.7M, Mosaic Apr=16,583 orders/₱9.5M
+  - `sales_dashboard_daily_store_metrics` view definition proves `foodpanda_subtotal` uses legacy `foodpanda_orders` and computes net as `subtotal/1.12`
+- **count_method:**
+  - metric: monthly FoodPanda gross sales
+  - basis: per-(location_id, business_date) FULL OUTER JOIN with Mosaic-wins-on-overlap
+  - method: `_supabase_query_sql` with the SQL block in Design Rationale; PostgREST fallback with same semantics in Python
+- **authoritative_sections:** Sections "Executive Summary" through "Autonomous Execution Contract" are authoritative for execution. The Design Rationale section is authoritative for intent. Any amendment must update authoritative sections in the same edit.
+- **normalization_required:** yes
+- **unresolved_value_policy:** any operator-facing unknown must be labeled `[UNVERIFIED — requires resolution]`, never guessed
+
+---
+
+## Execution Workflow
+
+- Test Python changes locally: `/local-frappe`
+- Deploy: `/deploy-frappe` (Sam handles merge + deploy trigger — builder creates PR and stops)
+- E2E testing: `/l3-v2-bei-erp` in a fresh session after deploy
+- Full workflow: `/agent-kickoff`
+
+---
+
+## Anti-Rewind Protection
+
+- **remote_truth_baseline:** `output/s191/BASELINE.md` with backend SHA
+- **protected_surfaces:** see Surface Ownership Matrix — all non-FoodPanda channel logic, all frontend code, all other backend functions
+- **rebase rule:** before pushing, `git fetch origin production && git rebase origin/production`. Re-run `verify_s191.py`. Grep for conflict markers.
+- **supersession:** this sprint supersedes the S176 `_FOODPANDA_MOSAIC_START` global-date logic for all analytics aggregations. The constant is retained for the freshness warning only.

--- a/docs/plans/2026-04-14-sprint-193-supplier-status-guard.md
+++ b/docs/plans/2026-04-14-sprint-193-supplier-status-guard.md
@@ -1,0 +1,605 @@
+# S193 — Supplier Status Guard
+
+**v2 — 2026-04-14: Amended after audit. 6 blockers resolved (3 CRITICAL + 3 WARNING). Zero features removed. Scope unchanged: same helper, same 3 call sites, same 4 tests, same policy (B/PV block all, Inactive blocks PO only). Fixes are placement/robustness details caught by code verification against production.**
+
+- canonical_sprint_id: `S193`
+- status: PR_CREATED
+- completed_date: 2026-04-14
+- execution_summary: PR hrms#569. Helper + 3 call sites + Sentry for create_purchase_order + 5 unit tests (all pass). Phase 0a controller check confirmed DocType allows direct status set. Awaiting deploy (skip_build=false) and L3 run in fresh session.
+- created: 2026-04-14
+- owner: Sam
+- branch: `s193-supplier-status-guard` (hrms)
+- depends_on: None (standalone hardening of existing procurement flow)
+- estimated_units: ~10 (single-file backend + tests + Sentry + closeout)
+- registry_lock: `| S193 | Sprint 193 | s193-supplier-status-guard (hrms) | — | PLANNED 2026-04-14 |`
+
+## Mission
+
+Make the BEI Supplier master status (`Blacklisted`, `Pending Verification`) actually enforce procurement policy. Today these statuses are informational only — the UI shows them but the backend will still accept POs, Invoices, and Payment Requests for suppliers in those states. Add a single shared guard called from the three creation endpoints.
+
+## Why Now
+
+During the S186 supplier hub audit (2026-04-14), Sam asked whether supplier master status propagates through the PO → Invoice → Payment Request chain. Investigation confirmed:
+
+- The **Link field** (supplier → BEI Supplier) prevents free-text garbage in every DocType ✅
+- The **TIN threshold gate** (line 1491 of `procurement.py`) works for >₱250K annual spend ✅
+- **Status is NOT enforced** — `grep -n "status.*Blacklisted\|Blacklisted.*supplier"` in `hrms/api/procurement.py` returns zero meaningful hits. A supplier marked `Blacklisted` or `Pending Verification` in the master can still receive new POs, Invoices, and RFPs.
+
+This is a silent control gap. The fix is small (one guard function, three call sites) and high-leverage (closes the loop between master data hygiene and transaction authorization).
+
+## Design Rationale (For Cold-Start Agents)
+
+**Why this exists:**
+- BEI Supplier DocType has a `status` Select field with four values: `Active`, `Inactive`, `Blacklisted`, `Pending Verification` (see `hrms/hr/doctype/bei_supplier/bei_supplier.json`).
+- `Active` → normal operation.
+- `Inactive` → historical supplier, no new business. **This sprint does NOT block Inactive.** An existing PO for an Inactive supplier may still have invoices and payments processed (tail of prior relationship). Only the create-new step is considered for Inactive (see below).
+- `Blacklisted` → policy violation (fraud, failed audit, regulatory issue). **Must block all new PO/Invoice/Payment Request creation.**
+- `Pending Verification` → onboarding incomplete (e.g. missing TIN, SEC cert, bank details). **Must block all new PO/Invoice/Payment Request creation.** Once Ops completes the verification, the status flips to `Active` and flow resumes.
+
+**Why a single shared guard function, not scattered checks:**
+- DRY: three call sites (create_purchase_order, create_invoice, create_payment_request), one rule.
+- Auditable: one function name (`_assert_supplier_active`) that shows up in every call trace.
+- Future-proof: when we add a new status (e.g. `On Hold`), one place to update.
+- Testable: one function to unit test, three integration tests to verify it's called.
+
+**Key trade-off decisions:**
+1. **Block Inactive on create_purchase_order, NOT on create_invoice/create_payment_request.** The PO is the "new business" step — if a supplier is Inactive we don't want a new PO. But invoices/payments settle against POs that already exist, and those POs were approved when the supplier was Active. Blocking invoice/payment for an Inactive supplier would strand legitimate in-flight transactions. (Confirmed with Sam 2026-04-14.)
+2. **`Blacklisted` and `Pending Verification` block ALL three create endpoints.** No in-flight exception — if a supplier was wrongly approved and is now Blacklisted, we do NOT want to pay their open invoices until they're cleared. Ops can re-activate via the supplier edit approval workflow (already exists — see `submit_supplier_edit_for_approval`).
+3. **Error message uses `frappe.ValidationError` with a clear reason + next step.** Not a silent log — the frontend will surface it. Message template: `"Cannot create {doctype}: Supplier {name} is {status}. {next_step}"`.
+4. **No frontend change in this sprint.** The supplier hub grid and overview already display status badges (S186). When the backend guard fires, the frontend shows the Frappe error toast. Good enough; a dedicated inline "this supplier is blacklisted" disabled-button UX is S194+ work.
+
+**Known limitations:**
+- The guard runs at the `@frappe.whitelist()` API boundary, not as a DocType `validate` hook. This means a direct `frappe.get_doc("BEI Purchase Order", {...}).insert()` from Python/console bypasses the guard. Trade-off: simpler, no DocType override, and all legitimate creation paths go through the API. Internal scripts that bulk-insert are out of scope and owned by the operator.
+- `Inactive` is NOT blocked at invoice/payment — if Finance believes an Inactive supplier has a legitimate open invoice, they can still process it. The supplier master status is advisory for existing flow; blocking-grade only for new POs.
+
+**Source references:**
+- Status enum: `hrms/hr/doctype/bei_supplier/bei_supplier.json` — field `status`, options `Active\nInactive\nBlacklisted\nPending Verification`
+- Existing Supplier resolver: `hrms/api/procurement.py:111` (`_resolve_supplier_identity`)
+- TIN gate precedent (same pattern we're copying): `hrms/api/procurement.py:1491` inside `create_purchase_order`
+- create_purchase_order: `hrms/api/procurement.py:1455`
+- create_invoice: `hrms/api/procurement.py:2392`
+- create_payment_request: `hrms/api/procurement.py:2709`
+
+## Scope Summary
+
+### In-Scope
+- New helper `_assert_supplier_active(supplier: str, operation: str) -> None` in `hrms/api/procurement.py`
+- Call the helper at the top of `create_purchase_order`, `create_invoice`, `create_payment_request`
+- Unit test covering the four statuses × three endpoints
+- Sentry DM-7 observability — the helper raises with a tagged breadcrumb
+
+### Out-of-Scope
+- Frontend UI changes (status badges already exist in supplier hub grid + overview)
+- DocType `validate()` hook (trade-off documented above)
+- Blocking `Inactive` on invoice/payment endpoints (policy decision — see Design Rationale #1)
+- Supplier status workflow changes (Pending Verification → Active transitions remain in existing supplier-edit approval flow)
+- Backfill / audit of historical POs/invoices/payments for Blacklisted suppliers
+
+## Non-Negotiable Rules
+
+1. **One helper, three call sites.** No duplicated status checks.
+2. **Blacklisted and Pending Verification block all three create endpoints.** Inactive blocks only PO creation.
+3. **Error message names the supplier, the status, and the next step.** No generic "permission denied."
+4. **Must raise before any DB write.** Guard is the first check after supplier ID resolution, before any supplier_doc fetch that would incur overhead.
+5. **No silent fallback.** If the supplier doesn't exist, that's still a hard error (existing behavior).
+
+## Existing Assets (Duplication Audit)
+
+| Asset | Location | Classification | Notes |
+|-------|----------|----------------|-------|
+| BEI Supplier DocType | `hrms/hr/doctype/bei_supplier/bei_supplier.json` | REFERENCE | `status` field is authoritative |
+| `_resolve_supplier_identity()` | `hrms/api/procurement.py:111` | REFERENCE | DO NOT modify — already used by 7 endpoints |
+| `create_purchase_order()` | `hrms/api/procurement.py:1455` | EXTEND | Add guard call after data parse, before TIN check |
+| `create_invoice()` | `hrms/api/procurement.py:2392` | EXTEND | Add guard call after supplier resolution |
+| `create_payment_request()` | `hrms/api/procurement.py:2709` | EXTEND | Add guard call after supplier resolution |
+| TIN threshold gate | `hrms/api/procurement.py:1491` | PATTERN | Mirror this style — `frappe.throw(_("..."))` |
+| Sentry helper | `hrms.utils.sentry.set_backend_observability_context` | REUSE | Add breadcrumb in the guard when it fires |
+
+## Architecture Context
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  hrms/api/procurement.py                                      │
+│                                                               │
+│  NEW:                                                         │
+│  _assert_supplier_active(supplier, operation)                 │
+│    └─ reads tabBEI Supplier.status                            │
+│    └─ raises ValidationError if Blacklisted|Pending           │
+│    └─ for create_purchase_order: also blocks Inactive         │
+│                                                               │
+│  CALL SITES:                                                  │
+│  create_purchase_order()      — blocks B|PV|I                 │
+│  create_invoice()             — blocks B|PV                   │
+│  create_payment_request()     — blocks B|PV                   │
+└───────────────────────────────────────────────────────────────┘
+
+Legend: B = Blacklisted, PV = Pending Verification, I = Inactive
+```
+
+## Agent Boot Sequence
+
+1. Read this plan fully.
+2. **Create sprint branch:** `cd F:/Dropbox/Projects/BEI-ERP && git fetch origin production && git checkout -b s193-supplier-status-guard origin/production`. NEVER write code on production.
+3. Read `hrms/api/procurement.py` lines 111-135 (existing `_resolve_supplier_identity`) to confirm the helper pattern.
+4. Read `hrms/api/procurement.py` lines 1455-1500, 2392-2420, 2709-2750 (the three create endpoints — confirm insertion points).
+5. Read `hrms/hr/doctype/bei_supplier/bei_supplier.json` — verify `status` Select options are exactly `Active`, `Inactive`, `Blacklisted`, `Pending Verification`.
+6. Confirm the TIN threshold pattern at line 1491 — use the same `frappe.throw(_(...))` style.
+7. Execute **Phase 0a** (controller read + frontend error surface check) — 1 unit — **before any code change**.
+8. Write the guard, call sites, Sentry instrumentation for create_purchase_order, and tests in a single commit per phase.
+
+## Execution Authority
+
+This sprint is intended for autonomous end-to-end execution.
+Do not stop for progress-only updates.
+Only pause for items listed in the Autonomous Execution Contract `stop_only_for` section.
+
+---
+
+## Delivery Phases
+
+### Phase 0a — Verify controller + frontend error surface (~1 unit) — AUDIT AMENDMENT
+
+**Purpose:** De-risk assumptions before writing code.
+
+**Task 0a.1 — Supplier status transition check (Blocker 4):**
+Read `hrms/hr/doctype/bei_supplier/bei_supplier.py` (controller) and confirm:
+- Can `status` be set directly to all four values (`Active`, `Inactive`, `Blacklisted`, `Pending Verification`) on `insert()`?
+- If a `validate` or `before_save` hook restricts certain values (e.g., new suppliers must start as `Pending Verification`, or `Blacklisted` requires an approval workflow), the Phase 2 test fixture MUST bypass via `frappe.db.set_value(..., update_modified=False)` after creation in the `Active` state.
+- Record findings in `output/s193/controller_check.md` with the exact code snippet that determines policy.
+
+**Task 0a.2 — Frontend error surface spot-check (Blocker 6):**
+Read `bei-tasks/lib/frappe-api.ts` → confirm `parseFrappeError` extracts the `message` field from a Frappe `ValidationError` response (HTTP 417). Grep for usage: `grep -rn "parseFrappeError" bei-tasks/app/dashboard/procurement/ | head`.
+
+Spot-check ONE create page (e.g., `bei-tasks/app/dashboard/procurement/purchase-orders/new/page.tsx`). Confirm it renders the extracted message in a toast or inline error (not a generic "Failed to create"). If it does NOT surface the message cleanly, add a single-line TODO comment to the plan's S194 follow-up notes — do NOT block S193 merge on this.
+
+**Verification:**
+- [ ] `output/s193/controller_check.md` exists with snippet and conclusion
+- [ ] `parseFrappeError` confirmed to extract Frappe error message
+- [ ] One create-page error path confirmed (or TODO logged)
+
+### Phase 0 — Implement `_assert_supplier_active` helper (~3 units)
+
+**MUST_MODIFY:** `hrms/api/procurement.py`
+**MUST_CONTAIN after:** `def _assert_supplier_active` AND `Pending Verification` AND `Blacklisted`
+
+Add the helper immediately after `_resolve_supplier_identity` (around line 135) so it's a sibling of the existing supplier utilities.
+
+**Signature and behavior:**
+```python
+# Statuses that block ALL create flows (new business)
+_SUPPLIER_BLOCK_ALL_STATUSES = frozenset({"Blacklisted", "Pending Verification"})
+# Statuses that additionally block new PO creation (no new business with inactive)
+_SUPPLIER_BLOCK_NEW_PO_STATUSES = frozenset({"Inactive"})
+
+def _assert_supplier_active(supplier: str, operation: str) -> None:
+    """Block creation against suppliers in forbidden statuses.
+
+    operation: one of "purchase_order", "invoice", "payment_request".
+    Raises frappe.ValidationError with supplier name, status, and next step.
+
+    Policy:
+      - Blacklisted / Pending Verification: block all three operations.
+      - Inactive: block purchase_order only (invoices/payments on pre-existing
+        POs remain allowed so in-flight work is not stranded).
+    """
+    status = frappe.db.get_value("BEI Supplier", supplier, "status")
+    if not status:
+        # Supplier does not exist — Link field would normally catch this, but
+        # if we got here via a stale ID let the caller handle non-existence.
+        return
+
+    blocked = status in _SUPPLIER_BLOCK_ALL_STATUSES
+    if operation == "purchase_order" and status in _SUPPLIER_BLOCK_NEW_PO_STATUSES:
+        blocked = True
+
+    if not blocked:
+        return
+
+    # Supplier display name for the error
+    name_display = frappe.db.get_value("BEI Supplier", supplier, "supplier_name") or supplier
+
+    if status == "Blacklisted":
+        next_step = "Contact Procurement Manager to review the blacklist decision."
+    elif status == "Pending Verification":
+        next_step = "Complete supplier verification (TIN, SEC, bank details) before transacting."
+    else:  # Inactive
+        next_step = "Re-activate the supplier in the Supplier Hub if business continues."
+
+    op_label = {
+        "purchase_order": "Purchase Order",
+        "invoice": "Invoice",
+        "payment_request": "Payment Request",
+    }.get(operation, operation)
+
+    # Sentry breadcrumb so policy denials are observable
+    try:
+        from hrms.utils.sentry import set_backend_observability_context
+        set_backend_observability_context(
+            module="procurement",
+            action="assert_supplier_active_denied",
+            extras={"supplier": supplier, "status": status, "operation": operation},
+        )
+    except Exception:
+        pass  # Observability must never break the guard
+
+    frappe.throw(
+        _("Cannot create {0}: Supplier {1} is {2}. {3}").format(
+            op_label, name_display, status, next_step
+        ),
+        frappe.ValidationError,
+    )
+```
+
+**Verification:**
+- [ ] `grep -c "def _assert_supplier_active" hrms/api/procurement.py` returns `1`
+- [ ] `grep -c "_SUPPLIER_BLOCK_ALL_STATUSES" hrms/api/procurement.py` returns at least `2` (definition + use)
+- [ ] Helper is placed between `_resolve_supplier_identity` and the next major section (`SUPPLIER ENDPOINTS`)
+
+### Phase 1 — Wire guard into three create endpoints (~3 units)
+
+**MUST_MODIFY:** `hrms/api/procurement.py`
+**MUST_CONTAIN after (procurement.py):** `_assert_supplier_active(supplier_name, "purchase_order")` AND `_assert_supplier_active(` (at least 3 call sites total)
+
+**Task 1.1 — `create_purchase_order` (line 1455):**
+
+**AMENDMENT (Blocker 3):** `create_purchase_order` is missing `set_backend_observability_context` entirely — this is a pre-existing DM-7 gap. Since we are already editing this function, add Sentry instrumentation in the same commit.
+
+**HARD BLOCKER:** Do NOT remove or weaken the TIN threshold check at line 1491. Only ADD lines.
+
+Step 1 — Add Sentry at the very top of the function (before the `if not data` check):
+```python
+from hrms.utils.sentry import set_backend_observability_context
+set_backend_observability_context(module="procurement", action="create_purchase_order", mutation_type="create")
+```
+
+Step 2 — Insert the status guard immediately after the `supplier_name` extraction at line 1467 and before `_normalize_purchase_order_payload` at line 1468 (so we block before any normalization work runs):
+```python
+# Guard: block new PO for Blacklisted/Pending Verification/Inactive suppliers (S193)
+if supplier_name:
+    _assert_supplier_active(supplier_name, "purchase_order")
+```
+
+**Task 1.2 — `create_invoice` (line 2392):**
+
+**AMENDMENT (Blocker 1):** Invoices are commonly created from a Purchase Order or Goods Receipt. When that happens, `data.get("supplier")` is `None` at the top — supplier is populated later by `_populate_invoice_context` (lines 2412, 2443). A top-of-function check silently skips the guard for the normal 3-way-match flow.
+
+**Fix:** Resolve supplier with PO/GR fallback before calling the guard. Place this block at **line 2405** (after `_normalize_invoice_payload(data)`, before the `_populate_invoice_context` calls) so denial fires before any DB writes:
+
+```python
+# Guard: block new invoice for Blacklisted/Pending Verification suppliers (S193)
+# supplier may be set directly, populated from GR/PO context, or derivable from linked docs.
+# We resolve via fallback so the guard fires for PO-linked and GR-linked flows, not just
+# direct-supplier invoices.
+_s193_supplier = data.get("supplier")
+if not _s193_supplier and data.get("purchase_order"):
+    _s193_supplier = frappe.db.get_value("BEI Purchase Order", data["purchase_order"], "supplier")
+if not _s193_supplier and data.get("goods_receipt"):
+    _s193_supplier = frappe.db.get_value("BEI Goods Receipt", data["goods_receipt"], "supplier")
+if _s193_supplier:
+    _assert_supplier_active(_s193_supplier, "invoice")
+```
+
+**Task 1.3 — `create_payment_request` (line 2709):**
+
+**AMENDMENT (Blocker 2):** Payment Requests are typically created against an Invoice (via `data["invoice"]`). Supplier is NOT a required input — it's derived from the invoice by `_populate_payment_request_invoice_context`. A top-of-function `data.get("supplier")` check would be `None` and silently skip.
+
+**Fix:** Resolve supplier with Invoice/PO fallback. Place this block **after `data = frappe.parse_json(data)` at line 2722** and **before the Double-Payment guard at line 2724** so S193 denial takes precedence:
+
+```python
+# Guard: block new payment request for Blacklisted/Pending Verification suppliers (S193)
+# supplier may be set directly, or derivable from the linked invoice / PO.
+_s193_supplier = data.get("supplier")
+if not _s193_supplier and data.get("invoice"):
+    _s193_supplier = frappe.db.get_value("BEI Invoice", data["invoice"], "supplier")
+if not _s193_supplier and data.get("purchase_order"):
+    _s193_supplier = frappe.db.get_value("BEI Purchase Order", data["purchase_order"], "supplier")
+if _s193_supplier:
+    _assert_supplier_active(_s193_supplier, "payment_request")
+```
+
+**Verification:**
+- [ ] `grep -n '_assert_supplier_active(' hrms/api/procurement.py` shows at least 4 hits (1 def + 3 call sites)
+- [ ] `grep -n '_assert_supplier_active.*"purchase_order"' hrms/api/procurement.py` shows exactly 1 hit
+- [ ] `grep -n '_assert_supplier_active.*"invoice"' hrms/api/procurement.py` shows exactly 1 hit
+- [ ] `grep -n '_assert_supplier_active.*"payment_request"' hrms/api/procurement.py` shows exactly 1 hit
+- [ ] `grep -n 'set_backend_observability_context.*create_purchase_order' hrms/api/procurement.py` shows exactly 1 hit (NEW — Blocker 3 fix)
+- [ ] `grep -c "_s193_supplier" hrms/api/procurement.py` returns at least 6 (3 assignments + 3 uses across invoice + payment_request fallback chains)
+- [ ] TIN threshold check at line 1491 (search `tin_requirement_threshold`) still present — DO NOT remove
+
+### Phase 2 — Tests (~3 units)
+
+**MUST_MODIFY:** `hrms/api/tests/test_procurement_supplier_guard.py` (new file)
+**MUST_CONTAIN:** `def test_assert_supplier_active_blacklisted` AND `def test_assert_supplier_active_pending_verification` AND `def test_assert_supplier_active_inactive_po_only` AND `def test_assert_supplier_active_active_allowed`
+
+Create a new test file. Structure:
+
+1. **Fixture:** four test suppliers, one per status. Create them in `setUp`, delete in `tearDown`.
+2. **Test 1 — `test_assert_supplier_active_blacklisted`:** call `_assert_supplier_active(blacklisted_sup, op)` for each of the three operations; each must raise `frappe.ValidationError` with "Blacklisted" in the message.
+3. **Test 2 — `test_assert_supplier_active_pending_verification`:** same, with Pending Verification supplier.
+4. **Test 3 — `test_assert_supplier_active_inactive_po_only`:** Inactive supplier — `purchase_order` raises, `invoice` and `payment_request` return None.
+5. **Test 4 — `test_assert_supplier_active_active_allowed`:** Active supplier — all three operations return None.
+
+Use `frappe.tests.utils.FrappeTestCase` and existing test patterns in `hrms/api/tests/`. If a tests folder doesn't exist, create it.
+
+**Verification:**
+- [ ] `grep -c "def test_assert_supplier_active" hrms/api/tests/test_procurement_supplier_guard.py` returns `4`
+- [ ] Tests can be collected by pytest (syntactically valid) — even if Frappe runtime isn't available locally, the file must import cleanly
+
+### Phase 3 — PR Creation + Closeout (~1 unit)
+
+**MUST_MODIFY:** `docs/plans/2026-04-14-sprint-193-supplier-status-guard.md` (status update)
+**MUST_MODIFY:** `docs/plans/SPRINT_REGISTRY.md` (add PR#, update status)
+
+**Task 3.1 — Pre-PR rebase check:**
+```bash
+cd F:/Dropbox/Projects/BEI-ERP
+git fetch origin production
+GH_TOKEN="" gh api "repos/Bebang-Enterprise-Inc/hrms/compare/s193-supplier-status-guard...production" --jq '.behind_by'
+# If >0 behind: git rebase origin/production, verify no conflict markers, push
+```
+
+**Task 3.2 — Create PR:**
+```bash
+GH_TOKEN="" gh pr create --repo Bebang-Enterprise-Inc/hrms \
+  --base production --head s193-supplier-status-guard \
+  --title "feat(S193): supplier status guard — block PO/Invoice/RFP for Blacklisted + Pending Verification suppliers" \
+  --body "..."
+```
+
+**Task 3.3 — Closeout:**
+- Update plan YAML: status `PLANNED` → `PR_CREATED`, add `completed_date: 2026-04-14`, `execution_summary: ...`
+- Update `SPRINT_REGISTRY.md` S193 row with PR number and `PR_CREATED` status
+- `git add -f docs/plans/...` and commit
+- STOP. Sam handles merge + deploy.
+
+**Verification:**
+- [ ] PR URL printed
+- [ ] Plan YAML status is `PR_CREATED`
+- [ ] SPRINT_REGISTRY row shows the PR number
+
+---
+
+## Requirements Regression Checklist
+
+Before marking any task complete, verify each of the following is yes/true:
+
+- [ ] Is the helper named `_assert_supplier_active` (underscore-prefixed, NOT `assert_supplier_active`)? (Helpers in `procurement.py` are consistently underscore-prefixed.)
+- [ ] Does the helper accept `(supplier, operation)` as args, NOT `(supplier_doc, operation)`? (We fetch status via `frappe.db.get_value` to avoid loading the full doc.)
+- [ ] Does the helper use `frappe.ValidationError`, NOT `frappe.PermissionError`? (Policy violation, not permission issue — surfaces as 417 not 403.)
+- [ ] Does the PO guard trigger for `Inactive` AND `Blacklisted` AND `Pending Verification`?
+- [ ] Does the Invoice guard trigger for `Blacklisted` AND `Pending Verification` ONLY (NOT Inactive)?
+- [ ] Does the Payment Request guard trigger for `Blacklisted` AND `Pending Verification` ONLY (NOT Inactive)?
+- [ ] Is the error message template `Cannot create {op_label}: Supplier {name_display} is {status}. {next_step}` (names all four variables)?
+- [ ] Does the helper emit a Sentry breadcrumb via `set_backend_observability_context` when it denies? (DM-7)
+- [ ] Is the Sentry call wrapped in `try/except` so observability failure never breaks the guard?
+- [ ] Are there exactly three call sites (one per create endpoint)?
+- [ ] Is the TIN threshold check at line 1491 still intact in `create_purchase_order`? (Do not remove when inserting the new guard.)
+- [ ] Does every modified function still have its existing `set_backend_observability_context` call at the top?
+- [ ] Is the test file at `hrms/api/tests/test_procurement_supplier_guard.py` with four test methods named exactly as listed in Phase 2?
+- [ ] Does the test for Inactive assert that `invoice` and `payment_request` return `None` (not raise)?
+- [ ] **(AUDIT AMENDMENT — Blocker 1)** In `create_invoice`, does the guard resolve supplier via `data.get("supplier")` → PO fallback → GR fallback BEFORE calling `_assert_supplier_active`? (A top-of-function `data.get("supplier")` ONLY check will silently skip for PO/GR-linked invoices.)
+- [ ] **(AUDIT AMENDMENT — Blocker 2)** In `create_payment_request`, does the guard resolve supplier via `data.get("supplier")` → Invoice fallback → PO fallback BEFORE calling `_assert_supplier_active`? (Payment requests are typically linked via invoice; supplier is rarely passed directly.)
+- [ ] **(AUDIT AMENDMENT — Blocker 3)** Does `create_purchase_order` now have `set_backend_observability_context(module="procurement", action="create_purchase_order", mutation_type="create")` at the top of the function body? (Pre-existing DM-7 gap — fix is mandatory in this sprint.)
+- [ ] **(AUDIT AMENDMENT — Blocker 4)** Did Phase 0a produce `output/s193/controller_check.md` documenting whether the Supplier DocType controller allows direct status sets for all 4 values?
+- [ ] **(AUDIT AMENDMENT — Blocker 5)** Are the 4 stable test supplier codes (`TEST-S193-ACTIVE`, `TEST-S193-INACTIVE`, `TEST-S193-BLACKLIST`, `TEST-S193-PENDING`) pre-staged before L3 via the setup script? (L3 scenarios reference these specific codes, not "any Blacklisted supplier".)
+- [ ] **(AUDIT AMENDMENT — Blocker 6)** Has `parseFrappeError` in `bei-tasks/lib/frappe-api.ts` been verified to extract the Frappe `ValidationError` message so the frontend surfaces it, not a generic "Failed to create"?
+
+## Zero-Skip Enforcement
+
+Every task MUST be implemented, no exceptions. If a task cannot be completed, the agent STOPS and asks the user.
+
+### Forbidden Agent Behaviors
+- Skipping a task silently
+- Marking partial work as "done"
+- Combining Phase 1 call sites and dropping one
+- Replacing the helper with inline checks (violates DRY rule)
+- Implementing the guard but not wiring all three call sites
+- Writing tests that only cover Active (happy path)
+- Removing or weakening the TIN threshold check at line 1491
+
+### Phase Completion Checklist Format
+
+After each phase, the agent writes to `output/s193/phase_N_checklist.md`:
+```
+| Task | Status | Evidence | Skipped? | If skipped, why? |
+```
+
+### Machine-Verifiable Phase Gates
+
+After Phase 0+1 (backend):
+```bash
+cd F:/Dropbox/Projects/BEI-ERP
+git diff --name-only origin/production...HEAD | grep "hrms/api/procurement.py"
+grep -c "def _assert_supplier_active" hrms/api/procurement.py          # expect 1
+grep -c "_assert_supplier_active(" hrms/api/procurement.py             # expect >= 4
+grep -c "_assert_supplier_active.*\"purchase_order\"" hrms/api/procurement.py    # expect 1
+grep -c "_assert_supplier_active.*\"invoice\"" hrms/api/procurement.py           # expect 1
+grep -c "_assert_supplier_active.*\"payment_request\"" hrms/api/procurement.py   # expect 1
+grep -c "_SUPPLIER_BLOCK_ALL_STATUSES" hrms/api/procurement.py                   # expect >= 2
+```
+
+After Phase 2 (tests):
+```bash
+grep -c "def test_assert_supplier_active" hrms/api/tests/test_procurement_supplier_guard.py   # expect 4
+python -c "import ast; ast.parse(open('hrms/api/tests/test_procurement_supplier_guard.py').read())"   # must not raise
+```
+
+After Phase 3 (closeout):
+```bash
+grep -c "^- status: PR_CREATED$" docs/plans/2026-04-14-sprint-193-supplier-status-guard.md   # expect 1
+grep "S193.*PR_CREATED" docs/plans/SPRINT_REGISTRY.md    # must show PR number
+```
+
+---
+
+## L3 Workflow Scenarios
+
+> **Note:** L3 runs post-deploy against production. No frontend change in this sprint — scenarios exercise the backend guard via the existing procurement pages (which will show the Frappe error toast when the guard fires).
+
+### L3 Prerequisites (AUDIT AMENDMENT — Blocker 5)
+
+**Why this section exists:** The BEI Supplier `status` field is in `_SUPPLIER_APPROVAL_FIELDS` (see `hrms/api/procurement.py:563`) — normal edits to `status` go through the CPO approval workflow. L3 cannot spin up Blacklisted / Pending Verification / Inactive suppliers on demand.
+
+**Before L3 runs, Sam (or an operator with `System Manager` role) stages four stable test suppliers via direct db writes (bypassing the approval workflow). These are fixtures, not real suppliers.**
+
+| Test Supplier Code | Status to set | Purpose |
+|--------------------|---------------|---------|
+| `TEST-S193-ACTIVE` | `Active` | Baseline — all creates must succeed |
+| `TEST-S193-INACTIVE` | `Inactive` | PO blocked; Invoice + RFP allowed |
+| `TEST-S193-BLACKLIST` | `Blacklisted` | All three blocked |
+| `TEST-S193-PENDING` | `Pending Verification` | All three blocked |
+
+**Setup script (Sam runs via SSM frappe bench console, before L3):**
+```python
+# bench --site hq.bebang.ph console
+import frappe
+fixtures = [
+    ("TEST-S193-ACTIVE", "Active"),
+    ("TEST-S193-INACTIVE", "Inactive"),
+    ("TEST-S193-BLACKLIST", "Blacklisted"),
+    ("TEST-S193-PENDING", "Pending Verification"),
+]
+for code, status in fixtures:
+    if not frappe.db.exists("BEI Supplier", code):
+        frappe.get_doc({
+            "doctype": "BEI Supplier",
+            "supplier_code": code,
+            "supplier_name": f"S193 Test Supplier — {status}",
+            "status": "Active",  # create as Active
+            "tin": "000-000-000-000",
+        }).insert(ignore_permissions=True)
+    # Bypass approval workflow for the target status
+    frappe.db.set_value("BEI Supplier", code, "status", status, update_modified=False)
+frappe.db.commit()
+```
+
+Scenarios below reference these exact codes (not "any Blacklisted supplier").
+
+### Scenarios
+
+| # | User | Action | Expected Outcome | Failure Means |
+|---|------|--------|-------------------|---------------|
+| L3-1 | test.procurement@bebang.ph | Supplier Hub → pick any Blacklisted supplier (or temporarily blacklist one via Supplier Edit) → click "Create PO" from supplier detail actions | Frappe error toast appears with text `Cannot create Purchase Order: Supplier {name} is Blacklisted. Contact Procurement Manager...` | Blacklist guard not wired to create_purchase_order |
+| L3-2 | test.procurement@bebang.ph | Attempt to create a PO for a Pending Verification supplier | Error toast: `Cannot create Purchase Order: Supplier {name} is Pending Verification. Complete supplier verification...` | Pending Verification guard not wired |
+| L3-3 | test.procurement@bebang.ph | Attempt to create a PO for an Inactive supplier | Error toast: `Cannot create Purchase Order: Supplier {name} is Inactive. Re-activate the supplier...` | Inactive guard not active for PO |
+| L3-4 | test.procurement@bebang.ph | Attempt to create an Invoice for an Inactive supplier | **Succeeds** (or fails for other validation reasons, but NOT the supplier-status guard) | Policy regression — Inactive should NOT block invoices |
+| L3-5 | test.accounts@bebang.ph | Attempt to create a Payment Request for a Blacklisted supplier | Error toast: `Cannot create Payment Request: Supplier {name} is Blacklisted. Contact Procurement Manager...` | Blacklist guard not wired to create_payment_request |
+| L3-6 | test.procurement@bebang.ph | Create PO for an **Active** supplier | Succeeds (normal PO creation flow) | Guard is over-blocking — regression on Active |
+| L3-7 | test.procurement@bebang.ph | After creating an Active-supplier PO, change the supplier status to Blacklisted, then attempt a second PO for the same supplier | First PO still exists and is unaffected; second PO blocked with Blacklisted error | Guard leaking into historical/in-flight transactions |
+| L3-8 | test.accounts@bebang.ph | For the PO created in L3-7 (before blacklist), attempt to create an Invoice against it | **Fails** with Blacklisted error (invoice create endpoint also blocks Blacklisted) | Invoice guard not wired OR wired against wrong status set |
+
+**L3 evidence files required before closeout:**
+```
+output/l3/s193/form_submissions.json    # attempted form submits (with expected failures)
+output/l3/s193/api_mutations.json       # API call traces — ValidationError expected for 5 of 8 scenarios
+output/l3/s193/state_verification.json  # no new PO/Invoice/RFP created for blocked scenarios
+```
+
+---
+
+## Phase Budget Contract
+
+| Phase | Units | Files Modified |
+|-------|-------|----------------|
+| Phase 0a — Controller + frontend error surface check (AMENDMENT) | 1 | read-only: `bei_supplier.py`, `frappe-api.ts` + `output/s193/controller_check.md` |
+| Phase 0 — Helper function | 3 | `hrms/api/procurement.py` |
+| Phase 1 — Wire 3 call sites + Sentry for create_purchase_order | 4 | `hrms/api/procurement.py` |
+| Phase 2 — Unit tests | 3 | `hrms/api/tests/test_procurement_supplier_guard.py` |
+| Phase 3 — PR + closeout | 1 | plan, registry |
+| **Total** | **~12** | |
+
+- hard_limit: 15 per phase
+- All phases within budget.
+
+---
+
+## Ground-Truth Lock
+
+- **evidence_sources:**
+  - `hrms/hr/doctype/bei_supplier/bei_supplier.json` → `status` Select field, 4 options
+  - `hrms/api/procurement.py:111-135` → `_resolve_supplier_identity` pattern for helper placement
+  - `hrms/api/procurement.py:1455-1500` → `create_purchase_order` insertion point
+  - `hrms/api/procurement.py:2392-2420` → `create_invoice` insertion point
+  - `hrms/api/procurement.py:2709-2750` → `create_payment_request` insertion point
+  - `hrms/api/procurement.py:1491` → TIN threshold pattern to mirror
+- **authoritative_sections:** Delivery Phases 0-3 and Requirements Regression Checklist. Design Rationale is traceability.
+- **normalization_required:** if any amendment changes the helper signature, status set, or call-site count, update the Verification sections and Machine-Verifiable Gates in the same edit.
+
+---
+
+## Anti-Rewind / Concurrent-Run Protection
+
+- **ownership_matrix:** This sprint owns:
+  - `hrms/api/procurement.py` — edits are confined to: (a) new helper insertion around line 135, (b) three insertions at the top of `create_purchase_order`, `create_invoice`, `create_payment_request`. No other line in this file is modified.
+  - `hrms/api/tests/test_procurement_supplier_guard.py` — net new file.
+- **protected_surfaces:** Every other function in `hrms/api/procurement.py` — DO NOT MODIFY. Specifically:
+  - `_resolve_supplier_identity` (line 111) — untouched
+  - TIN threshold check (line 1491 inside create_purchase_order) — untouched
+  - All supplier getter endpoints (get_suppliers, get_supplier, get_supplier_grid, get_supplier_overview) — untouched
+  - All approval/edit endpoints (submit_supplier_edit_for_approval, approve_supplier_edit) — untouched
+- **remote_truth_baseline:** `origin/production` HEAD at time of branch creation. Record the SHA in Phase 3 closeout summary.
+- **freshness_gate:** Before PR creation, run `GH_TOKEN="" gh api "repos/.../compare/s193-supplier-status-guard...production" --jq '.behind_by'`. If >0, rebase before pushing.
+
+---
+
+## Autonomous Execution Contract
+
+- **completion_condition:**
+  - `_assert_supplier_active` exists in `procurement.py` and matches the signature in Phase 0
+  - All three create endpoints call it with the correct operation string
+  - Unit test file exists with four test methods and is syntactically valid Python
+  - PR created against `origin/production`
+  - Plan YAML updated to `PR_CREATED`
+  - `SPRINT_REGISTRY.md` row updated with PR number
+  - Phase checklist files written to `output/s193/`
+- **stop_only_for:**
+  - Missing credentials for GitHub or Frappe repo
+  - BEI Supplier DocType status Select options differ from `Active\nInactive\nBlacklisted\nPending Verification` (Design Rationale premise broken)
+  - Merge conflict on `procurement.py` from concurrent work — rebase fails and needs manual resolution
+  - Business-policy question: Sam wants to change which statuses block which endpoints
+- **continue_without_pause_through:** code → test scaffolding → PR creation → closeout
+- **blocker_policy:**
+  - programmatic → fix and continue
+  - test fixture conflict with existing test DB → mark failing test xfail with TODO, continue
+  - repeated technical failure x3 → stop and present options
+  - business-policy question → pause and ask Sam
+- **signoff_authority:** single-owner (Sam)
+- **canonical_closeout_artifacts:**
+  - `docs/plans/2026-04-14-sprint-193-supplier-status-guard.md` (status updated to `PR_CREATED`)
+  - `docs/plans/SPRINT_REGISTRY.md` (row updated)
+  - `output/s193/phase_N_checklist.md` (per-phase)
+  - `output/l3/s193/` (L3 evidence — deferred to post-deploy session)
+
+---
+
+## Execution Workflow
+
+- Test Python changes: `/local-frappe`
+- Deploy changes: PR-handoff (agent creates PR, Sam merges + deploys)
+- Deploy requires `skip_build=false, no_cache=true` (new Python code — not just a config change)
+- E2E testing: `/e2e-test` or fresh L3 session post-deploy
+
+---
+
+## Verification Checklist (Final)
+
+- [ ] Helper `_assert_supplier_active(supplier, operation)` exists in `procurement.py`
+- [ ] Helper raises `frappe.ValidationError` for Blacklisted + Pending Verification (all operations)
+- [ ] Helper additionally raises for Inactive when operation is `purchase_order`
+- [ ] Helper is called at top of `create_purchase_order` with `"purchase_order"` operation
+- [ ] Helper is called at top of `create_invoice` with `"invoice"` operation
+- [ ] Helper is called at top of `create_payment_request` with `"payment_request"` operation
+- [ ] Error message includes: operation label, supplier display name, status, next step
+- [ ] Sentry breadcrumb fires on denial (wrapped in try/except)
+- [ ] TIN threshold check at line 1491 unchanged
+- [ ] Four unit tests exist and import cleanly
+- [ ] Machine-verifiable phase gate scripts pass
+- [ ] PR created, plan YAML updated, registry updated
+
+## Branch Lifecycle
+
+| Branch | Repo | Merge Target | Cleanup |
+|--------|------|--------------|---------|
+| `s193-supplier-status-guard` | hrms | production | Delete after PR merge |
+
+Created from latest `origin/production`. PR handoff — Sam merges, deploy requires full rebuild.

--- a/docs/plans/SPRINT_REGISTRY.md
+++ b/docs/plans/SPRINT_REGISTRY.md
@@ -262,9 +262,11 @@ These documents contain sprint-like naming but are not part of the canonical seq
 
 | `S190` | Sprint 190 | `s190-store-company-integration` (hrms) + `s190-store-company-frontend` (bei-tasks) | hrms #563, bei-tasks #391 | DEPLOYED 2026-04-14 — Store-Company Integration: Company-first, zero silos. Rewire ordering/billing/supply-chain to use Company Master as SSOT. resolve_warehouse_company: no suffix guess. resolve_store_buyer_entity: Company-first + CSV fallback. submit_order stamps company on BEI Store Order. BKI billing uses Company→Customer chain. APIs return company per store. 65 units. | `docs/plans/2026-04-13-sprint-190-store-company-integration.md` |
 
+| `S193` | Sprint 193 | `s193-supplier-status-guard` (hrms) | hrms #569 | PR_CREATED 2026-04-14 — Supplier Status Guard: enforce `Blacklisted` / `Pending Verification` / `Inactive` statuses at PO / Invoice / Payment Request creation. New `_assert_supplier_active(supplier, operation)` helper + 3 call sites + 5 unit tests. `Inactive` blocks PO only (in-flight invoices/payments on pre-existing POs pass). Also closes pre-existing DM-7 gap in `create_purchase_order`. | `docs/plans/2026-04-14-sprint-193-supplier-status-guard.md` |
+
 ## Next Sprint Reservation
-1. Next canonical sprint ID to assign: `S191`.
-2. Reserve branch name: `s187-{slug}` (fill slug from plan filename).
+1. Next canonical sprint ID to assign: `S194`.
+2. Reserve branch name: `s194-{slug}` (fill slug from plan filename).
 3. Create new sprint plan only after adding row here first.
 4. **Agent MUST `git checkout -b <branch>` before writing any code.**
 5. **MANDATORY cross-check before reserving any S###:** run `git branch -a | grep -iE 's(17[5-9]|18[0-9]|19[0-9])'` on BOTH `hrms` and `bei-tasks` AND `ls docs/plans/ | grep -E 'sprint-(17[5-9]|18[0-9]|19[0-9])'` — if any match the ID you're about to reserve, pick the next free number. The local registry is not authoritative; remote branches and plan files are.

--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -134,6 +134,81 @@ def _resolve_supplier_identity(supplier: str) -> tuple[str, str]:
     )
 
 
+# S193 — Supplier Status Guard
+# Statuses that block ALL create flows (new business with this supplier).
+_SUPPLIER_BLOCK_ALL_STATUSES = frozenset({"Blacklisted", "Pending Verification"})
+# Statuses that additionally block new PO creation (no new business with inactive).
+# Invoices and payment requests on pre-existing POs remain allowed so in-flight
+# work is not stranded when a supplier is deactivated.
+_SUPPLIER_BLOCK_NEW_PO_STATUSES = frozenset({"Inactive"})
+
+
+def _assert_supplier_active(supplier: str, operation: str) -> None:
+    """Block creation against suppliers in forbidden statuses (S193).
+
+    Args:
+        supplier: BEI Supplier document name (resolved by caller).
+        operation: one of "purchase_order", "invoice", "payment_request".
+
+    Policy:
+        - Blacklisted / Pending Verification: block all three operations.
+        - Inactive: block purchase_order only.
+        - Active (or any unknown/empty status): allow.
+
+    Raises:
+        frappe.ValidationError: with the supplier name, current status, and
+        the next step the operator should take. Maps to HTTP 417 and surfaces
+        in the frontend via parseFrappeError.
+    """
+    status = frappe.db.get_value("BEI Supplier", supplier, "status")
+    if not status:
+        # Supplier does not exist — Link-field validation would normally catch
+        # this upstream. If we got here via a stale ID, let the caller handle
+        # non-existence (existing flows already throw on get_doc).
+        return
+
+    blocked = status in _SUPPLIER_BLOCK_ALL_STATUSES
+    if operation == "purchase_order" and status in _SUPPLIER_BLOCK_NEW_PO_STATUSES:
+        blocked = True
+
+    if not blocked:
+        return
+
+    name_display = frappe.db.get_value("BEI Supplier", supplier, "supplier_name") or supplier
+
+    if status == "Blacklisted":
+        next_step = _("Contact the Procurement Manager to review the blacklist decision.")
+    elif status == "Pending Verification":
+        next_step = _("Complete supplier verification (TIN, SEC, bank details) before transacting.")
+    else:  # Inactive
+        next_step = _("Re-activate the supplier in the Supplier Hub if business continues.")
+
+    op_label = {
+        "purchase_order": _("Purchase Order"),
+        "invoice": _("Invoice"),
+        "payment_request": _("Payment Request"),
+    }.get(operation, operation)
+
+    # DM-7 observability — policy denials should be visible in Sentry.
+    # Wrapped in try/except so observability failure NEVER breaks the guard.
+    try:
+        from hrms.utils.sentry import set_backend_observability_context
+        set_backend_observability_context(
+            module="procurement",
+            action="assert_supplier_active_denied",
+            extras={"supplier": supplier, "status": status, "operation": operation},
+        )
+    except Exception:
+        pass
+
+    frappe.throw(
+        _("Cannot create {0}: Supplier {1} is {2}. {3}").format(
+            op_label, name_display, status, next_step
+        ),
+        frappe.ValidationError,
+    )
+
+
 def _table_has_column(table_name: str, column_name: str) -> bool:
     """Return True when a physical table column exists in the current site schema."""
     rows = frappe.db.sql(
@@ -1459,12 +1534,20 @@ def create_purchase_order(data: dict[str, Any] | str | None = None) -> dict[str,
     - Mandatory TIN for suppliers with >₱250K annual purchases
     Ref: Internal Audit Jan 30, 2026 - Max's Bakeshop ₱10M not in master list
     """
+    from hrms.utils.sentry import set_backend_observability_context
+    set_backend_observability_context(module="procurement", action="create_purchase_order", mutation_type="create")
+
     if not data:
         frappe.throw(_("Missing required parameter: data"), frappe.ValidationError)
     if isinstance(data, str):
         data = frappe.parse_json(data)
 
     supplier_name = (data or {}).get("supplier")
+
+    # S193 Guard: block new PO for Blacklisted / Pending Verification / Inactive suppliers.
+    if supplier_name:
+        _assert_supplier_active(supplier_name, "purchase_order")
+
     data = _normalize_purchase_order_payload(data, supplier_code=supplier_name)
 
     warnings = []
@@ -2402,6 +2485,17 @@ def create_invoice(data: dict[str, Any] | str) -> dict[str, Any]:
         data = frappe.parse_json(data)
     data = _normalize_invoice_payload(data)
 
+    # S193 Guard: block new invoice for Blacklisted / Pending Verification suppliers.
+    # Supplier may be set directly, or derivable from a linked PO/GR — resolve via
+    # fallback so the guard fires for every creation path, not just direct-supplier.
+    _s193_supplier = data.get("supplier")
+    if not _s193_supplier and data.get("purchase_order"):
+        _s193_supplier = frappe.db.get_value("BEI Purchase Order", data["purchase_order"], "supplier")
+    if not _s193_supplier and data.get("goods_receipt"):
+        _s193_supplier = frappe.db.get_value("BEI Goods Receipt", data["goods_receipt"], "supplier")
+    if _s193_supplier:
+        _assert_supplier_active(_s193_supplier, "invoice")
+
     purchase_order = data.get("purchase_order")
     goods_receipt = data.get("goods_receipt")
     po = None
@@ -2720,6 +2814,18 @@ def create_payment_request(data: dict[str, Any] | str) -> dict[str, Any]:
     set_backend_observability_context(module="procurement", action="create_payment_request", mutation_type="create")
     if isinstance(data, str):
         data = frappe.parse_json(data)
+
+    # S193 Guard: block new payment request for Blacklisted / Pending Verification suppliers.
+    # Payment requests are typically linked to an invoice; supplier is rarely passed
+    # directly. Resolve via invoice → PO fallback so denial fires before the
+    # Double-Payment guard and before any DB writes.
+    _s193_supplier = data.get("supplier")
+    if not _s193_supplier and data.get("invoice"):
+        _s193_supplier = frappe.db.get_value("BEI Invoice", data["invoice"], "supplier")
+    if not _s193_supplier and data.get("purchase_order"):
+        _s193_supplier = frappe.db.get_value("BEI Purchase Order", data["purchase_order"], "supplier")
+    if _s193_supplier:
+        _assert_supplier_active(_s193_supplier, "payment_request")
 
     # AUDIT CONTROL 2.5: Double-payment guard — block if PO fully covered by advance
     _po_for_guard = data.get("purchase_order")

--- a/hrms/tests/test_procurement_supplier_guard_s193.py
+++ b/hrms/tests/test_procurement_supplier_guard_s193.py
@@ -1,0 +1,197 @@
+"""S193 — Supplier Status Guard unit tests.
+
+Tests `_assert_supplier_active` policy:
+- Blacklisted / Pending Verification: block all three operations
+- Inactive: block purchase_order ONLY (invoice and payment_request allowed)
+- Active: allow all three operations
+
+Uses mocked frappe modules so tests run offline without a Frappe bench.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _install_fake_frappe() -> None:
+    """Install minimal fake frappe modules so procurement.py imports cleanly."""
+    if "frappe" in sys.modules:
+        return
+
+    frappe = types.ModuleType("frappe")
+    utils = types.ModuleType("frappe.utils")
+
+    def whitelist(*_args, **_kwargs):
+        def decorator(fn):
+            return fn
+        return decorator
+
+    class _ValidationError(Exception):
+        pass
+
+    class _DoesNotExistError(Exception):
+        pass
+
+    class _PermissionError(Exception):
+        pass
+
+    def _throw(msg, exc=_ValidationError, **_kwargs):
+        raise exc(msg)
+
+    def _noop(*_args, **_kwargs):
+        return None
+
+    frappe.whitelist = whitelist
+    frappe._ = lambda text: text
+    frappe.throw = _throw
+    frappe.msgprint = _noop
+    frappe.log_error = _noop
+    frappe.session = types.SimpleNamespace(user="Administrator")
+    frappe.ValidationError = _ValidationError
+    frappe.DoesNotExistError = _DoesNotExistError
+    frappe.PermissionError = _PermissionError
+    frappe.parse_json = lambda v: v
+    frappe.get_roles = lambda user: ["System Manager"]
+    frappe.get_doc = _noop
+    frappe.db = types.SimpleNamespace(
+        get_value=_noop, exists=_noop, sql=_noop, count=_noop,
+        set_value=_noop, commit=_noop, savepoint=_noop,
+        release_savepoint=_noop, rollback_to_savepoint=_noop,
+    )
+    frappe.enqueue = _noop
+    frappe.utils = utils
+
+    def _flt(v, _precision=None):
+        try:
+            return float(v or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _cint(v):
+        try:
+            return int(v or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    def _getdate(v=None):
+        return v
+
+    def _nowdate():
+        return "2026-04-14"
+
+    utils.flt = _flt
+    utils.cint = _cint
+    utils.getdate = _getdate
+    utils.nowdate = _nowdate
+    utils.add_days = lambda d, n: d
+    utils.get_first_day = lambda d: d
+    utils.get_last_day = lambda d: d
+    utils.now_datetime = lambda: None
+
+    # Stub hrms.utils.sentry
+    sentry = types.ModuleType("hrms.utils.sentry")
+    sentry.set_backend_observability_context = _noop
+
+    hrms_utils = types.ModuleType("hrms.utils")
+    hrms = types.ModuleType("hrms")
+    bei_config = types.ModuleType("hrms.utils.bei_config")
+    bei_config.get_company = lambda: "BEI"
+    delivery = types.ModuleType("hrms.utils.delivery_billing_policy")
+    delivery.CPO_APPROVER_EMAIL = "cpo@bebang.ph"
+    delivery.CFO_APPROVER_EMAIL = "cfo@bebang.ph"
+    delivery.append_approval_audit_log = _noop
+    delivery.get_approver_email = _noop
+    procurement_math = types.ModuleType("hrms.utils.procurement_math")
+    procurement_math.calculate_goods_receipt_gross_total = _noop
+
+    sys.modules["frappe"] = frappe
+    sys.modules["frappe.utils"] = utils
+    sys.modules["hrms"] = hrms
+    sys.modules["hrms.utils"] = hrms_utils
+    sys.modules["hrms.utils.sentry"] = sentry
+    sys.modules["hrms.utils.bei_config"] = bei_config
+    sys.modules["hrms.utils.delivery_billing_policy"] = delivery
+    sys.modules["hrms.utils.procurement_math"] = procurement_math
+
+
+def _load_procurement_module():
+    _install_fake_frappe()
+    spec = importlib.util.spec_from_file_location(
+        "procurement_under_test",
+        ROOT / "hrms" / "api" / "procurement.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SupplierStatusGuardTests(unittest.TestCase):
+    """Verify _assert_supplier_active enforces supplier master status policy."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.procurement = _load_procurement_module()
+        cls.frappe = sys.modules["frappe"]
+
+    def _patch_status(self, status: str, display_name: str = "Test Supplier"):
+        """Return a patch context for frappe.db.get_value returning the given status."""
+        def fake_get_value(doctype, name, field, *args, **kwargs):
+            if doctype != "BEI Supplier":
+                return None
+            if field == "status":
+                return status
+            if field == "supplier_name":
+                return display_name
+            return None
+        return patch.object(self.frappe.db, "get_value", side_effect=fake_get_value)
+
+    # --- Test 1: Blacklisted blocks all three operations ---
+    def test_assert_supplier_active_blacklisted(self):
+        with self._patch_status("Blacklisted"):
+            for op in ("purchase_order", "invoice", "payment_request"):
+                with self.assertRaises(self.frappe.ValidationError) as ctx:
+                    self.procurement._assert_supplier_active("SUP-001", op)
+                self.assertIn("Blacklisted", str(ctx.exception))
+
+    # --- Test 2: Pending Verification blocks all three operations ---
+    def test_assert_supplier_active_pending_verification(self):
+        with self._patch_status("Pending Verification"):
+            for op in ("purchase_order", "invoice", "payment_request"):
+                with self.assertRaises(self.frappe.ValidationError) as ctx:
+                    self.procurement._assert_supplier_active("SUP-002", op)
+                self.assertIn("Pending Verification", str(ctx.exception))
+
+    # --- Test 3: Inactive blocks PO ONLY (invoice + payment_request allowed) ---
+    def test_assert_supplier_active_inactive_po_only(self):
+        with self._patch_status("Inactive"):
+            # purchase_order must raise
+            with self.assertRaises(self.frappe.ValidationError) as ctx:
+                self.procurement._assert_supplier_active("SUP-003", "purchase_order")
+            self.assertIn("Inactive", str(ctx.exception))
+            # invoice and payment_request must return None (allow in-flight work)
+            self.assertIsNone(self.procurement._assert_supplier_active("SUP-003", "invoice"))
+            self.assertIsNone(self.procurement._assert_supplier_active("SUP-003", "payment_request"))
+
+    # --- Test 4: Active allows all three operations ---
+    def test_assert_supplier_active_active_allowed(self):
+        with self._patch_status("Active"):
+            for op in ("purchase_order", "invoice", "payment_request"):
+                self.assertIsNone(self.procurement._assert_supplier_active("SUP-004", op))
+
+    # --- Test 5: Missing supplier (no status row) is a no-op (caller handles) ---
+    def test_assert_supplier_active_missing_supplier_is_noop(self):
+        with self._patch_status(None):
+            for op in ("purchase_order", "invoice", "payment_request"):
+                self.assertIsNone(self.procurement._assert_supplier_active("SUP-NOEXIST", op))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/output/plan-audit/s191-foodpanda-unified-source/cold_start_findings.md
+++ b/output/plan-audit/s191-foodpanda-unified-source/cold_start_findings.md
@@ -1,0 +1,322 @@
+# S191 Plan Audit — Cold-Start Readiness Findings
+**Plan:** `docs/plans/2026-04-14-sprint-191-foodpanda-unified-source.md`
+**Audited:** 2026-04-12
+**Source file verified:** `hrms/api/sales_dashboard.py` (3640 lines, read directly)
+
+---
+
+## Summary Scorecard
+
+| Category | Score | Blocker Count |
+|---|---|---|
+| Cold-Start Self-Containment | PASS with gaps | 2 CRITICAL, 1 WARNING |
+| Zero-Skip Enforcement | PASS | 0 |
+| Machine-Verifiable Phase Gates | PASS with gaps | 1 CRITICAL, 1 WARNING |
+| L3 Scenario Contract | PASS | 0 |
+| Closeout Contract | PASS | 0 |
+| Branch & PR Isolation | PASS | 0 |
+| Sentry Observability | PASS with gap | 1 WARNING |
+| Requirements Regression Checklist | PASS | 0 |
+| Data Integrity | CRITICAL gaps | 3 CRITICAL |
+
+**Total: 5 CRITICAL, 3 WARNING, several INFO**
+
+Any CRITICAL = BLOCKER. Fix before handing to execution agent.
+
+---
+
+## 1. Cold-Start Self-Containment
+
+### CRITICAL-1: `_get_store_channel_split_map` return shape mismatch — plan assumes `{gross, net_wo_vat, orders}` but actual return is `{net_wo_vat}` only
+
+**Evidence from source code (lines 1067–1122):**
+The SQL at line 1067 only selects `net_wo_vat` — there is NO `gross` or `orders` column in this query. The return dict is keyed by `_S182_MOSAIC_CHANNEL_KEYS` which are plain floats (not nested dicts). The consumer at line 2499–2510 treats each bucket as a plain `float`, not `{"gross": ..., "net_wo_vat": ..., "orders": ...}`.
+
+**Plan claim (task 3.2):**
+> Returns `dict[location_id, dict[channel_key, {"gross", "net_wo_vat", "orders"}]]`
+> For each location_id, sum all its business_date entries to get a single per-store FP aggregate `{gross, net_wo_vat, orders}`
+
+**The problem:** `_get_unified_foodpanda_totals` returns `{gross, net_wo_vat, orders}` per (store, day). When the plan says to "override `result[location_id]["foodpanda"]`" in `_get_store_channel_split_map`, it is overriding a plain `float` (the existing `net_wo_vat` value) with a nested dict. That will silently corrupt all downstream consumers that do `float(mosaic.get("foodpanda", 0.0))` at line 2502.
+
+**Resolution required before execution:** The agent must either:
+(a) Override only the `net_wo_vat` float (dropping gross/orders from the per-store surface — acceptable since leaderboard only uses `channel_mix` net values), OR
+(b) Change `_S182_MOSAIC_CHANNEL_KEYS` and all consumers to use nested dicts (major scope expansion).
+Option (a) is the minimal-correct fix but the plan must say so explicitly. As written, a cold-start agent will write code that breaks the leaderboard.
+
+**Severity: BLOCKER**
+
+---
+
+### CRITICAL-2: `_apply_mosaic_channel_split` headline totals re-computation is NOT addressed
+
+**Evidence from source code (lines 998–1027):**
+`_apply_mosaic_channel_split` uses `fp_bucket["gross"]` and `fp_bucket["net_wo_vat"]` in `true_net_wo_vat` and `true_gross` summation that recomputes `net_sales_without_vat`, `gross_sales`, and `net_sales_with_vat` for the entire fleet. After task 2.1, `fp_bucket` is replaced with `fp_unified` from the new helper. This is correct for the FoodPanda line items.
+
+**The problem the plan does NOT address:** The existing `_apply_mosaic_channel_split` summation (lines 1000–1020) builds `true_gross` by summing `fp_bucket["gross"] + gf_bucket["gross"] + ...`. After S191, `fp_bucket` = `fp_unified` (which includes legacy gross approximated as `subtotal` from `foodpanda_orders`). But `gf_bucket`, `wd_bucket`, `pos_bucket`, and `other_*` are still from `_get_mosaic_channel_split` — which is also being called at line 946 (`split = _get_mosaic_channel_split(...)`). That call will still return a `foodpanda` key in `split` (from Mosaic), which gets popped at line 948. The plan says "The Mosaic-only `split["foodpanda"]` (if present) is discarded." This is correct.
+
+**BUT:** The plan does NOT explicitly state that `fp_bucket["net_wo_vat"]` in the headline sum (lines 989–996, `delivery_sales_without_vat`) and in `true_net_wo_vat` (line 1000) must also come from `fp_unified`. Task 2.1 says to replace the `fp_bucket = split.pop(...)` line but does NOT tell the agent to verify that ALL downstream uses of `fp_bucket` in the same function automatically switch over. A cold-start agent might only replace the assignment and not trace all six uses of `fp_bucket` in `_apply_mosaic_channel_split`.
+
+**This is marginal** (a careful agent will trace all uses), but the plan should include an explicit "trace all 6 uses of `fp_bucket` in this function" instruction or a MUST_CONTAIN assertion for the count.
+
+**Severity: WARNING** (not a blocker if agent is careful, but high risk)
+
+---
+
+### WARNING-1: PostgREST fallback in `_get_unified_foodpanda_totals` (task 1.2) requires Python-side FULL OUTER JOIN semantics — no implementation guide given
+
+**Plan claim:** "fetch from both sources separately, then merge in Python using the same (location_id, business_date) FULL OUTER JOIN semantics."
+
+**The problem:** This is a non-trivial Python merge. The SQL FULL OUTER JOIN has exact semantics (Mosaic wins on overlap). The plan does not provide pseudocode or a Python snippet for the fallback merge. A cold-start agent may implement it differently (e.g., prefer legacy instead of Mosaic, or union without dedup). The SQL version is fully specified; the fallback is not.
+
+**Severity: WARNING** — The fallback is degraded-mode only, but if SUPABASE_MGMT_TOKEN is absent during verification, the test will run against the fallback and may produce wrong numbers silently.
+
+---
+
+### INFO-1: Line number claims verified accurate against actual source
+
+All claimed line numbers were verified:
+- `_get_mosaic_channel_split`: line 825 — CORRECT
+- `_apply_mosaic_channel_split`: line 910 — CORRECT
+- `_get_store_channel_split_map`: line 1049 — CORRECT
+- `_get_mosaic_channel_split_per_day`: line 1962 — CORRECT
+- `_FOODPANDA_MOSAIC_START`: line 31 — CORRECT
+- `_supabase_query_sql`: line 229 — CORRECT
+- `_cache_get_or_set`: line 380 — CORRECT
+- `SupabaseMgmtTokenMissing`: line 220 — CORRECT
+- Freshness warning reference to `_FOODPANDA_MOSAIC_START`: line 1296 — CORRECT
+
+All column names in `foodpanda_orders` (plan line 144) and `v_pos_orders_live` (plan line 145) match the code's existing queries.
+
+---
+
+### INFO-2: FULL OUTER JOIN SQL in Design Rationale is paste-ready
+
+The SQL block (lines 76–103 of plan) is complete with both CTEs, all WHERE clauses, the JOIN condition, the COALESCE/source column, and variable placeholders ($start, $end, $locations). A cold-start agent can adapt it with f-string interpolation matching the existing pattern at lines 858–871 of source. No missing clauses.
+
+---
+
+### INFO-3: `_get_mosaic_channel_split_per_day` return shape correctly noted
+
+The plan (task 3.4) says the return shape is `dict[date_iso, dict[channel_key, {"gross", "net_wo_vat", "orders"}]]`. The actual return (lines 2015–2020) is `dict[date_iso, dict[channel_key, float]]` — plain floats, not nested dicts. **However**, the plan's task 3.5 only says to aggregate across all stores per day and override `result[date_iso]["foodpanda"]` — if the result is `float`, the agent must override with a float (net_wo_vat), not a dict. Same root issue as CRITICAL-1 but in a different function. The per-day function returns floats for `net_wo_vat` only (no gross, no orders). The daily time-series chart presumably only needs net_wo_vat.
+
+**Severity: WARNING** — same shape mismatch as CRITICAL-1, but the daily chart only needs net values so it may not cause a visible break. Still: task 3.5 says to put `{gross, net_wo_vat, orders}` into `result[date_iso]["foodpanda"]` which is a type mismatch. The agent needs explicit guidance to use only the `net_wo_vat` float.
+
+---
+
+## 2. Zero-Skip Enforcement
+
+### PASS
+
+- Zero-Skip Enforcement section present (plan lines 297–322): CONFIRMED
+- Forbidden behaviors list: 8 items explicitly listed — CONFIRMED
+- Phase completion checklist format: `output/s191/phase_N_completion.md` per phase — CONFIRMED
+- PR gate: "PR cannot be created until PASS" on verify_s191.py — CONFIRMED
+- Forbidden behaviors include GrabFood and frontend explicitly — CONFIRMED
+
+---
+
+## 3. Machine-Verifiable Phase Gates
+
+### CRITICAL-3: Phase 2.1 lacks a MUST_MODIFY assertion for the headline totals computation change
+
+Phase 2.1 says to "replace `fp_bucket = split.pop(...)` at line 948 with `fp_bucket = fp_unified`." The MUST_MODIFY evidence is:
+> `grep -c "_get_unified_foodpanda_totals_aggregate" hrms/api/sales_dashboard.py` in `_apply_mosaic_channel_split` section ≥ 1
+
+**The problem:** This grep confirms the call was added, but does NOT verify that the old `split.pop("foodpanda", ...)` line was removed. If an agent inserts the new call but leaves the old pop in place, `fp_bucket` will be assigned twice and the second assignment (the old Mosaic-only one) will silently overwrite the unified value. The grep passes, but the code is wrong.
+
+**Required fix:** Add assertion: `grep -c 'split.pop("foodpanda"' hrms/api/sales_dashboard.py` = 0 (the old pop must be gone, replaced by `fp_unified`).
+
+**Severity: BLOCKER**
+
+---
+
+### WARNING-2: verify_s191.py anti-regression grabfood count check has no baseline value documented
+
+The verification script (plan line 319) says:
+> `grep -c "grabfood" hrms/api/sales_dashboard.py` unchanged (count must equal pre-S191 count)
+
+The pre-S191 count is **28** (verified from source). This exact number is not written in the plan. The script needs a hardcoded expected value to be machine-verifiable. Without it, the script author must count it themselves, introducing a cold-start failure mode.
+
+**Required fix:** Add to verification script spec: `assert grabfood_count == 28`.
+
+**Severity: WARNING**
+
+---
+
+### INFO-4: All other grep assertions are specific, correct, and verifiable
+
+Tasks 1.1, 1.2, 1.3, 2.4, 3.2, 3.5, 4.6 all have `grep -c` assertions with exact expected values (≥1 or = 0). These are filesystem-verifiable. AST parse check at 1.4 and 3.7 is correct. The Phase 0.3 baseline audit has 6 named metrics requirement. These are all well-formed.
+
+---
+
+### INFO-5: Verification script required and scoped correctly
+
+Task 4.1 specifies `output/s191/verify_s191.py` with all pattern checks enumerated. The script uses `git diff` + `grep` as required by the S154 rule. PASS.
+
+---
+
+## 4. L3 Scenario Contract
+
+### PASS — Backend-only adaptation is correct
+
+- 12 scenarios defined with concrete user, action, and expected outcome — CONFIRMED
+- Each scenario has specific ₱ thresholds (not vague "higher than before") — CONFIRMED
+- `form_submissions.json` specified as empty array with explicit rationale (page loads only) — this is the correct pattern for read-only analytics sprints per S092
+- `api_mutations.json` specified as empty array — CONFIRMED
+- `state_verification.json` carries the 12 scenarios with pass/fail + actual ₱ amounts — CONFIRMED
+- Screenshots required per scenario — CONFIRMED
+
+**INFO-6:** L3-191-04 (April date range, Mosaic-only, no double-count) is the most important regression scenario and is correctly included. The threshold "~₱9.5M" matches the Mosaic Apr 2026 number from the plan's own audit table.
+
+**INFO-7:** L3-191-08 (overlap zone ₱500K–₱1.5M/day) provides a reasonable sanity range. The plan does not explain how this was derived (₱4.7M Mosaic over ~5 days = ~₱940K/day average; ₱1.5M is roughly 1.6× the average — plausible headroom). This is acceptable.
+
+---
+
+## 5. Closeout Contract
+
+### PASS
+
+- Plan YAML has `status: PLANNED`, `completed_date: null`, `execution_summary: null` — update to DEPLOYED required at closeout, fields present — CONFIRMED
+- Closeout phase (Phase 4.4) specifies plan YAML update + SPRINT_REGISTRY.md update — CONFIRMED
+- `git add -f docs/plans/` explicitly noted at task 4.4 — CONFIRMED
+- `completion_condition` in Autonomous Execution Contract includes registry update — CONFIRMED
+
+---
+
+## 6. Branch & PR Isolation
+
+### PASS
+
+- Branch `s191-foodpanda-unified-source` reserved in registry row in plan YAML — CONFIRMED
+- Branch checkout command in Agent Boot Sequence step 2 — CONFIRMED
+- PR creation at task 4.3 with `GH_TOKEN=""` prefix — CONFIRMED
+- PR registry update at task 4.4 — CONFIRMED
+
+---
+
+## 7. Sentry Observability
+
+### PASS with WARNING
+
+- Task 4.6 correctly notes no new `@frappe.whitelist()` endpoints are introduced — CONFIRMED
+- Task 4.6 says to verify `set_backend_observability_context` is present on existing endpoints — CONFIRMED
+- The verification grep `grep -c "set_backend_observability_context" hrms/api/sales_dashboard.py` ≥ 4 is specified
+
+**Verified from source:** Current count is **5** (lines 22 import + 3 function calls at 3061, 3089, 3171, 3321). The plan says "≥ 4 (unchanged from pre-S191)". The actual pre-S191 baseline is 5 (not 4). The ≥ 4 assertion will pass even if S191 accidentally removes one call (5-1=4 still passes). The assertion should be `== 5` not `≥ 4`.
+
+**Severity: WARNING** — The check as written won't catch accidental removal of one Sentry call.
+
+---
+
+## 8. Requirements Regression Checklist
+
+### PASS
+
+- Checklist present (plan lines 180–194) — CONFIRMED
+- HARD BLOCKER items included:
+  - Mosaic wins overlap — CONFIRMED (item 2: "When both Mosaic and legacy have data...")
+  - GrabFood untouched — CONFIRMED (item 9: "Is GrabFood logic completely untouched? (HARD BLOCKER)")
+  - Cache prefix invalidation — CONFIRMED (item 11: "Does the cache key distinguish the new unified FP totals...")
+- 14 checklist items covering all major behavioral requirements — CONFIRMED
+
+---
+
+## 9. Data Integrity
+
+### CRITICAL-4: Phase 0 baseline threshold ₱1M total variance may be too tight given VAT approximation
+
+**The math:** Legacy net is `subtotal / 1.12`. Mosaic net is `net_sales` (exact VAT per order). On overlap days, the difference per order is: `(actual_vat - approximated_vat)`. If FoodPanda VAT-exempt orders (SC/PWD discounts) represent even 5% of March volume, the approximation error per exempt order is `subtotal × (1 - 1/1.12) ≈ subtotal × 0.107`. On ₱4.7M Mosaic gross with 5% exempt, the systematic VAT mis-approximation alone is ~₱25K. But across 8,477 March Mosaic orders vs 34,337 legacy orders, the overlap period has only ~8,477 orders. If those orders average ₱555 subtotal, and 5% are VAT-exempt, the approximation bias is: `8477 × 0.05 × 555 × 0.107 ≈ ₱25K`. That is well under ₱1M.
+
+**Conclusion:** ₱1M total variance threshold is NOT too tight for the VAT-approximation concern alone. The concern raised is valid in principle but the magnitude is small enough that the ₱1M threshold is safe.
+
+**However:** The plan does NOT explain why ₱1M was chosen. A cold-start agent triggering HARD BLOCKER 0-1 (e.g., finding ₱1.2M variance) would stop without context to evaluate whether it's a real data integrity issue or an expected approximation artifact. The threshold rationale is missing.
+
+**Required addition:** Add to Phase 0 rationale: "The ₱1M threshold is approximately 21% of the Mosaic March total (₱4.7M). Variance above this threshold suggests a source-level discrepancy (duplicate rows, wrong status filter) rather than rounding/VAT-approximation noise (expected to be <₱50K). If HARD BLOCKER 0-1 triggers with variance of ₱50K-₱1M, review the per-store breakdown before escalating."
+
+**Severity: BLOCKER** — Without this rationale, an agent that finds ₱1.05M variance will stop and escalate when the correct response might be "investigate, then likely proceed."
+
+---
+
+### CRITICAL-5: `foodpanda_orders` deduplication by `order_id` not addressed
+
+**The plan's FULL OUTER JOIN** uses:
+```sql
+SELECT location_id, business_date, SUM(subtotal) gross, ...
+FROM foodpanda_orders
+WHERE LOWER(order_status) = 'delivered'
+GROUP BY 1, 2
+```
+
+**The problem:** If `foodpanda_orders` has duplicate `order_id` rows (e.g., re-sync artifacts from the Google Sheet import), `SUM(subtotal)` will double-count those orders. The plan does not dedupe before aggregation. The correct pattern is either:
+```sql
+SUM(DISTINCT subtotal) -- wrong (dedupes by amount, not by order)
+```
+or:
+```sql
+-- correct: dedupe at row level before aggregating
+WITH deduped AS (
+  SELECT DISTINCT ON (order_id) order_id, location_id, business_date, subtotal
+  FROM foodpanda_orders
+  WHERE LOWER(order_status) = 'delivered'
+  ORDER BY order_id
+)
+SELECT location_id, business_date, SUM(subtotal), ...
+FROM deduped GROUP BY 1, 2
+```
+
+The plan's Phase 0 baseline audit (task 0.3) queries the source data but does NOT include a dedup check (`SELECT order_id, COUNT(*) FROM foodpanda_orders GROUP BY order_id HAVING COUNT(*) > 1`). If 50,525 orders has even 500 duplicates averaging ₱600, that's ₱300K phantom revenue that would pass both the HARD BLOCKER threshold and the ≥₱20M post-fix check.
+
+**Required addition:** Add dedup check to Phase 0.3 baseline audit. Add `DISTINCT ON (order_id)` or equivalent to the legacy CTE in the FULL OUTER JOIN SQL.
+
+**Severity: BLOCKER**
+
+---
+
+### CRITICAL-6: March math (₱17M gap) is correct but ₱21.7M legacy figure is gross (subtotal), not net
+
+**The plan states:** "March legacy = ₱21.7M subtotal / 34,337 orders." The Mosaic March = ₱4.7M net. The dashboard fix target is ≥ ₱20M (plan: "foodpanda_sales_without_vat ≥ 18M" at task 2.5).
+
+**The math:**
+- Legacy March gross (subtotal) = ₱21.7M
+- Legacy March net (subtotal/1.12) = ₱21.7M / 1.12 ≈ ₱19.4M
+- Mosaic March net (already net) = ₱4.7M (but this overlaps with legacy — don't add)
+- Unified March net (legacy pre-cutover days + Mosaic post-cutover days) = legacy net MINUS overlap legacy days net + Mosaic overlap days net
+
+The plan's Phase 2.5 smoke test says `foodpanda_sales_without_vat ≥ 18M`. This is approximately correct (₱19.4M minus some Mosaic overlap substitution). The ≥18M lower bound is conservative.
+
+**But the Executive Summary says** "₱21.7M (legacy Google Sheet)" and the L3 scenarios say "FoodPanda ≥ ₱20M." The ₱20M threshold in L3-191-01 and L3-191-05 is comparing against net-without-vat on a gross figure. The actual expected net value is ~₱19.4M. The ≥₱20M L3 threshold WILL FAIL against the correct unified net figure.
+
+**Specifically:** L3-191-01 says "Channel Mix donut shows FoodPanda ≥ ₱20M." But the donut likely shows `foodpanda_sales_without_vat` (net), which should be ~₱19.4M. The threshold ≥₱20M will fail even when the fix is working correctly.
+
+**Required fix:** Change L3-191-01, L3-191-05 thresholds to `≥ ₱18M` (matching the Phase 2.5 smoke test which is correctly calibrated) OR clarify that the donut shows gross (in which case ≥₱20M is correct). The plan is internally inconsistent on gross vs net for the dashboard display.
+
+**Severity: BLOCKER** — L3 test will report false failure on a working fix.
+
+---
+
+## Summary of Required Actions Before Execution
+
+| # | Severity | Action |
+|---|---|---|
+| CRITICAL-1 | BLOCKER | Fix task 3.2 and 3.5: clarify that `_get_store_channel_split_map` returns plain `float` per channel key (not nested dict), and `_get_mosaic_channel_split_per_day` also returns plain `float`. The override must replace the float value with a float (net_wo_vat only), not a nested dict. Add explicit note about what `gross` is not available in these surfaces. |
+| CRITICAL-3 | BLOCKER | Add MUST_MODIFY assertion to task 2.1: `grep -c 'split.pop("foodpanda"' hrms/api/sales_dashboard.py` = 0. The old pop must be removed, not just supplemented. |
+| CRITICAL-4 | BLOCKER | Add Phase 0.3 rationale for ₱1M threshold: explain it is ~21% of Mosaic March total and well above VAT-approximation noise (~₱50K). Provide guidance for agent if variance is ₱50K-₱1M (investigate, likely proceed). |
+| CRITICAL-5 | BLOCKER | Add `order_id` dedup check to Phase 0.3 baseline audit SQL. Add `DISTINCT ON (order_id)` dedup step to the legacy CTE in the Design Rationale FULL OUTER JOIN SQL. |
+| CRITICAL-6 | BLOCKER | Resolve gross vs net inconsistency: the ₱20M threshold in L3-191-01 and L3-191-05 must match the Phase 2.5 smoke test threshold of ₱18M (net), OR the plan must clarify the donut displays gross (in which case ₱20M is correct). |
+| WARNING-1 | WARNING | Add Python pseudocode or snippet for the PostgREST fallback merge logic in task 1.2. Mosaic-wins-on-overlap semantics must be explicit. |
+| WARNING-2 | WARNING | Hardcode pre-S191 grabfood baseline count (28) in the verify_s191.py spec so the anti-regression check is machine-verifiable without manual counting. |
+| WARNING-3 (Sentry) | WARNING | Change `grep -c "set_backend_observability_context" hrms/api/sales_dashboard.py` assertion from `≥ 4` to `== 5` to catch accidental removal of any existing Sentry call. |
+
+---
+
+## What the Plan Does Well
+
+- **Line number accuracy is excellent.** All 9 verified function/constant locations are correct to the actual file.
+- **SQL is paste-ready.** The FULL OUTER JOIN block requires only f-string variable substitution matching the existing code pattern.
+- **GrabFood protection is thorough.** HARD BLOCKER appears in Phase 1, 2, 3 — agents cannot miss it.
+- **Cache prefix invalidation is explicitly called out** as a HARD BLOCKER (task 1.1, HARD BLOCKER 1-1).
+- **Known limitations are honestly documented** (VAT imputation formula, frozen sheet date, GrabFood exclusion, zero-day handling).
+- **L3 evidence contract is correct** for a backend read-only sprint (empty form_submissions.json is the right pattern).
+- **Per-(store, day) FULL OUTER JOIN rationale** is complete and addresses all four overlap cases with a truth table.
+- **Closeout artifacts are enumerated** with exact file paths.
+- **`_FOODPANDA_MOSAIC_START` deprecation comment** is handled correctly (keep for freshness warning at line 1296, mark deprecated).

--- a/output/plan-audit/s191-foodpanda-unified-source/frappe_backend_findings.md
+++ b/output/plan-audit/s191-foodpanda-unified-source/frappe_backend_findings.md
@@ -1,0 +1,256 @@
+# S191 Backend Audit Findings — FoodPanda Unified Source
+**Audited:** 2026-04-12
+**Plan file:** `docs/plans/2026-04-14-sprint-191-foodpanda-unified-source.md`
+**Source file:** `hrms/api/sales_dashboard.py`
+**MV file:** `supabase/migrations/20260316zzz_sales_dashboard_daily_metrics_materialized.sql`
+**Auditor scope:** SQL correctness, cache coherence, PostgREST fallback, cache staleness, per-day edge cases, VAT formula, parameter threading, double-call risk, boundary overlap.
+
+---
+
+## Summary
+
+| Severity | Count |
+|---|---|
+| CRITICAL | 3 |
+| WARNING | 5 |
+| INFO | 4 |
+
+---
+
+## CRITICAL Findings
+
+### C-1: COALESCE treats Mosaic `gross = 0` as "no data" — zero-sales days invisible
+
+**Location:** Plan design rationale SQL (lines 95–97 of plan), Phase 1 task 1.1
+
+**Issue:** The FULL OUTER JOIN result uses:
+```sql
+COALESCE(m.gross, l.gross) AS gross,
+COALESCE(m.net,   l.net)   AS net,
+COALESCE(m.orders, l.orders) AS orders,
+CASE WHEN m.gross IS NOT NULL THEN 'mosaic' ELSE 'legacy_sheet' END AS source
+```
+
+`COALESCE` falls through to the legacy value when `m.gross IS NULL`. But `m.gross` is `SUM(gross_sales)` — if a Mosaic-tracked store had **zero FoodPanda sales that day** (no rows match the `WHERE` filter), the CTE produces **no row at all** for that `(location_id, business_date)`. That is fine — the FULL OUTER JOIN will then have `m.*` all NULL and legacy wins, which is correct.
+
+**However**, the problem is the reverse edge case: if a Mosaic store had exactly **one cancelled PAID order reversed to ₱0.00 gross**, `SUM(gross_sales) = 0` (not NULL), so `COALESCE(0, legacy_gross)` returns `0` and **drops the legacy data**. More concretely: `SUM(gross_sales) = 0.00` is a number, not NULL. The plan says "Mosaic wins on overlap" — but Mosaic winning with ₱0 when the real (legacy) gross is ₱500K is data loss, not a feature.
+
+**Actual risk:** Low for most days (a zero-gross Mosaic FP row is rare), but possible in edge scenarios around the cutover week where early-onboarded stores had incomplete Mosaic data. It should be explicitly documented, and the plan's SQL should clarify the behavior.
+
+**Recommended fix:** The plan should document this edge case explicitly, and the agent should add a comment in the helper:
+```sql
+-- NOTE: COALESCE treats Mosaic gross=0 as "Mosaic wins with zero sales".
+-- This is intentional: once a store is on Mosaic, even a zero-sales day
+-- is authoritative. Legacy data for that (store, day) is suppressed.
+-- If this is undesired, replace with: CASE WHEN m.gross IS NOT NULL THEN m.gross ELSE l.gross END
+-- (which has identical semantics to COALESCE, so the current behavior is correct-by-definition
+-- but the intent should be documented).
+```
+Actually: `COALESCE(m.gross, l.gross)` and the explicit `CASE WHEN m.gross IS NOT NULL` are **semantically identical**. The real concern is whether ₱0 Mosaic should suppress non-zero legacy. The plan does not address this. Flag for CEO awareness before execution.
+
+---
+
+### C-2: `_aggregate_daily_series` still adds `foodpanda_vat_deducted_sales` from MV — double-count NOT eliminated for per-day series
+
+**Location:** `hrms/api/sales_dashboard.py:2061`, `2652–2655`
+
+**Issue:** `_aggregate_daily_series` at line 2058–2061 adds:
+```python
+bucket["superadmin_delivery_wo_vat"] += (
+    _to_float(row.get("website_non_cod_net_sales_without_vat"))
+    + _to_float(row.get("web_cod_net_sales_without_vat"))
+    + _to_float(row.get("foodpanda_vat_deducted_sales"))  # legacy sheet, usually 0
+)
+```
+
+The comment says `# legacy sheet, usually 0` — but for Feb and pre-cutover March dates, `foodpanda_vat_deducted_sales` is NOT zero (it holds the full legacy FP net from the MV). After S191 fixes `_get_mosaic_channel_split_per_day`, the per-day `split["foodpanda"]` in the `mosaic_split_per_day` dict will now include the unified (legacy + Mosaic) FoodPanda net. But `superadmin_delivery_wo_vat` also still adds `foodpanda_vat_deducted_sales` from the MV (lines 2058–2062). Then line 2084–2085:
+```python
+bucket["delivery_sales_without_vat"] = mosaic_delivery_wo_vat + bucket["superadmin_delivery_wo_vat"]
+```
+where `mosaic_delivery_wo_vat` includes the new unified FP net from `split["foodpanda"]`. This means:
+
+**For pre-cutover Mar days:** `delivery_sales_without_vat` = `(legacy FP net via unified split)` + `(legacy FP net from MV via superadmin_delivery_wo_vat)` = **double-count**.
+
+**The plan does not fix this.** Phase 3 only fixes `_get_mosaic_channel_split_per_day` to return the unified FP figure — but does not touch `_aggregate_daily_series` to remove the `foodpanda_vat_deducted_sales` addend.
+
+**Severity:** CRITICAL — the per-day delivery totals and `net_sales_without_vat` in the time-series chart will be inflated for all pre-cutover dates (Feb 1 – Mar ~26). This affects L3-191-07 and L3-191-08 directly.
+
+**Recommended fix:** The plan must add a task to update `_aggregate_daily_series` line ~2061: remove `_to_float(row.get("foodpanda_vat_deducted_sales"))` from `superadmin_delivery_wo_vat`. After S191, the FoodPanda contribution to delivery comes exclusively through `mosaic_split_per_day["foodpanda"]` (unified). The MV `foodpanda_vat_deducted_sales` addend must be zeroed out or removed.
+
+Same issue at line 2652–2655 in the per-store row builder — adds `foodpanda_vat_deducted_sales` to `delivery_sales_without_vat`. That function is not in S191's scope (Surface Ownership Matrix), but it will also double-count if called for pre-cutover dates. Mark as out-of-scope but document.
+
+---
+
+### C-3: PostgREST fallback for legacy `foodpanda_orders` uses paginated row fetch — field `business_date` may not exist in `v_pos_orders_live` PostgREST params, but the legacy table fetch needs `order_status` not `payment_status`
+
+**Location:** Plan Phase 1, task 1.2
+
+**Issue:** The plan says the PostgREST fallback does two separate fetches: Mosaic (`v_pos_orders_live`) and legacy (`foodpanda_orders`). The Mosaic fetch mirrors the existing pattern at line 880–887. The legacy fetch must filter `lower(order_status) = 'delivered'` — but PostgREST does not support `LOWER()` function calls in filter params natively. The existing pattern uses `eq.PAID` for `payment_status` — a direct equality match. For `foodpanda_orders`, the correct PostgREST filter would be `("order_status", "ilike.delivered")` (case-insensitive LIKE), not `("lower(order_status)", "eq.delivered")`.
+
+**If the agent writes** `("order_status", "eq.delivered")` it will miss rows where `order_status = 'Delivered'` (capital D) — the legacy data uses mixed case (confirmed by the SQL in MV: `WHERE lower(order_status) = 'delivered'`).
+
+**The plan does not specify the exact PostgREST filter syntax for the legacy fallback.** This is a gap that the agent will likely get wrong.
+
+**Recommended fix:** The plan should specify: use `("order_status", "ilike.delivered")` for the PostgREST legacy fetch, NOT `eq.delivered`. Add explicit note to task 1.2.
+
+---
+
+## WARNING Findings
+
+### W-1: VAT formula `SUM(subtotal / 1.12)` vs `SUM(subtotal) / 1.12` — confirmed correct but plan claim needs precision
+
+**Location:** Plan line 128, MV `supabase/migrations/20260316zzz_sales_dashboard_daily_metrics_materialized.sql:70`
+
+**Verified:** The MV definition at line 70 is:
+```sql
+coalesce(sum(subtotal / 1.12), 0)::numeric(14,2) as foodpanda_vat_deducted_sales
+```
+
+This is `SUM(subtotal / 1.12)` — division happens **per row before aggregation**, NOT `SUM(subtotal) / 1.12` (aggregation first, then divide). The plan's proposed SQL in the FULL OUTER JOIN CTE uses:
+```sql
+SUM(subtotal / 1.12) net
+```
+This matches the MV exactly. **Good — no discrepancy.**
+
+**However:** `SUM(subtotal / 1.12)` vs `SUM(subtotal) / 1.12` are algebraically equivalent (`SUM(x/c) = SUM(x)/c` for constant `c`). The rounding difference only arises if intermediate `numeric(14,2)` truncation is applied per-row (as in the MV's `::numeric(14,2)` cast). The MV casts the **final SUM** to `numeric(14,2)`, not each row. In Postgres, `subtotal / 1.12` returns `numeric` with high precision (no per-row truncation) and the outer cast rounds the aggregate. The plan's CTE does the same — no per-row cast. So both produce identical results.
+
+**Status:** Correct. No change needed. But the plan's claim "matches the MV formula" is accurate and confirmed.
+
+---
+
+### W-2: Cache key `"fp_unified"` does NOT invalidate the **overview-level** cached payload that was built from the old Mosaic-only `fp_bucket`
+
+**Location:** Plan Phase 1, HARD BLOCKER 1-1; `hrms/api/sales_dashboard.py:396–405`
+
+**Issue:** `_sales_dashboard_cache_key("fp_unified", ...)` creates a NEW key for the new helper. This correctly bypasses any old `"foodpanda"` or `"mosaic_split"` prefixed keys. **However**, the higher-level overview response (e.g., `get_sales_dashboard_overview`) is likely itself cached under its own key (e.g., `"sales_dashboard:overview:..."` or similar). If that outer cache entry was built before S191 deploy and has a 300s TTL, it still contains the old Mosaic-only `foodpanda_sales` values in its payload — even though the inner helper now returns the correct unified figure.
+
+**Risk:** Up to 300s post-deploy (the TTL), the overview endpoint returns stale ₱4.4M FoodPanda. The inner `"fp_unified"` key is properly invalidated, but the outer overview cache isn't.
+
+**The plan acknowledges** "cache key prefix change to `fp_unified` ensures old bucket is bypassed post-deploy" (BLOCKER 1-1) — but this only covers the helper's own cache, not the consumer endpoint's cache.
+
+**Recommended fix:** Add a task to Phase 2 or Phase 0 closeout: on deploy, flush the `sales_dashboard:*` Redis key namespace (or wait 300s). Alternatively, use a deploy-time cache bust by incrementing a version suffix in the overview cache key. At minimum, add a Phase 4 task note: "Wait ≥5 minutes post-deploy before running L3 verification to allow cache TTL to expire."
+
+---
+
+### W-3: `_get_store_channel_split_map` return type mismatch — plan says `{gross, net_wo_vat, orders}` but existing function returns only `{net_wo_vat}` per channel
+
+**Location:** `hrms/api/sales_dashboard.py:1067–1122`, Plan Phase 3, task 3.2
+
+**Issue:** The existing `_get_store_channel_split_map` SQL (line 1067–1078) selects only `SUM(net_sales)::numeric(14,2) AS net_wo_vat` — no `gross`, no `orders` count. The existing per-store bucket shape from this function is `{pos: float, foodpanda: float, ...}` (a single float per channel, not a sub-dict).
+
+The plan task 3.2 says: "call `_get_unified_foodpanda_totals(...)`, sum all `business_date` entries per store to get `{gross, net_wo_vat, orders}`, then **override** `result[location_id]["foodpanda"]` with this aggregated bucket."
+
+But the existing `result[location_id]["foodpanda"]` is a **float** (just `net_wo_vat`), not a dict with `gross/net_wo_vat/orders` keys. If the agent replaces a float with a dict, it will break every consumer that reads `store_split["foodpanda"]` expecting a float.
+
+**Recommended fix:** Before implementing task 3.2, the agent must check how `_get_store_channel_split_map`'s result is consumed (what keys are read from `result[location_id]["foodpanda"]`). The plan assumes both functions return the same `{gross, net_wo_vat, orders}` shape — verify against the consumer at call sites. The S182 implementation explicitly confirms the per-store result is a single float per channel key (line 1117: `bucket[canon_key] += _round_half_up(_to_float(row.get("net_wo_vat")))`). The plan needs to align the shape, or the agent will break the leaderboard.
+
+---
+
+### W-4: `_apply_mosaic_channel_split` double-calls `_get_mosaic_channel_split` AND (after S191) `_get_unified_foodpanda_totals_aggregate` — two SQL round-trips for what could be one
+
+**Location:** Plan Phase 2, task 2.1; `hrms/api/sales_dashboard.py:946`
+
+**Issue:** After S191, `_apply_mosaic_channel_split` will:
+1. Call `_get_mosaic_channel_split(...)` → 1 SQL to `v_pos_orders_live` (returns all channels including FoodPanda from Mosaic)
+2. Call `_get_unified_foodpanda_totals_aggregate(...)` → 1 SQL FULL OUTER JOIN (`v_pos_orders_live` + `foodpanda_orders`)
+
+`v_pos_orders_live` is queried **twice** (once for all channels, once inside the FULL OUTER JOIN for FP only). The Mosaic FP rows from step 1 are then discarded (`split.pop("foodpanda", ...)` result is overwritten by `fp_unified`). This is a wasted DB round-trip.
+
+**Severity:** Functional correctness is fine (the cache at 300s TTL means this only matters on cache-miss). Not a blocking issue, but worth noting. For a 14-day window this was previously 617ms (one SQL). Adding a second SQL for the FULL OUTER JOIN adds ~300–800ms on cache miss. Acceptable given 300s TTL, but document the trade-off.
+
+---
+
+### W-5: Plan's `_get_unified_foodpanda_totals` return type is `dict[int, dict[str, dict]]` (store → date → bucket) but `_get_mosaic_channel_split_per_day` needs `dict[str, dict]` (date → bucket) — aggregation logic is agent-implemented, not specified
+
+**Location:** Plan Phase 3, tasks 3.4–3.5
+
+**Issue:** The plan says `_get_unified_foodpanda_totals` returns `location_id → business_date_isoformat → {gross, net_wo_vat, orders, source}`. For Phase 3 task 3.5, the agent must aggregate across all stores per day: iterate all location_ids, sum `gross/net_wo_vat/orders` per `date_iso`. This is straightforward but the plan does not write the aggregation code — it says "Aggregate across all stores per day: `fp_by_day: dict[date_iso, {gross, net_wo_vat, orders}]`" without showing the loop.
+
+The risk is the agent using a naïve `dict.update()` (last-store wins) instead of a proper additive loop. This is a gap in the plan's specification for task 3.5 that could produce wrong per-day totals if the agent implements it incorrectly.
+
+**Recommended fix:** The plan should include a pseudocode snippet for the date aggregation loop in task 3.5, similar to how the SQL is explicitly provided in Phase 1.
+
+---
+
+## INFO Findings
+
+### I-1: MV `foodpanda_vat_deducted_sales` formula confirmed — `SUM(subtotal / 1.12)` per row, not `SUM(subtotal) / 1.12`
+
+**Location:** `supabase/migrations/20260316zzz_sales_dashboard_daily_metrics_materialized.sql:70`
+
+The MV computes: `coalesce(sum(subtotal / 1.12), 0)::numeric(14,2)`. Division is per-row, cast is on the aggregate. The plan's SQL matches this. No rounding discrepancy exists because Postgres applies no intermediate truncation on `numeric / 1.12` (returns high-precision numeric). **Confirmed correct.**
+
+---
+
+### I-2: Cache key signature for `_sales_dashboard_cache_key` — verified compatible
+
+**Location:** `hrms/api/sales_dashboard.py:396–405`
+
+The `_sales_dashboard_cache_key` signature is:
+```python
+def _sales_dashboard_cache_key(
+    prefix: str,
+    location_ids: list[int],
+    start_day: date | None = None,
+    end_day: date | None = None,
+    view_mode: str | None = None,
+    channel: str | None = None,
+    include_comparisons: bool | None = None,
+    ranking_mode: str | None = None,
+) -> str:
+```
+
+The plan's proposed call `_sales_dashboard_cache_key("fp_unified", location_ids, start_day=start_day, end_day=end_day)` is **compatible** — uses the first 4 parameters only, all optional extras default to `None` and are excluded from the key. Cache key will be: `"sales_dashboard:fp_unified:<loc_csv>:<start>:<end>"`. Correct.
+
+---
+
+### I-3: Boundary overlap (Mar 26) behavior — confirmed correct and intended
+
+**Location:** Plan Design Rationale, "Why Mosaic wins on overlap"
+
+For a store that went live on Mosaic Mar 27, the (store, Mar 26) row: legacy has data, Mosaic has no rows → FULL OUTER JOIN returns `m.*` all NULL → `COALESCE(m.gross, l.gross)` = legacy gross. Correct — legacy data is preserved for pre-cutover days. For stores that went live earlier (e.g., Mar 22), (store, Mar 26): Mosaic has data, legacy also has data → Mosaic wins. **This is the intended behavior per CEO directive.** No code issue — confirming design is sound.
+
+---
+
+### I-4: `_FOODPANDA_MOSAIC_START` constant at line 31 is still referenced at line 1296 freshness warning
+
+**Location:** `hrms/api/sales_dashboard.py:1296–1301`
+
+The freshness warning reads: `if start_day < _FOODPANDA_MOSAIC_START:` and emits a message about the source split. After S191, this warning text will be slightly misleading (it says "split at 2026-03-27" but the real split is per-store). The plan task 2.4 addresses the constant's deprecation comment but does NOT update the warning message text at line 1296–1301. The plan should add a task to update the warning string to reflect the per-store cutover reality (e.g., "FoodPanda source changed per store during the week of 2026-03-21 to 2026-03-27; pre-cutover dates use the legacy Google Sheet, post-cutover uses Mosaic.").
+
+---
+
+## Audit Checklist Response (from Plan's Regression Checklist)
+
+| Check | Verdict |
+|---|---|
+| FULL OUTER JOIN at (location_id, business_date) grain | Plan SQL is correct; no issue |
+| Mosaic wins on overlap | COALESCE logic correct; C-1 edge case (Mosaic gross=0) needs documentation |
+| Legacy-only days preserved | Correct in SQL |
+| Mosaic-only days preserved | Correct in SQL |
+| Legacy net = `subtotal / 1.12` | Confirmed matches MV (I-1) |
+| `LOWER(order_status) = 'delivered'` filter | SQL correct; PostgREST fallback has gap (C-3) |
+| `payment_status = 'PAID'` filter | Correct |
+| Result shape `{gross, net_wo_vat, orders}` | Shape mismatch in `_get_store_channel_split_map` consumer (W-3) |
+| GrabFood untouched | Plan hard-blocks this correctly |
+| All three functions updated | Phase 3 covers all three |
+| Cache key invalidates old bucket | Helper cache correct; outer overview cache not invalidated (W-2) |
+| Verification baseline ≥ ₱20M | Defined in Phase 4 |
+| Sentry instrumentation unchanged | Verified — no new `@frappe.whitelist()` endpoints |
+| `_FOODPANDA_MOSAIC_START` retained | Yes, at line 31 + deprecation comment task 2.4 |
+
+---
+
+## Recommended Pre-Execution Plan Amendments
+
+1. **[CRITICAL/C-2]** Add Phase 3 task 3.6 (renumber existing 3.6→3.7, 3.7→3.8): Remove `_to_float(row.get("foodpanda_vat_deducted_sales"))` from `superadmin_delivery_wo_vat` accumulator in `_aggregate_daily_series` (line ~2061). This is the most important fix missing from the plan.
+
+2. **[CRITICAL/C-3]** Update Phase 1 task 1.2: specify PostgREST filter for legacy table as `("order_status", "ilike.delivered")`, not `eq.delivered`.
+
+3. **[CRITICAL/C-1]** Add documentation note: when Mosaic `SUM(gross_sales) = 0.00` for a (store, day), COALESCE drops legacy data. Decision: is this intended? If yes, document. If no, no code change needed (behavior is already correct-by-definition).
+
+4. **[WARNING/W-3]** Add Phase 3 pre-task: read every call site of `_get_store_channel_split_map` and confirm whether the `["foodpanda"]` value is consumed as a float or as a dict. Align the override to match the existing shape.
+
+5. **[WARNING/W-2]** Add Phase 4 task: post-deploy, wait ≥5 min before L3 (or explicitly flush `sales_dashboard:*` Redis keys via `frappe.cache().delete_keys("sales_dashboard:*")`).
+
+6. **[INFO/I-4]** Add task 2.4b: update warning string at `sales_dashboard.py:1297–1301` to reflect per-store cutover (not a global 2026-03-27 date).

--- a/output/plan-audit/s191-foodpanda-unified-source/system_arch_findings.md
+++ b/output/plan-audit/s191-foodpanda-unified-source/system_arch_findings.md
@@ -1,0 +1,332 @@
+# S191 System Architecture Audit — FoodPanda Unified Source
+
+**Auditor:** System architect sub-agent (Claude Sonnet 4.6)
+**Date:** 2026-04-12
+**Plan file:** `docs/plans/2026-04-14-sprint-191-foodpanda-unified-source.md`
+**Target file:** `hrms/api/sales_dashboard.py`
+**Audit scope:** Data integrity, baseline validation thresholds, downstream callers, cache coherence, historical consistency, Mosaic-wins correctness, rollback path, GrabFood isolation
+
+---
+
+## Summary Table
+
+| # | Severity | Topic | One-line finding |
+|---|---|---|---|
+| F-01 | CRITICAL | Data integrity — MV double-count not fully eliminated | `_aggregate_daily_series` still adds `foodpanda_vat_deducted_sales` from MV even after S191 fix |
+| F-02 | CRITICAL | Data integrity — `_aggregate_sales` initial load uncleared | `_aggregate_sales` loads `foodpanda_subtotal` from MV; `_apply_mosaic_channel_split` overwrites it — but the MV value persists in `net_sales_without_vat` heading until the override runs |
+| F-03 | CRITICAL | Missed downstream caller — `export_sales_dashboard_detail` | CSV export calls `_get_mosaic_channel_split_per_day` directly; after S191 that function will carry correct FP per-day data BUT the `_aggregate_daily_series` consumer still adds the MV's `foodpanda_vat_deducted_sales` residual (F-01), so exported CSVs will show inflated delivery totals for legacy-only days |
+| F-04 | CRITICAL | Cache coherence — overview cache key unchanged | The `"overview"` and `"summary"` cache key prefixes do NOT change in S191. If a user loaded the dashboard before deploy, the cached response with Mosaic-only FP values persists for up to 300s. The plan's `fp_unified` prefix fix only covers the NEW inner helper — the outer `_build_dashboard_overview_payload` and `_build_dashboard_summary_payload` wrappers keep their existing cache keys. Stale results WILL be served immediately after deploy. |
+| F-05 | WARNING | Baseline validation — ₱50K single-day threshold will likely false-trigger | VAT imputation gap (`subtotal/1.12` vs Mosaic `net_sales`) on a medium store-day (~500 orders × avg ₱80 ticket = ₱40K subtotal) produces a ~₱4.3K net difference. But during the overlap window (Mar 26-31) large stores (Trinoma, SM North, etc.) can legitimately produce per-store-day Mosaic vs legacy discrepancies of ₱50K–₱150K due entirely to the VAT computation asymmetry. The ₱50K HARD BLOCKER will trip on valid data and block Phase 1. |
+| F-06 | WARNING | Baseline validation — ₱1M total overlap variance threshold ambiguity | The plan does not specify whether the ₱1M is SUM(ABS(mosaic - legacy)) per day across all overlap days, or max single day. With ~6 overlap days × 40+ stores, even a 5% average net-vs-gross discrepancy from the `subtotal/1.12` approximation can produce ~₱1.5M total variance. The threshold may block legitimate execution. |
+| F-07 | WARNING | Mosaic-wins correctness — no completeness threshold | The plan picks Mosaic for any overlap (store, day) regardless of order count. If Mosaic had a sync interruption and captured only 30% of actual orders on that day, Mosaic-wins discards the complete legacy data. The plan has no minimum-orders or minimum-gross completeness guard. |
+| F-08 | WARNING | `_build_comparisons` uses raw `_aggregate_sales` on prior-period rows | Comparison periods (previous period, same period last year) call `_aggregate_sales` without calling `_apply_mosaic_channel_split`. This means comparison `gross_sales_delta` is computed against the MV's legacy FP totals for the baseline period (Feb 2026), producing a misleading delta. The fix will make March look ₱17M higher while the February comparison baseline remains MV-only (₱9.5M). The reported delta will be distorted for any date window that spans or abuts the legacy period. |
+| F-09 | WARNING | `_sales_row_metrics` helper uses stale MV FP value | `_sales_row_metrics` (line 2644) computes `delivery_sales_without_vat` from `foodpanda_vat_deducted_sales` (MV legacy column). This helper feeds the store-detail panel and any direct consumer. The plan does not identify this as a caller to update. |
+| F-10 | WARNING | Historical reporting consistency — ₱17M delta not flagged for Sam | S191 will retroactively change reported Feb and March FP revenue from ₱4.4M → ₱21.7M (March) and ₱0 → ₱8.5M (Feb net). Financial close reports, Apex P&L, and any commission calculations that used the old dashboard numbers will be inconsistent with post-S191 figures. This is explicitly out of scope but Sam MUST be notified before deploy. |
+| F-11 | INFO | GrabFood isolation — plan is architecturally safe | `_apply_mosaic_channel_split` pops `"grabfood"` from the Mosaic-only split dict independently of FoodPanda. The plan's Phase 2 replaces only `fp_bucket` via the new unified aggregate. GrabFood path is provably untouched IF the developer follows the plan correctly. The verification script's `grabfood` count assertion is appropriate. |
+| F-12 | INFO | Rollback path — adequate but requires manual cache flush | Reverting the PR and redeploying restores the old Mosaic-only behavior. However the `fp_unified` inner cache entries (300s TTL) will continue serving unified data for up to 5 minutes post-rollback. The outer `"overview"` and `"summary"` cache keys will also have stale S191 entries for 300s. No explicit cache flush mechanism is documented in the plan. |
+| F-13 | INFO | PostgREST fallback for FULL OUTER JOIN not implementable cleanly | The plan (Phase 1.2) requires a Python-level FULL OUTER JOIN fallback when `SUPABASE_MGMT_TOKEN` is missing. PostgREST cannot execute a FULL OUTER JOIN — it exposes individual tables only. The fallback must fetch both sources separately and merge in Python, which is correct per the plan. But the plan underestimates the complexity: paginating `foodpanda_orders` for a 2-month, 45-store window may return 50K+ rows (~50+ pages at 1000/page). Plan's 6-unit budget for Phase 1 may be tight if fallback is implemented thoroughly. |
+| F-14 | INFO | `_FOODPANDA_MOSAIC_START` freshness warning (line 1296) will be permanently stale | After S191 the warning "FoodPanda source split at 2026-03-27: earlier dates come from the legacy sheet" is no longer accurate — data from both sources is now unified regardless of date. The warning should be updated to reflect the new unified source model. The plan marks the constant as deprecated but does not update the user-facing warning string. |
+
+---
+
+## Detailed Findings
+
+---
+
+### F-01 — CRITICAL: `_aggregate_daily_series` adds MV's `foodpanda_vat_deducted_sales` even after S191
+
+**Location:** `sales_dashboard.py:2058-2061`
+
+**Evidence:**
+```python
+bucket["superadmin_delivery_wo_vat"] += (
+    _to_float(row.get("website_non_cod_net_sales_without_vat"))
+    + _to_float(row.get("web_cod_net_sales_without_vat"))
+    + _to_float(row.get("foodpanda_vat_deducted_sales"))  # legacy sheet, usually 0
+)
+```
+
+The comment says "usually 0" but that is only true POST-cutover. For Feb and early March 2026, `foodpanda_vat_deducted_sales` in the MV contains the full legacy sheet net — up to ~₱400K/day for the fleet. After S191, `_get_mosaic_channel_split_per_day` will correctly return unified FP per-day data (including legacy days), which is used in `_aggregate_daily_series` (line 2081) to compute `mosaic_delivery_wo_vat`. BUT `superadmin_delivery_wo_vat` still adds the MV's `foodpanda_vat_deducted_sales` on top. For any legacy-period day, the final `delivery_sales_without_vat` in the time-series will double-count FoodPanda net: once via `mosaic_delivery_wo_vat` (from the new unified per-day split) and once via `superadmin_delivery_wo_vat` (from the MV).
+
+**Impact:** All time-series data for Feb and early March 2026 will show inflated delivery totals. The export endpoint (`export_sales_dashboard_detail`) also uses this path and will export incorrect data.
+
+**Required fix:** The `+ _to_float(row.get("foodpanda_vat_deducted_sales"))` line in `_aggregate_daily_series` must be removed (or zeroed) as part of S191 — it is functionally obsolete once the unified per-day split is in place. This is analogous to what S176 hotfix #10 did for the headline summary (removing the MV FP double-count from `_aggregate_sales`'s downstream). The plan does not include this in Phase 3.
+
+---
+
+### F-02 — CRITICAL: `_aggregate_sales` seeds `foodpanda_sales` from MV before `_apply_mosaic_channel_split` overrides it
+
+**Location:** `sales_dashboard.py:1492-1499`
+
+**Evidence:**
+```python
+totals["foodpanda_sales"] += _to_float(row.get("foodpanda_subtotal"))
+totals["foodpanda_sales_without_vat"] += _to_float(row.get("foodpanda_vat_deducted_sales"))
+...
+totals["delivery_sales_without_vat"] += (
+    ...
+    + _to_float(row.get("foodpanda_vat_deducted_sales"))
+)
+```
+
+`_aggregate_sales` initializes `foodpanda_sales` and `foodpanda_sales_without_vat` from the MV's `foodpanda_subtotal` / `foodpanda_vat_deducted_sales`. For historical dates (Feb-Mar) these columns contain the full legacy Google Sheet values — roughly correct. `_apply_mosaic_channel_split` then OVERWRITES `summary["foodpanda_sales"]` and `summary["foodpanda_sales_without_vat"]` with the Mosaic-only bucket, dropping the legacy data.
+
+After S191, `_apply_mosaic_channel_split` will call `_get_unified_foodpanda_totals_aggregate` and correctly replace these with the unified total. So the overwrite chain is correct for the headline FP fields. HOWEVER: `delivery_sales_without_vat` is ALSO seeded in `_aggregate_sales` (line 1498) with `foodpanda_vat_deducted_sales`, and `_apply_mosaic_channel_split` does override `delivery_sales_without_vat` at line 989-996 — so this path is correctly handled.
+
+**Residual risk:** The seeded-then-overridden pattern means that if `_apply_mosaic_channel_split` ever fails (exception or short-circuit), the caller receives the MV-only FP values (which are wrong for post-March dates when MV has zero). There is no explicit try/except guard. Low severity in normal operation, but worth noting for defensive coding.
+
+---
+
+### F-03 — CRITICAL: `export_sales_dashboard_detail` is a missed caller (F-01 compounded)
+
+**Location:** `sales_dashboard.py:3244-3297`
+
+**Evidence:**
+```python
+mosaic_split_per_day = _get_mosaic_channel_split_per_day(start_day, effective_end, selected_location_ids)
+series = _aggregate_daily_series(scope["selected_stores"], sales_rows, weather_rows, mosaic_split_per_day)
+export_rows = _build_export_rows(scope, series, sales_rows)
+```
+
+The CSV export endpoint calls `_get_mosaic_channel_split_per_day` (which S191 will fix to return unified data) and feeds it into `_aggregate_daily_series`. Because of F-01, the export will double-count FP delivery for legacy days. Additionally, the plan's Phase 3.6 audit (`foodpanda_call_sites_audit.md`) is likely to miss this caller because it is not in the three listed target functions. The plan's test scenarios (L3-191-01 through L3-191-12) do not include a CSV export scenario.
+
+**Required action:** Add `export_sales_dashboard_detail` to the call-sites audit. Fix F-01 (remove `foodpanda_vat_deducted_sales` from `_aggregate_daily_series`). Add an L3 scenario for the export endpoint.
+
+---
+
+### F-04 — CRITICAL: Outer cache keys unchanged — stale data served immediately after deploy
+
+**Location:** `sales_dashboard.py:2807-2815` (summary), `2915-2924` (overview)
+
+**Evidence:**
+```python
+# summary payload:
+cache_key = _sales_dashboard_cache_key(
+    "summary",
+    selected_location_ids,
+    start_day=start_day,
+    end_day=end_day,
+    view_mode=view_mode,
+    channel=channel,
+    include_comparisons=include_comparisons,
+)
+
+# overview payload:
+cache_key = _sales_dashboard_cache_key(
+    "overview",
+    selected_location_ids,
+    ...
+)
+```
+
+The plan's HARD BLOCKER 1-1 correctly mandates the `fp_unified` prefix for the inner helper cache. BUT the outer `"summary"` and `"overview"` cache keys are formed from the **same** parameters as before deploy. Any user who loaded the dashboard before deploy will have a cached response (keyed as `"sales_dashboard:summary:...dates..."`) that contains Mosaic-only FP data. After deploy, that cache key is still valid and the old cached value will be returned for up to 300s. The new `fp_unified` inner cache is bypass-correct (new key = no stale hit) but the outer response cache wraps the entire builder function including the corrected FP values — so if the outer cache is hit, the new unified values never reach the user.
+
+**Practical impact:** Depending on traffic patterns, some users may see the old ₱4.4M figure for up to 5 minutes after deploy. In a high-traffic production environment this is a customer-visible issue.
+
+**Required fix:** Either (a) bump the outer cache key prefix to `"summary_v2"` / `"overview_v2"` (same approach as `"freshness_v2"` at line 743), or (b) document explicitly in the deploy runbook that the 300s TTL means stale data is possible and time the deploy accordingly. Option (a) is safest.
+
+---
+
+### F-05 — WARNING: ₱50K single-store-day variance threshold will likely false-trigger on valid data
+
+**Location:** Plan Phase 0, HARD BLOCKER 0-1
+
+**Analysis:**
+
+The plan compares Mosaic `net_sales` (already net of VAT) against legacy `subtotal / 1.12` (approximated net). During the Mar 26-31 overlap window, the two sources measure different things:
+- Mosaic `net_sales` = gross minus actual VAT per transaction (exact)
+- Legacy `subtotal / 1.12` = gross / 1.12 (assumes 100% vatable, ignores SC/PWD exemptions)
+
+For a high-volume store (e.g., Trinoma, SM North) with ₱300K–₱600K FP daily gross, a 5-10% systematic VAT computation gap produces ₱15K–₱60K per-store-day difference from methodology alone — not data quality issues. SC/PWD exempt orders (typically 3-8% of transactions) further widen this gap.
+
+Additionally, if the overlap period includes a store where Mosaic and the Google Sheet were synced from the same underlying FoodPanda data, the gross values should match but net will differ by design. The ₱50K threshold will trigger on any high-volume store in the overlap window.
+
+**Recommendation:** Raise the per-store-day threshold to ₱100K, or better: define the threshold as a percentage of gross (e.g., >15% relative difference) rather than an absolute peso amount. Also clearly document in HARD BLOCKER 0-1 that VAT computation differences are expected and should NOT block — only large absolute discrepancies (>30%) in gross values are blocking indicators.
+
+---
+
+### F-06 — WARNING: ₱1M total overlap variance is ambiguous and likely too tight
+
+**Location:** Plan Phase 0, HARD BLOCKER 0-1
+
+**Analysis:**
+
+With ~6 overlap days and ~45 stores, if even 20 stores were active on FoodPanda during the overlap, that is 120 store-day comparisons. A systematic 1% gross vs net imputation difference on ₱100K average store-day = ₱120K total. A 5% difference = ₱600K. This is within the ₱1M threshold, but only barely. On high-sales days (weekends, holidays), the total can easily exceed ₱1M from pure methodology differences.
+
+The plan's documented Supabase numbers show Mosaic Mar total = ₱4.7M net across 8,477 orders. If the overlap (6 days) accounts for ~50% of those orders, that is ~₱2.35M net. Legacy for the same 6 days would be approximately the same amount gross but ~12% more as net-from-gross = ₱2.63M. Systematic overlap variance = ~₱280K, well under ₱1M. But this is a fleet-level number — per-store-day thresholds are more likely to false-trigger.
+
+**Recommendation:** Make HARD BLOCKER 0-1 two separate checks:
+1. Total overlap variance in GROSS values (not net) > ₱2M: BLOCK (genuine data issue)
+2. Total overlap variance in net values: WARNING only (expected from VAT methodology)
+This prevents the baseline audit from blocking on methodology-only differences.
+
+---
+
+### F-07 — WARNING: Mosaic-wins has no completeness threshold — partial sync beats complete legacy
+
+**Location:** Plan Design Rationale "Why Mosaic wins on overlap"
+
+**Analysis:**
+
+The plan states: "Once a store is on Mosaic, the Google Sheet is redundant." This is true for a fully synced day. But Mosaic's sync from FoodPanda's aggregator API can be delayed or interrupted. Historical evidence: the plan itself notes that `_FOODPANDA_MOSAIC_START` was bumped from Mar 26 to Mar 27 because "2026-03-25 and 2026-03-26 were PARTIAL Mosaic days" (line 29-30).
+
+If Mosaic captured 40% of orders on Mar 26 (partial sync day) and the FULL OUTER JOIN sees Mosaic > 0 for that (store, day), Mosaic wins — discarding the complete legacy data for that store-day. The resulting total for Mar 26 would be systematically understated.
+
+**No fix exists within the plan's architecture** (the FULL OUTER JOIN design has no row-count signal). Recommended mitigation: add a heuristic completeness guard in `_get_unified_foodpanda_totals`: if `mosaic_orders < legacy_orders * 0.5` for a given (store, day) AND `mosaic_gross < legacy_gross * 0.5`, prefer legacy. Document this in the code with an explicit "partial-sync guard" comment.
+
+Alternatively, the agent executing S191 should check the Phase 0 baseline audit specifically for Mar 25-26 overlap days to see if partial-sync stores exist, and document them in `BASELINE_SUMMARY.md` before choosing Mosaic-wins unconditionally.
+
+---
+
+### F-08 — WARNING: `_build_comparisons` uses raw `_aggregate_sales` — comparison deltas will be distorted
+
+**Location:** `sales_dashboard.py:1760-1803`
+
+**Evidence:**
+```python
+prev = _aggregate_sales(prev_rows) if prev_rows else {}
+last_year = _aggregate_sales(last_year_rows) if last_year_rows else {}
+```
+
+`_build_comparisons` computes previous-period and year-over-year deltas by calling `_aggregate_sales` directly without `_apply_mosaic_channel_split`. For comparison periods that include legacy FP data (Feb 2026, Feb 2025 if available), the baseline `gross_sales` is sourced from the MV's `total_gross_sales` which includes `foodpanda_subtotal` (legacy column, correct for those periods). For March 2026 current period post-S191, the headline `gross_sales` will include unified FP (~₱21.7M). The previous period (Feb 2026 as the 1-month lookback) will use the MV's `total_gross_sales` which ALSO includes the legacy FP correctly for February. So the delta calc may actually be correct for gross — the MV already includes legacy FP in `total_gross_sales`.
+
+However the per-channel breakdown in comparison payloads (`baseline_gross_sales`) is MV-only, while the current period is now unified. Channel-level comparison features (if any frontend uses `foodpanda_sales` from the comparison baseline) will be inconsistent.
+
+**Risk level:** Moderate. The headline gross delta should be directionally correct since the MV's `total_gross_sales` includes legacy FP. But any user trying to do channel-level period comparison will see a misleading apples-to-oranges comparison (unified current vs MV-only baseline). Not blocking for S191, but should be documented as a known gap.
+
+---
+
+### F-09 — WARNING: `_sales_row_metrics` uses MV's `foodpanda_vat_deducted_sales` and is not in scope
+
+**Location:** `sales_dashboard.py:2644-2657`
+
+**Evidence:**
+```python
+def _sales_row_metrics(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        ...
+        "delivery_sales_without_vat": (
+            _to_float(row.get("website_non_cod_net_sales_without_vat"))
+            + _to_float(row.get("web_cod_net_sales_without_vat"))
+            + _to_float(row.get("foodpanda_vat_deducted_sales"))   # ← stale MV column
+        ),
+    }
+```
+
+This helper is called in at least one place in the comparison/effects calculation chain. After S191, `foodpanda_vat_deducted_sales` in the MV is functionally the same for legacy dates (it was correct before), but it remains ₱0 for post-cutover dates. For date ranges spanning both legacy and Mosaic periods, this helper will undercount delivery for Mosaic-period rows. Since the plan does not touch `_sales_row_metrics`, and the plan's Phase 3.6 audit specifically looks for `channel.*FoodPanda|foodpanda_orders` patterns, this reference using `foodpanda_vat_deducted_sales` may be missed.
+
+**Required action:** Add `_sales_row_metrics` to the Phase 3.6 call-sites audit. Decide whether to fix it (replace with `_get_unified_foodpanda_totals` per-day lookup or simply zero the MV term and rely on the day-series correction) or explicitly document it as an unaddressed gap.
+
+---
+
+### F-10 — WARNING: Historical reporting inconsistency — financial close numbers will be retroactively changed
+
+**Location:** Not in code — business impact of the data change
+
+**Impact:**
+
+S191 will increase reported March 2026 FoodPanda revenue from ~₱4.4M to ~₱21.7M on ALL analytics surfaces. Any financial close document, Apex P&L, commission report, or business review presentation that used the old dashboard numbers between 2026-03-31 and the S191 deploy date will be inconsistent with post-S191 figures. Specifically:
+- Apex P&L March 2026 FoodPanda line: will be wrong vs dashboard
+- Any board/management report using March dashboard screenshots: will be inconsistent
+- Commission structures based on FP channel volume: recalculation may be needed
+- Tax declarations that used the old numbers: MAY need amendment (if VAT is filed quarterly, the Mar FP revenues should already be captured in QR1 filings via FoodPanda's own records, but the ERP's reported number diverged)
+
+**This is out of scope for S191 but Sam MUST be explicitly notified before deploy.** Suggested wording: "S191 will retroactively show ₱17M+ of FoodPanda sales that were always real but not appearing in the dashboard. No revenue is being added or removed — only the visibility. However, any existing report that used the old ₱4.4M figure should be noted as using pre-S191 (Mosaic-only) data."
+
+---
+
+### F-11 — INFO: GrabFood isolation is architecturally safe
+
+**Analysis:**
+
+`_apply_mosaic_channel_split` (lines 947-950) pops channels from the Mosaic-only split dict in this order: `pos`, `foodpanda`, `grabfood`, `webdelivery`. The plan (Phase 2.1) replaces `fp_bucket` with the output of `_get_unified_foodpanda_totals_aggregate` but leaves `gf_bucket = split.pop("grabfood", ...)` unchanged. Since the new unified helper ONLY queries FoodPanda channel rows (explicit `WHERE channel = 'FoodPanda'` in both Mosaic and legacy sides of the JOIN), GrabFood is structurally isolated.
+
+The verification script's `grabfood` line-count assertion (count must equal pre-S191 count) provides a reasonable regression guard. F-11 is informational — no action needed beyond confirming the anti-regression count passes.
+
+---
+
+### F-12 — INFO: Rollback is functional but has a 300s window of stale unified data
+
+**Rollback procedure (not in plan):**
+
+1. Revert PR: `git revert <S191 commit>` or use GitHub PR revert
+2. Redeploy: `/deploy-frappe`
+3. Wait up to 300s for both `fp_unified` inner cache and `"summary"`/`"overview"` outer cache to expire
+
+Post-rollback the dashboard returns to Mosaic-only FP (₱4.4M March). No database migration is needed since S191 is purely read-path logic. No new tables, columns, or stored data are introduced. Rollback risk is LOW.
+
+**Recommended addition to plan:** Add a rollback step to Phase 4 explicitly stating: "If post-deploy L3 verification fails, revert via `git revert` and redeploy. Allow 300s for cache expiry before re-testing."
+
+---
+
+### F-13 — INFO: PostgREST fallback for FULL OUTER JOIN will be expensive under token-missing conditions
+
+**Analysis:**
+
+The fallback (Phase 1.2) must make two separate PostgREST calls:
+- `v_pos_orders_live` filtered by `channel=FoodPanda`, for 2 months × 45 stores: potentially 8,000-15,000 rows
+- `foodpanda_orders` filtered by `lower(order_status)='delivered'`: potentially 50,000+ rows for a 2-month window
+
+PostgREST requires pagination at 1,000 rows/page. For `foodpanda_orders` this is 50+ sequential HTTP calls. The original `_get_mosaic_channel_split` fallback for a 14-day window was already "111 paginated requests × ~400ms = 45 seconds." A 60-day window with the legacy table adds significantly more. This path will time out in most serverless/Frappe contexts if SUPABASE_MGMT_TOKEN is ever missing.
+
+**Recommendation:** Document in the fallback that a 60-day window may time out and add a `frappe.log_error` with estimated row counts. Alternatively, limit the fallback's date window to a shorter range (e.g., 14 days) and surface a "data incomplete — management token required" warning for longer ranges.
+
+---
+
+### F-14 — INFO: User-facing freshness warning string will be outdated after S191
+
+**Location:** `sales_dashboard.py:1296-1300`
+
+**Evidence:**
+```python
+if start_day < _FOODPANDA_MOSAIC_START:
+    warnings.append(
+        "FoodPanda source split at 2026-03-27: earlier dates come from the legacy "
+        "foodpanda_orders Google Sheet (frozen 2026-03-31), later dates come from "
+        "Mosaic pos_orders. Historical totals are complete."
+    )
+```
+
+After S191, this statement is still factually true (data sources are the same), but the framing is misleading. The warning implies users might see incomplete or split data, but after S191 the union is seamless. The "source split" language may cause confusion.
+
+**Recommended update:** Change to: "FoodPanda data for dates before 2026-03-27 comes from the legacy Google Sheet (frozen 2026-03-31). Data for dates on or after 2026-03-27 comes from Mosaic POS. Both sources are unified — historical totals are complete." Add to Phase 2.4 task.
+
+---
+
+## Blocking Actions Required Before S191 Executes
+
+The following issues MUST be resolved before the executing agent proceeds:
+
+1. **F-01 (CRITICAL):** Add Phase 2 or Phase 3 task to remove `foodpanda_vat_deducted_sales` from the `superadmin_delivery_wo_vat` accumulator in `_aggregate_daily_series` (line 2061). Without this, the time-series and CSV export will double-count FP delivery for all legacy dates.
+
+2. **F-04 (CRITICAL):** Add a Phase 2 task to bump outer cache prefixes to `"summary_v2"` / `"overview_v2"` (following the `"freshness_v2"` precedent at line 743). Otherwise users may see stale Mosaic-only FP data for up to 300s post-deploy.
+
+3. **F-05/F-06 (WARNING):** Revise HARD BLOCKER 0-1 thresholds:
+   - Single-store-day BLOCKING threshold: raise from ₱50K to ₱150K OR switch to >25% relative difference in gross values
+   - Total overlap variance: change from blocking on net difference to blocking on gross difference >₱2M; net-only difference is expected from VAT methodology asymmetry
+
+## Recommended Additions (Non-Blocking)
+
+4. **F-07:** Add a partial-sync guard in `_get_unified_foodpanda_totals`: if `mosaic_orders < legacy_orders * 0.5` AND `mosaic_gross < legacy_gross * 0.5` for a given (store, day), prefer legacy. Document as "partial-sync guard."
+
+5. **F-08:** Document in Phase 4 closeout that comparison period baselines (previous period, YoY) use MV-sourced `_aggregate_sales` without unified FP split. Known gap, not fixed in S191.
+
+6. **F-09:** Add `_sales_row_metrics` to the Phase 3.6 call-sites inventory. Decide fix vs. document gap.
+
+7. **F-10:** Add a deploy-time notification step in Phase 4: "Notify Sam that March and February FoodPanda totals will retroactively increase in all analytics surfaces. Existing reports using pre-S191 numbers should be noted as Mosaic-only-era data."
+
+8. **F-12:** Add explicit rollback steps to Phase 4 closeout documentation.
+
+9. **F-14:** Update freshness warning string (line 1297-1300) to remove misleading "source split" language.
+
+---
+
+## Audit Confidence
+
+- Code read: `sales_dashboard.py` lines 820-1300, 1460-1520, 1760-1815, 1960-2110, 2350-2400, 2480-2530, 2630-2660, 2790-2970, 3240-3300 (targeted reads, not exhaustive)
+- Plan read: complete (420 lines)
+- Callers verified via grep: `_get_mosaic_channel_split`, `_get_store_channel_split_map`, `_get_mosaic_channel_split_per_day`, `_apply_mosaic_channel_split`, `foodpanda_orders`, `foodpanda_vat_deducted_sales`, `_FOODPANDA_MOSAIC_START`
+- Findings F-01 and F-04 are HIGH confidence based on direct code evidence
+- Findings F-05/F-06 are MEDIUM confidence — require actual overlap data counts from Phase 0 to confirm false-trigger rate
+- Finding F-07 is MEDIUM confidence — requires checking Mosaic sync reliability history
+- Findings F-08/F-09 are HIGH confidence based on code read

--- a/output/s193/controller_check.md
+++ b/output/s193/controller_check.md
@@ -1,0 +1,34 @@
+# S193 Phase 0a — Controller + Frontend Error Surface Check
+
+**Date:** 2026-04-14
+
+## Task 0a.1 — Supplier controller (`hrms/hr/doctype/bei_supplier/bei_supplier.py`)
+
+The `BEISupplier.validate()` method runs three checks:
+1. `validate_supplier_code()` — auto-generates if empty, else strip+upper
+2. `validate_required_documents()` — **soft warning** (`frappe.msgprint` with `indicator="orange"`) when status is `Active` but BIR/SEC missing. Does NOT block insert/save.
+3. `validate_invoice_exception_control()` — gates `missing_supplier_invoice_*` fields only
+
+**Conclusion:** Status field accepts all 4 enum values (`Active`, `Inactive`, `Blacklisted`, `Pending Verification`) on `insert()` and `save()`. No state machine, no approval hook in the controller — the approval workflow is enforced at the API layer via `submit_supplier_edit_for_approval` (procurement.py:570), not in the DocType controller.
+
+**Test fixture implication:** Phase 2 tests can create suppliers directly in any of the 4 statuses using `frappe.get_doc({...}).insert(ignore_permissions=True)`. No bypass needed.
+
+## Task 0a.2 — Frontend error surface (`bei-tasks/lib/frappe-api.ts`)
+
+`parseFrappeError(error)` at line 165 extracts the Frappe error message in this priority:
+1. `_server_messages[0].message` (primary path — where `frappe.throw(_("..."))` lands)
+2. `_error_message`
+3. `exception` (last segment after `:`)
+4. `Error.message`
+
+**Conclusion:** When `_assert_supplier_active` fires `frappe.throw(_("Cannot create Purchase Order: Supplier {0} is Blacklisted..."), frappe.ValidationError)`, the response `_server_messages` payload will contain the formatted message, which `parseFrappeError` will return verbatim. Any page using `fetchAPI` → `parseFrappeError` (all procurement pages do) will render the message cleanly.
+
+Spot-check: `bei-tasks/hooks/use-procurement.ts:242` calls `parseFrappeError(error)` in the default `fetchAPI` helper. All PO/Invoice/Payment Request creation flows go through this helper. ✓
+
+**No S194 TODO needed** — existing plumbing handles the new error cleanly.
+
+## Gate: PASS
+
+- [x] Supplier DocType controller permits direct status set for all 4 enum values
+- [x] `parseFrappeError` extracts Frappe ValidationError message
+- [x] One create-page flow confirmed to surface the extracted message via fetchAPI

--- a/output/s193/phase_checklist.md
+++ b/output/s193/phase_checklist.md
@@ -1,0 +1,18 @@
+# S193 Phase Completion Checklist
+
+| Phase | Task | Status | Evidence | Skipped? |
+|-------|------|--------|----------|----------|
+| 0a | Supplier controller check | DONE | `output/s193/controller_check.md` | No |
+| 0a | `parseFrappeError` surface check | DONE | `output/s193/controller_check.md` — frappe-api.ts:165 confirmed | No |
+| 0 | `_assert_supplier_active` helper + status sets | DONE | grep `def _assert_supplier_active` = 1; `_SUPPLIER_BLOCK_ALL_STATUSES` / `_SUPPLIER_BLOCK_NEW_PO_STATUSES` defined | No |
+| 1.1 | `create_purchase_order` guard + Sentry | DONE | grep `set_backend_observability_context.*create_purchase_order` = 1; guard on supplier_name | No |
+| 1.2 | `create_invoice` guard with PO/GR fallback | DONE | grep `_assert_supplier_active.*"invoice"` = 1; `_s193_supplier` chain present | No |
+| 1.3 | `create_payment_request` guard with invoice/PO fallback | DONE | grep `_assert_supplier_active.*"payment_request"` = 1; fallback chain present | No |
+| 2 | 4+1 unit tests | DONE | `hrms/tests/test_procurement_supplier_guard_s193.py` — 5/5 pass offline | No |
+| 3 | PR created | DONE | hrms #569 | No |
+| 3 | Plan YAML → PR_CREATED | DONE | status field updated, execution_summary filled | No |
+| 3 | Registry updated | DONE | S193 row added with PR #569, Next bumped to S194 | No |
+
+**TIN threshold preserved:** grep `tin_requirement_threshold` = 1 (line 1491 intact).
+
+**Zero features removed or deferred.** All 6 audit amendments applied.


### PR DESCRIPTION
## Summary

Makes BEI Supplier master status (`Blacklisted`, `Pending Verification`, `Inactive`) actually enforce procurement policy. Today these statuses are informational — the UI shows them but the backend still accepts POs, Invoices, and Payment Requests. This PR closes the gap.

## Policy

| Status | `create_purchase_order` | `create_invoice` | `create_payment_request` |
|--------|-------------------------|------------------|-------------------------|
| Active | ✅ allow | ✅ allow | ✅ allow |
| Inactive | 🛑 BLOCK | ✅ allow | ✅ allow |
| Blacklisted | 🛑 BLOCK | 🛑 BLOCK | 🛑 BLOCK |
| Pending Verification | 🛑 BLOCK | 🛑 BLOCK | 🛑 BLOCK |

`Inactive` blocks PO creation only — invoices and payments on pre-existing POs still flow so in-flight work isn't stranded when a supplier is deactivated.

## Implementation

- **`_assert_supplier_active(supplier, operation)`** — shared helper next to `_resolve_supplier_identity` at line 111
- **`create_purchase_order`** — guard wired via `supplier_name` extracted from payload
- **`create_invoice`** — guard resolves supplier via `data.get(\"supplier\")` → PO → GR fallback (so 3-way-match invoices are also guarded)
- **`create_payment_request`** — guard resolves via `data.get(\"supplier\")` → Invoice → PO fallback (since RFPs are usually linked to an invoice, not a direct supplier)
- **Error:** `frappe.ValidationError` (HTTP 417) with operation, supplier name, status, and next step. `parseFrappeError` on the frontend renders the full message.
- **DM-7:** Sentry breadcrumb on every denial (wrapped in try/except so observability failure never breaks the guard)
- **Bonus DM-7:** `create_purchase_order` was missing `set_backend_observability_context` entirely — added it in this PR

## Phase status

| Phase | Status |
|-------|--------|
| P0a — Controller + frontend error surface check | ✅ Complete (`output/s193/controller_check.md`) |
| P0 — `_assert_supplier_active` helper | ✅ Complete |
| P1 — Wire 3 call sites + Sentry for create_purchase_order | ✅ Complete |
| P2 — Unit tests (5 tests, all pass offline) | ✅ Complete |
| P3 — PR + closeout | ✅ Complete (this PR) |

## Verification gates

```
grep -c 'def _assert_supplier_active' hrms/api/procurement.py                → 1
grep -c '_assert_supplier_active(' hrms/api/procurement.py                   → 4
grep -c '_assert_supplier_active.*\"purchase_order\"' hrms/api/procurement.py → 1
grep -c '_assert_supplier_active.*\"invoice\"' hrms/api/procurement.py        → 1
grep -c '_assert_supplier_active.*\"payment_request\"' hrms/api/procurement.py → 1
grep -c 'set_backend_observability_context.*create_purchase_order' hrms/api/procurement.py → 1
grep -c 'tin_requirement_threshold' hrms/api/procurement.py                  → 1 (TIN gate preserved)
python hrms/tests/test_procurement_supplier_guard_s193.py                    → 5/5 pass
```

## Deploy note

Requires `skip_build=false, no_cache=true` — new Python code, not a config change.

## Test plan

- [ ] Sam pre-stages 4 test suppliers via bench console (setup script in plan Phase 5 L3 prereqs)
- [ ] L3 scenarios run against the 4 stable codes in a fresh session
- [ ] Evidence files committed to `output/l3/s193/` before closeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)