### PR TITLE
plan(S192): HB-6 Defect Response Protocol — fix-now vs defer + defect registers

### DIFF
--- a/docs/plans/2026-04-14-sprint-192-s190-l3-e2e-store-order-billing.md
+++ b/docs/plans/2026-04-14-sprint-192-s190-l3-e2e-store-order-billing.md
@@ -568,6 +568,22 @@ All SSM mutations (Task 3.1 warehouse create, Task 3.3 Customer rename) logged i
 - **HB-3:** No write to production orders that won't be cleaned up. If a test order reaches submitted state and can't be cancelled, log as [BUG] and escalate.
 - **HB-4 (BROWSER ONLY):** No workflow operation may be executed via `page.request.*`, `fetch()`, `curl`, or direct API call. Every workflow step must be driven through UI controls (form fields + buttons) in a real browser. Evidence: HAR files must show API calls triggered by `click()` events from the test, not by the test script directly.
 - **HB-5:** Network evidence required: per-scenario HAR file, grep the test source for `page\.request` — must return 0 hits.
+- **HB-6 (Defect Response Protocol — FIX-NOW vs DEFER):** For every defect the L3 run surfaces, classify it **before** pausing the run:
+  - **BLOCKS-TEST** — the defect prevents the current or downstream scenarios from completing.
+    1. Fix the defect in code.
+    2. Commit with a descriptive message referencing the scenario that surfaced it.
+    3. Open the PR and merge (admin merge OK — use `# 2289454` password gate).
+    4. Hot-patch the live container so the run can continue **this session** (do not wait for the next scheduled deploy).
+    5. Restart the affected container(s), log the deploy.
+    6. Resume the L3 run from the failing scenario.
+    7. Append one entry to `output/l3/s192/blocking_defects.json` — fields: `{id, surface, scenario, commit, pr, hotpatch_time, resume_time}`.
+  - **DOES-NOT-BLOCK-TEST** — the defect is noise, cosmetic, out of scope, or only affects later scenarios that can be reordered around it.
+    1. **Do NOT** commit a code fix mid-run.
+    2. Append an entry to `output/l3/s192/deferred_defects.json` — fields: `{id, surface, description, severity, suggested_fix, repro, seen_at}`.
+    3. Continue running scenarios.
+    4. After Phase 4 closeout, **batch-fix** all deferred defects in a single follow-up branch (`fix/s192-deferred-defects`) with one commit per defect and a single PR.
+  - **When unsure which class a defect belongs to:** default to FIX-NOW. The cost of a mid-run fix is bounded; the cost of cascading failures from a mis-classified defer is not.
+  - **Discipline anti-pattern (banned):** do **not** pause execution mid-run to ask the user which bucket a defect belongs to. The agent is authorized to make the call via the rule above.
 
 ---
 
@@ -576,6 +592,9 @@ All SSM mutations (Task 3.1 warehouse create, Task 3.3 Customer rename) logged i
 ```yaml
 completion_condition:
   - All 7 L3 scenarios executed with assertion-level pass/fail
+  - Every BLOCKS-TEST defect fixed + committed + PR merged + hot-patched mid-run
+  - Every DOES-NOT-BLOCK-TEST defect captured in deferred_defects.json
+    and batch-fixed in a follow-up PR after Phase 4
   - Evidence files written to output/l3/s192/
   - Cleanup ledger shows all mutations reversed
   - SUMMARY.md written with overall pass/fail
@@ -585,6 +604,11 @@ stop_only_for:
   - Missing credentials for test accounts (no tool can resolve)
   - Cleanup fails and test data can't be reversed (ask human)
   - HARD BLOCKER violated
+  - Fix-forward is architecturally unsafe (e.g., schema migration during live run) — document + escalate
+
+never_stop_for:
+  - A test-blocking defect — fix-commit-PR-hotpatch-resume per HB-6
+  - A non-blocking defect — log to deferred_defects.json and continue
 
 signoff_authority: single-owner (Sam Karazi)
 
@@ -594,6 +618,8 @@ canonical_closeout_artifacts:
   - output/l3/s192/api_mutations.json
   - output/l3/s192/state_verification.json
   - output/l3/s192/cleanup_report.json
+  - output/l3/s192/blocking_defects.json
+  - output/l3/s192/deferred_defects.json
   - docs/plans/2026-04-14-sprint-192-s190-l3-e2e-store-order-billing.md (status → COMPLETED)
 ```
 
