### PR TITLE
HOTFIX: Analytics showing 'Work in Progress' instead of store names

### DIFF
--- a/hrms/utils/sales_location_mapping.py
+++ b/hrms/utils/sales_location_mapping.py
@@ -53,8 +53,19 @@ def load_sales_location_mapping() -> dict[str, dict[str, Any]]:
 		fields=["name", "warehouse_name", "company"],
 	)
 
+	# Structural warehouse names that are NOT store-facing — must be excluded
+	# to prevent "Work In Progress", "Finished Goods", etc. from appearing
+	# in the Analytics Store Leaderboard.
+	_STRUCTURAL_NAMES = {
+		"Stores", "Finished Goods", "Goods In Transit", "Work In Progress",
+		"All Warehouses", "Raw Materials", "In Transit",
+	}
+
 	mapping: dict[str, dict[str, Any]] = {}
 	for wh in warehouses:
+		wh_name = (wh.get("warehouse_name") or wh.get("name") or "").strip()
+		if wh_name in _STRUCTURAL_NAMES:
+			continue
 		company = wh.get("company") or ""
 		location_id = co_location.get(company)
 		if not location_id:


### PR DESCRIPTION
## Problem

Analytics Store Leaderboard shows "Work in Progress" for most stores instead of actual store names.

## Root Cause

PR #591 rewired `sales_location_mapping.py` from CSV to `Company.mosaic_location_id` but included ALL leaf warehouses for each Company — including structural warehouses (Work In Progress, Finished Goods, Stores, Goods In Transit). These matched in `_filter_sales_warehouses` and appeared on the leaderboard.

## Fix

Filter out structural warehouse names from the mapping. Only the primary store-facing warehouse per Company is included.

```python
_STRUCTURAL_NAMES = {
    "Stores", "Finished Goods", "Goods In Transit", "Work In Progress",
    "All Warehouses", "Raw Materials", "In Transit",
}
```

## Expected after deploy

- Store Leaderboard shows actual store names (SM MEGAMALL, AYALA EVO CITY, etc.)
- 45 stores connected (unchanged)
- No structural warehouses in Analytics scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)