### PR TITLE
fix(S205): set match_status=Rejected on reject_variance (S194-27)

### DIFF
--- a/hrms/hr/doctype/bei_invoice/bei_invoice.json
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.json
@@ -179,7 +179,7 @@
    "fieldname": "match_status",
    "fieldtype": "Select",
    "label": "Match Status",
-   "options": "Pending\nMatched\nVariance Detected\nApproved with Variance",
+   "options": "Pending\nMatched\nVariance Detected\nApproved with Variance\nRejected",
    "read_only": 1
   },
   {

--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -223,6 +223,12 @@ class BEIInvoice(Document):
 
 		self.variance_notes = reason
 		self.status = "Match Failed"
+		# Surface rejection on the displayed match-status badge so operators
+		# (and S194-27 cert) can see the disposition without drilling into
+		# raw status. The "Match Failed" status keeps the existing semantics
+		# for downstream filters; "Rejected" on match_status is the
+		# user-visible decision label.
+		self.match_status = "Rejected"
 		self.save()
 
 		return {"success": True, "message": _("Invoice rejected due to variance")}


### PR DESCRIPTION
## Summary
iter30 showed S194-27 backend reject_variance returns 200 success and the Reject Variance UI (from PR #437) clicks correctly, but \`assertStatusIs(/Rejected|Pending\s*3-Way/)\` still fails because the visible badge near the invoice h1 shows \`match_status\` (\"Variance Detected\") not \`status\` (\"Match Failed\") — and neither matches the test pattern.

## Fix
1. Add \"Rejected\" to the match_status DocType options
2. In reject_variance(), set match_status=\"Rejected\" alongside the existing status=\"Match Failed\"

The status=\"Match Failed\" semantics are preserved for any downstream filters; match_status=\"Rejected\" surfaces the disposition on the user-visible badge so operators (and S194-27 cert) can read the decision.

## Test plan
- [ ] Deploy to hq.bebang.ph
- [ ] Re-run S194 sweep → expect S194-27 PASS
- [ ] Existing variance tests (S194-10 approve, S194-17/21 unrelated) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)