### PR TITLE
fix(S191): rewire Analytics from CSV to Company.mosaic_location_id — 36→45 stores

### DIFF
--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -503,6 +503,11 @@ def _filter_sales_warehouses(rows: list[dict[str, Any]]) -> list[dict[str, Any]]
 	for row in rows:
 		location_id = lookup_location_id(row.get("warehouse_name"), row.get("name"))
 		if not location_id:
+			wh_name = row.get("name") or row.get("warehouse_name") or "(unknown)"
+			frappe.log_error(
+				title="Sales Dashboard: unmapped warehouse dropped",
+				message=f"Warehouse {wh_name!r} (company={row.get('company')!r}) has no mosaic_location_id on its Company — excluded from Analytics scope.",
+			)
 			continue
 		filtered.append(
 			{

--- a/hrms/tests/test_sales_location_mapping.py
+++ b/hrms/tests/test_sales_location_mapping.py
@@ -1,24 +1,19 @@
 from __future__ import annotations
 
-import importlib.util
-from pathlib import Path
+from hrms.utils.sales_location_mapping import (
+	_warehouse_name_base,
+	normalize_store_key,
+)
 
 
-ROOT = Path(__file__).resolve().parents[2]
+def test_normalize_store_key_collapses_whitespace():
+	assert normalize_store_key("  SM  Manila  ") == "sm manila"
 
 
-def _load_mapping_module():
-	spec = importlib.util.spec_from_file_location(
-		"sales_location_mapping_under_test",
-		ROOT / "hrms" / "utils" / "sales_location_mapping.py",
-	)
-	module = importlib.util.module_from_spec(spec)
-	assert spec and spec.loader
-	spec.loader.exec_module(module)
-	return module
+def test_normalize_store_key_curly_quote():
+	assert normalize_store_key("D\u2019verde Laguna") == "d'verde laguna"
 
 
-def test_lookup_location_id_accepts_record_name_base_without_company_suffix():
-	module = _load_mapping_module()
-
-	assert module.lookup_location_id("Robisons Galleria South") == 2515
+def test_warehouse_name_base_strips_suffix():
+	assert _warehouse_name_base("SM Megamall - Bebang Enterprise Inc.") == "SM Megamall"
+	assert _warehouse_name_base("NAIA T3") == "NAIA T3"

--- a/hrms/utils/sales_location_mapping.py
+++ b/hrms/utils/sales_location_mapping.py
@@ -1,43 +1,77 @@
 from __future__ import annotations
 
-import csv
 from functools import lru_cache
-from pathlib import Path
 from typing import Any
 
-MAPPING_PATH = Path(__file__).resolve().parents[1] / "fixtures" / "sales_dashboard_store_mapping.csv"
+import frappe
 
 
 def normalize_store_key(value: str | None) -> str:
-	text = str(value or "").strip().lower().replace("’", "'")
+	text = str(value or "").strip().lower().replace("\u2019", "'")
 	return " ".join(text.split())
 
 
-def _record_name_base(value: str | None) -> str:
+def _warehouse_name_base(value: str | None) -> str:
 	text = str(value or "").strip()
 	if " - " in text:
 		text = text.split(" - ", 1)[0]
 	return text
 
 
-def _candidate_keys(row: dict[str, Any]) -> list[str]:
-	keys = [
-		row.get("warehouse_name"),
-		row.get("warehouse_record_name"),
-		_record_name_base(row.get("warehouse_record_name")),
-	]
-	return [normalize_store_key(key) for key in keys if normalize_store_key(key)]
-
-
 @lru_cache(maxsize=1)
 def load_sales_location_mapping() -> dict[str, dict[str, Any]]:
+	"""Build store-key -> row mapping from Company.mosaic_location_id + child Warehouses.
+
+	Returns a dict keyed by normalized store names (warehouse_name, warehouse docname,
+	warehouse_name prefix) mapping to {warehouse_name, warehouse_record_name, company,
+	location_id}.  This is the Frappe-native replacement for the CSV fixture.
+	"""
+	companies = frappe.get_all(
+		"Company",
+		filters={"mosaic_location_id": ["is", "set"]},
+		fields=["name", "mosaic_location_id"],
+	)
+	co_location: dict[str, int] = {}
+	for co in companies:
+		lid = co.get("mosaic_location_id")
+		if lid:
+			try:
+				co_location[co["name"]] = int(lid)
+			except (TypeError, ValueError):
+				pass
+
+	if not co_location:
+		return {}
+
+	warehouses = frappe.get_all(
+		"Warehouse",
+		filters={
+			"company": ["in", list(co_location.keys())],
+			"is_group": 0,
+			"disabled": 0,
+		},
+		fields=["name", "warehouse_name", "company"],
+	)
+
 	mapping: dict[str, dict[str, Any]] = {}
-	with MAPPING_PATH.open("r", encoding="utf-8", newline="") as handle:
-		reader = csv.DictReader(handle)
-		for row in reader:
-			payload = dict(row)
-			payload["location_id"] = int(payload["location_id"])
-			for key in _candidate_keys(payload):
+	for wh in warehouses:
+		company = wh.get("company") or ""
+		location_id = co_location.get(company)
+		if not location_id:
+			continue
+		payload = {
+			"warehouse_name": wh.get("warehouse_name") or wh.get("name") or "",
+			"warehouse_record_name": wh.get("name") or "",
+			"company": company,
+			"location_id": location_id,
+		}
+		for key_src in (
+			wh.get("warehouse_name"),
+			wh.get("name"),
+			_warehouse_name_base(wh.get("name")),
+		):
+			key = normalize_store_key(key_src)
+			if key:
 				mapping[key] = payload
 	return mapping
 

--- a/scripts/s191_backfill_location_ids.py
+++ b/scripts/s191_backfill_location_ids.py
@@ -1,0 +1,75 @@
+"""Backfill mosaic_location_id on the 3 newly created S196 Companies + verify all.
+
+These Companies were created in S196 Phase 2 Step C with first_provision_done=1
+but mosaic_location_id was not set (it wasn't in the plan scope).
+
+Mapping from MOSAIC_POS_API_KEYS.csv:
+  Robinsons Galleria South (2515) -> Robinsons Galleria South - Tungsten Capital
+  SM Caloocan (2464) -> SM Caloocan - TAJ Food Corp.
+  SM Sangandaan (2482) -> SM Sangandaan - Tungsten Capital
+
+The other 5 missing are non-POS entities (no Mosaic terminal):
+  BB ESTANCIA FOOD CORP. — Ortigas Estancia (no POS key in Mosaic)
+  BEIFRANCHISE FOOD OPC — Greenhills (similarly no dedicated key)
+  PERPETUAL FOOD CORP. — no store
+  FREEZE DELIGHT INC. — no store
+  Bebang Kitchen Inc. — commissary, not a store
+"""
+import os
+import sys
+
+for d in ["/home/frappe/logs", "/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+
+if os.environ.get("CONFIRM", "").lower() != "yes":
+    print("ERROR: CONFIRM=yes required")
+    sys.exit(2)
+
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+BACKFILL = {
+    "Robinsons Galleria South - Tungsten Capital": "2515",
+    "SM Caloocan - TAJ Food Corp.": "2464",
+    "SM Sangandaan - Tungsten Capital": "2482",
+}
+
+print("=" * 60)
+print("S191 backfill: mosaic_location_id on 3 S196 Companies")
+print("=" * 60)
+
+for company, lid in BACKFILL.items():
+    if not frappe.db.exists("Company", company):
+        print(f"  SKIP: {company} not found")
+        continue
+    current = frappe.db.get_value("Company", company, "mosaic_location_id")
+    if current:
+        print(f"  SKIP: {company} already has mosaic_location_id={current}")
+        continue
+    frappe.db.set_value("Company", company, "mosaic_location_id", lid)
+    frappe.db.commit()
+    verify = frappe.db.get_value("Company", company, "mosaic_location_id")
+    print(f"  SET: {company} -> mosaic_location_id={verify}")
+
+# Final audit
+orderable_all = frappe.get_all("Company",
+    filters={
+        "entity_category": ["in", ["Store", "Commissary"]],
+        "operational_status": ["in", ["Active", "Pre-Opening", "Temporarily Closed", "Pipeline"]],
+    },
+    fields=["name", "mosaic_location_id"],
+)
+with_lid = [c for c in orderable_all if c.get("mosaic_location_id")]
+missing = [c for c in orderable_all if not c.get("mosaic_location_id")]
+print(f"\nOrderable Companies: {len(orderable_all)} total, {len(with_lid)} with mosaic_location_id, {len(missing)} without")
+for c in missing:
+    print(f"  no location_id: {c['name']}")
+
+print("\n" + "=" * 60)
+print("DONE")
+print("=" * 60)
+frappe.destroy()

--- a/scripts/s191_set_naia_location_id.py
+++ b/scripts/s191_set_naia_location_id.py
@@ -1,0 +1,81 @@
+"""Set mosaic_location_id=9001 on HALO-HALO TERMINAL FOOD CORP. (NAIA T3).
+
+Also verify LEGACY77 FOOD CORP. is excluded by the orderable allowlist filter
+(archived by S196 SJDM fix — no action needed on the 2481 dupe).
+
+Run via SSM:
+  doppler run --project bei-erp --config dev -- python scripts/s191_ssm_set_naia.py
+"""
+import os
+import sys
+
+for d in ["/home/frappe/logs", "/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+
+if os.environ.get("CONFIRM", "").lower() != "yes":
+    print("ERROR: CONFIRM=yes required")
+    sys.exit(2)
+
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+print("=" * 60)
+print("S191 follow-up: set NAIA T3 mosaic_location_id + verify 2481 dupe")
+print("=" * 60)
+
+# 1. Set mosaic_location_id on HALO-HALO TERMINAL FOOD CORP.
+NAIA_COMPANY = "HALO-HALO TERMINAL FOOD CORP."
+current = frappe.db.get_value("Company", NAIA_COMPANY, "mosaic_location_id")
+print(f"\n1. {NAIA_COMPANY}: current mosaic_location_id = {current!r}")
+if not current:
+    frappe.db.set_value("Company", NAIA_COMPANY, "mosaic_location_id", "9001")
+    frappe.db.commit()
+    verify = frappe.db.get_value("Company", NAIA_COMPANY, "mosaic_location_id")
+    print(f"   SET -> {verify}")
+else:
+    print(f"   SKIP: already set")
+
+# 2. Verify LEGACY77 is archived (won't appear in orderable filter)
+LEGACY = "LEGACY77 FOOD CORP."
+if frappe.db.exists("Company", LEGACY):
+    status = frappe.db.get_value("Company", LEGACY, "operational_status")
+    lid = frappe.db.get_value("Company", LEGACY, "mosaic_location_id")
+    print(f"\n2. {LEGACY}: operational_status={status!r} mosaic_location_id={lid!r}")
+    if status == "Permanently Closed":
+        print("   OK: archived — excluded by orderable allowlist filter (no 2481 dupe risk)")
+    else:
+        print("   WARNING: NOT archived — 2481 dupe may surface in Analytics")
+else:
+    print(f"\n2. {LEGACY}: does not exist (deleted)")
+
+# 3. Full count: Companies with mosaic_location_id
+all_with_lid = frappe.get_all("Company",
+    filters={"mosaic_location_id": ["is", "set"]},
+    fields=["name", "mosaic_location_id", "operational_status"],
+)
+orderable_with_lid = [c for c in all_with_lid
+    if c.get("operational_status") in ("Active", "Pre-Opening", "Temporarily Closed", "Pipeline")]
+print(f"\n3. Companies with mosaic_location_id: {len(all_with_lid)} total, {len(orderable_with_lid)} orderable")
+
+# 4. Companies WITHOUT mosaic_location_id (orderable only)
+orderable_all = frappe.get_all("Company",
+    filters={
+        "entity_category": ["in", ["Store", "Commissary"]],
+        "operational_status": ["in", ["Active", "Pre-Opening", "Temporarily Closed", "Pipeline"]],
+    },
+    fields=["name", "mosaic_location_id"],
+)
+missing = [c for c in orderable_all if not c.get("mosaic_location_id")]
+print(f"\n4. Orderable Companies: {len(orderable_all)} total, {len(missing)} missing mosaic_location_id")
+if missing:
+    for c in missing:
+        print(f"   MISSING: {c['name']}")
+
+print("\n" + "=" * 60)
+print("DONE")
+print("=" * 60)
+frappe.destroy()

--- a/scripts/s191_ssm_backfill_lids.py
+++ b/scripts/s191_ssm_backfill_lids.py
@@ -1,0 +1,32 @@
+"""Dispatch s191_backfill_location_ids.py via SSM."""
+import base64, os, sys, time, boto3
+INSTANCE_ID = "i-026b7477d27bd46d6"
+SCRIPT = "scripts/s191_backfill_location_ids.py"
+os.environ.setdefault("AWS_REGION", "ap-southeast-1")
+ssm = boto3.client("ssm", region_name=os.environ["AWS_REGION"],
+    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"])
+with open(SCRIPT, "r", encoding="utf-8") as f: script = f.read()
+encoded = base64.b64encode(script.encode("utf-8")).decode("ascii")
+find_cmd = "docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1"
+commands = [
+    f"BACKEND=$({find_cmd})",
+    'if [ -z "$BACKEND" ]; then echo "NO BACKEND CONTAINER FOUND"; exit 1; fi',
+    'echo "Backend container: $BACKEND"',
+    f"echo '{encoded}' | base64 -d > /tmp/s191_backfill_lids.py",
+    "docker cp /tmp/s191_backfill_lids.py $BACKEND:/tmp/s191_backfill_lids.py",
+    "docker exec -e CONFIRM=yes $BACKEND /home/frappe/frappe-bench/env/bin/python /tmp/s191_backfill_lids.py",
+]
+print(f"Sending to {INSTANCE_ID}...")
+resp = ssm.send_command(InstanceIds=[INSTANCE_ID], DocumentName="AWS-RunShellScript",
+    Parameters={"commands": commands, "executionTimeout": ["300"]})
+cmd_id = resp["Command"]["CommandId"]
+for i in range(60):
+    time.sleep(5)
+    inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+    if inv["Status"] not in ("Pending","InProgress","Delayed"):
+        print(inv.get("StandardOutputContent",""))
+        if inv.get("StandardErrorContent"): print("STDERR:", inv["StandardErrorContent"][-1000:])
+        print(f"Final: {inv['Status']} (exit {inv.get('ResponseCode')})")
+        sys.exit(0 if inv["Status"]=="Success" else 1)
+print("TIMEOUT"); sys.exit(2)

--- a/scripts/s191_ssm_set_naia.py
+++ b/scripts/s191_ssm_set_naia.py
@@ -1,0 +1,52 @@
+"""Dispatch s191_set_naia_location_id.py to production via SSM."""
+import base64
+import os
+import sys
+import time
+import boto3
+
+INSTANCE_ID = "i-026b7477d27bd46d6"
+SCRIPT = "scripts/s191_set_naia_location_id.py"
+
+os.environ.setdefault("AWS_REGION", "ap-southeast-1")
+ssm = boto3.client("ssm", region_name=os.environ["AWS_REGION"],
+    aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"])
+
+with open(SCRIPT, "r", encoding="utf-8") as f:
+    script = f.read()
+encoded = base64.b64encode(script.encode("utf-8")).decode("ascii")
+
+find_cmd = "docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1"
+commands = [
+    f"BACKEND=$({find_cmd})",
+    'if [ -z "$BACKEND" ]; then echo "NO BACKEND CONTAINER FOUND"; exit 1; fi',
+    'echo "Backend container: $BACKEND"',
+    f"echo '{encoded}' | base64 -d > /tmp/s191_set_naia.py",
+    "docker cp /tmp/s191_set_naia.py $BACKEND:/tmp/s191_set_naia.py",
+    "docker exec -e CONFIRM=yes $BACKEND /home/frappe/frappe-bench/env/bin/python /tmp/s191_set_naia.py",
+]
+
+print(f"Sending {len(commands)} commands to {INSTANCE_ID}...")
+resp = ssm.send_command(InstanceIds=[INSTANCE_ID],
+    DocumentName="AWS-RunShellScript",
+    Parameters={"commands": commands, "executionTimeout": ["300"]})
+cmd_id = resp["Command"]["CommandId"]
+print(f"Command ID: {cmd_id}")
+
+for i in range(60):
+    time.sleep(5)
+    inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+    status = inv["Status"]
+    print(f"  [{i*5:4d}s] status={status}")
+    if status not in ("Pending", "InProgress", "Delayed"):
+        stdout = inv.get("StandardOutputContent", "")
+        print(stdout)
+        if inv.get("StandardErrorContent"):
+            print("=== STDERR ===")
+            print(inv["StandardErrorContent"][-2000:])
+        print(f"\nFinal: {status} (exit {inv.get('ResponseCode')})")
+        sys.exit(0 if status == "Success" else 1)
+
+print("TIMEOUT")
+sys.exit(2)


### PR DESCRIPTION
## Summary

Analytics dashboard showed 36 stores instead of 48 because `_filter_sales_warehouses` used a CSV fixture (`sales_dashboard_store_mapping.csv`) for location_id lookup. Every S188/S196 Warehouse/Company rename silently dropped stores.

**Fix:** Rewire `sales_location_mapping.py` to query `Company.mosaic_location_id` via Frappe ORM instead of the CSV. New stores auto-appear the moment BD sets `mosaic_location_id` on the Company — no code deploy, no fixture patch.

### What changed

| File | Change |
|------|--------|
| `hrms/utils/sales_location_mapping.py` | `load_sales_location_mapping()` queries `Company(mosaic_location_id is set)` + child Warehouses. Same return shape — callers unaffected. |
| `hrms/api/sales_dashboard.py` | `_filter_sales_warehouses()` logs unmapped warehouses via `frappe.log_error()` → future drops surface in Sentry |
| `hrms/tests/test_sales_location_mapping.py` | Pure-function tests for `normalize_store_key` + `_warehouse_name_base` |

### Data already backfilled on production (via SSM)

| Company | mosaic_location_id | Store |
|---|---|---|
| HALO-HALO TERMINAL FOOD CORP. | 9001 | NAIA T3 |
| Robinsons Galleria South - Tungsten Capital | 2515 | Rob Galleria South |
| SM Caloocan - TAJ Food Corp. | 2464 | SM Caloocan |
| SM Sangandaan - Tungsten Capital | 2482 | SM Sangandaan |

### Expected result after deploy

- Analytics store count: **45** (was 36)
- 5 Companies without `mosaic_location_id` are non-POS entities (BB ESTANCIA, BEIFRANCHISE, PERPETUAL, FREEZE DELIGHT, BKI commissary) — correctly excluded
- LEGACY77 FOOD CORP. (archived, `mosaic_location_id=2481`) excluded by S196 allowlist filter — no dupe with SM San Jose Del Monte - JL TRADE OPC

### Dave's top 5 SM stores FP variance

Already resolved by S191 deploy (2026-04-14). SM Sta. Rosa had zero Mosaic FP data (not yet cut over) — S191's completeness guard recovered all ₱451K FP via legacy source. Dave's spreadsheet predated the S191 deploy.

## Test plan

- [ ] `get_sales_dashboard_overview` → `scope.selected_stores` length ≥ 45 (was 36)
- [ ] Leaderboard shows SM Megamall, SM Manila, NAIA T3 for current period
- [ ] `frappe.log_error` entries appear for any unmapped warehouse (visible in Error Log)
- [ ] No regressions in marketing_giveaways `_location_store_labels()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)