### PR TITLE
fix(S204 followup): clamp both positional args in patched_log_error

### DIFF
--- a/hrms/utils/sentry.py
+++ b/hrms/utils/sentry.py
@@ -312,17 +312,24 @@ def _patch_log_error():
 
 		def patched_log_error(*args, **kwargs):
 			# S204: Error-handler self-harm guard — Frappe's Error Log.method
-			# field is VARCHAR(140). When the title (second positional) or
-			# derived first-line-of-message exceeds that limit, the insert
-			# throws `throw_length_exceeded_error`, which PROPAGATES OUT of
-			# the except block the caller thought was silent. Callers across
-			# hrms/api pass long exception reprs as message; the first line
-			# becomes the title and trips the 140-char cap, masking the real
-			# root cause. Clamp title explicitly before forwarding.
-			if len(args) >= 2 and isinstance(args[1], str) and len(args[1]) > 135:
-				args = (args[0], args[1][:132] + "...", *args[2:])
-			if "title" in kwargs and isinstance(kwargs["title"], str) and len(kwargs["title"]) > 135:
-				kwargs["title"] = kwargs["title"][:132] + "..."
+			# field is VARCHAR(140). frappe.log_error's own auto-swap only
+			# fires when `"\n" in title`; single-line long strings (common
+			# for `frappe.ValidationError("...allowlist...")`) stay as title
+			# and trip the cap. This causes the insert to throw, which
+			# propagates OUT of the caller's silent except block and masks
+			# the real root cause. Clamp BOTH positional args + title kwarg
+			# defensively, regardless of argument order / intent.
+			new_args = list(args)
+			for idx in (0, 1):
+				if idx < len(new_args) and isinstance(new_args[idx], str) and len(new_args[idx]) > 135:
+					new_args[idx] = new_args[idx][:132] + "..."
+			args = tuple(new_args)
+			for key in ("title", "message"):
+				if key in kwargs and isinstance(kwargs[key], str) and len(kwargs[key]) > 135:
+					# Only clamp title; leave message alone unless it's also overlong
+					# enough to cause issues (Error Log.error is TEXT, no cap).
+					if key == "title":
+						kwargs[key] = kwargs[key][:132] + "..."
 			result = _original_log_error(*args, **kwargs)
 
 			try:


### PR DESCRIPTION
## Summary
Follow-up to hrms#621. The original clamp only guarded `args[1]` (title-position when called with two positionals). But many hrms callers pass a long exception repr as the FIRST arg — `frappe.log_error(f\"S198: Auto-create WR failed ...: {e}\", \"Warehouse API\")`. Frappe's signature is `log_error(title=None, message=None, ...)` so the long string lands as TITLE and trips the 140-char Error Log.method cap.

Frappe has an auto-swap fallback — but only when `\"\n\" in title`. Single-line long validation errors (like `frappe.ValidationError(\"Target warehouse must belong to one of: [allowlist]\")`) don't contain newlines, so the swap doesn't fire and the insert throws `CharacterLengthExceededError`. That propagates out of the caller's silent except block and masks the real root cause.

## Observed this session
During S204 L3 S2 rerun, SE `MAT-STE-2026-00413` (SM Megamall dispatch via test.scm) silently failed WR auto-create. Error Log for the window shows:
```
CharacterLengthExceededError: Error Log ...: '<strong>Title</strong>' will get truncated, as max characters allowed is 140
```
No S198 error log entry (because the log itself crashed). Direct SSM call to `_create_warehouse_receiving_for_se(se, contract)` as Administrator succeeded immediately — proving the product code works, the log wrapper is what's broken.

## Fix
Clamp both `args[0]` AND `args[1]` in `patched_log_error` regardless of intent. Also clamp `title` kwarg (message kwarg is left alone — `Error Log.error` is TEXT, no cap). Order-agnostic, defensive.

## Blast radius
Pure wrapper change. No semantic change. Only trims overlong strings before forwarding. Frappe's own auto-swap and `log_error` body run unchanged.

## Test plan
- [x] Verified root cause via S204 S2 trace.
- [ ] After merge + deploy: rerun S204 L3 S2 — WR auto-create should fire + get logged if anything still fails.

## Related
- hrms#621 (initial clamp + admin wrap + auto-derive allowlist) — MERGED
- output/l3/s204/ evidence shows SE created without WR for SM Megamall when hook error got swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)