### PR TITLE
fix(S194-6/16): S193 guard on PR convert_to_po

### DIFF
--- a/hrms/hr/doctype/bei_purchase_requisition/bei_purchase_requisition.py
+++ b/hrms/hr/doctype/bei_purchase_requisition/bei_purchase_requisition.py
@@ -137,6 +137,12 @@ class BEIPurchaseRequisition(Document):
         if not frappe.db.exists("BEI Supplier", supplier_code):
             frappe.throw(_("Supplier not found"))
 
+        # S193 guard — block conversion against Blacklisted / Pending Verification /
+        # Inactive suppliers. convert_to_po was previously bypassing the guard that
+        # applies to direct create_purchase_order calls. Discovered by S194-6.
+        from hrms.api.procurement import _assert_supplier_active
+        _assert_supplier_active(supplier_code, "purchase_order")
+
         # Create PO
         po = frappe.new_doc("BEI Purchase Order")
         po.pr_reference = self.name


### PR DESCRIPTION
## Summary

- Adds `_assert_supplier_active(supplier, \"purchase_order\")` to `BEI Purchase Requisition.convert_to_po`
- Closes a bypass where PR-to-PO conversion skipped the Blacklisted / Pending Verification / Inactive supplier guard that applies to `create_purchase_order`
- Discovered by S194 L3 scenarios 6 (PV) and 16 (Inactive asymmetry)

## Test plan
- [ ] S194-6 PV supplier convertToPO — expect frappe.ValidationError \"Cannot create Purchase Order: Supplier X is Pending Verification\"
- [ ] S194-16 Inactive supplier convertToPO — expect \"...is Inactive\"
- [ ] Existing Active supplier convertToPO — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)