### PR TITLE
fix(S205): setSupplierField NULL uses empty string (S194-15)

### DIFF
--- a/scripts/s194_preflight_setup.py
+++ b/scripts/s194_preflight_setup.py
@@ -159,7 +159,10 @@ def cmd_set_supplier_status(args: argparse.Namespace) -> None:
 
 
 def cmd_set_supplier_field(args: argparse.Namespace) -> None:
-    value = None if args.value == "NULL" else args.value
+    # Frappe REST PUT ignores JSON null — use empty string to actually clear
+    # a field. S194-15: setSupplierField(..., tin, NULL) needs to empty the
+    # TIN so the gate fires. Sending {"tin": null} was a no-op.
+    value = "" if args.value == "NULL" else args.value
     _update_doc(SUPPLIER_DOCTYPE, args.code, {args.field: value})
     print(json.dumps({"code": args.code, "field": args.field, "value": value}))
 


### PR DESCRIPTION
iter19 trace S194-15: convert-to-po succeeded (PO created) because setSupplierField with NULL value didn't actually clear TIN. Frappe REST PUT ignores JSON null. Fix: use empty string "" to actually clear. Tests unblocked: S194-15 (TIN gate).