### PR TITLE
fix(S192): rollback_to_savepoint → rollback(save_point=...)

### DIFF
--- a/hrms/api/commissary_planning.py
+++ b/hrms/api/commissary_planning.py
@@ -422,7 +422,7 @@ def set_production_targets(production_date=None, targets=None):
 		}
 
 	except Exception as e:
-		frappe.db.rollback_to_savepoint("set_targets")
+		frappe.db.rollback(save_point="set_targets")
 		frappe.log_error("set_production_targets failed", str(e))
 		return {"success": False, "saved": [], "failed": failed, "error": str(e)}
 

--- a/hrms/api/payroll_compensation.py
+++ b/hrms/api/payroll_compensation.py
@@ -665,7 +665,7 @@ def approve_compensation_change(change_id, approver_action, remarks=None):
 			_activate_compensation_change(doc)
 			frappe.db.release_savepoint("compensation_activation")
 		except Exception as e:
-			frappe.db.rollback_to_savepoint("compensation_activation")
+			frappe.db.rollback(save_point="compensation_activation")
 			frappe.log_error(
 				message=frappe.get_traceback(),
 				title=f"S172: Compensation activation failed for {doc.name}",

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -3819,7 +3819,7 @@ def _create_mr_for_store_order(order):
 			mr.append("items", row)
 
 		if not mr.items:
-			frappe.db.rollback_to_savepoint("create_mr_for_store_order")
+			frappe.db.rollback(save_point="create_mr_for_store_order")
 			return None
 
 		mr.insert(ignore_permissions=True)
@@ -3827,7 +3827,7 @@ def _create_mr_for_store_order(order):
 		frappe.db.release_savepoint("create_mr_for_store_order")
 		return mr.name
 	except Exception as e:
-		frappe.db.rollback_to_savepoint("create_mr_for_store_order")
+		frappe.db.rollback(save_point="create_mr_for_store_order")
 		frappe.log_error(
 			title=f"MR Creation Error for Store Order {order.name}",
 			message=str(e),
@@ -7023,7 +7023,7 @@ def copy_week(source_week: str, target_week: str) -> dict:
 		target_doc.save(ignore_permissions=True)
 		frappe.db.release_savepoint("copy_week")
 	except Exception:
-		frappe.db.rollback_to_savepoint("copy_week")
+		frappe.db.rollback(save_point="copy_week")
 		frappe.log_error("copy_week failed", "Delivery Schedule Copy Error")
 		frappe.throw(_("Failed to copy schedule. No changes were made."))
 
@@ -7567,7 +7567,7 @@ def _create_delivery_fee_billing_on_acceptance(receiving_doc):
 		return schedule.name
 	except Exception:
 		try:
-			frappe.db.rollback_to_savepoint("s168_delivery_fee_billing")
+			frappe.db.rollback(save_point="s168_delivery_fee_billing")
 		except Exception:
 			pass
 		frappe.log_error(

--- a/hrms/overrides/company.py
+++ b/hrms/overrides/company.py
@@ -707,7 +707,7 @@ def auto_provision_company(doc, method=None):
 			alert=True,
 		)
 	except Exception:
-		frappe.db.rollback_to_savepoint("s181_auto_provision")
+		frappe.db.rollback(save_point="s181_auto_provision")
 		frappe.log_error(
 			title=f"S181 auto-provision failed for {doc.name}",
 			message=frappe.get_traceback(),


### PR DESCRIPTION
MariaDBDatabase does not expose rollback_to_savepoint; use rollback(save_point=<name>). 7 callsites fixed. Unblocks MR creation in store-order approval flow.

# 2289454