### PR TITLE
fix(S205): preserve match_status=Rejected through validate() (S194-27 round 2)

### DIFF
--- a/hrms/hr/doctype/bei_invoice/bei_invoice.py
+++ b/hrms/hr/doctype/bei_invoice/bei_invoice.py
@@ -116,8 +116,12 @@ class BEIInvoice(Document):
 			self.match_status = "Pending"
 			return
 
-		# Preserve approved variance status - don't recalculate after approval
-		if self.match_status == "Approved with Variance":
+		# Preserve terminal match dispositions — don't recalculate after a
+		# variance has been explicitly approved or rejected. Without this
+		# guard, every validate() (including the one triggered by
+		# reject_variance's self.save()) would reset match_status back to
+		# "Variance Detected" and overwrite the operator's decision.
+		if self.match_status in ("Approved with Variance", "Rejected"):
 			return
 
 		# Calculate variances


### PR DESCRIPTION
## Summary
PR #658 set match_status=\"Rejected\" in reject_variance, but iter31 still failed S194-27. Live data proves the bug: after reject_variance runs, invoices have status=\"Match Failed\" BUT match_status=\"Variance Detected\" — my set is being overwritten.

Root cause: \`perform_three_way_match\` runs in \`validate()\` on every save (including the save inside \`reject_variance\`). It only preserves \"Approved with Variance\" as a terminal state; \"Rejected\" isn't in the preservation list, so it gets reset back to \"Variance Detected\" based on the live variance numbers.

## Fix
Extend the terminal-disposition preservation branch from \`Approved with Variance\` to also cover \`Rejected\`.

## Live verification
\`\`\`
{name: INV-2026-10458, status: Match Failed, match_status: Variance Detected}
{name: INV-2026-10454, status: Match Failed, match_status: Variance Detected}
{name: INV-2026-10354, status: Match Failed, match_status: Variance Detected}
\`\`\`
All three had reject_variance run (status=Match Failed) but match_status lost.

## Test plan
- [ ] Deploy to hq.bebang.ph
- [ ] Re-run S194 sweep → expect S194-27 PASS
- [ ] S194-10 (variance approve) unaffected (Approved with Variance preservation preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)