### PR TITLE
fix: delivery schedule broken — drift check must allow Commissary in non-store entities

### DIFF
--- a/hrms/api/company_master.py
+++ b/hrms/api/company_master.py
@@ -2130,7 +2130,9 @@ def _drift_check_non_store_entities():
 		if not frappe.db.exists("Company", co_name):
 			continue
 		ec = frappe.db.get_value("Company", co_name, "entity_category")
-		if ec in ("Store", "Commissary"):
+		# Commissary IS allowed in non-store entities (BKI orders raw materials
+		# from warehouse but should NOT appear on the store grid/delivery schedule)
+		if ec == "Store":
 			msg = (
 				f"S196 drift: Company {co_name!r} is in _NON_STORE_ENTITIES "
 				f"(expected non-store) but has entity_category={ec!r}. "


### PR DESCRIPTION
## Problem

Delivery schedule returns 417 error:
> S196 drift: Company 'BEBANG KITCHEN INC.' is in _NON_STORE_ENTITIES but has entity_category='Commissary'

## Root Cause

The drift assertion rejects BOTH Store AND Commissary from `_NON_STORE_ENTITIES`. But BKI (Commissary) correctly belongs there — it orders raw materials from warehouse but should NOT appear on the store grid or delivery schedule.

## Fix

Change `if ec in ("Store", "Commissary")` to `if ec == "Store"`. Commissary is allowed in the non-store map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)