### PR TITLE
S201 Option X: disable Employee.company auto-reassignment; keep legal employer stable

### DIFF
--- a/docs/plans/2026-04-17-sprint-201-per-store-employee-billing-foundation.md
+++ b/docs/plans/2026-04-17-sprint-201-per-store-employee-billing-foundation.md
@@ -3,7 +3,21 @@ sprint: S201
 title: Per-Store Employee Billing Foundation
 branch: s201-per-store-employee-billing
 base: production
-status: GO
+status: SUPERSEDED_BY_OPTION_X
+option_x_branch: fix/s201-option-x-billing-layer
+option_x_pr: (pending)
+audit_date: 2026-04-17
+audit_version: v3
+architectural_pivot_date: 2026-04-17
+architectural_pivot: |
+  Sam chose Option X (2026-04-17 PHT) after audit:
+  - Employee.company stays on the legal employer (stable for statutory filings)
+  - Per-store internal billing delivered by S202 allocation JE engine
+    (month-end inter-Company labor cost reclassification by punch share)
+  - Frappe Desk Company dropdown remains the HR-driven manual change path
+    (already a Link field — no code needed)
+  - The shipped validate hook, Transfer API company-derivation, and Phase 7
+    backfill patch are DEPRECATED and hard-gated under Option X.
 planned_date: 2026-04-17
 planned_by: Claude (BEI-ERP)
 owner: Sam Karazi (CEO)
@@ -274,6 +288,73 @@ If backfill patch causes payroll regression:
 
 ## Notes
 
-- `my.bebang.ph` frontend: no changes expected in S201. Company field on Employee Detail Dialog already reads from backend. Backfill makes it show correct value automatically.
-- Frappe desk Employee form: Company field becomes read-only after Phase 4 hook is live, unless user has HR Manager role (manual override allowed).
-- Backfill assumes EMPLOYEE_MASTER.csv counts are approximately correct — Phase 0 pre-counts are the authoritative baseline.
+- `my.bebang.ph` frontend: Company field on Employee Detail Dialog is currently READ-ONLY (`FieldRow`). Under Option X, HR changes Company via Frappe Desk (hq.bebang.ph) — the Employee doctype's Company field is a standard Link→Company, auto-rendered as typeahead dropdown of all 49+ Companies. my.bebang.ph Company editability is OUT OF SCOPE for S201.
+- Frappe desk Employee form: Company field is a standard Link dropdown. HR can change Employee.company manually when a real legal employer change happens.
+- Backfill assumes EMPLOYEE_MASTER.csv counts are approximately correct — retained here for historical reference but SUPERSEDED by Option X (no auto-reassignment).
+
+---
+
+## POST-AUDIT AMENDMENTS v3 — OPTION X PIVOT (2026-04-17)
+
+Full audit report: `output/plan-audit/s201/verified_blockers.md`
+Raw counts: 17 CRITICAL / 42 WARNING / 16 INFO across 5 domain agents.
+
+### Why Option X
+
+The audit's PH Finance domain surfaced 5 CRITICAL statutory blockers (B1-B4 + unresolved apply timing). When asked, Sam clarified the actual business intent:
+
+> "Employees will not change company on Paper. What I need is to know where to bill employees internally so stores are charged based on the manpower deployed in it, but for compliance we can handle reporting differently while minimizing tax exposure per store."
+
+This is **transfer pricing**, not employer reassignment. The correct architecture:
+
+| Layer | Value |
+|---|---|
+| Legal employer (`Employee.company`) | Stable — one legal entity per employee, drives SSS/PhilHealth/HDMF/BIR 2316 |
+| Internal billing | Punch-based — where labor cost flows for per-store P&L |
+| Tax reporting | Per-store optimization — handled by allocation policy, not legal reassignment |
+
+### What Option X changes in the SHIPPED code
+
+| File | Option A/Y behavior (shipped via PR #603) | Option X behavior |
+|---|---|---|
+| `hrms/hooks.py` Employee.validate | Invokes `derive_company_from_branch` | Hook commented out (function kept for reference) |
+| `hrms/api/transfers.py::create_transfer` | Computes `new_company` from branch via `_derive_new_company` helper | `new_company = emp_doc.company` — legal stays stable. Helper deleted. |
+| `hrms/patches/v16_0/s201_backfill_employee_company.py` | `S201_APPLY=1` runs UPDATE on 510 employees | Apply path raises RuntimeError with Option X rationale; dry-run inspection still works |
+| `hrms/patches/v16_0/s201_rename_branches.py` | Renames branches to match Company prefix | **UNCHANGED — still active.** Cosmetic rename (Analytics/ordering naming) has no legal impact. |
+| `hrms/utils/company_lookup.py` + `non_store_billing.py` + `branch_company_map.csv` | Drives validate hook | **KEPT as libraries** — S202 allocation engine will consume them to classify punches without touching Employee.company. |
+
+### What Option X delivers
+
+- Branch rename (Phase 6) stays — branches align with Analytics/ordering naming.
+- `company_lookup` + `non_store_billing` modules stay — S202 uses them for punch classification.
+- Cache invalidation on Branch + Company updates stays wired.
+- Savepoint + Sentry improvements in both patches stay (B7+B8 audit fixes).
+
+### What Option X punts to S202
+
+Everything that actually moves money between Companies per store:
+- Punch-based monthly allocation JE engine
+- Per-store labor cost attribution
+- Reliever/roving cost flow-through based on actual punch location
+
+S202 hard deadline remains **May 15, 2026** payroll cutoff — beyond that date April and early-May labor mis-allocation would require manual JV cleanup.
+
+### Open policy questions — STATUS AFTER OPTION X
+
+- **B1** (SSS/PhilHealth/HDMF registrations live): Sam confirmed registrations exist in the real world; I need a separate task to verify Frappe Company docs have the IDs populated (`custom_sss_employer_id`, `custom_philhealth_employer_id`, `custom_hdmf_employer_id` or whatever BEI uses). NOT A BLOCKER under Option X because Employee.company isn't moving.
+- **B2** (BIR 2316 mid-year change): RESOLVED by Option X — no mid-year change happens.
+- **B3** (existing Draft Salary Slips): RESOLVED by Option X — slips stay on legal employer.
+- **B4** (apply timing): RESOLVED by Option X — no apply happens.
+- **B15** (S202 deadline): May 15, 2026 stands.
+
+### Audit-driven code fixes (still apply under Option X)
+
+- `Company.on_update` now also calls `company_lookup.clear_cache` (B6 — cache invalidation gap found by code verifier).
+- Branch rename patch wraps batches in `frappe.db.savepoint()` with rollback on partial failure (B7 — DM-2 compliance).
+- Patch failures route through `frappe.log_error()` so Sentry captures them (B8 — DM-7).
+
+### Plan status trail
+
+- v1 (2026-04-17 morning): GO — Option A (home-store = Employee.company) with S202 allocation layered on top.
+- v2 (2026-04-17 afternoon): post-audit amendments — 17 CRITICAL findings surfaced, PH Finance raised statutory red flags.
+- v3 (2026-04-17 evening): SUPERSEDED_BY_OPTION_X — Sam clarified actual intent (transfer pricing, not reassignment), plan pivots, backfill deprecated.

--- a/hrms/api/transfers.py
+++ b/hrms/api/transfers.py
@@ -13,41 +13,15 @@ from hrms.utils.api_helpers import (
     _check_hr_permission,
     _paginate,
 )
-from hrms.utils.company_lookup import (
-    UnknownBranch,
-    get_non_store_parent,
-    resolve_branch_to_company,
-)
-from hrms.utils.non_store_billing import is_non_store_billing_doc
 from hrms.utils.sentry import set_backend_observability_context
 
 
-def _derive_new_company(emp_doc, new_branch: str) -> str:
-    """S201: compute `new_company` for an Employee Transfer.
-
-    Roving / AS / HO / non-store employees stay on BEI parent regardless of
-    the new branch. Store employees follow the branch to its store Company.
-    """
-    # Build a shadow doc with the new_branch so is_non_store_billing_doc picks
-    # up the branch category check (e.g. new_branch == SHAW COMMISSARY - LOGISTICS
-    # which is HO per the map).
-    class _Shadow:
-        pass
-    shadow = _Shadow()
-    shadow.attendance_device_id = getattr(emp_doc, "attendance_device_id", None)
-    shadow.new_attendance_device_id = getattr(emp_doc, "new_attendance_device_id", None)
-    shadow.department = emp_doc.department
-    shadow.designation = emp_doc.designation
-    shadow.branch = new_branch
-
-    if is_non_store_billing_doc(shadow):
-        return get_non_store_parent()
-    try:
-        return resolve_branch_to_company(new_branch, department=emp_doc.department)
-    except UnknownBranch:
-        # Unresolvable branch — do not silently pivot; keep current company and
-        # let HR investigate. The validate hook will log on employee save.
-        return emp_doc.company
+# S201 Option X (2026-04-17): `_derive_new_company` was removed — transfers no
+# longer auto-change `Employee.company`. Legal employer stays stable; internal
+# per-store billing is handled by S202 allocation JE engine (punch-based). If
+# HR genuinely needs to move an employee between legal entities (rare), they
+# can edit Company directly on the Employee form (Link dropdown) before
+# creating the transfer, or after approval via a separate HR Personnel Action.
 
 
 @frappe.whitelist()
@@ -101,16 +75,11 @@ def create_transfer(employee, new_branch, transfer_date, reason,
         "new": new_branch,
     })
 
-    # S201: derive new_company from new_branch unless employee is non-store billing
-    new_company = _derive_new_company(emp_doc, new_branch)
-
-    # Company change row (only when company actually changes)
-    if new_company and new_company != emp_doc.company:
-        transfer_details.append({
-            "property": "Company",
-            "current": emp_doc.company or "",
-            "new": new_company,
-        })
+    # S201 Option X (2026-04-17): new_company stays on the employee's current
+    # legal employer. HR changes legal employer manually (Frappe Desk Company
+    # dropdown) when there's a real legal move; the Transfer API does not
+    # infer this from branch.
+    new_company = emp_doc.company
 
     # Reports To change (optional)
     if new_reports_to and new_reports_to != emp_doc.reports_to:

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -190,6 +190,11 @@ doc_events = {
 			# S200 — clear Analytics store mapping cache so new Companies
 			# appear in the Store Leaderboard within 30 seconds
 			"hrms.utils.sales_location_mapping.clear_cache",
+			# S201 audit fix — invalidate branch->Company resolver cache when
+			# Company docs change (rename, entity_category flip). Branch hook
+			# was wired originally but not Company; a Company rename could leave
+			# the resolver returning the old full name for up to 60s.
+			"hrms.utils.company_lookup.clear_cache",
 		],
 		"on_trash": "hrms.overrides.company.handle_linked_docs",
 	},
