### PR TITLE
fix(cashflow): base64-decode service account JSON secret

### DIFF
--- a/.github/workflows/weekly-bdo-reconciliation.yml
+++ b/.github/workflows/weekly-bdo-reconciliation.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Write service account credentials
         run: |
           mkdir -p credentials
-          printf '%s' "${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}" > credentials/task-manager-service.json
+          echo "${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}" | base64 -d > credentials/task-manager-service.json
           if [ ! -s credentials/task-manager-service.json ]; then
             echo "::error::GOOGLE_SERVICE_ACCOUNT_JSON secret is not set"
             exit 1


### PR DESCRIPTION
## Summary

- First dispatch of weekly-bdo-reconciliation.yml failed at credential-write step
- Root cause: `GOOGLE_SERVICE_ACCOUNT_JSON` secret is stored **base64-encoded** across all BEI workflows (confirmed in daily-pos-sync.yml, sync-adms.yml, s189-webhook-*)
- My initial workflow wrote the base64 string as-is → `json.decoder.JSONDecodeError: Expecting value: line 1 column 1`
- This PR pipes through `base64 -d` to match the established pattern

## Changed
- `.github/workflows/weekly-bdo-reconciliation.yml` — one-line fix, same as every other workflow that uses this secret

## Failed run for reference
https://github.com/Bebang-Enterprise-Inc/hrms/actions/runs/24549670890

## Test plan
- [ ] Merge this PR
- [ ] Dispatch the workflow manually from Actions tab (leave both inputs as default `false`)
- [ ] Verify: no credentials error, script runs, exits cleanly with "No new file" report (since BDO file already archived)

🤖 Generated with [Claude Code](https://claude.com/claude-code)