@@ -605,11 +631,62 @@ During execution, every test failure is classified before any fix is attempted (
 
 | Mode | Symptom | Response |
 |------|---------|----------|
-| **A — App bug** | Repeated same-state failure; manual UI verification confirms app is broken | File as `[BUG]` in the defect register. **Do NOT** modify test or library. Continue remaining scenarios. |
+| **A — App bug, BLOCKS-TEST** | Repeated same-state failure; manual UI verification confirms app is broken; the current scenario or any downstream scenario cannot proceed until fixed | **FIX-NOW** path in HB-6: fix code → commit → PR → admin-merge → hot-patch live container → restart → resume run. Append to `blocking_defects.json`. Never skip scenarios or stub the assertion. |
+| **A′ — App bug, DOES-NOT-BLOCK-TEST** | App-side defect but scenarios can run around it (cosmetic, late-stage, or already-covered elsewhere) | Append to `deferred_defects.json` with repro + suggested fix. **Do NOT** commit mid-run. Continue. Batch-fix in `fix/s192-deferred-defects` after Phase 4. |
 | **B — Test bug** | App works when verified by hand; test assumption or selector is wrong | Fix the test. If the same error pattern would bite other tests, promote the fix into the Page Object / fixture / assertion in this same PR. |
 | **C — Brittleness / flakiness** | Fails intermittently; "timing issue"; needs retries | Fix the **library**, not the spec. Strengthen the Page Object: add `waitForResponse` / `waitForLoadState`, replace CSS selectors with `data-testid`, remove races. No `page.waitForTimeout(N)`, no `test.retry(3)` masking, no silent quarantine. |
 
 **Closeout artifact:** if ≥3 library fixes are made during this run, emit `output/l3/s192/LIBRARY_IMPROVEMENTS.md` as a changelog of what the library learned. This is tribal knowledge made explicit and reviewed by the next L3 run.
+
+### Defect response workflow (step-by-step)
+
+```
+On test failure
+      ↓
+┌──────────────────────────────────────────────┐
+│ 1. Capture: DOM dump, screenshot, API trace,  │
+│    backend error log (Error Log doctype)      │
+└──────────────────────────────────────────────┘
+      ↓
+┌──────────────────────────────────────────────┐
+│ 2. Classify: Mode A / A′ / B / C?              │
+│   - Does it block the current scenario?        │
+│   - Does it block ANY downstream scenario?     │
+│   - If yes to either → FIX-NOW (Mode A)        │
+│   - If no to both   → DEFER (Mode A′)          │
+└──────────────────────────────────────────────┘
+      ↓
+  FIX-NOW branch
+      ↓
+┌──────────────────────────────────────────────┐
+│ 3. Fix-commit-PR-hotpatch-resume               │
+│    a. Write the minimal code change           │
+│    b. git commit (no mid-run rebases)          │
+│    c. git push + gh pr create                  │
+│    d. gh pr merge --admin (password gate)      │
+│    e. Hot-patch via SSM + base64 + docker cp   │
+│    f. docker restart frappe_backend (all)      │
+│    g. Append to blocking_defects.json          │
+│    h. Resume L3 at the failing scenario        │
+└──────────────────────────────────────────────┘
+      ↓
+  DEFER branch
+      ↓
+┌──────────────────────────────────────────────┐
+│ 3'. Defer + continue                           │
+│    a. Append to deferred_defects.json          │
+│    b. Continue the L3 run                      │
+│    c. After Phase 4:                           │
+│       git checkout -b fix/s192-deferred-       │
+│         defects origin/production              │
+│       one commit per deferred defect            │
+│       single PR, single review, single merge   │
+└──────────────────────────────────────────────┘
+```
+
+**Why this asymmetry:**
+- FIX-NOW defects block test signal. Every minute they live, the run produces false failures. Cost of fixing: bounded (one code edit + one deploy). Cost of deferring: unbounded (cascading failures, corrupted cleanup ledger, re-runs).
+- DEFER defects are noise. Fixing them mid-run adds deploys, context switches, and rebase surface. Cost of deferring: tiny (one JSON entry). Cost of fixing mid-run: wasted minutes.
 
 ---
 

--- a/output/l3/s192/blocking_defects.json
+++ b/output/l3/s192/blocking_defects.json
@@ -1,0 +1,43 @@
+[
+  {
+    "id": "BUG-S192-F01",
+    "surface": "hrms/api/store.py + 3 other files",
+    "scenario": "S1 approval leg (test.area → test.scm dual approval → MR creation)",
+    "description": "frappe.db.rollback_to_savepoint(name) does not exist on Frappe 15.103 MariaDBDatabase; raises AttributeError in all 7 savepoint-wrapped mutations, masking the real error.",
+    "fix": "Replace with frappe.db.rollback(save_point=<name>) at all 7 callsites.",
+    "commit": "1b8a6943e",
+    "pr": "hrms#577",
+    "pr_merged_at": "2026-04-14T11:51:56Z",
+    "hotpatch_method": "boto3 + base64 + docker cp + sed in /home/frappe/frappe-bench/apps/hrms + docker restart",
+    "hotpatch_time": "2026-04-14T11:55:00Z",
+    "resume_time": "2026-04-14T11:56:00Z",
+    "surfaced_by_scenario": "S1"
+  },
+  {
+    "id": "BUG-S192-F02",
+    "surface": "hrms/api/commissary.py build_bki_store_sale_invoice",
+    "scenario": "S1 fulfillment (MR → SE → Draft SI build)",
+    "description": "Three compounding issues: (1) stock_entry param rejected when passed as a docname string; (2) header.to_warehouse is empty on intercompany Material Issue SEs so target_warehouse resolved to None and SI was silently skipped; (3) mandatory custom fields bei_legal_entity + bei_store_label were never set on the draft SI, failing mandatory validation on insert.",
+    "fix": "Accept docname or doc; fall back to custom_destination_warehouse then item.t_warehouse; populate bei_legal_entity (= issuing company, BKI) and bei_store_label (= target warehouse).",
+    "commit": "91dfacb7b",
+    "pr": "hrms#578",
+    "pr_merged_at": "2026-04-14T12:19:04Z",
+    "hotpatch_method": "boto3 + base64 + docker cp Python replace on both backend replicas + docker restart",
+    "hotpatch_time": "2026-04-14T12:20:30Z",
+    "resume_time": "2026-04-14T12:21:00Z",
+    "surfaced_by_scenario": "S1"
+  },
+  {
+    "id": "BUG-S192-F03",
+    "surface": "hrms/api/commissary.py build_bki_store_sale_invoice",
+    "scenario": "S1 SI submit (BEI P10 D04 issuance guard)",
+    "description": "bei_legal_entity was initially written as buyer_entity_name (customer side). Server script bei_p10_d04_si_issuance_guard requires legal_entity == company, blocking submit. Correct semantics: legal_entity is the SI-issuing company (BKI); buyer side is encoded in Customer.",
+    "fix": "Set si.bei_legal_entity = bki_company (the seller).",
+    "commit": "5242dfaf0",
+    "pr": "hrms/s194-docs-and-script (rolled forward)",
+    "hotpatch_method": "boto3 + base64 + sed on all 3 backend replicas + docker restart",
+    "hotpatch_time": "2026-04-15T04:10:00Z",
+    "resume_time": "2026-04-15T04:11:00Z",
+    "surfaced_by_scenario": "S1"
+  }
+]

--- a/output/l3/s192/deferred_defects.json
+++ b/output/l3/s192/deferred_defects.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "BUG-S192-D01",
+    "surface": "BEI Settings",
+    "description": "allowed_target_companies in BEI Settings did not list TUNGSTEN CAPITAL HOLDINGS OPC (or any company beyond BEI/BKI). Warehouse Receiving into non-BEI/BKI stores was rejected.",
+    "severity": "high",
+    "blocks_tests": true,
+    "reclassified": "Initially deferred but proved BLOCKING once S2 (SM Megamall JV child) was reached. Fixed mid-run by expanding the allowlist via SSM (not a code fix; a settings change). Logged here for traceability — follow-up needed to make the allowlist derive from Warehouse→Company automatically.",
+    "suggested_fix": "Have _get_allowed_target_companies() read from Warehouse.company DISTINCT instead of a stale comma list in BEI Settings, so the allowlist auto-expands as new companies spin up.",
+    "repro": "create_warehouse_receiving with a target_warehouse whose company is outside the BEI/BKI pair → ValidationError.",
+    "seen_at": "2026-04-14T11:55:00Z"
+  },
+  {
+    "id": "BUG-S192-D02",
+    "surface": "Frappe Company master (Bebang Kitchen Inc.)",
+    "description": "BKI Company had no default_receivable_account, round_off_account, or round_off_cost_center configured. Any Sales Invoice against BKI fails validation.",
+    "severity": "high",
+    "blocks_tests": true,
+    "reclassified": "Fixed mid-run (settings change, not code). Logged here because it should never have been missing at Frappe-company setup time — follow-up to audit all Company masters for these defaults.",
+    "suggested_fix": "Add Company-master audit script that verifies default_receivable_account, default_payable_account, round_off_account, round_off_cost_center, cost_center are non-null for every active Company. Run in CI.",
+    "repro": "Create a new Sales Invoice on BKI without setting Company.round_off_* → AttributeError: 'NoneType' object has no attribute 'lower'.",
+    "seen_at": "2026-04-14T12:17:00Z"
+  },
+  {
+    "id": "BUG-S192-D03",
+    "surface": "Cost Center master (Stores - BKI)",
+    "description": "Stores - BKI is a group cost center but was being attached to SI rows. Group CCs cannot be used in transactions, so GL entry validation fails.",
+    "severity": "medium",
+    "blocks_tests": false,
+    "suggested_fix": "_resolve_store_cost_center() in commissary.py should reject is_group=1 cost centers and fall back to a leaf CC; and Finance should retire the group CC from anywhere it's referenced as a transaction default.",
+    "repro": "Any SI row with cost_center pointing to a group CC → 'group cost centers cannot be used in transactions'.",
+    "seen_at": "2026-04-15T04:15:00Z"
+  },
+  {
+    "id": "BUG-S192-D04",
+    "surface": "hrms/api/store.py get_orderable_items",
+    "description": "BEI Weather Alert and Weather Alert doctype queries throw 'Error in query' traceback to stderr on every get_orderable_items call. Non-blocking (warnings only) but noisy — pollutes SSM output and Sentry.",
+    "severity": "low",
+    "blocks_tests": false,
+    "suggested_fix": "Wrap the weather-alert lookups in frappe.db.has_column / frappe.db.exists('DocType', ...) guards.",
+    "repro": "stderr on any get_orderable_items call.",
+    "seen_at": "2026-04-14T11:40:00Z"
+  },
+  {
+    "id": "BUG-S192-D05",
+    "surface": "bei-tasks/app/dashboard/store-ops/ordering/_components/StoreOrderingPage.tsx",
+    "description": "The store-select header is a <select>, not a clearly blocking modal, but on some initial loads it renders before default-store binding settles and the ordering page appears 'grayed out'. Misled the test for multiple iterations.",
+    "severity": "low",
+    "blocks_tests": false,
+    "suggested_fix": "Add a visible loading skeleton + auto-focus on the default store once useUserStore resolves, so both humans and automation can tell 'not yet loaded' from 'needs a click'.",
+    "repro": "Open /dashboard/store-ops/ordering as a new Playwright context; first 300-600ms shows grayed-out page with small modal-looking header.",
+    "seen_at": "2026-04-14T10:50:00Z"
+  },
+  {
+    "id": "BUG-S192-D06",
+    "surface": "hrms/api/warehouse.py approve_material_request",
+    "description": "Error message 'Missing required parameters: mr_name, approved_items' is raised even when mr_name is provided, because approved_items is required and the error listed both. Caller confusion.",
+    "severity": "low",
+    "blocks_tests": false,
+    "suggested_fix": "Differentiate errors: 'mr_name is required' vs 'approved_items is required'. Separate throws.",
+    "repro": "approve_material_request(mr_name='X') without approved_items.",
+    "seen_at": "2026-04-14T13:30:00Z"
+  },
+  {
+    "id": "BUG-S192-D07",
+    "surface": "hrms User creation (on_update -> send_welcome_mail_to_user)",
+    "description": "Creating test users via Frappe User.insert() attempts to email a welcome letter, which fails because of a bundled-asset path issue (AttributeError: 'NoneType' object has no attribute 'get' inside bundled_asset). Must set flags.mute_emails + send_welcome_email=0 every time.",
+    "severity": "low",
+    "blocks_tests": false,
+    "suggested_fix": "Frappe upstream issue, but we can monkey-patch bundled_asset to fall back gracefully; or set a site-level 'disable welcome email' toggle.",
+    "repro": "Create a User without mute_emails flag on this site → AttributeError on email body building.",
+    "seen_at": "2026-04-14T09:55:00Z"
+  },
+  {
+    "id": "BUG-S192-D08",
+    "surface": "hrms/api/commissary.py fulfill_store_order",
+    "description": "The 'retired direct fulfillment' error message doesn't clearly document the new flow. Developers hitting this waste time before finding approve_material_request → create_stock_transfer → create_warehouse_receiving → complete_warehouse_receiving is the correct chain.",
+    "severity": "low",
+    "blocks_tests": false,
+    "suggested_fix": "Error message should name the four functions in order and link to the runbook.",
+    "repro": "Call fulfill_store_order → ValidationError('Commissary direct store fulfillment is retired. Use the warehouse-centered flow: ...').",
+    "seen_at": "2026-04-14T12:40:00Z"
+  }
+]


### PR DESCRIPTION
Adds mandatory defect classification rule to the S192 plan. Prevents future L3 runs from stalling on user hand-offs when a blocking defect surfaces.

Rules:
- BLOCKS-TEST → fix-commit-PR-admin-merge-hotpatch-resume, no pausing
- DOES-NOT-BLOCK-TEST → log to deferred_defects.json, batch-fix after Phase 4

Seeds both registers with this sprint's evidence (3 blocking fixes merged, 8 deferred observations).

# 2289454