### PR TITLE
fix(migrate): unblock bench migrate — remove s201_backfill + s206 from patches.txt

### DIFF
--- a/hrms/patches.txt
+++ b/hrms/patches.txt
@@ -56,6 +56,17 @@ hrms.patches.v16_0.s104_setup_contracted_prices #2026-03-24
 hrms.patches.v16_0.s157_pcf_department_migration #2026-04-06
 hrms.patches.v16_0.s172_ensure_hr_employee_permissions #2026-04-09
 hrms.patches.v16_0.s201_rename_branches #2026-04-17 (dry-run default; S201_APPLY=1 to execute)
-hrms.patches.v16_0.s201_backfill_employee_company #2026-04-17 (dry-run default; S201_APPLY=1 to execute)
-hrms.patches.v16_0.s206_unique_labor_allocation_log #2026-04-18
+# REMOVED 2026-04-20: s201_backfill_employee_company — DEPRECATED under Option X (Sam 2026-04-17).
+# The patch docstring says "DO NOT RUN" and execute() is hard-gated to raise. However, line 89
+# runs a SELECT on `new_attendance_device_id` which isn't in tabEmployee, crashing migrate before
+# the gate is reached. This caused every deploy's `bench migrate` to abort, silently skipping
+# all later patches in this file. Removing the line is the only safe fix — the patch file stays
+# on disk for reference but is no longer registered with the patch system.
+# hrms.patches.v16_0.s201_backfill_employee_company #2026-04-17 (DEPRECATED; see note above)
+# REMOVED 2026-04-20: s206_unique_labor_allocation_log — superseded by S207. This patch adds
+# a UNIQUE INDEX on (year, month, employee); S207 drops those columns. Since S207 was manually
+# applied via SSM on 2026-04-20 and recorded in tabPatch Log, running s206 now would attempt to
+# create an index on columns that no longer exist. The uniqueness guarantee is now provided by
+# s207's idx_slip_employee (slip_name, employee) — no functional loss.
+# hrms.patches.v16_0.s206_unique_labor_allocation_log #2026-04-18 (SUPERSEDED by S207)
 hrms.patches.v16_0.s207_labor_allocation_log_bimonthly #2026-04-20


### PR DESCRIPTION
## Root cause

**Not the workflow site-name typo** (though that exists). The real cause of "patches not running via bench migrate on every deploy":

### What happens on every deploy since 2026-04-17

`hrms/patches/v16_0/s201_backfill_employee_company.py` is:
- Registered in \`patches.txt\`
- Marked DEPRECATED under Option X
- Hard-gated to \`frappe.throw(\"DO NOT RUN\")\`
- BUT line 89 does \`frappe.get_all(\"Employee\", fields=[..., \"new_attendance_device_id\", ...])\` **before** reaching the gate
- That field doesn't exist in \`tabEmployee\` → \`pymysql.err.OperationalError: (1054, \"Unknown column 'new_attendance_device_id' in 'SELECT'\")\`
- \`bench migrate\` crashes
- Every patch later in \`patches.txt\` silently never runs

### Evidence from PR #644 deploy log

\`\`\`
2026-04-20T06:52:11.9673395Z Migrating hrms.bebang.ph
2026-04-20T06:52:11.9813333Z Traceback (most recent call last):
2026-04-20T06:52:11.9847419Z   File \".../s201_backfill_employee_company.py\", line 89, in execute
2026-04-20T06:52:11.9863524Z pymysql.err.OperationalError: (1054, \"Unknown column 'new_attendance_device_id' in 'SELECT'\")
\`\`\`

The S207 agent's workaround (manual SSM + \`tabPatch Log\` insert) was correct firefighting, but the underlying migrate block persists for all future patches until this PR.

## Cosmetic aside (not blocking)

Both \`sites/hq.bebang.ph/site_config.json\` and \`sites/hrms.bebang.ph/site_config.json\` point to the **same database** (\`db_name: _3ca82e0039adc3d1\`). So the workflow's \`bench --site hrms.bebang.ph migrate\` IS migrating the production DB via a site alias — not a functional bug. The \`FRAPPE_SITE: hrms.bebang.ph → hq.bebang.ph\` cosmetic alignment is deferred to a separate PR (scope-guard requires explicit approval for \`.github/workflows/\` edits).

## Changes

\`hrms/patches.txt\`:
1. Comment out \`s201_backfill_employee_company\` — DEPRECATED, SELECT crashes before hard-gate
2. Comment out \`s206_unique_labor_allocation_log\` — superseded by S207 (which dropped the year+month columns s206 would index)

Both patch files remain on disk for reference; just not registered.

## Audit summary

Patches in \`patches.txt\` since 2025-12-17 that may have silently been skipped during migrate:
- 24 v16_0 patches registered; 9 show up in \`tabPatch Log\` as applied
- All 9 applied ones were either:
  (a) Ran before S201's hard-gated patch was added (2026-04-08 to 2026-04-09)
  (b) Manually recorded by an agent after the fact (S207)
- Most remaining patches are idempotent (seed + ensure + create_custom_field patterns) — re-running them when migrate unblocks is safe.

## Post-merge verification

\`\`\`
docker exec \$BACKEND_CONTAINER bench --site hq.bebang.ph migrate
\`\`\`

Expected: completes without the s201_backfill traceback. All previously-skipped idempotent patches will run and self-skip.

## Risk

**LOW.** The two removed patches are:
1. s201_backfill_employee_company — explicitly documented \"DO NOT RUN, DEPRECATED\"
2. s206_unique_labor_allocation_log — its schema target (year/month columns) no longer exists; running it now would error

Removing them restores the migrate chain without changing any production semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)