### PR TITLE
S189 hotfix: seeder UOM + Frappe push company/valuation

### DIFF
--- a/scripts/s189_push_consumption_to_frappe.py
+++ b/scripts/s189_push_consumption_to_frappe.py
@@ -30,6 +30,12 @@ SB_HEADERS = {"apikey": SB_KEY, "Authorization": f"Bearer {SB_KEY}"}
 
 BEI_SOURCE = "S189_POS_BOM_CONSUMPTION"
 DEFAULT_WAREHOUSE = "Stores - BEI"
+DEFAULT_COMPANY = "Bebang Enterprise Inc."
+
+# Frappe rejects qty < 0.001 on Kg UOM Stock Entries with "Qty in Stock UOM can not be
+# zero". Set a floor at 0.001 Kg = 1 gram. Below this, the consumption is negligible
+# and not worth an SE line.
+MIN_QTY = 0.001
 
 # UOM mapping: Supabase material_code prefix -> Frappe UOM + conversion
 # RM/FG items: grams -> KG (divide by 1000)
@@ -144,13 +150,18 @@ def create_or_update_draft_se(date, consumption_rows):
             float(row.get("total_grams", 0)),
             int(row.get("total_cups", 0)),
         )
-        if qty <= 0:
+        if qty < MIN_QTY:
             continue
         items.append({
             "item_code": row["material_code"],
             "qty": qty,
             "uom": uom,
             "s_warehouse": DEFAULT_WAREHOUSE,
+            # HOTFIX (2026-04-14): items without a valuation rate set fail stock
+            # entry submission. For BEI's consumption-tracking use case we don't
+            # care about valuation here — the accounting comes from invoices.
+            "allow_zero_valuation_rate": 1,
+            "basic_rate": 0,
         })
 
     if not items:
