### PR TITLE
fix(S203 followup): bei_legal_entity = bki_company (issuer), not buyer

### DIFF
--- a/hrms/api/commissary.py
+++ b/hrms/api/commissary.py
@@ -1134,11 +1134,14 @@ def build_bki_store_sale_invoice(
 	si.taxes_and_charges = vat_template
 	if debit_to:
 		si.debit_to = debit_to
-	# S192: bei_legal_entity + bei_store_label are mandatory custom fields on
-	# Sales Invoice for ERP-sync attribution. Set them from the resolved
-	# Company-first chain (S190).
+	# S192+S203: bei_legal_entity must equal the ISSUING Company (the seller,
+	# which is BKI on the BKI->store external sale), NOT the buyer. This is
+	# enforced by the `bei_p10_d04_si_issuance_guard` server script which
+	# throws "Legal Entity must match Company for issuance" when they differ.
+	# Prior fix (S192 F03) set this to buyer_entity_name and was reverted —
+	# do not regress.
 	if frappe.get_meta("Sales Invoice").has_field("bei_legal_entity"):
-		si.bei_legal_entity = buyer_entity_name
+		si.bei_legal_entity = bki_company
 	if frappe.get_meta("Sales Invoice").has_field("bei_store_label"):
 		si.bei_store_label = target_warehouse
 	# Linkage (custom fields added by Phase 1 fixtures)


### PR DESCRIPTION
## What

One-line fix in \`hrms/api/commissary.py\` — \`build_bki_store_sale_invoice\` was setting \`bei_legal_entity = buyer_entity_name\` (regression of S192 F03). The \`bei_p10_d04_si_issuance_guard\` server script requires \`bei_legal_entity == company\` (the issuer). On BKI→store external sales the issuer is BKI, so \`bei_legal_entity\` must be \`bki_company\`, not the buyer.

## Why it matters

Surfaced by the S198 L3 retry (2026-04-17). After S203 was deployed, Draft SIs were being CREATED at dispatch (great) but couldn't be SUBMITTED on store acceptance because the guard threw "Legal Entity must match Company for issuance".

After this fix, a real SI was submitted end-to-end through the browser:
- ACC-SINV-2026-00003 for BEI-ORD-2026-00269 (SM Tanza)
- Customer: BEBANG MEGA INC., TIN 010-885-436-00000
- Grand total ₱16,977.27, 12% VAT (₱1,818.99 exact)
- GL balanced with Customer party on Debtors - BKI AR row (DM-1 compliant)

## Test plan
- [x] Submitted SI in production manually after flipping the one field
- [ ] After merge + deploy: new dispatches should produce Draft SIs with \`bei_legal_entity = BKI\` so they can submit without manual patching
- [ ] S198 L3 retry continues (S2, S3, S4, F1-F3 scenarios)