### PR TITLE
S210 Phase 10: multi-line delivery support + SI match bug fix

### DIFF
--- a/output/s210/ONBOARDING_3PL_COMMS.md
+++ b/output/s210/ONBOARDING_3PL_COMMS.md
@@ -63,6 +63,35 @@ Material Description | Qty Received | UoM | SI Number | Trucker's Name |
 Plate Number | Production Date | Expiration Date | Received By | Notes
 ```
 
+### Multi-line deliveries (Phase 10 UX assist)
+
+One PO drop often has multiple items on the same truck with the same SI. The
+3PL types the **header fields** on the first line of the delivery, then
+leaves them BLANK on subsequent lines of the same delivery — Apps Script
+auto-inherits from the most recent prior row.
+
+**Header fields (auto-inherited when blank):** RR Number, PO Number, Supplier,
+SI Number, Trucker's Name, Plate Number, Received By.
+
+**Per-line fields (NEVER inherited — must be typed every row):** Material Code,
+Material Description, Qty Received, UoM, Production Date, Expiration Date, Notes.
+
+Example — one 3MD delivery with 3 items:
+
+| Timestamp | RR# | PO# | Supplier | Material | Qty | UoM | SI# | Trucker |
+|---|---|---|---|---|---|---|---|---|
+| 10:15 | RR-0041 | PO-2026-1234 | DIMAX | FLOUR-25KG | 10 | BAG | SI-8877 | Juan |
+| 10:15 | _(blank)_ | _(blank)_ | _(blank)_ | SUGAR-50KG | 5 | BAG | _(blank)_ | _(blank)_ |
+| 10:15 | _(blank)_ | _(blank)_ | _(blank)_ | YEAST-1KG | 2 | PC | _(blank)_ | _(blank)_ |
+
+Sheet C consolidated still gets 3 rows, each with RR-0041 / PO-2026-1234 /
+DIMAX / SI-8877 / Juan fully populated. When the supplier later uploads
+SI-8877 via the form, all 3 rows are tagged `SI_Matched=TRUE`
+simultaneously (Phase 10 fix to match-all-rows).
+
+The audit log records `inherited_cols=3,4,5,9,10,11,14` (or whichever
+columns were auto-filled) so the trail is explicit.
+
 ### Edit behaviour gotchas
 
 | Action | Effect |

--- a/output/s210/phase10_redeploy.py
+++ b/output/s210/phase10_redeploy.py
@@ -1,0 +1,94 @@
+"""S210 Phase 10 — redeploy updated .gs to the existing web-app URL.
+
+Why: we added multi-line delivery support to _handleNewReceipts
+(header-field inheritance) and fixed the SI-match bug in handleSiUpload
+(tag ALL matching consolidated rows, not just the first). Cloud Scheduler
+jobs already point to the existing web-app URL, so we:
+
+  1. Re-upload .gs via Apps Script API
+  2. Create a new version (snapshot of the updated source)
+  3. PATCH the existing deployment to point to the new version -
+     URL stays the same, Scheduler jobs require no changes.
+  4. Smoke-test /exec?fn=ping to confirm the new code is live.
+
+Run:
+    python output/s210/phase10_redeploy.py
+"""
+import json, pathlib, sys, urllib.parse, urllib.request
+sys.stdout.reconfigure(encoding='utf-8')
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SA = pathlib.Path(r'F:\Dropbox\Projects\BEI-ERP\credentials\task-manager-service.json')
+ids = json.loads((ROOT / 'output/s210/SHEET_IDS.json').read_text())
+cloud = json.loads((ROOT / 'output/s210/CLOUD_SCHEDULER.json').read_text())
+
+SHARED_TOKEN = 's210-b3i-a8F2kQ9mZv7RpYxLnCdT4wE6hG1jN5uH0sK3'
+
+creds = service_account.Credentials.from_service_account_file(
+    str(SA),
+    scopes=[
+        'https://www.googleapis.com/auth/script.projects',
+        'https://www.googleapis.com/auth/script.deployments',
+    ],
+).with_subject('sam@bebang.ph')
+api = build('script', 'v1', credentials=creds, cache_discovery=False)
+
+gs = (ROOT / 'scripts/google_apps/s210_master_handler.gs').read_text(encoding='utf-8')
+manifest = (ROOT / 'scripts/google_apps/s210_appsscript.json').read_text(encoding='utf-8')
+
+script_id = ids['apps_script_id']
+deployment_id = cloud['deployment_id']
+
+print(f'[1/4] Pushing updated source to {script_id}')
+cur = api.projects().getContent(scriptId=script_id).execute()
+new_files = []
+for f in cur.get('files', []):
+    if f['name'] == 'appsscript':
+        new_files.append({'name': 'appsscript', 'type': 'JSON', 'source': manifest})
+    elif f['name'] == 's210_master_handler':
+        new_files.append({'name': 's210_master_handler', 'type': 'SERVER_JS', 'source': gs})
+    else:
+        new_files.append({'name': f['name'], 'type': f['type'], 'source': f['source']})
+
+api.projects().updateContent(scriptId=script_id, body={'files': new_files}).execute()
+
+print(f'[2/4] Creating new version')
+v = api.projects().versions().create(
+    scriptId=script_id,
+    body={'description': 'S210 Phase 10: multi-line delivery support + SI match fix'},
+).execute()
+version_num = v['versionNumber']
+print(f'  Version {version_num}')
+
+print(f'[3/4] Updating deployment {deployment_id} to new version')
+updated = api.projects().deployments().update(
+    scriptId=script_id,
+    deploymentId=deployment_id,
+    body={
+        'deploymentConfig': {
+            'versionNumber': version_num,
+            'manifestFileName': 'appsscript',
+            'description': f'S210 Phase 10 (v{version_num})',
+        },
+    },
+).execute()
+web_url = None
+for ep in updated.get('entryPoints', []):
+    if ep.get('entryPointType') == 'WEB_APP':
+        web_url = ep['webApp']['url']
+        break
+web_url = web_url or cloud['web_app_url']
+print(f'  URL unchanged: {web_url}')
+
+print('[4/4] Smoke-test')
+test_url = f'{web_url}?{urllib.parse.urlencode({"key": SHARED_TOKEN, "fn": "ping"})}'
+with urllib.request.urlopen(test_url, timeout=30) as r:
+    print(f'  Ping: {r.read().decode()[:200]}')
+
+poll_url = f'{web_url}?{urllib.parse.urlencode({"key": SHARED_TOKEN, "fn": "pollAll"})}'
+with urllib.request.urlopen(poll_url, timeout=120) as r:
+    print(f'  pollAll: {r.read().decode()[:400]}')
+
+print('\nDone. Cloud Scheduler jobs continue hitting the same URL; they pick up the new code on next fire.')

--- a/scripts/google_apps/s210_master_handler.gs
+++ b/scripts/google_apps/s210_master_handler.gs
@@ -253,6 +253,13 @@ function validateReceipt(rowData) {
  * Shared handler — reads new rows from a source sheet's Receipts tab since
  * last run, writes each into Sheet C consolidated + (validated → Pending GR)
  * or (invalid → Variance Queue), and posts Chat notifications.
+ *
+ * Multi-line delivery support (Phase 10): header fields (RR#, PO#, Supplier,
+ * SI#, Trucker, Plate, Received By) auto-inherit from the most recent prior
+ * row with a non-blank value in each column. This lets the 3PL type header
+ * fields once for the first line of a delivery and leave them blank on
+ * subsequent lines (just Material Code + Qty + UoM + dates). Per-line fields
+ * (Material, Qty, UoM, Production/Expiration Date, Notes) are NEVER inherited.
  */
 function _handleNewReceipts(sourceSheetId, sourceLabel) {
   const props = PropertiesService.getScriptProperties();
@@ -275,11 +282,22 @@ function _handleNewReceipts(sourceSheetId, sourceLabel) {
   let latestMs = lastSeen;
   let processed = 0;
   for (let i = 1; i < data.length; i++) {
-    const row = data[i];
-    const tsRaw = row[COL_TIMESTAMP];
+    const rawRow = data[i];
+    const tsRaw = rawRow[COL_TIMESTAMP];
     if (!tsRaw) continue;
     const rowMs = new Date(tsRaw).getTime();
     if (isNaN(rowMs) || rowMs <= lastSeen) continue;
+
+    // Phase 10: inherit blank header fields from the most recent prior row
+    // that has them populated. Lets 3PL type shared fields once per delivery.
+    const row = _fillInheritedHeaders(data, i);
+    const inherited = [];
+    const HEADER_COLS = [COL_RR, COL_PO, COL_SUPPLIER, COL_SI_NUM,
+                         COL_TRUCKER, COL_PLATE, COL_RECEIVED_BY];
+    for (const c of HEADER_COLS) {
+      if (!_isBlank(rawRow[c]) && _isBlank(row[c])) continue;
+      if (_isBlank(rawRow[c]) && !_isBlank(row[c])) inherited.push(c);
+    }
 
     const validation = validateReceipt(row);
 
@@ -309,7 +327,8 @@ function _handleNewReceipts(sourceSheetId, sourceLabel) {
         'PENDING', // Status
         false,     // Picked_Up_By_AppSheet
       ]);
-      _logAudit(auditLog, 'receipt_edit', sourceLabel, i + 1, 'Pending_GR_written', 'OK', '');
+      _logAudit(auditLog, 'receipt_edit', sourceLabel, i + 1, 'Pending_GR_written', 'OK',
+                inherited.length ? 'inherited_cols=' + inherited.join(',') : '');
       postChatNotification({
         source: sourceLabel,
         po: row[COL_PO],
@@ -341,6 +360,39 @@ function _handleNewReceipts(sourceSheetId, sourceLabel) {
 function handleNewReceipt_3MD() { _handleNewReceipts(SHEET_A, '3MD'); }
 function handleNewReceipt_Pinnacle() { _handleNewReceipts(SHEET_B, 'Pinnacle'); }
 function handleNewReceipt_Shaw() { _handleNewReceipts(SHEET_D, 'Shaw'); }
+
+/**
+ * _isBlank — treats '', null, undefined, whitespace-only strings as blank.
+ */
+function _isBlank(v) {
+  if (v === null || v === undefined) return true;
+  return String(v).trim() === '';
+}
+
+/**
+ * _fillInheritedHeaders — returns a copy of data[rowIdx] with blank header
+ * fields populated from the most recent prior row that has them. Per-line
+ * fields are NEVER inherited.
+ *
+ * Inherited header columns: RR#, PO#, Supplier, SI#, Trucker, Plate, Received By.
+ * Per-line (never inherited): Material Code/Desc, Qty, UoM, Production Date,
+ * Expiration Date, Notes, Timestamp, 3PL.
+ */
+function _fillInheritedHeaders(data, rowIdx) {
+  const HEADER_COLS = [COL_RR, COL_PO, COL_SUPPLIER, COL_SI_NUM,
+                       COL_TRUCKER, COL_PLATE, COL_RECEIVED_BY];
+  const row = data[rowIdx].slice();  // shallow copy
+  for (const col of HEADER_COLS) {
+    if (!_isBlank(row[col])) continue;
+    for (let j = rowIdx - 1; j >= 1; j--) {
+      if (!_isBlank(data[j][col])) {
+        row[col] = data[j][col];
+        break;
+      }
+    }
+  }
+  return row;
+}
 
 // ========================================================================
 // Chat notifications
@@ -779,12 +831,14 @@ function handleSiUpload(e) {
 
   const timestamp = new Date();
 
-  // Attempt match by (PO#, SI#) — normalize whitespace + case
+  // Attempt match by (PO#, SI#) — normalize whitespace + case.
+  // Phase 10: match ALL consolidated rows with the same (PO#, SI#), not just
+  // the first. Multi-line deliveries create N consolidated rows sharing the
+  // PO#/SI#; every one must be tagged SI_Matched when the supplier uploads.
   const normPo = String(poNumber).trim().toUpperCase();
   const normSi = String(siNumber).trim().toUpperCase();
 
-  let matchedRow = -1;
-  let matchedRRNumber = '';
+  const matchedConsolidatedRows = [];  // [{ rowIdx, rr }]
   if (normPo && normSi) {
     const data = consolidated.getDataRange().getValues();
     // col indexes (0-based in data): 3=RR, 4=PO, 10=SI Number
@@ -792,32 +846,34 @@ function handleSiUpload(e) {
       const rowPo = String(data[i][4] || '').trim().toUpperCase();
       const rowSi = String(data[i][10] || '').trim().toUpperCase();
       if (rowPo === normPo && rowSi === normSi) {
-        matchedRow = i + 1;  // 1-based for setValue
-        matchedRRNumber = data[i][3];
-        break;
+        matchedConsolidatedRows.push({ rowIdx: i + 1, rr: data[i][3] });
       }
     }
   }
 
-  const matchStatus = matchedRow > 0 ? 'MATCHED' : 'ORPHAN';
+  const matchStatus = matchedConsolidatedRows.length > 0 ? 'MATCHED' : 'ORPHAN';
+  const matchedRRList = matchedConsolidatedRows.map(function(m) { return m.rr; }).join(',');
 
   // Write into 03_Supplier_SI_Uploads
   siUploads.appendRow([
     timestamp, supplierName, poNumber, siNumber, siDate,
-    amount, siPdfLink, notes, matchStatus, matchedRRNumber,
-    matchedRow > 0 ? timestamp : '',
+    amount, siPdfLink, notes, matchStatus, matchedRRList,
+    matchedConsolidatedRows.length > 0 ? timestamp : '',
   ]);
 
-  if (matchedRow > 0) {
-    // Tag the matched DR row in consolidated:
+  if (matchedConsolidatedRows.length > 0) {
+    // Tag EVERY matched DR row in consolidated:
     // col T = SI_Matched (20), col U = SI_Upload_Link (21), col V = SI_Match_Timestamp (22)
-    consolidated.getRange(matchedRow, 20).setValue(true);
-    consolidated.getRange(matchedRow, 21).setValue(siPdfLink);
-    consolidated.getRange(matchedRow, 22).setValue(timestamp);
+    for (const m of matchedConsolidatedRows) {
+      consolidated.getRange(m.rowIdx, 20).setValue(true);
+      consolidated.getRange(m.rowIdx, 21).setValue(siPdfLink);
+      consolidated.getRange(m.rowIdx, 22).setValue(timestamp);
+    }
 
-    // Also tag Pending GR row if present
+    // Also tag EVERY matching Pending GR row (same multi-line fix)
     const pending = masterSs.getSheetByName('06_Pending_GR');
     const pendingData = pending.getDataRange().getValues();
+    let pendingTagged = 0;
     for (let i = 1; i < pendingData.length; i++) {
       const rowPo = String(pendingData[i][3] || '').trim().toUpperCase();
       const rowSi = String(pendingData[i][9] || '').trim().toUpperCase();
@@ -825,13 +881,14 @@ function handleSiUpload(e) {
         // Update SI PDF Link (col 11 = K, 1-based index 11)
         pending.getRange(i + 1, 11).setValue(siPdfLink);
         pending.getRange(i + 1, 12).setValue('READY');
-        break;
+        pendingTagged++;
       }
     }
 
-    _logAudit(auditLog, 'handleSiUpload', supplierName, matchedRow,
-              'SI_matched_to_RR_' + matchedRRNumber, 'OK',
-              'PO=' + poNumber + ' SI=' + siNumber);
+    _logAudit(auditLog, 'handleSiUpload', supplierName, matchedConsolidatedRows.length,
+              'SI_matched_' + matchedConsolidatedRows.length + '_DR_rows', 'OK',
+              'PO=' + poNumber + ' SI=' + siNumber +
+              ' RRs=' + matchedRRList + ' pendingTagged=' + pendingTagged);
   } else {
     // Orphan: write to 04_Match_Queue for manual resolution
     matchQueue.appendRow([


### PR DESCRIPTION
## Summary

Two issues fixed in the already-live S210 pipeline:

### 1. SI match bug (prod bug — silent)

Previous `handleSiUpload` stopped at the first matching (PO#, SI#) row and tagged only that one. On multi-line deliveries (1 PO + 1 SI covering 3 materials = 3 consolidated rows), lines 2..N stayed \`SI_Matched=FALSE\` forever and aged into the Variance Queue at 72h even though the supplier uploaded correctly.

Fix: collect all matches into \`matchedConsolidatedRows[]\`, tag every consolidated + pending-GR row. Audit log reads \`SI_matched_N_DR_rows\` so multi-line matches are visible.

### 2. Multi-line delivery UX (new feature)

One truck drop + one PO + one SI often covers multiple materials. The 3PL should type the header fields (RR#, PO#, Supplier, SI#, Trucker, Plate, Received By) **once**, leave them blank on subsequent lines, and only fill Material + Qty + UoM + dates.

\`_fillInheritedHeaders()\` in \`_handleNewReceipts\` does the inheritance in-memory during the poll. Per-line fields (Material, Qty, UoM, Production/Expiration Date, Notes) are NEVER inherited — must be typed every row.

Example (3PL types this):

| RR# | PO# | Supplier | Material | Qty | UoM | SI# | Trucker |
|---|---|---|---|---|---|---|---|
| RR-0041 | PO-2026-1234 | DIMAX | FLOUR-25KG | 10 | BAG | SI-8877 | Juan |
| _blank_ | _blank_ | _blank_ | SUGAR-50KG | 5 | BAG | _blank_ | _blank_ |
| _blank_ | _blank_ | _blank_ | YEAST-1KG | 2 | PC | _blank_ | _blank_ |

Sheet C master receives 3 fully-populated rows; supplier's single SI-8877 upload tags all 3.

## Deployment

Updated existing web-app deployment to version 4 (URL unchanged — Cloud Scheduler jobs need no reconfig).

Live smoke tests PASS:
- \`GET /exec?fn=ping\` → \`{"ok":true,"fn":"ping","result":{"pong":true}}\`
- \`GET /exec?fn=pollAll\` → \`{"ok":true,"elapsed_ms":7687,"result":{"receipts":{"a":"ok","b":"ok","d":"ok"},"form":{"processed":0}}}\`

## Docs

ONBOARDING_3PL_COMMS.md gains a new section "Multi-line deliveries" with concrete example and explicit header-vs-per-line field lists.

## Test plan

- [x] Ping live web app
- [x] pollAll returns ok across all 3 sheets + form poll
- [ ] Create a 3-line test delivery in Sheet A: header-filled line 1, blank headers lines 2-3 → confirm 3 consolidated rows with identical header fields
- [ ] Submit test SI for that delivery's (PO#, SI#) via form → confirm all 3 consolidated rows get SI_Matched=TRUE and SI_Upload_Link populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)