@@ -171,6 +182,8 @@ def create_or_update_draft_se(date, consumption_rows):
         result = frappe_post("/api/resource/Stock Entry", {
             "stock_entry_type": "Material Issue",
             "posting_date": date,
+            # HOTFIX (2026-04-14): company is mandatory on Stock Entry; default to BEI.
+            "company": DEFAULT_COMPANY,
             "bei_source": BEI_SOURCE,
             "bei_supabase_date": date,
             "items": items,

--- a/scripts/s189_seed_product_bom.py
+++ b/scripts/s189_seed_product_bom.py
@@ -90,16 +90,39 @@ def fetch_frappe_boms():
     boms = r.json()["data"]
     print(f"  Found {len(boms)} active default BOMs")
 
+    # HOTFIX (2026-04-14): `/api/resource/BOM Item?filters=[["parent",...]]` returns
+    # HTTP 403 for our API token. `GET /api/resource/BOM/{name}` returns the full BOM
+    # doc with embedded `items` child table, which works for us.
     for bom in boms:
-        items_r = requests.get(f"{FRAPPE_URL}/api/resource/BOM Item", params={
-            "filters": f'[["parent","=","{bom["name"]}"]]',
-            "fields": '["item_code","item_name","qty","uom","rate"]',
-            "limit_page_length": 0,
-        }, headers=FRAPPE_AUTH, timeout=30)
-        items_r.raise_for_status()
-        bom["items"] = items_r.json()["data"]
+        detail_r = requests.get(f"{FRAPPE_URL}/api/resource/BOM/{bom['name']}",
+                                headers=FRAPPE_AUTH, timeout=30)
+        detail_r.raise_for_status()
+        bom["items"] = detail_r.json().get("data", {}).get("items", [])
 
     return boms
+
+
+def _qty_to_grams(qty, uom):
+    """Convert BOM item (qty, uom) to grams per serving.
+
+    Frappe BOM items store qty in their native UOM (usually KG for raw materials,
+    G for finer items, Nos/Pcs for packaging). This normalizes everything to
+    grams for RM/FG rows. Packaging items (Nos/Pcs/Pack/Box) keep their count.
+    """
+    if not qty:
+        return 0
+    q = float(qty)
+    u = (uom or "").strip().upper()
+    if u == "KG":
+        return q * 1000
+    if u in ("G", "GRAM", "GRAMS"):
+        return q
+    if u in ("L", "LITER", "LITERS"):
+        return q * 1000  # approximate liquids
+    if u == "ML":
+        return q
+    # Nos, Pcs, Pack, Box — packaging items; count is the meaningful unit
+    return q
 
 
 def fetch_tikim_recipes():
@@ -183,8 +206,10 @@ def build_product_bom_rows(boms, tikim_recipes):
         for item in bom["items"]:
             material_code = item["item_code"]
             material_name = item["item_name"]
-            # grams_per_serving = qty in BOM / bom_quantity (normalize to 1 serving)
-            grams = float(item["qty"]) / bom_qty
+            # grams_per_serving = qty-in-grams / bom_quantity (normalize to 1 serving)
+            # HOTFIX (2026-04-14): BOM items store qty in their native UOM (mostly KG).
+            # Must multiply by 1000 for KG items — _qty_to_grams does this.
+            grams = _qty_to_grams(item.get("qty"), item.get("uom")) / bom_qty
 
             key = (product_name, material_code)
             if key in seen:


### PR DESCRIPTION
## Purpose

End-to-end validation of the deployed S189 pipeline (after #564/#565/#567/#568) surfaced 3 bootstrap-blocking bugs in the scripts. All 3 fixed and the fixes proven against live production.

## The 3 bugs

### 1. `scripts/s189_seed_product_bom.py` — silent 1000x undercount
**Symptom:** after seeding, `daily_material_consumption` showed RM018 at 0.19 kg/day, vs expected 230 kg/day.

**Root cause:** Frappe BOM items store `qty` in native UOM. For raw materials, the UOM is **KG**:
```
FG002 BANANA CINNAMON qty=0.013 uom=KG  # = 13 grams
RM018 UBE HALAYA      qty=0.014 uom=KG  # = 14 grams
```
The seeder treated `qty` as grams directly. 0.014 grams of ube per cup instead of 14 grams → 1000x undercount across every consumption number.

**Fix:** `_qty_to_grams(qty, uom)` helper. Multiplies KG → 1000, keeps G as-is, handles ML/L, leaves counted items (Nos/Pcs/Pack/Box) unchanged.

### 2. `scripts/s189_seed_product_bom.py` — BOM Item child-table 403
**Symptom:** `HTTPError: 403 Client Error: Forbidden for /api/resource/BOM Item?filters=[["parent","=","BOM-..."]]`

**Root cause:** API token lacks read permission on the `BOM Item` DocType (child tables have separate permissions).

**Fix:** Use `GET /api/resource/BOM/{name}` (parent endpoint) — returns the BOM with `items` child table embedded, and works with our token.

### 3. `scripts/s189_push_consumption_to_frappe.py` — 3 validation failures
**Symptom:** `HTTPError 417` on Stock Entry POST with three sequential errors:
- `Row 47: Qty in Stock UOM can not be zero` — qty < 0.001 Kg rejected
- `Valuation Rate for the Item FG023 is required` — items without costing rate
- `[Stock Entry, ...]: company` — mandatory field

**Fixes:**
- `MIN_QTY = 0.001` — skip sub-gram consumption lines
- `allow_zero_valuation_rate: 1` + `basic_rate: 0` per item (BEI consumption tracking doesn't need valuation; accounting comes from invoices)
- `company: "Bebang Enterprise Inc."` on SE payload

## Evidence these fixes work (live production, 2026-04-14)

Bootstrap executed inline with these fixes:

| Component | Before | After |
|-----------|--------|-------|
| `product_bom` rows | 0 (seeder 403) | 286 (21 products, 57 materials) |
| RM018 grams per Presidential cup | 0.014g (1000x undercount) | 14g (matches reality) |
| `daily_material_consumption` | 0 rows | 16,194 rows (7 days × POS + Web) |
| RM018 avg_daily_kg | 0 | **230 kg/day** (matches S189 problem statement of 245 weekend) |
| `fn_material_dtl('RM018', 1067)` | empty | 4.6 days, status LOW |
| Frappe Stock Entry | none | `MAT-STE-2026-00347` Draft with 48 items for 2026-04-13 |

## Test plan

- [x] Syntax checked (both files parse)
- [x] Bootstrap executed live via inline test scripts — all 3 fixes confirmed working
- [ ] After merge, next scheduled `hourly-consumption-to-frappe.yml` run (next :10) will use the fixed push script
- [ ] Run `scripts/s189_seed_product_bom.py` once more manually to confirm the official script now works

🤖 Generated with [Claude Code](https://claude.com/claude-code)