### PR TITLE
fix(S205): GR auto_submit calls submit_receipt() not gr.submit() (S194-9)

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -2521,7 +2521,7 @@ def create_invoice(data: dict[str, Any] | str) -> dict[str, Any]:
         # Note: GR status can be "Accepted" after the receive+inspect workflow
         gr_exists = frappe.db.exists("BEI Goods Receipt", {
             "purchase_order": purchase_order,
-            "status": ["in", ["Submitted", "Approved", "Inspected", "Accepted"]]
+            "status": ["in", ["Submitted", "Approved", "Inspected", "Accepted", "Partially Accepted"]]
         })
         if not gr_exists:
             # Check if an approved match exception exists for this PO
@@ -2948,7 +2948,7 @@ def create_payment_request(data: dict[str, Any] | str) -> dict[str, Any]:
             # Note: GR status can be "Accepted" after the receive+inspect workflow
             gr_exists = frappe.db.exists("BEI Goods Receipt", {
                 "purchase_order": purchase_order,
-                "status": ["in", ["Submitted", "Approved", "Inspected", "Accepted"]]
+                "status": ["in", ["Submitted", "Approved", "Inspected", "Accepted", "Partially Accepted"]]
             })
             if not gr_exists:
                 # Check if an approved match exception exists for this PO

--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -2225,9 +2225,12 @@ def create_goods_receipt(data: dict[str, Any] | str | None = None) -> dict[str, 
     # When called from API integrations (E2E tests, batch import), allow the
     # caller to advance the GR straight to "Pending Inspection" so the
     # downstream complete_inspection action is reachable in a single call
-    # chain. Default behaviour stays unchanged for the standard UI flow.
-    if auto_submit and gr.docstatus == 0:
-        gr.submit()
+    # chain. Use the BEI submit_receipt() business method (sets status to
+    # "Pending Inspection") rather than Frappe's bare gr.submit() which only
+    # flips docstatus and leaves status="Draft" — that broke S194-9 because
+    # complete_inspection() requires status="Pending Inspection".
+    if auto_submit and gr.status == "Draft":
+        gr.submit_receipt()
     frappe.db.release_savepoint("goods_receipt_creation")
 
     return {"success": True, "name": gr.name, "status": gr.status, "message": _("GR created")}


### PR DESCRIPTION
## Summary
- `create_goods_receipt(auto_submit=true)` now calls `gr.submit_receipt()` (BEI business method) instead of `gr.submit()` (Frappe's bare docstatus flip)
- This sets `status = "Pending Inspection"` so the immediately-following `complete_inspection()` call succeeds

## Root cause
iter13 trace for S194-9 (GR full receive + Invoice 3-way matched):
```
trace6: 200 POST create_goods_receipt
trace6: 417 POST run_doc_method (complete_inspection)
  -> {"exception":"ValidationError: GR is not pending inspection"}
trace7: 200 POST create_invoice
  -> {"success":false,"message":"No Goods Receipt found for PO. Exception approval required."}
```

`gr.submit()` only flips `docstatus` 0→1 — leaves the BEI `status` field at "Draft". `complete_inspection()` (line 154) checks `if self.status != "Pending Inspection": frappe.throw()`. The throw cascaded into invoice creation finding no usable GR.

## Test plan
- [ ] iter14 sweep: S194-9 (GR full receive + Invoice 3-way matched) passes
- [ ] S194-10/11/12/etc that depend on `auto_submit` GR creation also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)