@@ -236,8 +241,13 @@ doc_events = {
 		"validate": [
 			"hrms.overrides.employee_master.validate_onboarding_process",
 			"hrms.utils.bio_id_validation.validate_employee_bio_id",
-			# S201 — derive company from branch (store child / BEI parent / BKI)
-			"hrms.overrides.employee_master.derive_company_from_branch",
+			# S201 Option X (2026-04-17): derive_company_from_branch hook is
+			# DISABLED. Employee.company stays on the legal employer and is
+			# only changed manually by HR via the Frappe Desk Company dropdown.
+			# Per-store internal billing is handled by S202 allocation JE engine
+			# (punch-based), NOT by moving Employee.company. Keeping the
+			# function in employee_master.py for reference / future use.
+			# "hrms.overrides.employee_master.derive_company_from_branch",
 		],
 		"on_update": [
 			"hrms.overrides.employee_master.update_approver_role",

--- a/hrms/patches/v16_0/s201_backfill_employee_company.py
+++ b/hrms/patches/v16_0/s201_backfill_employee_company.py
@@ -1,17 +1,24 @@
-"""S201 Phase 7: backfill Employee.company based on branch + non-store rules.
+"""S201 Phase 7: (DEPRECATED under Option X) backfill Employee.company.
 
-For every Active Employee, computes the target Company (same logic as the
-Employee.validate hook) and UPDATEs tabEmployee.company via direct SQL
-(bypasses validate to avoid hook re-firing and to keep the patch fast).
+**IMPORTANT: This patch is kept for reference only. DO NOT RUN.**
 
-Safety:
-  - DRY-RUN by default. Writes a line-by-line change list to
-    output/s201/diagnostics/backfill_report_<timestamp>.json and exits.
-  - To apply: S201_APPLY=1 env var.
-  - Idempotent: rerunning after apply is a no-op (everyone already at target).
-  - Emits per-Company before/after counts for audit.
+Original intent (Option A / Y): walk every Active Employee and UPDATE
+tabEmployee.company to the store's child Company derived from branch.
 
-Run directly:
+Why deprecated (Sam 2026-04-17):
+- Employees should NOT change their legal employer on paper just because
+  they work at a store. Legal employer (Employee.company) stays stable for
+  SSS/PhilHealth/HDMF/BIR 2316 compliance.
+- Internal per-store billing is delivered by S202 via punch-based allocation
+  JEs (month-end inter-Company labor cost reclassification).
+
+The execute() function is hard-gated: even with S201_APPLY=1 it now raises
+so the patch cannot silently move production data down the wrong path.
+
+DRY-RUN mode is preserved so anyone curious can still see "what would have
+happened" under Option A, but no actual UPDATEs are issued.
+
+Run directly (dry-run inspection only):
     bench --site hq.bebang.ph execute \\
       hrms.patches.v16_0.s201_backfill_employee_company.execute
 """
@@ -162,33 +169,27 @@ def execute() -> None:
 	if not apply_mode:
 		report_path = _write_report(summary)
 		frappe.logger().info(
-			f"[S201] DRY-RUN. {len(changes)} changes planned; "
+			f"[S201] DRY-RUN (Option X: apply is disabled). "
+			f"{len(changes)} changes planned under Option A; "
 			f"{len(unresolvable)} unresolvable. Report: {report_path}"
 		)
 		return
 
-	# Apply changes via direct SQL to avoid re-firing the Employee.validate
-	# hook we just shipped (it would compute the same target anyway, but
-	# direct SQL is faster and keeps the patch deterministic).
-	applied = 0
-	errors = []
-	for ch in changes:
-		try:
-			frappe.db.sql(
-				"UPDATE `tabEmployee` SET company=%s WHERE name=%s",
-				(ch["new_company"], ch["employee"]),
-			)
-			applied += 1
-		except Exception as exc:
-			errors.append({"employee": ch["employee"], "error": str(exc)})
-
-	frappe.db.commit()
-
-	summary["totals"]["applied"] = applied
-	summary["totals"]["errors"] = len(errors)
-	summary["errors"] = errors
+	# S201 Option X (2026-04-17) hard gate: the apply path was removed because
+	# Sam decided Employee.company stays stable; per-store billing goes
+	# through S202 allocation JEs instead. Writing the dry-run report for
+	# audit, then raising so nobody accidentally moves legal employers.
 	report_path = _write_report(summary)
-	frappe.logger().info(
-		f"[S201] APPLIED. {applied} company reassignments. "
-		f"{len(errors)} errors. Report: {report_path}"
+	frappe.log_error(
+		title="S201 backfill apply attempt blocked (Option X)",
+		message=(
+			f"{len(changes)} planned changes were NOT applied because Option X "
+			f"keeps Employee.company stable. Dry-run report: {report_path}."
+		),
+	)
+	raise RuntimeError(
+		"S201 Option X: Employee.company backfill is intentionally disabled. "
+		"Per-store billing is delivered via S202 allocation JE engine. "
+		"If you really need to move legal employers, do it manually in Frappe "
+		"Desk one employee at a time (use the Company dropdown on Employee)."
 	)

--- a/hrms/patches/v16_0/s201_rename_branches.py
+++ b/hrms/patches/v16_0/s201_rename_branches.py
@@ -123,6 +123,10 @@ def execute() -> None:
 		return
 
 	# Execute renames. Merge when target already exists.
+	# S201 audit fix: wrap in savepoint so a mid-batch failure rolls back the
+	# partial renames (DM-2). Errors route through log_error so Sentry catches
+	# them (DM-7).
+	frappe.db.savepoint("s201_rename_branches")
 	for entry in plan:
 		old = entry["old"]
 		new = entry["new"]
@@ -141,11 +145,27 @@ def execute() -> None:
 			errors.append({"old": old, "new": new, "reason": str(exc)})
 			entry["status"] = f"failed: {exc}"
 
-	frappe.db.commit()
-
 	summary["errors"] = errors
+
+	if errors:
+		frappe.db.rollback(save_point="s201_rename_branches")
+		frappe.log_error(
+			title="S201 rename_branches rolled back on partial failure",
+			message=(
+				f"planned={len(plan)}, errors={len(errors)}; "
+				f"first_error={errors[0]}"
+			),
+		)
+		report_path = _write_report(summary)
+		frappe.logger().error(
+			f"[S201] ROLLBACK. {len(errors)} errors. Report: {report_path}"
+		)
+		return
+
+	frappe.db.release_savepoint("s201_rename_branches")
+	frappe.db.commit()
 	report_path = _write_report(summary)
 	frappe.logger().info(
 		f"[S201] APPLIED. {len([p for p in plan if p.get('status')=='renamed'])} renames. "
-		f"{len(errors)} errors. Report: {report_path}"
+		f"Report: {report_path}"
 	)

--- a/output/plan-audit/s201/code_verification.md
+++ b/output/plan-audit/s201/code_verification.md
@@ -1,0 +1,197 @@
+# S201 Code Verification
+
+**Verifier:** Code Verification Agent
+**Date:** 2026-04-17 PHT
+**Branches verified against:** `fix/s200-drift-check-allow-commissary` (working tree) + shipped code from PR #603 + PR #604
+**Files read:** company_lookup.py, non_store_billing.py, employee_master.py, transfers.py, hooks.py, s201_rename_branches.py, s201_backfill_employee_company.py, roving_employees.py
+
+---
+
+## Domain Findings Re-Classified
+
+### From frappe_backend_findings.md
+
+- **FRAPPE-W2 (DM-2 Backfill Atomicity) [NEEDS_FIX]**: `frappe.db.commit()` is at line 185, after the loop. Errors are appended to `errors[]` but the commit fires unconditionally even when `len(errors) > 0`. The auditor's recommended fix (abort commit if errors) is NOT present in the shipped code. Partial batch will commit silently on per-row SQL errors.
+
+- **FRAPPE-W8 (HR Manager override flag dead code) [CONFIRMED]**: `company_manual_override` appears in exactly two places — both in `employee_master.py` (line 66 docstring, line 82 read). No setter exists anywhere in the codebase (no form JS, no API endpoint, no other Python file). The flag is read-only dead code.
+
+- **FRAPPE-W11 (rename_doc merge=True no Warehouse/Cost Center check) [CONFIRMED]**: `s201_rename_branches.py` dry-run report captures `employees_on_old` and `will_merge` flag but no Warehouse/Cost Center comparison for merge candidates. The auditor's finding stands.
+
+- **FRAPPE-W12 (direct SQL bypasses track_changes) [CONFIRMED]**: Verified — backfill uses raw `UPDATE tabEmployee SET company=%s WHERE name=%s`. No `tabVersion` entries created. `backfill_report_*.json` is the only audit trail.
+
+- **FRAPPE-W13 (Commissary plan-code mismatch) [CONFIRMED]**: Plan Phase 4 says "Elif department=Commissary → BKI" without branch exceptions. Code correctly routes `SHAW COMMISSARY - LOGISTICS` and `SHAW COMMISSARY - RD QC` to BEI parent via `HO` category in `branch_company_map.csv`, but plan text does not document this. The code is correct; the plan description is incomplete.
+
+---
+
+### From ph_finance_findings.md
+
+All PH Finance findings (PH-C1 through PH-C5, PH-W3 through PH-W10) are claims about the plan's omissions relative to Philippine statutory law, not claims about the code. Verification:
+
+- **PH-C1 (SSS/PhilHealth split) [CONFIRMED — PLAN OMISSION]**: Grep of `hrms/` for `SSS`, `PhilHealth`, `Pag-IBIG` returns only `hrms/payroll/ph_statutory.py` (payroll computation module) — no references in any S201 file. The plan contains zero language about statutory employer registration for the 49 new Companies. Finding stands as a plan gap.
+
+- **PH-C2 (BIR Form 2316 dual-employer) [CONFIRMED — PLAN OMISSION]**: No code in S201 scope addresses dual-employer 2316 handling. Finding is about plan omission, not a code bug.
+
+- **PH-C3 (BIR 1905 withholding agent registration) [CONFIRMED — PLAN OMISSION]**: No BIR 1905 pre-check in any S201 file. Finding stands.
+
+- **PH-C4 (Draft Salary Slips pre-backfill) [CONFIRMED — PLAN OMISSION]**: Backfill patch (`s201_backfill_employee_company.py`) queries `status=Active` employees but does NOT check for existing Draft/Submitted Salary Slips for April 2026. No pre-backfill query for `tabSalary Slip WHERE docstatus IN (0,1) AND start_date >= '2026-04-01'` exists anywhere in the code. Finding stands.
+
+- **PH-C5 (HDMF 49 employer accounts) [CONFIRMED — PLAN OMISSION]**: Same as PH-C1 — statutory registration gap is real and not addressed in code.
+
+- **PH-W6 (Leave Balance carryover) [CONFIRMED — PLAN OMISSION]**: No leave allocation audit step in backfill patch.
+
+- **PH-W7 (Cost Center continuity) [CONFIRMED — PLAN OMISSION]**: Backfill patch updates `company` only. `payroll_cost_center` field is not touched. No cost center migration step.
+
+- **PH-W9 (Group HMO coverage break) [CONFIRMED — PLAN OMISSION]**: No HMO/benefits configuration audit in any S201 file.
+
+- **PH-W10 (Consolidated reporting) [CONFIRMED — PLAN OMISSION]**: No consolidated report verification step in any S201 file.
+
+- **PH-C11 (April 1-16 split-month retroactive risk) [CONFIRMED — PLAN OMISSION]**: Plan has no LD-8 decision recorded. Code cannot address what the plan doesn't specify.
+
+---
+
+### From deployment_qa_findings.md
+
+- **DEPLOY-C1 (Deploy workflow has no apply-mode trigger mechanism) [CONFIRMED]**: `build-and-deploy.yml` line 388: `docker exec $BACKEND_CONTAINER bench --site $FRAPPE_SITE migrate` — no `S201_APPLY=1` parameter, no workflow input. The automated workflow can only trigger dry-run mode.
+
+- **DEPLOY-C3 (S201_APPLY env var will not propagate through docker exec) [CONFIRMED]**: Verified. The migrate step at line 388 is a bare `docker exec $BACKEND_CONTAINER bench ...` with no `-e S201_APPLY=1` flag. Even if a local operator sets `S201_APPLY=1` in their shell, it does NOT reach the process inside the Docker container. The correct command requires `docker exec -e S201_APPLY=1 $BACKEND_CONTAINER bench ...`. This is absent from the plan, PR body, and workflow.
+
+- **DEPLOY-C5 (No Playwright L3 script, no output/l3/s201/) [CONFIRMED]**: `output/l3/s201/` does NOT exist on disk. The directory listing of `output/l3/` shows entries up to `s198` — no `s201` subdirectory. No `l3_s201_*.py` or `l3_s201_*.mjs` files found in `scripts/testing/`. L3 is fully unscripted.
+
+- **DEPLOY-C11 (Phase 7 HARD BLOCKER unactionable) [CONFIRMED]**: Same root cause as DEPLOY-C3. No runbook for retrieval or apply-mode trigger exists in the code or workflow.
+
+- **DEPLOY-W4 (Rollback has orphaned Salary Slip gap) [CONFIRMED — PLAN OMISSION]**: Rollback SQL is not in any shipped code file. Finding is about plan rollback section text. No Salary Slip pre-rollback query in the plan.
+
+- **DEPLOY-W6 (L3-6 no payroll fixture) [CONFIRMED — PLAN OMISSION]**: No fixture data in any test file for L3-6.
+
+- **DEPLOY-W7 (Plan YAML status=GO post-merge, no intermediate status) [STALE — ACCEPTABLE]**: Both PRs (#603 and #604) are merged. Status `GO` in the plan is now stale but this is a documentation governance issue, not a code bug.
+
+- **DEPLOY-W8 (Governor handlers not specified) [CONFIRMED — PLAN OMISSION]**: No `governor_handlers` block in plan YAML. Both PRs are already merged so moot for this sprint, but finding stands for future plan quality.
+
+---
+
+### From cross_cutting_findings.md
+
+- **CROSS-C1 (S154 no Zero-Skip enforcement section) [CONFIRMED — PLAN TEXT]**: Plan text does not contain any enforcement language prohibiting phase-skip. The plan has a Requirements Regression Checklist but no "NEVER proceed to Phase N+1 without Phase N evidence" statement.
+
+- **CROSS-C2 (S154 no per-phase completion gate) [CONFIRMED — PLAN TEXT]**: Phase tasks are prose checkboxes; no machine-readable PASS/FAIL gate per phase.
+
+- **CROSS-C3 (S154 no MUST_MODIFY inline assertions) [CONFIRMED — PLAN TEXT]**: Verified by reading plan text. Files-to-modify table exists at end of plan but individual phase tasks do not have inline `MUST_MODIFY:` assertions.
+
+- **CROSS-C4 (S154 no MUST_CONTAIN assertions) [CONFIRMED — PLAN TEXT]**: No `MUST_CONTAIN:` assertions anywhere in plan.
+
+- **CROSS-C5 (S087 no protected surfaces list) [CONFIRMED — PLAN TEXT]**: Plan has "Files To Be Modified" table but no complementary "DO NOT TOUCH" list.
+
+- **CROSS-C (pre-touch backup before Phase 7 bulk SQL) [CONFIRMED — CODE GAP]**: Backfill patch (`s201_backfill_employee_company.py`) captures `pre_counts` (aggregated per-Company counts) and includes the full `changes[]` list in the JSON report — this constitutes a per-employee before/after log. However, it does NOT emit a standalone `PRETOUCH_BACKUP.json` of `{employee_id: old_company}` values before any UPDATE runs. The `changes[]` list is equivalent data but it is embedded inside the report JSON. There is no CSV backup of pre-state written before the SQL loop begins, unlike S196's `PRETOUCH_BACKUP.json` pattern. Finding is **PARTIALLY CONFIRMED**: per-employee pre-state IS captured in the report JSON (the `changes[].old_company` field), but only after classification runs — not as a separate pre-touch snapshot written before any SQL.
+
+---
+
+### From system_arch_findings.md
+
+- **SYSARCH-C3 (Classifier rule ordering — commissary split undocumented) [CONFIRMED]**: Verified in `non_store_billing.py`. The commissary classification is absent from `is_non_store_billing()` entirely — commissary employees return `False` from that function and are handled by `resolve_branch_to_company()` via `DEPT_DRIVEN` hint. This split is not documented in either function's docstring.
+
+- **SYSARCH-C6 (Roving reliever mis-allocation estimate) [CONFIRMED AS ACCURATE]**: EMPLOYEE_MASTER.csv has 621 rows with monthly_rate. Average = PHP 20,397. 27 roving × PHP 20K = PHP 540,000; 27 × PHP 35K = PHP 945,000. The auditor's PHP 540K–945K estimate is arithmetically correct based on actual salary data. The "27 employees" figure also matches: ROVING_EMPLOYEES dict contains exactly 26 entries (auditor said "~27" — close enough, actual count is 26 not 27). Magnitude of concern is confirmed.
+
+- **SYSARCH-C13 (HR Manager override dead code — doc.flags is runtime-only) [CONFIRMED]**: `company_manual_override` appears in only one Python file (`employee_master.py`, 2 lines: docstring + read). No setter exists in any `.py`, `.js`, or `.ts` file. No Frappe Custom Field for `custom_company_manual_override` exists. No form JS in `hrms/public/js/erpnext/employee.js` sets this flag. The bypass is confirmed dead code — HR Managers cannot exercise the override.
+
+- **SYSARCH-W1 (Three-source resolver disagreement — silent miss) [CONFIRMED]**: `resolve_branch_to_company()` raises `UnknownBranch` when a branch prefix is not in `_store_company_index`. In `derive_company_from_branch()`, `UnknownBranch` is caught at line 90-91: `except UnknownBranch: return`. No `frappe.log_error()` call. The miss is truly silent — no Error Log entry, no msgprint, nothing.
+
+- **SYSARCH-W2 (60s cache TTL — worker isolation) [CONFIRMED — ACCEPTABLE RISK]**: Cache is a module-level `dict`. Worker process isolation is a real gap. But sequential phase execution (Phase 6 → Sam approval → Phase 7) provides adequate time for cache expiry. Risk is bounded.
+
+- **SYSARCH-W4 (New branch not in CSV — silent mis-allocation) [CONFIRMED]**: Same code path as SYSARCH-W1. Silent `return` on `UnknownBranch`.
+
+- **SYSARCH-W9 (Direct SQL no Version records) [CONFIRMED — PLAN OMISSION]**: Same as FRAPPE-W12. Plan does not acknowledge `track_changes` bypass.
+
+- **SYSARCH-W10 (my.bebang.ph 60s stale cache) [STALE — LOW SEVERITY]**: `use-employee.ts` does use SWR with 60s dedup. The plan's "automatic" claim is imprecise by 60 seconds. Display-only field — no RBAC logic depends on company. Acceptable.
+
+- **SYSARCH-W12 (rename_doc cascade leaves company stale) [CONFIRMED — INFO]**: `frappe.rename_doc()` updates `Employee.branch` via SQL cascade but does NOT re-fire Employee validate. Company stays stale until Phase 7 backfill runs. Plan sequences correctly but does not explain WHY Phase 7 is needed.
+
+---
+
+## NEW GAPs Discovered (not reported by any domain auditor)
+
+### NEW-GAP-1
+**Issue:** `Company.on_update` does NOT call `company_lookup.clear_cache()`. The plan and SYSARCH-W2 state "on_update hooks on Branch and Company doctypes call `clear_cache()`" but the actual code only wires Branch → `company_lookup.clear_cache`. Company on_update calls `sales_location_mapping.clear_cache` (S200 analytics), not the S201 company resolver cache.
+**Evidence:** `hooks.py` lines 181-193: `Company.on_update` list = `[make_company_fixtures, set_default_hr_accounts, auto_provision_company, auto_enroll_adms_devices, sales_location_mapping.clear_cache]`. No `company_lookup.clear_cache` entry. Branch on_update (lines 201-205) correctly has `company_lookup.clear_cache`. If a Company is renamed or added post-deploy, the resolver cache will NOT be invalidated — it will serve stale data for up to 60 seconds.
+**Severity:** WARNING — The _store_company_index is rebuilt at 60s TTL anyway, so the gap only matters in the first 60 seconds after a Company change. But the plan's stated invariant ("Company on_update triggers cache clear") is false.
+
+### NEW-GAP-2
+**Issue:** `is_non_store_billing_doc()` reads `attendance_device_id` (old 6-digit field) FIRST, then falls back to `new_attendance_device_id`. ROVING_EMPLOYEES dict uses exclusively `9xxxxxx` format (new format). If a live employee still has a stale 6-digit value in `attendance_device_id` AND a correct `9xxxxxx` value in `new_attendance_device_id`, `is_non_store_billing_doc()` will pass the 6-digit value to `is_roving()`, which will NOT find it in ROVING_EMPLOYEES. The employee would be silently misclassified as a store biller instead of BEI-parent biller.
+**Evidence:** `non_store_billing.py` line 132: `bio_id=getattr(employee_doc, "attendance_device_id", None) or getattr(employee_doc, "new_attendance_device_id", None)`. `roving_employees.py` keys are all `9xxxxxx`. MEMORY.md: "Legacy 6-digit Bio IDs (like 324002, 225034) are fully deprecated — the correct format is `9xxxxxx`". Backfill patch correctly reads `new_attendance_device_id` first (line 48: `emp.get("new_attendance_device_id") or emp.get("attendance_device_id")`). Inconsistency between backfill patch and doc-wrapper function.
+**Severity:** WARNING — Risk is bounded to the migration window if `attendance_device_id` column still holds legacy values in tabEmployee. Post-S164 cleanup may have cleared them. But the field priority is reversed vs the backfill patch, creating inconsistent behavior.
+
+### NEW-GAP-3
+**Issue:** `frappe.db.commit()` in the backfill patch fires unconditionally after the UPDATE loop, even when `len(errors) > 0`. Errors are collected in `errors[]` but there is no guard before `frappe.db.commit()`. A partial batch (e.g., 480 of 510 employees updated, 30 failures) will be committed silently.
+**Evidence:** `s201_backfill_employee_company.py` lines 174-188:
+```python
+errors = []
+for ch in changes:
+    try:
+        frappe.db.sql(...)
+        applied += 1
+    except Exception as exc:
+        errors.append(...)
+
+frappe.db.commit()   # ← commits even if errors is non-empty
+```
+The FRAPPE-W2 finding from the domain auditor recommended adding `if errors: return` before the commit. That fix is NOT present in the shipped code.
+**Severity:** WARNING — MariaDB will commit whatever succeeded. In a partial failure, the report will show `applied=480, errors=30` but the 480 changes are already committed. Re-running is safe (idempotent), but the partial state is not signaled as a failure.
+
+### NEW-GAP-4
+**Issue:** `s201_rename_branches.py` uses `frappe.logger().error()` for critical failure paths (lines 42, 67). `frappe.logger()` writes to the server log file only — it does NOT create a Frappe Error Log entry, so Sentry does not capture it. The domain auditor (FRAPPE-W7/DM-7) flagged this for the rename patch, but the shipped code still uses `frappe.logger().error()` in both patches. The backfill patch also uses `frappe.logger().warning()` for report write failures (line 75). These are genuinely silent failure modes in Sentry.
+**Evidence:** `s201_rename_branches.py` line 42: `frappe.logger().error(...)`. Line 67: `frappe.logger().error(...)`. `s201_backfill_employee_company.py` line 75: `frappe.logger().warning(...)`. None of these call `frappe.log_error()`.
+**Severity:** WARNING (INFO-level for operability, but creates gap in Sentry observability per DM-7).
+
+### NEW-GAP-5
+**Issue:** The backfill patch's `frappe.db.commit()` in the rename patch (`s201_rename_branches.py` line 144) fires after the apply loop regardless of error count. Same pattern as NEW-GAP-3.
+**Evidence:** `s201_rename_branches.py` line 144: `frappe.db.commit()` is after the loop with no `if errors: return` guard.
+**Severity:** WARNING — Consistent with NEW-GAP-3, partial rename batches will commit.
+
+---
+
+## Spot-Check Results Summary
+
+| Spot-Check | Claim | Verdict |
+|---|---|---|
+| 1. FRAPPE-W8: company_manual_override dead code | Flag only read, never set | **CONFIRMED DEAD CODE** — only in employee_master.py, no setter anywhere |
+| 2. FRAPPE-W13/CROSS-C3: Commissary dept → BKI routing | Code routes via branch category, not dept alone | **CONFIRMED PLAN-CODE MISMATCH** — `is_non_store_billing()` runs first; Commissary dept alone is insufficient if branch is HO |
+| 3. DEPLOY-C3: S201_APPLY doesn't propagate through docker exec | No `-e` flag in workflow | **CONFIRMED** — workflow line 388 has no env injection; `-e S201_APPLY=1` required |
+| 4. DEPLOY-C5: No Playwright script, no output/l3/s201/ | Directory absent | **CONFIRMED** — `output/l3/s201/` does not exist; no l3_s201 script file found |
+| 5. PH-C1/C2/C3/C4/C5: SSS/BIR/HDMF plan omissions | About plan text, not code | **CONFIRMED AS PLAN OMISSIONS** — no S201 code addresses statutory registrations |
+| 6. SYSARCH-C6: 27 roving × PHP 540K-945K estimate | Salary data available | **CONFIRMED ACCURATE** — avg salary PHP 20,397; 26 roving × avg ≈ PHP 530K; magnitude correct |
+| 7. SYSARCH-C13: HR Manager override dead code | No UI setter | **CONFIRMED DEAD CODE** — same as #1 |
+| 8. CROSS-C1/C2/C3/C4: S154 enforcement gaps | Plan text gaps | **CONFIRMED AS PLAN TEXT GAPS** — no enforcement language, no MUST_MODIFY/MUST_CONTAIN |
+| 9. CROSS-C (pre-touch backup before Phase 7 SQL) | Report JSON has per-employee before-state | **PARTIALLY CONFIRMED** — per-employee old_company IS in changes[] report, but no standalone PRETOUCH_BACKUP.json written before SQL loop |
+| 10. FRAPPE-W2: partial commit on mid-loop error | commit fires unconditionally | **CONFIRMED — NEW-GAP-3** — commit fires even when errors[] is non-empty |
+
+---
+
+## Summary
+
+| Category | CRITICAL | WARNING |
+|---|---|---|
+| CONFIRMED | 7 | 18 |
+| STALE | 0 | 2 |
+| NEEDS_FIX (code bug in shipped code) | 0 | 3 |
+| NEW GAPS | 0 | 5 |
+
+**CONFIRMED CRITICAL (7):**
+FRAPPE-W8 (dead code), DEPLOY-C3 (env propagation), DEPLOY-C5 (no L3 script), PH-C1 (SSS), PH-C2 (2316), PH-C4 (draft slips), PH-C5/HDMF, SYSARCH-C13 (dead override), CROSS-C1-C4 (S154 enforcement)
+
+> Note: Multiple findings share the same root cause (dead HR Manager override = FRAPPE-W8 + SYSARCH-C13 = one confirmed bug). Deduped above.
+
+**STALE (2):**
+DEPLOY-W7 (plan status GO — both PRs merged, moot), SYSARCH-W10 (60s stale cache in my.bebang.ph — display-only, no RBAC impact)
+
+**NEW GAPS (5):**
+- NEW-GAP-1 [WARNING]: Company.on_update does NOT call company_lookup.clear_cache (only Branch does)
+- NEW-GAP-2 [WARNING]: is_non_store_billing_doc reads old attendance_device_id first; ROVING_EMPLOYEES uses new 9xxxxxx format — field priority reversed vs backfill patch
+- NEW-GAP-3 [WARNING]: Backfill patch commits even with errors[] non-empty (unconditional commit after loop)
+- NEW-GAP-4 [WARNING]: Both patches use frappe.logger().error() not frappe.log_error() — Sentry silent on critical failures
+- NEW-GAP-5 [WARNING]: Rename patch also commits unconditionally after loop (same pattern as NEW-GAP-3)
+
+**Highest-Priority Fixes Before Apply-Mode Execution:**
+1. **DEPLOY-C3 + DEPLOY-C11**: Update apply-mode runbook to use `docker exec -e S201_APPLY=1` — without this, S201_APPLY will silently not take effect
+2. **NEW-GAP-3**: Add `if errors: <abort commit>` before `frappe.db.commit()` in backfill patch
+3. **FRAPPE-W8 / SYSARCH-C13**: Either implement the HR Manager override properly (Custom Field + form JS) or document it as intentionally non-functional
+4. **NEW-GAP-1**: Add `company_lookup.clear_cache` to Company.on_update in hooks.py
+5. **NEW-GAP-2**: Flip field priority in `is_non_store_billing_doc` to read `new_attendance_device_id` first

--- a/output/plan-audit/s201/cross_cutting_findings.md
+++ b/output/plan-audit/s201/cross_cutting_findings.md
@@ -1,0 +1,131 @@
+---
+audit_target: S201 Per-Store Employee Billing Foundation
+plan_file: docs/plans/2026-04-17-sprint-201-per-store-employee-billing-foundation.md
+audited_by: Cross-Cutting Auditor Agent
+audit_date: 2026-04-17
+rules_checked: [S091, S154-ZeroSkip, S154-PhaseGate, S089, S092-Closeout, S092-CorruptSuccess, S087, S099, S026]
+branch_verified: s201-per-store-employee-billing (5 commits ahead of production, 0 behind)
+---
+
+# S201 Cross-Cutting Audit Findings
+
+## S091 Cold-Start Self-Containment
+
+- [OK] "Design Rationale (For Cold-Start Agents)" section present at line 87.
+- [OK] Option C rejection is explained with specific statutory reason: "PH payroll law (SSS, PhilHealth, Pag-IBIG, BIR 2316) requires one legal employer per period." Sufficient for a cold-start agent to understand without needing external context.
+- [OK] Option A vs Option B vs Option C comparison is documented inline. Option A limitation is explicit ("3 days at SM MOA by a Tanza employee still bill to Tanza — insufficient per Sam's ask"). Option B benefit is explicit ("fair per-store P&L without breaking statutory"). Option C rejection is explicit.
+- [OK] S201 + S202 split rationale is citable: "Splitting S201 (foundation) + S202 (allocation) avoids the 80-unit single-session ceiling (S089 rule)."
+- [OK] Branch rename rationale is citable: "Analytics + Store Ordering + Delivery Schedule all use Company prefix. Keeping a separate branch naming convention creates permanent alias debt."
+- [OK] "Why not blank Employee.branch" rationale cites specific downstream consumers: "Branch drives geofence, attendance device selection, and scheduling."
+- [WARNING] The rationale section does not cite a specific source file for the statutory single-employer rule. It says "PH payroll law" but does not point to a PH-finance rules file or regulatory reference. A cold-start agent cannot verify this claim without external knowledge. Suggested fix: add `(See: memory/ph-finance-accounting.md or BIR RR 2-98 reference in .claude/rules/frappe-development.md DM-3)`.
+- [WARNING] Known limitation: the plan assumes EMPLOYEE_MASTER.csv counts (~80 non-store, ~44 commissary, ~510 store) are approximately correct and uses Phase 0 pre-counts as authoritative baseline. This assumption is stated (line 279) but the consequences of drift are not documented. If the actual Frappe tabEmployee counts diverge significantly from EMPLOYEE_MASTER.csv, the Phase 7 verification thresholds ("expect ~45 on BEI parent") will be wrong and the agent may declare success prematurely.
+- [INFO] Locked Decisions table is comprehensive and directly citable. All 7 LDs are present with source attribution (Sam Q1-Q5, Scoping).
+
+## S154 Zero-Skip Enforcement
+
+- [CRITICAL] No explicit "Zero-Skip Enforcement" section in the plan. The plan has a Requirements Regression Checklist (line 72-85) but it is framed as a declaration checklist, not an enforcement mechanism. There is no statement prohibiting the executing agent from skipping any phase or marking a task complete without evidence. The plan does not say: "An agent MUST NOT mark any phase complete without running its Verification step."
+- [CRITICAL] Phase completion checklist format is prose checkboxes only. Phases 0-7 each have a bullet list of tasks but there is no standardized "Phase N DONE" gate that an agent must explicitly pass before proceeding to Phase N+1. The Verification sub-sections exist but are not formally gated — they read as advisory rather than mandatory.
+- [WARNING] No explicit prohibition of skipping behaviors. Contrast with best-practice plans that include language such as: "NEVER proceed to the next phase if any verification in this phase fails. STOP and report the failure." S201 lacks this language entirely.
+- [WARNING] The Phase 7 Verification section lists expected before/after counts ("Before: 541 on BEI parent, 0 on per-store Companies") but does not specify a tolerance or explicit PASS/FAIL criterion. An agent with slightly wrong pre-counts could rationalize a different distribution as correct.
+- [INFO] The completion_condition YAML block (lines 16-25) is the closest thing to enforcement — it is machine-readable and enumerates 9 required conditions. However, it is only checked at the very end, not per phase.
+
+## S154 Machine-Verifiable Phase Gate
+
+- [CRITICAL] Tasks do not contain inline MUST_MODIFY assertions naming exact file paths. The plan has a "Files To Be Modified/Created" table (lines 246-262) as a summary, but individual phase tasks do not say "MUST_MODIFY: hrms/api/transfers.py" inline. For a 13-file change plan, an executing agent could modify the wrong file version or miss a file entirely without a per-task MUST_MODIFY contract.
+- [CRITICAL] No MUST_CONTAIN assertions for features. For example, Phase 4 requires `derive_company_from_branch` to call `is_non_store_billing()` with a specific rule hierarchy. There is no assertion like: `MUST_CONTAIN: hrms/overrides/employee_master.py::derive_company_from_branch calls is_non_store_billing(doc)`. Verification is "create a test employee and observe" which requires a live bench, not a file-level check.
+- [WARNING] Phase 5 Verification is "git diff hrms/api/transfers.py shows new_company computed dynamically" — this is the best verification in the plan (file-level), but it relies on the agent interpreting diff output rather than a script-verified assertion.
+- [WARNING] Phase 6 (branch rename patch) and Phase 7 (backfill patch) are bulk-mutation phases with the highest risk of silent partial completion. Neither phase has a script-based verification requirement that runs the patch with --dry-run and asserts specific output (e.g., "dry-run must emit exactly 54 branch rename rows"). The Phase 6 verification is prose: "SELECT DISTINCT branch FROM tabEmployee returns branch names that all match Company prefixes."
+- [OK] Phase 0 Verification is partially machine-verifiable: `jq '.[] | select(.company=="Bebang Enterprise Inc.") | .COUNT' output/s201/diagnostics/pre_counts.json` — this is a concrete command with expected output format. Good model for other phases.
+- [INFO] The plan is backend-only (no UI). S154 was originally frontend-focused but the MUST_MODIFY/MUST_CONTAIN principle applies equally to backend: Python functions, patch scripts, and unit tests can be verified by file existence and content grep before execution.
+
+## S089 Requirements Drift
+
+- [OK] Requirements Regression Checklist present at lines 72-85 with 9 explicit YES/NO questions.
+- [OK] Scope is right-sized: 38u estimated, well within the 80u single-session ceiling.
+- [OK] S202 deferral is explicit and justified (reliever allocation JE engine deferred, sprint split rationale citable).
+- [WARNING] Only ONE Hard Blocker is marked inline in tasks (Phase 7: "HARD BLOCKER: patch must be --dry-run first. No direct execution without Sam approval"). The other key Sam-approval gates are in the Locked Decisions table (LD-1 through LD-7) but are NOT inlined as HARD BLOCKER annotations in the relevant phases. Specifically:
+  - Phase 6 (branch rename) modifies 54+ Branch doctype records and all Employee.branch values. This is a destructive bulk rename but has no inline HARD BLOCKER requiring Sam approval before live execution.
+  - Phase 4 (Employee.validate() hook) is a permanent schema behavior change on every employee save — no inline HARD BLOCKER.
+- [WARNING] stop_only_for list (YAML lines 26-30) includes "Destructive bulk mutation requires Sam approval" but this is in the YAML header, not inline in Phase 6 tasks where the agent needs the reminder at execution time.
+- [INFO] The plan correctly defers the monthly JE reclassification engine to S202 and explicitly labels it as "Out of Scope."
+- [INFO] 9 phases (0-7 + 9) in 38u is reasonable; average 4u/phase. Single-session executable.
+
+## S092 Closeout
+
+- [OK] Phase 9 (Closeout) is present at line 228.
+- [OK] Plan YAML has `status: GO` field; closeout requires changing it to `COMPLETED`.
+- [OK] completion_condition YAML block includes "Plan YAML status=COMPLETED and SPRINT_REGISTRY.md updated."
+- [OK] `git add -f` instruction present at line 233 with explicit file paths.
+- [OK] Phase 9 includes: S202 row reservation, PR creation, registry update. Closeout sequence is complete.
+- [WARNING] Plan YAML has no `completed_date:` field. When status changes to COMPLETED, the date would need to be added manually. Other sprint plans (e.g., S200) include `completed_date` in the YAML. This is a minor inconsistency but could cause registry update confusion.
+- [WARNING] Phase 9 `git add -f` line (233) does not include `output/s201/diagnostics/pre_counts.json`, `output/s201/diagnostics/pre_branches.txt`, `output/s201/diagnostics/pre_companies.json`, or `output/s201/diagnostics/classifier_results.csv` — all required diagnostic outputs from Phases 0 and 3. The git add line only covers `docs/plans/*.md output/s201/ output/l3/s201/ hrms/data_seed/branch_*.csv`. The `output/s201/` glob should cover diagnostics, but no explicit listing means these can be silently omitted.
+- [INFO] Registry verified: S201 row exists in SPRINT_REGISTRY.md (line 285) with correct branch `s201-per-store-employee-billing`, status `GO`, and PR `TBD`. S202 row already reserved (line 287). Registry is current.
+
+## S092 Anti-Corrupt-Success (L3)
+
+- [OK] "L3 Workflow Scenarios" section present at line 210 with 6 scenarios in a structured table.
+- [OK] Evidence file contract is explicit: `form_submissions.json`, `api_mutations.json`, `state_verification.json` in `output/l3/s201/`.
+- [OK] Scenarios are concrete: each row specifies Action (what to do in the UI) and Verify (what DB state to confirm via API). L3-1 through L3-5 are well-formed; L3-6 requires salary slip generation and JE confirmation.
+- [WARNING] L3 evidence directory `output/l3/s201/` does NOT YET EXIST. The L3 section says "Run these in a fresh Playwright session" but no l3/s201/ directory or files are present. This is expected pre-execution, but confirms L3 has not been run yet. The completion_condition requires L3 evidence before COMPLETED can be declared.
+- [WARNING] Plan is 38u — exactly at the threshold where the S092 rule recommends a fresh session for L3. The plan does NOT include an explicit recommendation for L3 to run in a separate session. For 38u plans, this is borderline; the plan should include: "L3 MUST run in a separate Claude session from implementation (context budget)."
+- [WARNING] L3-6 (Salary Slip posts to store Company) is the most complex scenario and requires the backfill patch to be applied first. The scenario does not specify: "L3-6 is only runnable AFTER Phase 7 is applied (not dry-run)." An agent running L3 before the live backfill will get a false negative on L3-6.
+- [INFO] L3 scenarios cover create (L3-1 to L3-3), transfer (L3-4 to L3-5), and payroll (L3-6) — good coverage of the three main mutation paths.
+
+## S087 Anti-Rewind
+
+- [CRITICAL] No explicit protected surfaces list. The plan has a "Files To Be Modified/Created" table (lines 246-262) which implicitly defines in-scope surfaces, but there is no complementary "DO NOT TOUCH these files" list. Critical protected surfaces not mentioned:
+  - `hrms/utils/roving_employees.py` — the plan says "keep ROVING_EMPLOYEES dict for backward compat" but there is no formal protection contract (e.g., "MUST NOT remove any existing bio_id from ROVING_EMPLOYEES dict").
+  - `hrms/hr/doctype/employee/employee.py` — if Phase 4 adds to this file rather than using hooks.py override, existing Employee validate logic must not be removed.
+  - `hrms/api/transfers.py` — existing transfer logic for non-company fields must remain intact.
+- [WARNING] No remote-truth baseline SHA cited. The plan says "base: production" in YAML but does not capture the production HEAD SHA at plan creation time. If the branch drifts or production is updated before S201 merges, there is no recorded baseline to diff against for rewind detection. Best practice: `git log --oneline -1 production` SHA in plan or in `output/s201/diagnostics/`.
+- [WARNING] No pre-touch backup contract for existing files. The Rollback Contract (lines 236-244) is execution-level (SQL TRUNCATE + git revert) but does not require a JSON/SQL backup of current tabEmployee.company values BEFORE Phase 7 runs. Compare with S196 which captured `output/s196/state/PRETOUCH_BACKUP.json` before any live mutation.
+- [OK] Rollback Contract is present and covers all four mutation phases (4, 5, 6, 7) with specific reversal instructions.
+- [OK] S201 is a single-agent plan with no concurrent agent ownership conflicts. Ownership matrix is implicitly satisfied by single-agent scope.
+- [INFO] Branch is confirmed 5 commits ahead of production and 0 behind (git local check). Rebase rule is satisfied.
+
+## S099 Branch & PR Isolation
+
+- [OK] Plan YAML `branch: s201-per-store-employee-billing` present at line 4.
+- [OK] Branch exists and matches the SPRINT_REGISTRY.md entry exactly.
+- [OK] Branch is confirmed in git: `s201-per-store-employee-billing` local + `remotes/origin/s201-per-store-employee-billing` present.
+- [OK] S201 branch is 0 commits behind production (verified via local git log). Rebase-before-merge requirement is satisfied at audit time.
+- [OK] PR registry update is in completion_condition and Phase 9 closeout.
+- [WARNING] A second branch `fix/s201-bgc-regional-area-manager` exists (both local and remote origin) and contains at least one commit (`322c7ea5e fix(S201): classifier catches REGIONAL AREA MANAGER; BGC resolves to BEI parent`). This commit is also present on `s201-per-store-employee-billing` (it appears in the branch log as the HEAD commit). If `fix/s201-bgc-regional-area-manager` was a hotfix that was already merged into the main S201 branch, the branch should be deleted to avoid confusion. If it is a separate ongoing fix, it needs its own PR isolated from S201.
+- [WARNING] Plan does not have an explicit "Agent Boot Sequence" section telling the executing agent to `git checkout s201-per-store-employee-billing && git pull origin s201-per-store-employee-billing` before starting work. This is implicit from the branch YAML field but not stated as a mandatory first action.
+- [INFO] No merged PRs exist for S201 yet (PR field is TBD in registry). The `block-push-to-merged-branch.py` hook is not yet a risk.
+
+## S026 Shell-Prevention
+
+- [INFO] S201 is backend-only (Python utilities, patches, hooks). `touches_frontend: false` confirmed in YAML. No Ionic Vue or React/Next.js surfaces are created or modified. S026 shell-prevention rules are largely not applicable.
+- [WARNING] The plan's Notes section (line 278) states: "Frappe desk Employee form: Company field becomes read-only after Phase 4 hook is live, unless user has HR Manager role." This is a Frappe Desk UI behavior change that is NOT explicitly tested in the L3 scenarios. L3 scenarios test via API (`frappe.client.get_value`) not via Frappe Desk form interaction. If Phase 4 hook incorrectly sets `read_only` on the company field (or if Frappe Desk does not respect validate-hook-set fields as read-only), this becomes a hidden false-affordance: the UI field appears editable but any manual entry is silently overwritten on next save. This is a correctness risk, not a UI shell creation risk.
+- [WARNING] Phase 4 includes "HR Manager role bypass: if user has HR Manager role AND company was manually changed in this save, skip derivation." The mechanism for detecting "manually changed in this save" is not specified. In Frappe, `doc.get_doc_before_save()` or `doc.flags` must be used. If implemented incorrectly (e.g., comparing doc.company to derived value AFTER the hook already set it), the bypass will never fire and all HR Manager manual overrides will be silently ignored.
+- [INFO] No client-side JS is introduced in S201. The `hrms/public/js/erpnext/company.js` file in the diff is an existing file from earlier sprints, not added by S201.
+
+---
+
+## SUMMARY
+
+| Severity | Count | Items |
+|----------|-------|-------|
+| CRITICAL | 5 | S154-ZeroSkip: no enforcement section; S154-ZeroSkip: no per-phase completion gate; S154-PhaseGate: no MUST_MODIFY inline in tasks; S154-PhaseGate: no MUST_CONTAIN assertions; S087: no protected surfaces list |
+| WARNING | 14 | S091: statutory rule has no source file citation; S091: EMPLOYEE_MASTER count assumption undocumented risk; S154-ZeroSkip: no explicit skip-prohibition language; S154-ZeroSkip: Phase 7 thresholds lack tolerance/PASS-FAIL; S154-PhaseGate: Phase 5 git diff is advisory not scripted; S154-PhaseGate: Phases 6+7 bulk mutations lack script-based assertion; S089: Phase 6 branch rename has no inline HARD BLOCKER; S089: stop_only_for in YAML only, not at Phase 6 task level; S092-Closeout: no completed_date field in YAML; S092-Closeout: git add line may miss specific diagnostic files; S092-CorruptSuccess: L3 directory does not exist yet; S092-CorruptSuccess: no explicit fresh-session recommendation for L3; S092-CorruptSuccess: L3-6 dependency on live Phase 7 not stated; S087: no remote-truth baseline SHA; S087: no pre-touch backup contract before Phase 7 |
+| WARNING (continued) | 3 | S099: fix/s201-bgc-regional-area-manager branch may be stale/orphaned; S099: no explicit Agent Boot Sequence; S026: Frappe Desk read-only behavior not L3-tested; S026: HR Manager bypass mechanism unspecified |
+| INFO | 7 | S091: Locked Decisions comprehensive; S091: Design Rationale section covers all options; S089: scope right-sized at 38u; S092-Closeout: registry current with S202 reserved; S092-CorruptSuccess: 3 mutation paths covered in L3; S099: branch aligned with registry and 0 behind production; S026: fully backend-only |
+
+**CRITICAL: 5, WARNING: 17, INFO: 7**
+
+### Mandatory Fixes Before Execution
+
+1. **Add Zero-Skip Enforcement section** to plan with explicit language: "NEVER proceed to Phase N+1 unless Phase N Verification has passed and evidence is written to output/s201/."
+2. **Add inline MUST_MODIFY assertions** to each phase's task list referencing the exact file paths from the Files table.
+3. **Add HARD BLOCKER annotation** to Phase 6 (branch rename) matching Phase 7's existing HARD BLOCKER pattern.
+4. **Add pre-touch backup requirement** before Phase 7: capture current tabEmployee.company distribution to `output/s201/diagnostics/PRETOUCH_BACKUP.json`.
+5. **Clarify fix/s201-bgc-regional-area-manager branch** — either confirm it is merged into the main S201 branch and delete the remote, or document why it exists as a separate branch.
+
+### Recommended Fixes (Non-Blocking)
+
+6. Add `completed_date:` field to plan YAML.
+7. Add source file citation for statutory single-employer rule in Design Rationale.
+8. Add explicit L3 fresh-session recommendation for 38u plan.
+9. Specify L3-6 prerequisite: "Phase 7 must be live (not dry-run) before L3-6 is executable."
+10. Specify HR Manager bypass implementation mechanism (doc.get_doc_before_save pattern).

--- a/output/plan-audit/s201/deployment_qa_findings.md
+++ b/output/plan-audit/s201/deployment_qa_findings.md
@@ -1,0 +1,324 @@
+# S201 Deployment & QA Audit — Findings Report
+
+**Auditor:** Deployment & QA Domain Agent
+**Plan:** `docs/plans/2026-04-17-sprint-201-per-store-employee-billing-foundation.md`
+**Patches audited:**
+- `hrms/patches/v16_0/s201_rename_branches.py`
+- `hrms/patches/v16_0/s201_backfill_employee_company.py`
+**Audit date:** 2026-04-17 PHT
+**PR status at audit time:** PR #603 MERGED 2026-04-16 23:22 PHT, PR #604 MERGED 2026-04-17 00:34 PHT
+
+---
+
+## Finding 1 — Dry-Run Default Is Safe, But Deploy Workflow Bypasses the Manual Apply Step
+
+**Severity:** [CRITICAL]
+
+**Evidence:**
+The patches implement dry-run correctly: `_apply_mode()` checks `os.environ.get("S201_APPLY", "")`. When `bench migrate` runs automatically, `S201_APPLY` is not set, so patches execute in dry-run mode — writing a report to `site/private/files/` and returning without mutating data. This part is safe.
+
+However, the GHA `build-and-deploy.yml` migration step (lines 388, ~374-410) runs:
+```
+docker exec $BACKEND_CONTAINER bench --site $FRAPPE_SITE migrate
+```
+No `S201_APPLY=1` is injected. The workflow has no step, no input parameter, and no manual hook for re-running the patches in apply mode. The plan's PR body (step 5) says:
+> S201_APPLY=1 bench --site hq.bebang.ph execute hrms.patches.v16_0.s201_rename_branches.execute
+
+This requires **direct SSH access to the EC2 instance and manual bench execution** — which is outside the automated deploy workflow entirely. The plan does not document this as a manual step that must occur after the GHA workflow finishes, nor does it tell Sam how to confirm the SSM-dispatched `bench migrate` has completed and where to find the dry-run report before proceeding.
+
+**Recommended amendment:**
+Add an explicit Phase 7.5 or Phase 8 (see also Finding 12) documenting:
+1. After GHA deploy + migrate completes, the patches have run in dry-run mode.
+2. How to retrieve the report: `aws ssm start-session --target <EC2_INSTANCE_ID>` then `docker exec $BACKEND bench --site hq.bebang.ph execute hrms.patches.v16_0.s201_rename_branches.execute` — **or** locate the report at `site/private/files/branch_rename_report_*.json` via the Frappe file manager.
+3. How Sam signals approval (e.g., replies to the PR comment or runs a specific one-liner).
+4. The exact command for the apply run with `S201_APPLY=1`.
+
+---
+
+## Finding 2 — Idempotency on Re-Migrate Is Safe by Frappe Patch Tracking
+
+**Severity:** [INFO]
+
+**Evidence:**
+Frappe records executed patches in `tabPatchLog`. Once `s201_rename_branches` and `s201_backfill_employee_company` have executed (even in dry-run mode), Frappe will NOT re-execute them on subsequent `bench migrate` calls unless `--force` is used. The patches themselves are also idempotent by design: `s201_rename_branches.py` skips rows where `old == new` with `"already canonical"` reason; `s201_backfill_employee_company.py` skips employees where `target == current`.
+
+However, there is a subtle interaction: the dry-run execution IS recorded in `tabPatchLog` as "executed." When Sam later wants to run the patch in apply mode (`S201_APPLY=1`), he **cannot use `bench migrate`** — he must use `bench execute` directly. This is correct behavior and the PR body documents it, but the plan body does not. This is a documentation gap, not a code gap.
+
+**Recommended amendment:**
+Add a note in the deploy sequence: "After dry-run executes via `bench migrate`, subsequent `bench migrate` calls will skip these patches. Apply mode MUST use `bench execute`, not `bench migrate`."
+
+---
+
+## Finding 3 — S201_APPLY Env Var Will NOT Propagate Through GHA/SSM/Docker
+
+**Severity:** [CRITICAL]
+
+**Evidence:**
+The GHA workflow dispatches commands via AWS SSM `send-command` with a hardcoded `commands=[...]` array. There is no mechanism in `.github/workflows/build-and-deploy.yml` to inject `S201_APPLY=1` into this command array — not as a workflow input, not as a secret, not as an environment variable. Even if an operator sets `S201_APPLY=1` in their local shell, it does not reach the `docker exec` call inside the SSM-dispatched command on EC2.
+
+The patches check `os.environ.get("S201_APPLY")` inside the Python process running inside the Docker container. To propagate the env var, the command must be:
+```bash
+docker exec -e S201_APPLY=1 $BACKEND_CONTAINER bench --site hq.bebang.ph execute \
+  hrms.patches.v16_0.s201_rename_branches.execute
+```
+The `-e S201_APPLY=1` flag is **not** documented anywhere in the plan, the PR body, or the GHA workflow. The PR body step 5 shows a bare `S201_APPLY=1 bench ...` command that assumes a shell where the env var is pre-set, which is not how `docker exec` works — the env var will not be visible inside the container unless explicitly passed with `-e`.
+
+**Recommended amendment:**
+Update all apply-mode instructions to use `docker exec -e S201_APPLY=1 $BACKEND_CONTAINER bench ...`. Add this to the plan and to a runbook entry. Also consider whether the GHA workflow needs a `apply_s201` boolean input that injects `-e S201_APPLY=1` when true.
+
+---
+
+## Finding 4 — Rollback Contract Has Orphaned Salary Slip Gap
+
+**Severity:** [WARNING]
+
+**Evidence:**
+The Rollback Contract (plan lines 239-244) and the PR body rollback SQL both reset `Employee.company` back to `BEBANG ENTERPRISE INC.` but do not address `Salary Slip` documents created after the backfill. A Salary Slip in Frappe snapshots `company` at generation time and stores it as a static field. After backfill:
+- Salary Slips created = `company = SM MEGAMALL - BEBANG ENTERPRISE INC.`
+- Rollback resets `Employee.company` back to BEI parent
+- The Salary Slips still carry the store Company name
+
+In submitted/paid state, these Slips cannot be edited without cancellation. If the payroll run has been submitted and a GL Entry has been posted against the store Company's books, rolling back the Employee record does not undo the GL entries. The rollback SQL alone creates an inconsistency between `tabEmployee.company` and existing `tabSalary Slip.company`.
+
+**Recommended amendment:**
+Add to Rollback Contract:
+1. State explicitly: "If any Salary Slips have been created post-backfill, they must be cancelled before Employee rollback, or accepted as-is and the rollback declared partial."
+2. Add a pre-rollback check query: `SELECT name, company, status FROM \`tabSalary Slip\` WHERE company != 'BEBANG ENTERPRISE INC.' AND docstatus IN (0,1) ORDER BY creation DESC LIMIT 50`.
+3. Distinguish between: (a) rollback before any payroll run (safe), (b) rollback after payroll run (requires GL reversal — escalate to Sam).
+
+---
+
+## Finding 5 — L3 Evidence Contract Has No Playwright Script and No Capture Mechanism
+
+**Severity:** [CRITICAL]
+
+**Evidence:**
+The plan (line 212) states: "Run these in a fresh Playwright session. Record each in `output/l3/s201/`." The PR body repeats this. However:
+1. No Playwright script file exists for S201. `ls scripts/testing/` shows L3 scripts for s094, s101-s108, s122, s126, s134-s135, s152, s166 — but no `l3_s201_*.py` or `l3_s201_*.mjs`.
+2. `output/l3/s201/` does not exist on disk.
+3. The three required evidence files (`form_submissions.json`, `api_mutations.json`, `state_verification.json`) do not exist.
+4. The plan does not name a script file to run, does not specify who writes the script, and does not specify in what format the evidence files should be structured.
+
+"Run these in a fresh Playwright session" implies a script exists and just needs to be invoked. No such script exists. This means L3 is currently blocked on script authoring, not just execution.
+
+**Recommended amendment:**
+Either (a) author `scripts/testing/l3_s201_company_billing.mjs` as part of Phase 8 (see Finding 12), specifying the six scenarios and the evidence output format, or (b) add an explicit Phase 8 task: "Author L3 script covering scenarios L3-1 through L3-6. Script must produce `output/l3/s201/{form_submissions,api_mutations,state_verification}.json`."
+
+---
+
+## Finding 6 — L3-6 Salary Slip Test Has No Payroll Fixture and Is Environment-Dependent
+
+**Severity:** [WARNING]
+
+**Evidence:**
+L3-6 requires: "Generate Salary Slip for store employee (post-backfill) for April 2026 cutoff." Generating a Salary Slip in Frappe requires:
+1. A `Salary Structure` assigned to the employee.
+2. A `Payroll Entry` or direct Salary Slip creation for April 2026.
+3. The Payroll Period for April 2026 to exist.
+
+The plan provides no fixture for any of these. If HR has not created the April 2026 Payroll Entry, L3-6 will fail with a Frappe validation error, not a useful test failure. The plan does not specify a test employee with a known Salary Structure, nor does it specify whether to use a test employee (from `memory/testing-accounts.md`) or a real employee.
+
+Additionally, since the backfill must run before L3-6 is meaningful, L3-6 has a strict ordering dependency on the apply-mode execution of the backfill patch — which itself is blocked by Sam's approval of the dry-run report (Finding 1). The plan does not call this ordering dependency out.
+
+**Recommended amendment:**
+1. Specify a test employee by ID with a known Salary Structure (or document how to create a minimal test fixture).
+2. Specify: "If no April 2026 Payroll Entry exists, create a single Salary Slip directly for the test employee via Frappe desk."
+3. Add explicit note: "L3-6 MUST run after the backfill patch has been applied in apply mode, not just dry-run."
+4. Document how to clean up the test Salary Slip post-verification (cancel + delete).
+
+---
+
+## Finding 7 — Plan YAML status=GO After Merge, No Post-Merge Update Path
+
+**Severity:** [WARNING]
+
+**Evidence:**
+The plan YAML header has `status: GO`. PR #603 was merged 2026-04-16 23:22 PHT. The plan was committed as part of PR #603 (per `gh pr view 603 --json files` output showing `docs/plans/2026-04-17-sprint-201-per-store-employee-billing-foundation.md`). The SPRINT_REGISTRY.md was also updated in PR #603.
+
+Phase 9 Closeout says to set `status: COMPLETED` and update the registry, but Phase 9 is marked as pending (L3 has not run). The plan is now on the `production` branch with `status: GO` — a status that implies "approved to execute" rather than "in progress" or "deployed." There is no intermediate status defined (e.g., `DEPLOYED_PENDING_L3`).
+
+The governor PR handoff workflow (per `memory/pr-handoff-workflow.md`) has the governor disabled — Sam merges. But no one is tracking the plan status update to COMPLETED after L3 passes. Phase 9 step says `git add -f docs/plans/*.md output/s201/ output/l3/s201/ ...` — but this requires a new commit on production branch (or a new PR), which is not explicit.
+
+**Recommended amendment:**
+Add a `DEPLOYED_PENDING_L3` intermediate status to the plan governance vocabulary, or explicitly say: "After PR #603 merge, update plan status to `DEPLOYED` and commit directly to production. After L3 passes, update to `COMPLETED`."
+
+---
+
+## Finding 8 — Governor Feedback Loop: REJECT/NEEDS_FIX/Deploy Failure Handlers Are Not Specified
+
+**Severity:** [WARNING]
+
+**Evidence:**
+The plan has `stop_only_for` (lines 26-30) listing four valid stop triggers. However, the S027 governor contract also requires handlers for:
+- REJECT: what should the executing agent do if the governor rejects the code review?
+- NEEDS_FIX: which file/line does the agent go back to?
+- Merge Conflict during rebase onto production: which commits to keep?
+- Deploy Failure: what constitutes a deploy failure vs. a transient SSM timeout?
+
+`stop_only_for` lists "Merge conflict on production during rebase" as a stop condition — but does not say what the agent should present to Sam when it stops (options, context, recommended resolution).
+
+For REJECT and NEEDS_FIX, the plan does not reference any handler. Given PR #604 was also needed (BGC employee fix) post-merge, this gap was live in practice.
+
+**Recommended amendment:**
+Add a `governor_handlers` block to the plan YAML or a "Governor Response Protocol" section:
+```yaml
+governor_handlers:
+  REJECT: "Identify failing check, create new branch fix/<issue>, fix and resubmit"
+  NEEDS_FIX: "Apply amendment, push to current branch, governor re-reviews"
+  merge_conflict: "Stop. Present conflict file list to Sam. Ask which version to keep."
+  deploy_failure: "Check SSM output for error. If transient, retry once. If persistent, stop and present error."
+```
+
+---
+
+## Finding 9 — PR #603 Merged Without L3 Evidence: Release Gate Correctly Skipped (NOT a violation)
+
+**Severity:** [INFO]
+
+**Evidence:**
+The release gate in `scripts/merge_governor/release_gate.py::find_sprint_plan()` identifies sprint PRs by matching `s0?(\d{2,3})` in the **branch name**. PR #603's branch is `s201-per-store-employee-billing` — this matches the pattern. The gate would have looked for `output/l3/s201/form_submissions.json` in the branch.
+
+However, `scripts/merge_governor/merge_serializer.py:1052` skips the gate when `det_result.skip_reason` is set. Examining `release_gate.py` line 60 context: the gate returns `skip_reason` when the branch name does not match the sprint pattern OR when no plan file is found. Since the plan WAS committed to this branch, the gate should have attempted to enforce L3 evidence.
+
+`output/l3/s201/` does not exist in the branch (not in PR #603 files list). The gate should have BLOCKED this merge. Whether it was actually enforced depends on whether the governor was running at merge time. Per `memory/pr-handoff-workflow.md`: "governor disabled, agents create PRs and STOP, Sam merges." Sam merged PR #603 directly — bypassing the automated gate.
+
+This is not a plan violation: Sam as CEO has authority to merge directly. But it means L3 evidence is now a post-merge obligation rather than a merge pre-condition, and the plan does not explicitly acknowledge this.
+
+**Recommended amendment:**
+Add a note to Phase 9 / L3 section: "Because Sam merged PR #603 directly (governor in PR-Handoff mode), L3 evidence was not a gate condition. L3 remains a completion obligation. Plan status cannot move to COMPLETED until L3 evidence files are committed to production."
+
+---
+
+## Finding 10 — Large Diff (1,463 Lines, 10 Files, New Module + Hook + Patch) Not Acknowledged in Plan
+
+**Severity:** [WARNING]
+
+**Evidence:**
+S027-3c requires plans to note when a diff is large/complex enough to trigger <0.80 confidence in the governor's AI review. PR #603 introduced:
+- 2 new utility modules (`company_lookup.py`, `non_store_billing.py`)
+- 1 new override module (`overrides/employee_master.py`)
+- 1 hooks.py modification
+- 2 new patch files
+- 3 new test files
+- Modified `transfers.py`, `patches.txt`
+- 2 CSV data seed files
+
+The plan has no `confidence_note`, no `complexity_warning`, and no acknowledgment that the reviewer should apply extra scrutiny given the surface area. The governor's confidence calculation (per S101) applies a penalty for diffs >500 lines — a 1,463-line diff would likely trigger the <0.80 threshold.
+
+The plan was effectively self-approved (Sam merged directly), so this gap did not block delivery. But it is a governance gap for future reference.
+
+**Recommended amendment:**
+Add to plan YAML:
+```yaml
+complexity_note: "Large diff: ~1,463 lines, 10 files, new module + validate hook + 2 patches. Governor confidence may fall below 0.80 threshold. Extra review recommended for company_lookup.py cache invalidation and non_store_billing.py rule ordering."
+```
+
+---
+
+## Finding 11 — Preflight Dry-Run Approval Has No Actionable Trigger Mechanism
+
+**Severity:** [CRITICAL]
+
+**Evidence:**
+Phase 7 states: "HARD BLOCKER: patch must be `--dry-run` first. No direct execution without Sam approval confirming dry-run report."
+
+The actual execution sequence is:
+1. `bench migrate` runs automatically (via GHA or manually) → patches run in dry-run mode → report written to `site/private/files/backfill_report_<timestamp>.json`.
+2. Sam must review the report.
+3. Sam must trigger re-execution in apply mode.
+
+But there is no documented mechanism for step 3. The plan does not say:
+- How Sam retrieves the report (Frappe file manager URL? SSH to EC2? `aws s3 cp`?).
+- How Sam signals approval (comment on PR? Slack message? Direct SSH?).
+- Who executes the apply command and where.
+- What command to run exactly (and with correct `docker exec -e S201_APPLY=1` syntax — see Finding 3).
+
+The PR body (step 5) gives the bare command but not the Docker wrapper, and does not describe the triggering mechanism. Phase 7 HARD BLOCKER is therefore unactionable as written.
+
+**Recommended amendment:**
+Add an explicit "Phase 7.5 — Dry-Run Review & Apply Authorization" section:
+1. How to locate the dry-run report (Frappe > File Manager > search `backfill_report_`).
+2. What Sam should verify in the report (before/after counts match expected ~510 store, ~45 HO, ~44 BKI).
+3. Sam authorizes by replying on PR #603 thread or Slack `#erp-deploy` with "DRY-RUN APPROVED".
+4. Exact apply command:
+   ```bash
+   BACKEND=$(docker ps --filter name=frappe_backend --format "{{.Names}}" | head -1)
+   docker exec -e S201_APPLY=1 $BACKEND bench --site hq.bebang.ph execute \
+     hrms.patches.v16_0.s201_rename_branches.execute
+   docker exec -e S201_APPLY=1 $BACKEND bench --site hq.bebang.ph execute \
+     hrms.patches.v16_0.s201_backfill_employee_company.execute
+   ```
+
+---
+
+## Finding 12 — Phase 8 Is Missing (Gap Between Phase 7 and Phase 9 Closeout)
+
+**Severity:** [WARNING]
+
+**Evidence:**
+Plan headings go: Phase 0, 1, 2, 3, 4, 5, 6, 7, then "Phase 9 — Closeout." There is no Phase 8. The PR body under "Phase status" table shows `P8 | L3 scenarios | Paused — Runs in fresh session post-deploy`. Phase 8 exists conceptually in the PR but not as a plan section.
+
+This is not just a numbering typo — the absence means there is no Phase 8 section specifying:
+- Who authors the Playwright script.
+- What the script filename is.
+- What the prerequisite state is (apply-mode must have run).
+- What "fresh session" means operationally (new Claude Code session? New browser context?).
+- Acceptance criteria for Phase 8 completion.
+
+**Recommended amendment:**
+Add Phase 8 between Phase 7 and Phase 9:
+
+```markdown
+## Phase 8 — L3 Evidence Capture (4u)
+
+**Prerequisite:** Apply-mode patches have run. Employee counts verified per Phase 7.
+
+- [ ] Author `scripts/testing/l3_s201_company_billing.mjs` covering scenarios L3-1 through L3-6.
+- [ ] Run script in fresh Playwright session (new browser context, authenticated as test HR Manager).
+- [ ] Confirm `output/l3/s201/{form_submissions,api_mutations,state_verification}.json` created.
+- [ ] `git add -f output/l3/s201/` && commit to production.
+```
+
+---
+
+## Finding 13 — L3-4 Transfer Test Requires Real Store Employee on SM Megamall; No Fixture Specified
+
+**Severity:** [WARNING]
+
+**Evidence:**
+L3-4 says: "Pick store employee on SM MEGAMALL - BEI. Transfer to branch=SM MOA." This requires a real active employee currently assigned to SM MEGAMALL. After the backfill runs, any SM MEGAMALL employee will have `company = SM MEGAMALL - BEBANG ENTERPRISE INC.` — correct precondition.
+
+However:
+1. The plan does not specify which employee to use (employee ID, name).
+2. Using a real production employee for a Transfer test creates a real Transfer record in Frappe (even if cancelled afterward), which may appear in HR audit logs.
+3. If the test Transfer is submitted and approved, it changes the real employee's branch — requiring a manual reversal.
+4. The plan does not include a cleanup step for test Transfers.
+
+L3-5 at least specifies a bio ID (`bio 9000037`) for the roving employee test. L3-4 has no equivalent anchor.
+
+**Recommended amendment:**
+Either (a) specify a test employee ID (from `memory/testing-accounts.md`) assigned to SM MEGAMALL, or (b) create a test employee fixture with `designation=CASHIER, branch=SM MEGAMALL, dept=Operations` at the start of the L3 session and delete at the end. Add a cleanup step to the L3 script for all test employees and cancelled Transfer records created during the run.
+
+---
+
+## Summary
+
+**CRITICAL: 4, WARNING: 6, INFO: 3**
+
+| # | Severity | Finding |
+|---|---|---|
+| 1 | CRITICAL | Dry-run default safe but deploy workflow has no mechanism to trigger apply-mode |
+| 2 | INFO | Idempotency safe; patch tracking means apply must use `bench execute`, not `bench migrate` |
+| 3 | CRITICAL | `S201_APPLY=1` will not propagate through `docker exec` without `-e` flag |
+| 4 | WARNING | Rollback contract does not address orphaned Salary Slips created post-backfill |
+| 5 | CRITICAL | No Playwright L3 script exists; no capture mechanism; evidence directory absent |
+| 6 | WARNING | L3-6 Salary Slip test has no payroll fixture and requires ordering dependency on apply-mode |
+| 7 | WARNING | Plan YAML `status: GO` post-merge; no intermediate `DEPLOYED` status or update path |
+| 8 | WARNING | Governor REJECT/NEEDS_FIX/deploy failure handlers not specified in plan |
+| 9 | INFO | PR #603 merged without L3 evidence — release gate correctly bypassed (Sam direct merge); acknowledged as post-merge obligation |
+| 10 | WARNING | 1,463-line diff not acknowledged; confidence threshold gap not documented |
+| 11 | CRITICAL | Phase 7 HARD BLOCKER is unactionable — no mechanism to retrieve report or trigger apply run |
+| 12 | WARNING | Phase 8 entirely absent from plan (exists in PR body only) |
+| 13 | WARNING | L3-4 Transfer test uses unspecified real employee with no cleanup contract |
+
+**CRITICAL: 4, WARNING: 6, INFO: 3**

--- a/output/plan-audit/s201/frappe_backend_findings.md
+++ b/output/plan-audit/s201/frappe_backend_findings.md
@@ -1,0 +1,341 @@
+# S201 — Frappe Backend Audit Findings
+
+**Auditor:** Claude (Frappe-backend domain auditor)
+**Date:** 2026-04-17 PHT
+**Plan file:** `docs/plans/2026-04-17-sprint-201-per-store-employee-billing-foundation.md`
+**Shipped code base:** PR #603 + PR #604 (merged)
+**DM rules source:** `.claude/rules/frappe-development.md`
+
+---
+
+## Finding 1 — DM-1: Party Fields on GL Entries
+
+**Severity:** [N/A]
+
+S201 does not post any Journal Entries or Payment Entries. The plan explicitly states:
+> "S201 is the foundation. S202 will add punch-based reliever allocation (month-end JE reclassification)."
+
+No GL-posting code exists in any shipped file. DM-1 does not apply to this sprint.
+
+**Recommended amendment:** None. Add a note to the S202 plan to enforce DM-1 on all inter-Company reclassification JEs.
+
+---
+
+## Finding 2 — DM-2: Backfill Patch Atomicity
+
+**Severity:** [WARNING]
+
+The Phase 7 backfill patch (`hrms/patches/v16_0/s201_backfill_employee_company.py`) iterates ~510 employees and issues individual `UPDATE tabEmployee SET company=%s WHERE name=%s` statements in a for-loop, then calls `frappe.db.commit()` once at the end. There is **no savepoint** wrapping the batch.
+
+Plan text:
+> "UPDATE tabEmployee SET company = <target> (direct SQL, bypassing Employee validate to avoid hook re-firing)"
+
+If the patch fails mid-loop (e.g., disk error, deadlock, timeout), the commit is never reached and MariaDB rolls back the uncommitted transaction — **this is actually safe for a single-session patch** because all the UPDATEs sit in one implicit transaction. The rollback behaviour is correct here.
+
+However, there is a subtler risk: the patch calls `frappe.db.commit()` **once at the very end**. If `frappe.db.commit()` itself is preceded by any auto-commit from the Frappe ORM in the pre-loop query (`frappe.get_all("Employee", ...)`) — which uses a read-only query and does not commit — the batch UPDATEs would still be inside the same transaction boundary.
+
+DM-2 was designed for multi-doc creations (JV + Payment Request + GR) where each doc's `save()` triggers its own commit. A raw `frappe.db.sql()` loop in a patch does not trigger intermediate commits, so the scenario DM-2 guards against does not apply here.
+
+**The real risk** is that if the patch is re-run after a partial failure (e.g., process killed between UPDATE calls), some employees have already been updated in memory but not committed. On re-run, the idempotency check `if target == current` (line ~119) correctly skips already-updated rows, so re-run is safe.
+
+**Recommended amendment:** Add a comment in the patch clarifying why savepoint is not needed (single-transaction batch, not multi-doc creation). Also add a safety check: if `len(errors) > 0` after the loop, log a WARNING and do NOT call `frappe.db.commit()` — force the caller to investigate before committing a partial batch.
+
+Code currently:
+```python
+frappe.db.commit()
+summary["totals"]["applied"] = applied
+```
+
+Should be:
+```python
+if errors:
+    frappe.logger().warning(f"[S201] {len(errors)} errors; NOT committing partial batch.")
+    summary["totals"]["applied"] = 0
+    # Do not commit — let Frappe rollback on exit.
+    return
+frappe.db.commit()
+```
+
+---
+
+## Finding 3 — DM-3: EWT + VAT
+
+**Severity:** [N/A]
+
+S201 creates no Payment Entry or Journal Entry. No money changes hands. EWT and VAT are irrelevant. DM-3 does not apply.
+
+---
+
+## Finding 4 — DM-4: Link vs Data Fields
+
+**Severity:** [N/A]
+
+`Employee.company` is a standard Frappe `Link` field pointing to the `Company` DocType (upstream erpnext). No new fields are added in S201. DM-4 does not apply.
+
+---
+
+## Finding 5 — DM-5: Computed vs Stored — Validate-Hook Pattern
+
+**Severity:** [INFO]
+
+The plan uses a validate-hook approach (`derive_company_from_branch`) to auto-populate `Employee.company` as a **stored** field. This appears to conflict with DM-5 ("don't store values that can be derived"). However, the DM-5 intent is to prevent stale copied values from linked docs (e.g., copying PO grand_total onto another DocType). This is a **different pattern**.
+
+`Employee.company` is not a copy of data from a linked doc — it is the **authoritative legal entity assignment** derived from a rule, not fetched from a parent. It must be stored because:
+
+1. `Salary Slip` and `GL Entries` read `employee.company` at submission time — they need a stable value, not a dynamic derivation.
+2. Frappe payroll runs batch queries: `SELECT company FROM tabEmployee WHERE ...` — computing on-read is not possible at payroll scale.
+3. The `validate` hook re-derives on every save, so the stored value is kept fresh.
+
+**This is the correct pattern for S201.** The stored + validate-hook approach is the standard Frappe idiom for this type of "derived configuration" field. DM-5 does not apply as written.
+
+**Recommended amendment to plan:** Add a note in Phase 4 clarifying *why* stored + validate is preferred over on-read derivation. This prevents future agents from flagging it as a DM-5 violation.
+
+---
+
+## Finding 6 — DM-6: Reclassification JVs
+
+**Severity:** [N/A]
+
+S201 explicitly defers all inter-Company JE reclassification to S202. No JEs are created in this sprint. DM-6 does not apply.
+
+---
+
+## Finding 7 — DM-7: Sentry Observability
+
+**Severity:** [INFO]
+
+The plan states:
+> "Add Frappe Sentry context per DM-7 if the hook becomes an `@frappe.whitelist()` endpoint — currently it's a validate hook so Sentry auto-captures via `frappe.log_error`."
+
+This is correct for the validate hook. The `derive_company_from_branch` function in `employee_master.py` is not `@frappe.whitelist()` decorated and is called by Frappe's event system — any unhandled exceptions would propagate through `frappe.log_error` which feeds Sentry.
+
+`create_transfer` in `transfers.py` correctly calls `set_backend_observability_context(module="hr", action="create_transfer", mutation_type="create")` as the first line after the decorator.
+
+**Gap identified:** The two patches (`s201_rename_branches.py` and `s201_backfill_employee_company.py`) are invoked via `bench execute` — they run as server-side scripts, not HTTP requests. Sentry's Frappe monkey-patch **does** capture `frappe.log_error()` calls from these scripts, so errors in the patch are captured. However, the patches use `frappe.logger().error()` rather than `frappe.log_error()` for failure reporting. `frappe.logger()` is a Python logging call — it does NOT feed Sentry. Only `frappe.log_error()` creates an Error Log doc that Sentry captures.
+
+In `s201_rename_branches.py` (line 67):
+```python
+frappe.logger().error(f"[S201] branch_company_map.csv missing at {path}")
+```
+
+And in `s201_backfill_employee_company.py` (line 44):
+```python
+frappe.logger().error(f"[S201] No map rows loaded; aborting.")
+```
+
+**Recommended amendment:** Change `frappe.logger().error(...)` to `frappe.log_error(title="...", message="...")` for critical failure paths in both patches so Sentry captures them. Non-critical progress logs can stay as `frappe.logger().info()`.
+
+---
+
+## Finding 8 — Employee DocType Override Safety / Hook Order
+
+**Severity:** [WARNING]
+
+The `EmployeeMaster.validate()` override in `hrms/overrides/employee_master.py` contains the S172 BEI-EMP preservation fix:
+
+```python
+def validate(self):
+    saved_employee = (self.employee or "")
+    is_bei_id = saved_employee.startswith("BEI-EMP-")
+    super().validate()  # upstream runs self.employee = self.name here
+    if is_bei_id and self.employee != saved_employee:
+        self.employee = saved_employee
+```
+
+S201 adds `derive_company_from_branch` as a **doc_events** hook on `Employee.validate`:
+
+```python
+"Employee": {
+    "validate": [
+        "hrms.overrides.employee_master.validate_onboarding_process",
+        "hrms.utils.bio_id_validation.validate_employee_bio_id",
+        "hrms.overrides.employee_master.derive_company_from_branch",  # S201
+    ],
+```
+
+**Frappe hook execution order:** When a DocType is subclassed AND doc_events handlers are registered, Frappe calls them in this sequence:
+1. `DocType.validate()` (the class method — `EmployeeMaster.validate()` here, which includes `super().validate()`)
+2. All `doc_events["Employee"]["validate"]` handlers, in list order
+
+This means `derive_company_from_branch` runs **after** `EmployeeMaster.validate()` has already restored the BEI-EMP id. The hook order is safe with respect to S172.
+
+**However**, there is a subtle ordering issue within the doc_events list: `validate_onboarding_process` runs FIRST, then `validate_employee_bio_id`, then `derive_company_from_branch`. This ordering is correct — `derive_company_from_branch` should run last (after bio_id validation and onboarding checks) so it has access to a fully-validated branch and department.
+
+**One real concern:** the `derive_company_from_branch` hook checks:
+```python
+is_hr_manager = "HR Manager" in frappe.get_roles(frappe.session.user)
+manual_override = bool(getattr(doc, "flags", {}).get("company_manual_override"))
+```
+
+The `doc.flags` check reads from `doc.flags` as if it were a dict (`getattr(doc, "flags", {})`), but in Frappe, `doc.flags` is a `frappe._dict` (a dict subclass). The `.get()` call is correct. However, `flags.company_manual_override` is never set by any other part of the code — neither in the form JS nor in the API. The HR Manager bypass condition is therefore **never triggered** in practice. The code path is dead until a mechanism to set `doc.flags.company_manual_override = True` is implemented.
+
+**Recommended amendment:** Either implement the flag-setting mechanism (form JS or explicit API call) or document it clearly with a TODO comment in the code. Without the setter, the bypass is broken-by-design, and HR Managers cannot override company even when they need to.
+
+---
+
+## Finding 9 — Cache Invalidation Race Condition
+
+**Severity:** [INFO]
+
+The plan says:
+> "Wire `on_update` hook on Branch doctype and Company doctype to call `clear_cache()`."
+
+The shipped code wires `Branch.on_update` to `company_lookup.clear_cache()` (hooks.py lines 201-204). This is correct.
+
+The potential race condition is:
+1. In-flight `Employee.validate()` calls `_ensure_fresh()` at time T, gets cached map with old branch value.
+2. A Branch rename completes at time T+1ms, firing `clear_cache()`.
+3. The in-flight validate() continues with stale cached data, writes old company to the doc.
+
+This is an **accepted race** in Frappe cache patterns — the 60-second TTL means a stale result is possible during the rename window. The impact is bounded: the next save of the employee document will recompute the correct company. For a rename event, this is acceptable.
+
+**The more serious scenario** would be if a Branch rename fires during a backfill patch run. The backfill patch does NOT use the cache (it calls `resolve_branch_to_company()` which uses `_ensure_fresh()`, but the patch runs in a single bench-execute session). If a rename happens concurrently during backfill, one employee might get the old company. This is an edge case since the rename patch and backfill patch are run sequentially with Sam approval between them.
+
+**Recommended amendment:** Add a comment in the backfill patch warning that it should not be run concurrently with the rename patch. The plan already addresses this through the sequential phase structure (Phase 6 before Phase 7), but it is not explicitly called out in the patch code.
+
+---
+
+## Finding 10 — Patch Idempotency
+
+**Severity:** [INFO]
+
+Both patches implement idempotency correctly:
+
+**s201_rename_branches.py:**
+- `old == new` case is explicitly detected and logged as "already canonical" (line 81). No rename attempt is made.
+- If `old != new` but the rename was already applied: `exists_old` would be False (old branch no longer exists), causing the entry to be logged as "source branch missing" (line 131). This is benign — the rename already happened.
+
+**s201_backfill_employee_company.py:**
+- The check `if target == current` (line ~119) correctly skips employees already at their target company. Re-running after full apply is a no-op.
+
+Both patches are safe to re-run after apply. No finding — just confirming this is correctly implemented.
+
+---
+
+## Finding 11 — rename_doc Safety with merge=True
+
+**Severity:** [WARNING]
+
+The plan uses `frappe.rename_doc("Branch", old, new, force=True, merge=True)` when the target branch name already exists.
+
+Plan text:
+> "For each `(old_branch, new_branch)` pair where old ≠ new: `frappe.rename_doc("Branch", old, new, force=True, merge=True)`"
+
+**What `merge=True` does:** Frappe's `rename_doc` with `merge=True` will:
+1. Reassign all child records (Employees, Attendance, etc.) that reference `old` to reference `new` instead.
+2. Then delete the `old` Branch document.
+
+**The risk:** If `old_branch` and `new_branch` are two **distinct physical branches** (e.g., `BGC` store and `BRITTANY HOTEL` store are two separate locations that happen to get merged into one canonical name), then all Employees on `BGC` will be reassigned to `BRITTANY HOTEL` silently. Their attendance records, leave applications, and any other Branch-linked docs also get reassigned.
+
+Looking at the CSV, the merge case most likely occurs with HO variants (MYTOWN → MY TOWN, BRITTANY OFFICE → BRITTANY HOTEL) where the "old" and "new" are the **same physical location** just renamed. However, if two branches have different Warehouses or different Cost Centers, the merge will combine them into one Branch record that carries only the target's metadata — the source's Warehouse/Cost Center links are dropped.
+
+**Specific risky rows in branch_company_map.csv:**
+- `BRITTANY OFFICE` → `BRITTANY HOTEL` (HO): if both existed as Branches pointing to different Warehouses/Cost Centers, employees on BRITTANY OFFICE would be moved to BRITTANY HOTEL but BRITTANY OFFICE's Warehouse reference is lost.
+
+The shipped code in `s201_rename_branches.py` does check `exists_new` and sets `will_merge` correctly, and the dry-run report includes a `merges` count. The plan requires Sam to review the dry-run report before executing. This is adequate governance.
+
+**Recommended amendment:** Add a pre-merge validation step in the dry-run report: for every pair marked `will_merge=True`, list the Warehouse and Cost Center linked to BOTH the old and new Branch docs. If they differ, flag them as `MERGE_CONFLICT` requiring manual review. Currently the dry-run only counts employees — it does not surface the Warehouse/Cost Center divergence risk.
+
+---
+
+## Finding 12 — Employee.company Update Method: Direct SQL Safety
+
+**Severity:** [WARNING]
+
+The backfill patch updates Employee.company via:
+```python
+frappe.db.sql(
+    "UPDATE `tabEmployee` SET company=%s WHERE name=%s",
+    (ch["new_company"], ch["employee"]),
+)
+```
+
+**Is this safe given Employee's `track_changes`?**
+
+Per Frappe/ERPNext standard, the Employee DocType has `track_changes = 1` enabled. When `track_changes` is enabled, Frappe creates a `Version` document recording field changes on every `doc.save()`. **Direct SQL bypasses this mechanism entirely** — no `Version` document is created, no audit trail exists for the company change.
+
+For a one-time backfill, this is an acceptable trade-off (the plan explicitly acknowledges this: "direct SQL, bypassing Employee validate to avoid hook re-firing"). The patch itself generates a `backfill_log.csv` with before/after per employee, which serves as a substitute audit trail.
+
+**However**, the plan should explicitly acknowledge that:
+1. No `Version` docs are created for the ~510 company changes.
+2. The `backfill_log.csv` is the only audit trail.
+3. Using `frappe.db.set_value()` would have been an alternative that respects `track_changes` but triggers validate hook re-firing.
+
+**Could `frappe.db.set_value()` have been used instead?**
+
+`frappe.db.set_value("Employee", name, "company", new_company, update_modified=False)` does NOT trigger validate but DOES update `modified`/`modified_by` fields. It also does NOT create Version docs (it's still a raw SQL wrapper). The behaviour with respect to audit trail is identical to the direct SQL approach. The plan's choice of direct SQL is therefore equivalent to `frappe.db.set_value()` for audit purposes.
+
+**Employee is NOT submittable** (docstatus is always 0 in standard ERPNext Employee DocType). The concern about submittable doc integrity is therefore not applicable here.
+
+**Recommended amendment to plan:** Add a note in Phase 7 acknowledging that direct SQL bypasses `track_changes` versioning and that `backfill_log.csv` is the authoritative audit record for this operation. No code change needed.
+
+---
+
+## Finding 13 — LD-3 Commissary Routing: Plan vs Code Mismatch
+
+**Severity:** [WARNING]
+
+**The plan (Phase 4) states:**
+> "Elif `department in {"Commissary"}` (case-insensitive): set `doc.company = get_commissary_company()` (BKI)."
+
+This reads as if **all** employees with `department=Commissary` route to BKI, regardless of branch.
+
+**The shipped code is more nuanced.** In `company_lookup.py`, the commissary routing logic is:
+
+```python
+if category == CATEGORY_COMMISSARY:
+    if hint == "DEPT_DRIVEN":
+        if _normalize(department) == "COMMISSARY":
+            return BKI_COMMISSARY_COMPANY
+        return BEI_PARENT_COMPANY
+    if hint:
+        return hint
+    return BKI_COMMISSARY_COMPANY
+```
+
+And in `non_store_billing.py`:
+- `SCM` department → `True` (routes to BEI parent, not BKI)
+- `SHAW COMMISSARY - LOGISTICS` branch → `HO` category → BEI parent (even if dept=Commissary)
+- `SHAW COMMISSARY - RD QC` branch → `HO` category → BEI parent
+
+The `is_non_store_billing()` check runs **first** in `derive_company_from_branch()`. So an employee with `department=Commissary` AND `branch=SHAW COMMISSARY - LOGISTICS` would pass the `is_non_store_billing` check (because the branch maps to `HO`) and route to BEI parent — NOT BKI.
+
+**This is correct per Sam's decision (2026-04-17):**
+> "SCM team at commissary (branch SHAW COMMISSARY - LOGISTICS) -> BEI parent"
+> "R&D at commissary (SHAW COMMISSARY - RD QC) -> BEI parent"
+
+But the **plan text at Phase 4 bullet 2** (`Elif department in {"Commissary"} → BKI`) does NOT document these exceptions. An agent reading the plan would implement a simple `dept == Commissary → BKI` rule and miss the branch-overrides.
+
+**Plan-code mismatch confirmed:** The plan says "Commissary dept → BKI" without the branch exception. The code correctly implements the exception but the plan text is incomplete.
+
+**Recommended amendment:** Update Phase 4 bullet 2 in the plan to:
+```
+Elif department == "Commissary" AND branch is NOT in {SHAW COMMISSARY - LOGISTICS, SHAW COMMISSARY - RD QC}:
+    → BKI (BEBANG KITCHEN INC.)
+Elif department == "Commissary" AND branch IS in {SHAW COMMISSARY - LOGISTICS, SHAW COMMISSARY - RD QC}:
+    → BEI parent (handled by is_non_store_billing via HO branch category)
+```
+
+Or more concisely: document that `is_non_store_billing()` is evaluated first and can redirect Commissary-dept employees to BEI parent if their branch category is HO.
+
+---
+
+## Summary
+
+| # | Title | Severity |
+|---|-------|----------|
+| 1 | DM-1 GL Party Fields | [N/A] |
+| 2 | DM-2 Backfill Atomicity — partial-apply commit should be blocked on errors | [WARNING] |
+| 3 | DM-3 EWT + VAT | [N/A] |
+| 4 | DM-4 Link vs Data | [N/A] |
+| 5 | DM-5 Computed vs Stored — validate-hook is correct pattern | [INFO] |
+| 6 | DM-6 Reclassification JVs | [N/A] |
+| 7 | DM-7 Sentry — patches use logger() not log_error(); Sentry misses critical failures | [INFO] |
+| 8 | Hook Order — safe, but HR Manager bypass flag is never set (dead code path) | [WARNING] |
+| 9 | Cache Invalidation Race — bounded/acceptable, add comment | [INFO] |
+| 10 | Patch Idempotency — correctly implemented | [INFO] |
+| 11 | rename_doc merge=True — no Warehouse/Cost Center conflict check in dry-run | [WARNING] |
+| 12 | Direct SQL bypasses track_changes — Employee is not submittable; backfill_log is audit trail | [WARNING] |
+| 13 | LD-3 Plan-Code Mismatch — Phase 4 doesn't document branch-override exceptions for Commissary dept | [WARNING] |
+
+**CRITICAL: 0, WARNING: 5, INFO: 4, N/A: 6**

--- a/output/plan-audit/s201/ph_finance_findings.md
+++ b/output/plan-audit/s201/ph_finance_findings.md
@@ -1,0 +1,267 @@
+# S201 Per-Store Employee Billing Foundation — PH Finance & Compliance Audit
+
+**Audited by:** PH Finance & Compliance Domain Auditor
+**Date:** 2026-04-17 PHT
+**Plan file:** `docs/plans/2026-04-17-sprint-201-per-store-employee-billing-foundation.md`
+**Plan status at audit time:** GO
+
+---
+
+## Finding 1 — SSS / PhilHealth / Pag-IBIG Remittance Split Across 49+ Employers
+
+**Severity:** [CRITICAL]
+
+**Evidence from plan:**
+LD-1 moves ~510 store employees from `BEBANG ENTERPRISE INC.` (one employer) to 49 per-store child Companies. Each child Company in ERPNext has its own `branch_tin` and `bir_rdo_code` (created by S188). The plan's Phase 7 backfill patch will execute this change with direct SQL on Active employees.
+
+**Issue:**
+SSS, PhilHealth, and Pag-IBIG statutory filings are employer-account-specific:
+- SSS R-3 (Monthly Contribution Collection List), SSS R-5 (remittance), PhilHealth RF-1, and Pag-IBIG MCRF are all filed per-employer. Each employer has its own SSS Employer Number, PhilHealth Employer Number, and HDMF Employer ID.
+- Moving 510 employees across 49 new "employers" mid-year (April 17, 2026) means:
+  - Each of the 49 store Companies needs to register as a NEW employer with SSS, PhilHealth, and HDMF — or the remittances will post against invalid/unfiled employer accounts.
+  - Monthly filings that were already submitted for Q1 2026 under `BEBANG ENTERPRISE INC.` cannot be retroactively split — those employees' contributions are already on the parent employer's record.
+  - Any APRIL 2026 contribution filings (due May 10–31) must decide: does `SM MEGAMALL - BEBANG ENTERPRISE INC.` file its own R-3/RF-1, or does the parent still remit? The plan has no answer.
+- The plan's design rationale (Design Rationale section) correctly rejects Option C (shift-level payslip splitting) for this statutory reason, but does NOT address that Option A itself creates 49 new "employers of record" for statutory purposes.
+
+**Recommended amendment:**
+Add a Phase 0.5 or pre-requisite gate:
+1. Verify whether the 49 child Companies have SSS, PhilHealth, and HDMF employer registration numbers. If they do NOT, the backfill must be BLOCKED until registration is complete — payroll processed under an unregistered employer account is a statutory violation.
+2. If BEI's intent is to keep ONE employer for statutory remittances (the parent `BEBANG ENTERPRISE INC.`) and use child Companies only for P&L cost-center allocation (not legal employment), then `Employee.company` must NOT change for payroll purposes — only cost center attribution changes. In that case, re-evaluate whether changing Employee.company at all is the right mechanism, or whether inter-Company JE at month-end (S202 approach) should apply to labor costs too.
+3. Add an explicit decision record: "Are the 49 store Companies registered employers for SSS/PhilHealth/HDMF? YES/NO. If NO, backfill is deferred until registration complete."
+
+---
+
+## Finding 2 — BIR Form 2316 Employer Change Mid-Year
+
+**Severity:** [CRITICAL]
+
+**Evidence from plan:**
+LD-6 says data starts April 1, 2026. Backfill runs April 17, 2026. S188 gave each store Company its own `branch_tin` and `bir_rdo_code`. Phase 7 will change `Employee.company` (the ERPNext employer) for ~510 employees mid-tax-year.
+
+**Issue:**
+BIR Form 2316 (Certificate of Compensation Payment / Tax Withheld) is issued by the employer of record at year-end (or upon separation). For 2026:
+- January 1 – April 17: employer of record = `BEBANG ENTERPRISE INC.` (TIN/RDO of the parent)
+- April 17 onwards: employer of record = `<STORE> - BEBANG ENTERPRISE INC.` (store TIN/RDO)
+- This creates a **dual-employer 2316 situation for calendar year 2026**: two 2316s must be issued per affected employee (one from parent for Jan–Apr, one from store Company for May–Dec). This is legal but requires the receiving employer (store Company) to properly account for prior-employer withholding when computing annualized WT.
+- The alphanumeric tax code (ATC) for the withholding agent changes when the employer's TIN changes. The receiving employer's ATC 1601-C filing must reflect only the months they were employer of record.
+- Additionally: BIR RMC (Revenue Memorandum Circular) practice requires the new employer to request a Certificate of Prior Employment Compensation (essentially informal transfer of 2316 data) so the annualized withholding is not recomputed from zero in April.
+- The plan has NO mention of dual-2316 handling, annualized WT re-computation upon company change, or ATC 1601-C impact.
+
+**Recommended amendment:**
+1. Add a Finance/HR action item: for every employee whose `Employee.company` changes in the backfill, the payroll system must record "prior employer compensation" (total taxable compensation Jan–Apr from the parent Company) into the new employer's payroll record to avoid over-withholding in the second half of the year.
+2. Add a note that the parent `BEBANG ENTERPRISE INC.` must issue interim 2316 certificates for April 2026 cutoff to all transferred employees, and the store Companies must accept and incorporate those certificates for annualized WT computation.
+3. State explicitly in the plan whether ERPNext HRMS handles dual-employer 2316 within one system (it can, since both Companies are in the same ERPNext instance — but this must be verified and documented).
+
+---
+
+## Finding 3 — BIR 1905 / Certificate of Registration Update Not Addressed
+
+**Severity:** [WARNING]
+
+**Evidence from plan:**
+S188 created 49 Companies each with `branch_tin` and `bir_rdo_code`. Plan does not mention BIR registration obligations for those Companies as employers.
+
+**Issue:**
+When a Company begins withholding employee compensation (becomes an employer), BIR requires:
+- The Company must be registered as a withholding agent (BIR Form 1903 — Application for Registration for Corporations/Partnerships).
+- If already registered but not yet a withholding-agent employer, BIR Form 1905 (Update of Registration Information) is required to add "Withholding Agent" as a tax type.
+- Monthly/quarterly 1601-C (Monthly Remittance Return of Income Taxes Withheld on Compensation) filings begin from the first month the Company has employees.
+- If any of the 49 store Companies are NOT yet registered as withholding agents, withholding compensation taxes before registration is a BIR compliance violation.
+
+**Recommended amendment:**
+Add a Pre-backfill Compliance Checklist item: "Confirm all 49 store Companies are registered with BIR as withholding agents (1601-C filers). Block backfill for any Company not yet registered."
+
+---
+
+## Finding 4 — Draft Salary Slips for April 2026 Pre-Backfill
+
+**Severity:** [CRITICAL]
+
+**Evidence from plan:**
+Phase 7 (Employee.company backfill) runs on April 17, 2026. The plan's completion requirement (Requirements Regression Checklist item 8) checks that a NEW Salary Slip posts to the store Company — but does not address Salary Slips already in Draft/Submitted state for the April 2026 payroll period.
+
+**Issue:**
+Frappe HRMS Salary Slip stores `company` at creation time. If a payroll run was already started for April 1–15 (semi-monthly cutoff) before April 17:
+- All Draft Salary Slips created pre-backfill will have `company = BEBANG ENTERPRISE INC.`
+- The backfill changes `Employee.company` but does NOT retroactively update existing Draft/Submitted Salary Slips
+- Submitting those pre-existing Draft Slips AFTER the backfill will post GL entries to the PARENT company's books, not the store Company — silently defeating the entire purpose of S201 for April 2026
+- Salary Slips in Submitted state cannot be amended without cancellation — any already-submitted April slips on parent Company will require cancel → repost cycle
+
+**Recommended amendment:**
+Add a mandatory Phase 6.5 (pre-backfill audit):
+1. Query: `SELECT name, employee, company FROM tabSalary Slip WHERE docstatus IN (0,1) AND start_date >= '2026-04-01'`
+2. If ANY Draft (docstatus=0) slips exist for April: CANCEL THEM before running backfill. Do not submit until Employee.company is updated.
+3. If ANY Submitted (docstatus=1) slips exist for April on the parent Company: flag to Sam for a decision — cancel/repost or accept that April's first cutoff stays on parent.
+4. Add this to the Requirements Regression Checklist.
+
+---
+
+## Finding 5 — BIR Form 2307 (Creditable Withholding Tax Certificate) — Cross-Company Impact
+
+**Severity:** [INFO]
+
+**Evidence from plan:**
+Plan does not address supplier-facing withholding. The change affects Employee.company only.
+
+**Issue:**
+BIR Form 2307 (Certificate of Creditable Tax Withheld at Source) is issued by the withholding agent (the buyer/payor Company) to suppliers. When a store Company is the employer, any purchases or expense reimbursements originating from that store Company must issue 2307 from the store Company's TIN — not the parent's TIN.
+
+However, S201 only changes Employee.company for payroll purposes. Purchase Invoices, Expense Claims, and supplier payments remain on whatever Company the Purchase Invoice was created against. There is no cross-Company 2307 impact from S201 alone. The impact would arise if expense claims by store employees are re-routed to their new Company in a future sprint.
+
+**Recommended amendment:**
+No immediate action needed for S201 scope. Document as a known follow-up: "Expense Claims by store employees currently post to BEI parent. When expense management is brought into S202+ scope, 2307 issuance must shift to the store Company TIN."
+
+---
+
+## Finding 6 — Leave Balance Carryover When Employee.company Changes
+
+**Severity:** [WARNING]
+
+**Evidence from plan:**
+Phase 4 sets Employee.validate() to derive Company from branch/department. Phase 7 bulk-updates Employee.company via direct SQL. Neither phase mentions Leave Allocations or Leave Balances.
+
+**Issue:**
+In ERPNext/HRMS, Leave Allocation records are linked to Employee (by `employee` name field) and to `company` (in some versions). Critically:
+- Leave Policies and Leave Period are defined at the Company level in ERPNext — when `Employee.company` changes, the Leave Policy assignment may reference the old Company's Leave Period.
+- Annual Leave allocations for 2026 were created when all employees were under `BEBANG ENTERPRISE INC.`. If the Leave Period for the store Companies is different (or not yet created), leave balance lookups may return zero or throw errors for store employees.
+- The backfill uses direct SQL (bypassing `validate()`), which means the `derive_company_from_branch` hook will NOT fire for historical Leave Allocation records — they remain on the parent Company.
+- DOLE Republic Act 9292 and the Labor Code mandate that accrued leave credits survive employer entity changes for the same economic unit — they cannot be reset to zero simply because the billing Company changed.
+
+**Recommended amendment:**
+1. Before backfill, run: `SELECT employee, company, leave_type, total_leaves_allocated, total_leaves_taken FROM tabLeave Allocation WHERE docstatus=1 AND from_date >= '2026-01-01'`
+2. Verify that Leave Period records exist for all 49 store Companies (or confirm ERPNext resolves leave balance from Employee rather than Company-level period).
+3. If store Companies do not have Leave Period records, create them before backfill or freeze leave for affected employees during transition.
+4. Add to Requirements Regression Checklist: "Leave balance for a transferred store employee returns the correct accrued balance post-backfill."
+
+---
+
+## Finding 7 — Cost Center Assignment on Salary Slips After Company Change
+
+**Severity:** [WARNING]
+
+**Evidence from plan:**
+Requirements Regression Checklist item 8 states: "Salary Slip generated against a store employee posts to the store's Company (not parent)." L3-6 verifies `Slip.company = store's Company` and "Journal Entry posts to that Company's books." However, Cost Center is NOT verified.
+
+**Issue:**
+In ERPNext HRMS, Salary Slip GL entries (debit: Salary Expense, credit: Payable Account) use Cost Center from `Employee.payroll_cost_center` or the Company's default Cost Center. When `Employee.company` changes:
+- The store Company's Cost Center tree may not include the same Cost Center as was previously assigned to the employee.
+- `Employee.payroll_cost_center` may still point to a BEI parent Cost Center (e.g., `Main - BEI`), not a store-level Cost Center (e.g., `SM Megamall - SMBL`).
+- A Salary Slip posting to `SM MEGAMALL - BEBANG ENTERPRISE INC.` company but with Cost Center `Main - BEI` will fail GL validation or post to the wrong Cost Center tree.
+- The plan's design rationale (Phase 7) mentions cost center stamping in S202 (from punch data), but does not address the default Cost Center for the April 2026 payroll cycle which is the FIRST payroll under the new Company structure.
+
+**Recommended amendment:**
+1. Add to Phase 7: check `Employee.payroll_cost_center` for all ~510 affected employees. If it references a BEI parent Cost Center, update to the store Company's default Cost Center as part of the backfill.
+2. Add to L3-6 verification: explicitly check `Salary Slip.cost_center` (or the GL entry's `cost_center`) to confirm it maps to the store Company's cost center, not the parent.
+3. Add to Requirements Regression Checklist: "Salary Slip for a store employee uses a Cost Center belonging to the store Company's Cost Center tree."
+
+---
+
+## Finding 8 — HDMF (Pag-IBIG) — 49 Employer Sub-Accounts Required
+
+**Severity:** [CRITICAL]
+
+**Evidence from plan:**
+Plan moves 510 employees across 49 Companies. No mention of HDMF employer registration.
+
+**Issue:**
+HDMF (Home Development Mutual Fund / Pag-IBIG) employer accounts are per-Company. For BEI to remit Pag-IBIG contributions under each store Company:
+- Each of the 49 store Companies needs a HDMF Employer Registration Number (ER Number).
+- Monthly Contribution Collection List (MCCL) must be filed per employer.
+- HDMF accepts batch remittance via HDMF I-Collect, but each batch must be tagged to the correct employer ER number.
+- If the 49 store Companies do not yet have HDMF ER Numbers, Pag-IBIG contributions deducted from store employees cannot be legally remitted — the deductions would be "floating" with no registered employer to accept them.
+- This is not a theoretical risk: HDMF MCRF audits have penalized companies for remitting under incorrect employer numbers.
+
+**Recommended amendment:**
+Add a Statutory Registration Pre-requisite gate (combine with Finding 1 recommendation):
+1. List all 49 store Companies.
+2. For each: verify SSS Employer Number, PhilHealth Employer Number, and HDMF ER Number.
+3. Block the backfill for any Company without all three registrations active.
+4. Escalate to Sam: registering 49 new employer accounts with SSS, PhilHealth, and HDMF is a significant operational undertaking — it may take weeks to months. If registrations are not in place, the S202 JE reclassification model (keeping ONE employer of record = BEI parent) may be the only legally safe path for statutory remittances, with S201's Company change limited to cost-center and P&L allocation only (no payroll-entity change).
+
+---
+
+## Finding 9 — Group HMO / Insurance Policy Coverage Break
+
+**Severity:** [WARNING]
+
+**Evidence from plan:**
+Plan does not mention HMO, group life insurance, or benefits administration.
+
+**Issue:**
+BEI's group HMO policy (if any) is typically issued to the parent company `BEBANG ENTERPRISE INC.` as the sole policyholder. When `Employee.company` changes in ERPNext:
+- Any ERPNext module or third-party integration that queries `Employee.company` to determine HMO eligibility or premium allocation may break for store employees.
+- The HMO provider's employee census is typically submitted per policyholder (BEI parent). Moving employees to child Companies in ERPNext does NOT automatically update the HMO provider's records — a census amendment must be filed with the provider.
+- If BEI uses ERPNext's Health Insurance module or a custom field to track HMO enrollment, those records reference the old Company.
+- For group life insurance (SSS Flexi-Fund, BEI-sponsored), similar policy-level risks apply.
+
+**Recommended amendment:**
+1. Add a Phase 0 checklist item: "Confirm HMO and group insurance policies are issued to BEI parent only. Verify that ERPNext HMO/benefits configuration does not use Employee.company as an eligibility filter."
+2. If ERPNext benefits modules ARE company-scoped, add a sub-task to clone/extend benefits configuration to all 49 store Companies before backfill.
+3. Notify HMO/insurance provider that the employer of record for billing may change to 49 entities — or confirm that all employees remain under the parent policy regardless of ERPNext Company field.
+
+---
+
+## Finding 10 — Consolidated Financial Reporting During S201 Interim Period
+
+**Severity:** [WARNING]
+
+**Evidence from plan:**
+Design Rationale notes: "Option B (monthly reclassification JE) delivers fair per-store P&L... Post inter-Company JE: debit covered-store Salaries, credit home-store Salaries by punch share. This is the standard accounting practice for shared services." S202 is deferred. Plan says S201 is "independently useful."
+
+**Issue:**
+In the S201 interim period (after backfill, before S202 JE engine):
+- Labor costs for ~510 store employees post directly to 49 child Company P&Ls.
+- Relievers' labor still posts to their home store Company (not punch location) — this is acknowledged as a known gap deferred to S202.
+- Finance needs CONSOLIDATED labor reports. ERPNext's standard P&L report is per-Company. To view Group-level labor, Finance must either: (a) run reports for all 50 Companies (49 stores + BEI parent) separately and manually aggregate, or (b) use ERPNext's Consolidated Financial Statements feature.
+- The plan does NOT confirm whether Consolidated Financial Statements are configured for the BEI group entity tree (TUNGSTEN CAPITAL HOLDINGS OPC → BEI parent → 49 store Companies).
+- If the parent-child Company linkage is set correctly in ERPNext (which S188 should have established), ERPNext's Consolidated Balance Sheet / P&L should work — but this is untested.
+- For April 2026 payroll (the first payroll under the new structure), Finance will need to confirm their reporting workflow before month-end close.
+
+**Recommended amendment:**
+1. Add a Phase 8 (Reporting Verification) sub-task: run ERPNext Consolidated Financial Statements for the BEI group for April 2026 and confirm that all 49 store Company labor costs roll up correctly to the parent.
+2. Alert Finance team that April 2026 payroll reporting will require consolidated report runs — single-Company P&L is no longer sufficient.
+3. If Consolidated Financial Statements are not configured (parent-child links broken), add that as a blocking dependency from S188/S190.
+
+---
+
+## Finding 11 — Retroactive Risk: April 1–16 Payroll Already Processed
+
+**Severity:** [CRITICAL]
+
+**Evidence from plan:**
+LD-6 states "Data starts April 01, 2026 forward — no retroactive allocation to Feb 01." Backfill runs on April 17, 2026. The plan's Phase 7 note says "Data from April 01, 2026 forward" but does not address what happens to payroll transactions ALREADY processed for April 1–16 before the backfill runs.
+
+**Issue:**
+This is an extension of Finding 4 but specifically about the April semi-monthly payroll cycle:
+- BEI's payroll cycle appears to be semi-monthly (April 1–15 cutoff, April 16–30 cutoff based on standard PH practice).
+- If the April 1–15 payroll run was already processed (Salary Slips drafted or submitted) before April 17, those slips are on `BEBANG ENTERPRISE INC.`
+- The plan implies that post-backfill, future payroll will correctly use the new Company — but the April 1–15 slips already processed are on the OLD Company.
+- This creates a SPLIT WITHIN THE SAME MONTH: first half on parent, second half on store. This is not just a P&L cleanliness issue — it affects BIR 1601-C monthly remittance (which employer files for April compensation? Both?).
+- LD-6 "no retro to Feb" covers historical periods — but the plan should explicitly state the April 1–15 handling decision: accept split-month (April 1–15 on parent, April 16–30 on store) OR delay backfill to May 1 to get a clean month-start cutover.
+
+**Recommended amendment:**
+Add to Locked Decisions: "LD-8: Backfill Timing — April 1–15 payroll slips already on BEI parent are accepted as-is (not re-posted). Backfill applies from April 16, 2026 forward. OR: Delay backfill to May 1 start for a clean month-start cutover." Sam must make this decision explicitly. The current plan has no decision recorded.
+
+---
+
+## Summary
+
+**CRITICAL: 4, WARNING: 4, INFO: 1, N/A: 1**
+
+| # | Finding | Severity |
+|---|---------|----------|
+| 1 | SSS/PhilHealth/HDMF employer accounts — 49 new employer registrations required before backfill | CRITICAL |
+| 2 | BIR Form 2316 dual-employer mid-year — annualized WT re-computation not addressed | CRITICAL |
+| 4 | Draft/Submitted April 2026 Salary Slips pre-backfill will silently remain on parent Company | CRITICAL |
+| 11 | April 1–16 split-month retroactive risk — no LD decision recorded | CRITICAL |
+| 3 | BIR 1905 / withholding agent registration for 49 store Companies | WARNING |
+| 6 | Leave Balance carryover and Leave Period records for 49 store Companies | WARNING |
+| 7 | Cost Center continuity — payroll_cost_center not updated in backfill | WARNING |
+| 8 | HDMF 49 employer ER numbers (combined with Finding 1 — flagged separately for HDMF specifics) | CRITICAL |
+| 9 | Group HMO/insurance policy coverage break — benefits eligibility lookup | WARNING |
+| 10 | Consolidated reporting for Finance not verified or configured | WARNING |
+| 5 | BIR 2307 cross-Company impact | INFO |
+
+**CRITICAL: 5, WARNING: 5, INFO: 1, N/A: 0**
+
+> Note: Finding 8 (HDMF) was assessed as CRITICAL upon review (not WARNING as initially indicated in the table above — the 49-employer registration gap is as severe as SSS/PhilHealth). The summary count reflects the revised severity.

--- a/output/plan-audit/s201/system_arch_findings.md
+++ b/output/plan-audit/s201/system_arch_findings.md
@@ -1,0 +1,289 @@
+# S201 System Architecture Audit Findings
+
+**Auditor:** System Architecture Domain Auditor (Claude Sonnet 4.6)
+**Date:** 2026-04-17
+**Plan file:** docs/plans/2026-04-17-sprint-201-per-store-employee-billing-foundation.md
+**Code reviewed:** hrms/utils/company_lookup.py, hrms/utils/non_store_billing.py,
+  hrms/overrides/employee_master.py, hrms/api/transfers.py,
+  hrms/data_seed/branch_company_map.csv, hrms/utils/roving_employees.py,
+  hrms/hooks.py, bei-tasks/hooks/use-employee.ts,
+  bei-tasks/app/api/employee/me/route.ts
+
+---
+
+## FINDING-1 [WARNING] — Three-Source Resolver: Disagreement Protocol Undefined
+
+**Topic:** Branch → Company resolution path
+
+The resolver in `company_lookup.py` pulls from three sources:
+
+1. `branch_company_map.csv` (file on disk, loaded at startup + 60s TTL)
+2. `roving_employees.py` (hardcoded Python dict, compile-time constant)
+3. Live Frappe Company table (`entity_category='Store'`, queried at cache load)
+
+**Disagreement scenarios not handled:**
+
+- **CSV says Store/SM MEGAMALL but live Frappe Company no longer exists** (e.g., company was deleted/renamed post-S196): `_store_company_index.get()` returns None, triggers `UnknownBranch`. The plan's validate hook swallows this silently (`return` on UnknownBranch). The employee saves without updating company. No alert, no audit trail. Silent regression.
+
+- **CSV has old_branch key but new_branch differs from Company prefix** (e.g., `target_company_hint='SM MEGAMALL'` but live Company is actually `SM MEGAMALL - BEBANG ENTERPRISE INC.`): The prefix split `name.split(" - ", 1)[0]` depends on the ` - ` separator being present. If a Company name was created without that separator (e.g. `BEBANG KITCHEN INC.`), it never appears in `_store_company_index` for store lookups. This is currently benign only because BKI is handled via category=Commissary, but the pattern is fragile.
+
+- **CSV updated on disk but cache not yet expired**: up to 60 seconds of stale lookups. During a live branch rename, employees saving in that window get the wrong company. No mechanism to detect or alert on this.
+
+**Recommendation:** Add a `frappe.log_error` call on each `UnknownBranch` catch in `derive_company_from_branch` so silent misses appear in Frappe Error Log. The current code returns silently with no trace.
+
+---
+
+## FINDING-2 [WARNING] — 60s Cache TTL Acceptable for Payroll-Affecting Data; Failure Mode Is Silent
+
+**Topic:** Cache invalidation strategy
+
+The 60s TTL is acceptable in steady state. The on_update hooks on Branch and Company doctypes (`hooks.py:203-204`) correctly call `clear_cache()` immediately on any Frappe Desk edit.
+
+**However, two gaps exist:**
+
+1. **Direct SQL updates bypass on_update hooks.** Phase 6 (branch rename) uses `frappe.rename_doc()` which does fire hooks. Phase 7 (backfill) uses direct `UPDATE tabEmployee SET company=...` which does NOT fire Employee on_update, but that is intentional. The risk is if a third-party migration script or a future sprint directly updates `tabBranch` or `tabCompany` via SQL — the cache will not be invalidated and the 60s TTL is the only backstop.
+
+2. **Worker process isolation.** Frappe runs multiple worker processes (RQ workers). `_branch_map_cache` is a module-level dict — it is process-local. If a web worker clears the cache via `clear_cache()` triggered by an on_update hook, other worker processes (background jobs) keep their own stale copy until their own TTL expires. This means the backfill patch (Phase 7) runs in a background worker context and may resolve companies from a cache that is up to 60s stale relative to the just-renamed branches. Phase 6 must complete and all worker caches must have expired before Phase 7 runs.
+
+**Mitigation already present:** Phase plan says dry-run Phase 7 requires Sam approval, implying sequential execution with time gap. Sufficient if operators follow the order.
+
+---
+
+## FINDING-3 [CRITICAL] — Classifier Rule Ordering: bio_id First Is Wrong Precedence
+
+**Topic:** Classifier rule ordering
+
+The plan states: `bio_id → designation → department → branch category → default`.
+
+The **actual shipped code** in `non_store_billing.py` implements: `bio_id → designation → department → branch category → default`. This matches the plan. The concern is with the **direction of the rules when conflicts arise**:
+
+**Gap 1 — AS (designation=Area Supervisor) with department=Operations:**
+- Rule 2 matches: `"AREA SUPERVISOR" in desig` → returns True (BEI parent). Correct per LD-2.
+- No conflict. However the plan says rule ordering is `bio_id → designation → department` but does not document that it was intentionally chosen for this case.
+
+**Gap 2 — Roving bio (bio_id in ROVING_EMPLOYEES) but department=IT:**
+- Rule 1 matches: `is_roving(bio_id)` → returns True (BEI parent). Correct — the explicit roving list overrides department.
+- But this means an IT employee who has NOT been added to ROVING_EMPLOYEES but has department=IT will be caught by Rule 3. If someone accidentally adds a store-employee's bio_id to ROVING_EMPLOYEES (the dict is manually maintained), they will be silently routed to BEI parent regardless of their actual department/designation.
+
+**Gap 3 — Commissary classification is NOT in is_non_store_billing at all.** The classify chain for commissary employees is: `is_non_store_billing_doc()` returns False (no commissary logic there) → falls through to `resolve_branch_to_company(branch, department=department)` in the validate hook. Commissary routing is handled inside `resolve_branch_to_company` via `DEPT_DRIVEN` hint. This split means the "commissary biller" classification is spread across two functions with no single authoritative entry point documenting the three-way split (BEI | BKI | Store). A future developer reading `is_non_store_billing.py` will not know BKI routing exists.
+
+**Gap 4 — No conflict enumeration in plan.** The plan has zero documentation of what happens when rules collide. Recommend adding a conflict table in the plan or code docstring.
+
+---
+
+## FINDING-4 [WARNING] — CSV as SSOT + Frappe Desk as SSOT: Two Sources Can Diverge
+
+**Topic:** Single source of truth
+
+The plan states "`hrms/data_seed/branch_company_map.csv` is SSOT." But Frappe Branch doctype is separately the truth for valid Branch names.
+
+**Gap:** If an operator creates a new Branch directly in Frappe Desk (e.g., a new store opening mid-year), the Branch exists in `tabBranch` but has no row in `branch_company_map.csv`. The next Employee save with that new branch will throw `UnknownBranch` inside `derive_company_from_branch`, which the hook catches and silently no-ops (line 90-91: `return`). The employee saves with an unchanged — possibly wrong — company. No error surfaces to the operator.
+
+**Is this intended?** The plan does not address this explicitly. The validate hook behavior (silent no-op on UnknownBranch) means new-branch employees are silently mis-allocated until someone notices and updates the CSV + deploys.
+
+**Risk level:** This is a deployment-day risk for any new store opened after S201 ships. The gap between a new Frappe Branch record and the CSV being updated is unbounded.
+
+**Recommendation:** In `derive_company_from_branch`, on `UnknownBranch` exception, add `frappe.log_error(...)` AND `frappe.msgprint(...)` (warning, not error) so HR sees a notification that the branch is unmapped. Current code silently returns.
+
+---
+
+## FINDING-5 [WARNING] — Stored vs Computed: Correct Choice With Undocumented Drift Risk
+
+**Topic:** Employee.company as stored vs computed
+
+The plan chose: **stored, derived at write time via validate hook**.
+
+**Trade-off analysis (not in plan):**
+
+| Approach | Pro | Con |
+|---|---|---|
+| Stored (chosen) | Fast reads; works with Frappe reports, Salary Slips, GL posting without extra joins | Can drift if department/designation changes without triggering validate; direct SQL updates bypass hook |
+| Computed at read time | Always fresh | Requires every consumer to call the resolver; incompatible with Frappe's Company field type on Employee (Link field); breaks Salary Slip generation which reads stored company |
+
+Stored is the correct choice for Frappe. The drift risk is real but manageable.
+
+**Documented drift vectors not in plan:**
+
+1. A future sprint changes `Employee.department` via direct SQL (as this sprint's Phase 7 does for company) — validate hook does not fire, company does not update.
+2. Frappe bulk-edit through Desk (Edit Multiple) may or may not fire validate depending on Frappe version. If it does not, bulk dept changes leave company stale.
+3. The plan's Phase 7 backfill patch intentionally bypasses validate (direct SQL) to avoid recursion. This is correct, but it sets a precedent that future sprint authors may copy without the same care.
+
+---
+
+## FINDING-6 [CRITICAL] — S201→S202 Gap: Reliever Labor Is Mis-Allocated During Interim Period
+
+**Topic:** Deferral to S202
+
+Between S201 deploy and S202 deploy, the situation for reliever employees is:
+
+- `Employee.company` = their **home store's Company** (correct per S201 logic)
+- Salary Slip posts to home store Company (correct for statutory)
+- But punch-based allocation JE does not exist yet (S202 not deployed)
+- Result: if a Tanza employee relieves at SM MOA for 3 days in April 2026, ALL of April's salary bills to SM Tanza. SM MOA gets free labor. SM Tanza overpays.
+
+**Plan acknowledges this** (LD-5, Design Rationale section) but does not quantify the exposure or state an acceptable gap duration.
+
+**Gap not stated:** How long between S201 and S202? If S202 ships in the same payroll cycle (April 2026), the gap is tolerable. If S202 slips to May, an entire payroll cycle runs with mis-allocated reliever labor (~27 roving employees * avg relief days). With an estimated PHP 20K-35K monthly salary per reliever, one-month slip represents PHP 540K–945K of cross-company mis-allocation that requires manual retroactive JEs.
+
+**Recommendation:** Plan should state explicit S202 target date and a maximum tolerable gap (suggested: same payroll cycle). If S202 slips beyond April payroll close, Sam should be alerted to decide between: (a) deferring S201 backfill until S202 is ready, (b) accepting the mis-allocation, or (c) doing a manual interim JE.
+
+---
+
+## FINDING-7 [WARNING] — Reporting Discontinuity at S201 Deploy Date Not Addressed
+
+**Topic:** Backward compatibility for historical Salary Slips
+
+Historical Salary Slips (Feb–Mar 2026) on `BEBANG ENTERPRISE INC.` parent stay there — they are not retroactively moved (LD-6: no retro to Feb). This is correct per plan.
+
+**Gap not mentioned:** Any report that aggregates labor cost per Company will show a hard discontinuity at the S201 deploy date:
+
+- Feb–Mar 2026: 100% of payroll on BEI parent, 0% on store Companies
+- April 2026 forward: ~75% on store Companies, ~6% BKI, ~19% BEI parent
+
+Finance/management reports comparing April 2026 to March 2026 per store will show implausible numbers (March: PHP 0 labor, April: full labor). This is a **reporting artifact**, not a data error, but it will confuse management and potentially trigger erroneous financial analysis.
+
+**Recommendation:** Plan should include a note for Finance that pre-S201 comparisons require a manual adjustment note. The Salary Slip discontinuity date should be documented in a journal note or ERP system note accessible to Alyssa/Denise.
+
+---
+
+## FINDING-8 [WARNING] — Employee Master Google Sheet Not Updated by Backfill
+
+**Topic:** Employee Master Google Sheet sync
+
+MEMORY.md lesson: "Always update BOTH CSV and Google Sheet together" (Google Sheet: `1QP_sdazVy1AzjK7ZHWmN6v3tZNYdpiUcdRebJJZY9Ms`, "BEI Employee Master 2026", sheet "Employee Master").
+
+The backfill patch in Phase 7 updates `tabEmployee.company` in Frappe. `data/_FINAL/EMPLOYEE_MASTER.csv` is a migration snapshot, not a live sync target. However the Google Sheet is supposed to reflect current employee state.
+
+**Gap:** Phase 7 does not include a step to update the Google Sheet's Company column for ~510 employees. The Google Sheet will remain showing `BEBANG ENTERPRISE INC.` for all employees post-backfill, creating a divergence between ERP state and the "source of truth" spreadsheet used by HR and potentially Finance.
+
+**Recommendation:** Add a Phase 7 sub-step to either: (a) run a Google Sheets API update after backfill, or (b) explicitly document that the Google Sheet's Company column is considered stale/read-only post-S201 and the ERP is the live authority. Given that `data/_FINAL/EMPLOYEE_MASTER.csv` is a Feb 2026 snapshot, option (b) may be the correct governance decision — but it needs to be explicitly stated.
+
+---
+
+## FINDING-9 [WARNING] — Direct SQL Backfill Does Not Create Frappe Version Records
+
+**Topic:** Frappe Versioning
+
+Employee is a versioned doctype in Frappe (track_changes is enabled by default for all DocTypes unless explicitly disabled). Phase 7 explicitly uses direct SQL (`UPDATE tabEmployee SET company=...`) to bypass the validate hook. Direct SQL bypasses the Frappe ORM entirely, meaning:
+
+- No `tabVersion` rows are created for the ~510 company changes
+- The Frappe "Track Changes" audit trail shows no record of who changed company or when
+- If an auditor checks an employee's change log in Frappe Desk, the company field change is invisible
+
+**Plan does not address this.** The plan's mitigation is the `backfill_log.csv` file written by the patch itself. This is a custom audit log, not an ERP audit log.
+
+**Risk:** If there is ever a dispute about when an employee's company changed (e.g., a payroll dispute or statutory filing question), the ERP audit trail will not corroborate the backfill log. The backfill log exists only as a file on disk, not in the ERP database.
+
+**Recommendation:** Either:
+(a) Accept this gap and explicitly document it in the plan as a known audit trail limitation, OR
+(b) After direct SQL update, insert `tabVersion` rows manually for each changed employee (complex), OR
+(c) Use `frappe.db.set_value("Employee", name, "company", target, update_modified=True)` with `flags.ignore_validate=True` instead of raw SQL — this updates `tabVersion` but triggers `on_update` hooks (which would need to be guarded).
+
+Option (a) is pragmatic given the one-time nature of the backfill, but must be documented.
+
+---
+
+## FINDING-10 [WARNING] — my.bebang.ph Has 60-Second Stale Cache for Employee Company Field
+
+**Topic:** Interop with my.bebang.ph
+
+The plan states: "Backfill makes it show correct value automatically."
+
+**This is partially correct but not immediate.**
+
+`use-employee.ts` in bei-tasks uses SWR with `dedupingInterval: 60000` (60 seconds). This means:
+- After S201 backfill updates `tabEmployee.company`, a user who already has a browser session open will see stale company data for up to 60 seconds.
+- After a page reload or 60-second expiry, SWR refetches `/api/employee/me` which calls live Frappe. The new company value will appear.
+
+**This is low severity** — 60 seconds is acceptable for a company name display. The concern escalates only if my.bebang.ph has RBAC or routing logic that branches on `employee.company`. Checking `use-employee.ts`: the company field is fetched but there is **no RBAC logic** based on company in the hook itself (RBAC uses `roles`, not `company`). The company field is display-only in the current implementation.
+
+**Net assessment:** Low severity, but the plan's claim of "automatic" display is imprecise — it is "automatic within 60 seconds per session." No action needed unless company-based routing is added in a future sprint.
+
+---
+
+## FINDING-11 [WARNING] — Concurrent Employee Saves: Validate Hook Has a Read-Then-Write Race
+
+**Topic:** Concurrent safety
+
+The `derive_company_from_branch` hook follows the pattern:
+1. Read `doc.company` (the current value on the doc object in memory)
+2. Read `target` from resolver
+3. If `doc.company != target`: set `doc.company = target`
+
+This is a validate hook — it operates on the in-memory doc object before database write. Frappe's `frappe.db.savepoint()` is not used here (validate hooks do not participate in savepoints automatically).
+
+**Race scenario:** Two HR users simultaneously edit the same Employee doc. Both load the doc. Both call validate. Both compute `target`. Both set `doc.company = target`. Frappe's last-write-wins semantics mean the second save overwrites the first. For company derivation this is **idempotent** — both compute the same `target` from the same branch/department/designation values. No data corruption.
+
+**The actual race risk is different:** If one HR user changes `department` (which changes the target) while another is saving with the old department:
+
+1. HR-A loads doc: department=Operations, derive target=SM MEGAMALL
+2. HR-B loads doc simultaneously
+3. HR-A saves: company set to SM MEGAMALL
+4. HR-B changes department to IT: derive target=BEI parent
+5. HR-B saves: company set to BEI parent
+
+This is correct eventual behavior — the last save wins, which is the HR-B intent. No corruption.
+
+**True gap:** If the validate hook is called from within `frappe.rename_doc()` during Phase 6 branch rename, the hook fires during the rename cascade on each affected Employee. If a concurrent HR save is in progress on the same employee, the two validate calls may interleave. Frappe handles this via row-level locking in the DB write, but the in-memory doc state may be stale at validate time. This is a low-probability edge case on deployment day.
+
+**Net assessment:** No critical race condition. Idempotent derivation makes concurrent saves safe. Low risk.
+
+---
+
+## FINDING-12 [INFO] — Branch Rename Cascade via frappe.rename_doc: Verified Safe
+
+**Topic:** Architecture of the rename
+
+`frappe.rename_doc("Branch", old_name, new_name, force=True, merge=True)` in Frappe v15:
+
+- Frappe automatically updates all Link field references to the renamed doc across all doctypes, including `tabEmployee.branch`
+- The cascade runs via `frappe.model.rename_doc.update_link_field_values()` which issues `UPDATE tabXXX SET branch=new_name WHERE branch=old_name` for every doctype that has a Link field to Branch
+- The `merge=True` flag merges duplicate Branch records if new_name already exists (used for `AYALA UPTC` → `AYALA UP TOWN CENTER` where the canonical may already exist)
+
+**Gap:** The cascade update fires `tabEmployee` update queries but does NOT re-fire the Employee validate hook (it is a direct DB update via rename cascade, not an ORM save). This means after Phase 6 rename, Employee.branch is updated but Employee.company is NOT re-derived.
+
+**This is why Phase 7 (backfill) must run AFTER Phase 6 (rename).** The plan sequences them correctly. However, the plan does not explicitly state that Phase 6's rename cascade leaves company stale and that is why Phase 7 is needed. A future sprint author might incorrectly believe Phase 6 alone updates company.
+
+**Recommendation:** Add an explicit note in Phase 6: "rename_doc cascade updates Employee.branch but not Employee.company — Phase 7 is required to re-derive company from the renamed branches."
+
+---
+
+## FINDING-13 [CRITICAL] — HR Manager Override Flag: No UI Mechanism to Set It; Undocumented
+
+**Topic:** HR Manager override flag
+
+The plan describes (Phase 4):
+> "HR Manager role bypass: if user has HR Manager AND company was manually changed in this save, skip derivation. Flag: `flags.company_manual_override`"
+
+**The shipped code in `employee_master.py` line 82:**
+```python
+manual_override = bool(getattr(doc, "flags", {}).get("company_manual_override"))
+```
+
+**Critical gap:** Frappe `doc.flags` is a runtime-only dict that is set programmatically. It is NOT persisted to the database and cannot be set via the Frappe Desk UI form. There is no mechanism for an HR Manager user, working in Frappe Desk's Employee form, to set `doc.flags.company_manual_override = True`.
+
+**Result:** The HR Manager bypass described in the plan is effectively **dead code**. An HR Manager who tries to manually set a different company via the Desk form will have their change overwritten by `derive_company_from_branch` on every save, regardless of their HR Manager role. They cannot exercise the override.
+
+**How to fix:** Options:
+(a) Add a hidden boolean field `custom_company_manual_override` on Employee DocType (Custom Field, hidden, only visible to HR Manager). When set to True, the hook reads it and skips derivation. This survives across saves.
+(b) Remove the bypass clause entirely (simpler). If HR Manager needs to override, they can disable the hook in bench and do a direct SQL update.
+(c) Change override detection: instead of checking a flag, check if `doc.company` was explicitly set to a Company that cannot be derived from the current branch/dept (i.e., if `doc.company != target` AND the user has HR Manager). This is the current code's logic but the flag check makes it unreachable.
+
+**The current implementation means HR Manager gets NO override capability**, contrary to what the plan documents. This is a behavioral gap between plan and code.
+
+---
+
+## Summary Count
+
+| Severity | Count | Finding IDs |
+|---|---|---|
+| [CRITICAL] | 3 | FINDING-3 (rule ordering — commissary split undocumented; FINDING-6 (S202 gap exposure unquantified); FINDING-13 (HR Manager override is dead code) |
+| [WARNING] | 9 | FINDING-1, FINDING-2, FINDING-4, FINDING-5, FINDING-7, FINDING-8, FINDING-9, FINDING-10, FINDING-11, FINDING-12 |
+| [INFO] | 1 | FINDING-12 (also logged as WARNING for rename-cascade ordering gap) |
+
+**Total findings: 13**
+**CRITICAL: 3 | WARNING: 9 | INFO: 1**
+
+---
+
+*Generated by System Architecture Domain Auditor, 2026-04-17 PHT*

--- a/output/plan-audit/s201/verified_blockers.md
+++ b/output/plan-audit/s201/verified_blockers.md
@@ -1,0 +1,118 @@
+# S201 Audit — Verified Blocker Report
+
+**Plan:** `docs/plans/2026-04-17-sprint-201-per-store-employee-billing-foundation.md`
+**PR:** #603 MERGED (2026-04-16T23:22 UTC) + #604 follow-up (BGC fix)
+**Audit date:** 2026-04-17
+**Auditors:** 5 parallel domain agents + code verifier (read actual source).
+
+## Raw counts (pre-verification)
+
+| Domain | CRITICAL | WARNING | INFO |
+|---|---|---|---|
+| Frappe backend | 0 | 5 | 4 |
+| PH Finance | 5 | 5 | 1 |
+| Deployment QA | 4 | 6 | 3 |
+| Cross-cutting | 5 | 17 | 7 |
+| System architecture | 3 | 9 | 1 |
+| **Total** | **17** | **42** | **16** |
+
+## Verified counts (post code-verifier)
+
+- CONFIRMED: 7 CRITICAL, 18 WARNING
+- STALE (false positive): 0 CRITICAL, 2 WARNING
+- NEW GAPS (code verifier): 0 CRITICAL, 5 WARNING
+
+## Top 10 Verified Blockers
+
+### GROUP A — Policy decisions Sam must make BEFORE running `S201_APPLY=1`
+
+#### B1 [CRITICAL] SSS/PhilHealth/HDMF 49 employer registrations
+**Status:** CONFIRMED (plan omission, not code bug)
+**Evidence:** Plan has zero language on statutory employer registration per child Company. S188 created 49 child Companies each with its own `branch_tin` and `bir_rdo_code`. Backfill sets `Employee.company = <store-child>` but SSS/PhilHealth/HDMF employer IDs are typically ONE per legal entity.
+**Decision needed:** Are 49 separate SSS/PhilHealth/HDMF employer accounts already registered? If not, backfill makes remittance filings ambiguous.
+
+#### B2 [CRITICAL] BIR Form 2316 dual-employer mid-year handling
+**Status:** CONFIRMED (plan omission)
+**Evidence:** When Employee.company changes mid-year, BIR considers this "multiple employers" — affects 2316 issuance, potentially requires 1905.
+**Decision needed:** Confirm with Finance that child Companies issue 2316 as "same employer group" under BEI HoldCo, or prepare 1905 batch filings.
+
+#### B3 [CRITICAL] April 2026 Draft/Submitted Salary Slips stay on parent
+**Status:** CONFIRMED
+**Evidence:** Backfill patch UPDATEs tabEmployee.company but doesn't touch existing Salary Slip records. Any April 1-16 cutoff slip already posted sits on BEI parent forever.
+**Decision needed:** Cancel + regenerate April 2026 cutoff slips after backfill? Or accept the discontinuity starting May 2026?
+
+#### B4 [CRITICAL] April 1-16 split-month risk
+**Status:** CONFIRMED (LD-6 says April 01 start but doesn't define behavior if backfill runs mid-period)
+**Evidence:** If Sam runs `S201_APPLY=1` on April 18, half the April cutoff is pre-backfill (BEI parent) and half is post (store child). Labor cost per store P&L will have a 50% gap.
+**Decision needed:** Wait for next payroll cutoff (April 30 → May 1) to apply, OR apply now and regenerate slips?
+
+### GROUP B — Code bugs (follow-up PR)
+
+#### B5 [CRITICAL → FIX REQUIRED] S201_APPLY env var doesn't propagate through docker exec
+**Status:** CONFIRMED
+**Evidence:** `.github/workflows/build-and-deploy.yml:388` runs `docker exec $BACKEND_CONTAINER bench ... migrate` with no `-e S201_APPLY=1`. The env var set in host shell never reaches the container.
+**Fix:** Sam must run `docker exec -e S201_APPLY=1 $BACKEND_CONTAINER bench --site hq.bebang.ph execute hrms.patches.v16_0.s201_rename_branches.execute`. Update plan + PR body to show correct syntax. (Requires separate invocation — NOT part of normal `bench migrate` flow.)
+
+#### B6 [WARNING → FIX REQUIRED] Company.on_update does NOT call company_lookup.clear_cache
+**Status:** NEW GAP (not caught by domain agents; code verifier found)
+**Evidence:** `hrms/hooks.py` registers `sales_location_mapping.clear_cache` on Company.on_update (S200) but NOT `company_lookup.clear_cache` (S201). Plan claims both Branch and Company invalidate the resolver.
+**Fix:** Add `hrms.utils.company_lookup.clear_cache` to Company.on_update list.
+
+#### B7 [WARNING → FIX REQUIRED] Backfill commits on partial errors
+**Status:** CONFIRMED + NEW GAP
+**Evidence:** Both `s201_rename_branches.py` and `s201_backfill_employee_company.py` call `frappe.db.commit()` after the loop unconditionally — even when `errors[]` is non-empty. Partial batch commits silently.
+**Fix:** If errors exist, rollback savepoint or skip commit + log loudly.
+
+#### B8 [WARNING → FIX REQUIRED] Patches use logger.error (no Sentry capture)
+**Status:** NEW GAP
+**Evidence:** Both patches call `frappe.logger().error(...)` on failure — server log only, NOT fed to Sentry. `frappe.log_error(title, message)` is the Sentry pathway (per DM-7).
+**Fix:** Replace `frappe.logger().error()` with `frappe.log_error(title="S201 patch failure", message=...)`.
+
+#### B9 [CRITICAL → AMENDMENT] Commissary classification split across two modules
+**Status:** CONFIRMED (code works correctly, plan description is misleading)
+**Evidence:** Plan Phase 4 task says "department == Commissary → BKI". Actual code: `is_non_store_billing` runs FIRST (no BKI logic), then `resolve_branch_to_company` handles commissary via branch suffix + dept. Result: dept=Commissary + branch=SHAW COMMISSARY - LOGISTICS → BEI parent (correct per Sam's SCM rule), but plan text suggests dept alone routes to BKI.
+**Fix:** Update plan Phase 4 task to accurately describe the two-stage rule.
+
+#### B10 [CRITICAL → DOCUMENT ONLY] HR Manager override is dead code
+**Status:** CONFIRMED
+**Evidence:** `company_manual_override` flag exists in exactly 2 lines of `employee_master.py` (read, never set). No Form JS, no Custom Field, no API sets it.
+**Options:** (a) Leave as-is — override may not be needed in practice; (b) Remove dead code; (c) Wire a real override via Custom Field + Form JS.
+**Recommendation:** Leave as-is for S201 (no employee needs it today); wire when a real override case arises.
+
+### GROUP C — Plan-integrity amendments (not blocking apply, but add rigor)
+
+#### B11 [WARNING] S154 Zero-Skip enforcement section missing
+**Fix:** Add explicit "PHASE N DONE" gate requiring each phase's Verification step to pass before advancing.
+
+#### B12 [WARNING] S154 no MUST_MODIFY / MUST_CONTAIN assertions
+**Fix:** Add inline file-level assertions per phase task.
+
+#### B13 [WARNING] S087 no protected surfaces list
+**Fix:** Name `roving_employees.py`, existing `Employee.validate` BEI-EMP preservation, and Transfer DocType stock fields as DO-NOT-TOUCH.
+
+#### B14 [WARNING] L3 Playwright script does not exist
+**Fix:** Author `tests/playwright/s201/*.spec.ts` covering the 6 L3 scenarios OR document that L3 runs via manual Python scripts against Frappe API.
+
+#### B15 [CRITICAL] S202 slippage = roving mis-allocation exposure
+**Fix:** Set a maximum tolerable gap (e.g., "S202 must ship before May 15 payroll cutoff or Sam must accept April-May roving labor on home store"). Plan must cite a date.
+
+## Action matrix
+
+| Blocker | Action | Owner | Timing |
+|---|---|---|---|
+| B1-B4 (PH Finance) | Finance sign-off | Sam + Denise | Before `S201_APPLY=1` |
+| B5 (docker exec syntax) | Plan amendment + PR body | Me | Now |
+| B6 (Company.on_update) | Code fix follow-up PR | Me | Now |
+| B7 (partial commit) | Code fix follow-up PR | Me | Now |
+| B8 (Sentry pathway) | Code fix follow-up PR | Me | Now |
+| B9 (Commissary plan description) | Plan amendment | Me | Now |
+| B10 (HR Manager dead code) | Note in plan, defer fix | Me | Note now |
+| B11-B14 (plan rigor) | Plan amendment (retroactive) | Me | Now |
+| B15 (S202 deadline) | Plan amendment cite date | Me | Now |
+
+## What the audit did NOT find
+
+- No DM-1..6 violations (S201 doesn't post GL).
+- No S091 cold-start gaps (Design Rationale is present).
+- No S099 branch isolation issues (branch reserved, PR created).
+- Closeout contract exists (S092 satisfied).


### PR DESCRIPTION
## Summary

Architectural pivot on S201 after the 5-agent audit surfaced 5 PH-Finance statutory blockers (B1-B4). Sam clarified that the real business intent is **transfer pricing (internal billing), not legal employer reassignment**. This PR implements that correctly — legal employer stays stable, per-store billing is deferred to S202's allocation JE engine.

**Supersedes PR #605** (closes without merge — its audit fixes are included here).

## The pivot

| Layer | Before (Option A / shipped) | After (Option X) |
|---|---|---|
| Legal employer (`Employee.company`) | Auto-moves to store child Company on save/transfer/backfill | Stays on legal employer; HR changes manually via Frappe Desk dropdown |
| Per-store billing | Would flow from Salary Slip posting to store Company | Delivered via S202 punch-based allocation JE (inter-Company reclassification) |
| Statutory compliance (SSS/PhilHealth/HDMF/BIR 2316) | Broken by mid-year employer moves | Untouched — single legal employer per period |

## What this PR changes

1. **`hooks.py`** — `derive_company_from_branch` hook commented out (function kept for reference); added `company_lookup.clear_cache` to `Company.on_update` (audit fix B6 — cache invalidation gap).
2. **`hrms/api/transfers.py`** — `_derive_new_company` helper deleted; `new_company = emp_doc.company` so transfers don't move legal employer.
3. **`hrms/patches/v16_0/s201_backfill_employee_company.py`** — apply path raises `RuntimeError`; dry-run inspection still works for reference.
4. **`hrms/patches/v16_0/s201_rename_branches.py`** — unchanged behavior; plus B7 savepoint + B8 Sentry routing.
5. **Plan doc v3** — documents the pivot with full rationale; status flipped to `SUPERSEDED_BY_OPTION_X`.

## What's kept as library code (S202 will use)

- `hrms/utils/company_lookup.py` — branch → Company resolver (for classifying punches into store buckets)
- `hrms/utils/non_store_billing.py` — HO/roving/AS classifier (deciding which punches attribute where)
- `hrms/data_seed/branch_company_map.csv` — 60-row canonical map
- `hrms/tests/test_s201_*.py` — all 3 test files still relevant

## Open policy blockers — RESOLVED status after Option X

- B1 (SSS/PhilHealth/HDMF registrations live): Sam confirmed ✓ — need Frappe Company doc audit (separate task)
- B2 (BIR 2316 mid-year change): RESOLVED by Option X
- B3 (existing Draft Salary Slips): RESOLVED by Option X
- B4 (apply timing): RESOLVED by Option X
- B15 (S202 deadline May 15, 2026): stands

## Deploy sequence after merge

1. Merge + deploy.
2. `bench --site hq.bebang.ph migrate` — patches register; rename runs in dry-run.
3. Review rename dry-run report in site's `private/files/`.
4. When ready: `docker exec -e S201_APPLY=1 $BACKEND_CONTAINER bench --site hq.bebang.ph execute hrms.patches.v16_0.s201_rename_branches.execute` (this applies the branch rename only — backfill is hard-gated and will raise).
5. Verify branches match Company prefixes; Analytics naming stays consistent.
6. Proceed to S202 planning for the actual billing layer.

## Audit artifacts

Full audit report bundled under `output/plan-audit/s201/`:
- `verified_blockers.md` (top-level summary)
- 5 domain findings + `code_verification.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)