### PR TITLE
investigate(S220): backend probe rules out filter hypothesis — UI rendering is the bug

### DIFF
--- a/output/l3/s220/BACKEND_INVESTIGATION_FINDINGS.md
+++ b/output/l3/s220/BACKEND_INVESTIGATION_FINDINGS.md
@@ -1,0 +1,70 @@
+# S220 Backend Investigation — Key Finding
+
+**Date:** 2026-04-22 PHT
+**Objective:** Find why ARANETA GATEWAY passes approval but FESTIVAL MALL ALABANG fails
+**Method:** Direct API submit of fresh orders + live backend probe as test.area
+
+## Result — my DEFECT-11 hypothesis was WRONG
+
+### Both orders look identical at the backend
+
+| Field | ARANETA | FESTIVAL MALL |
+|---|---|---|
+| Order status | Pending Approval | Pending Approval |
+| approval_stage | Pending Area Supervisor | Pending Area Supervisor |
+| requires_dual_approval | 1 | 1 |
+| edited_lines_count | 3 | 2 |
+| Queue entries (recent) | 10 (1 Pending) | 8 (1 Pending) |
+| Latest queue: approver | test.area@bebang.ph | test.area@bebang.ph |
+| Latest queue: status | Pending | Pending |
+
+### UI filter result (`get_order_review_queue` as test.area)
+
+```
+Total orders visible: 2
+ARANETA visible: True
+FESTIVAL visible: True
+```
+
+**Both orders are visible to test.area via the backend UI filter.**
+
+## What this rules out
+
+- ~~`requires_manual_approval=False` leaves orders without queue entries~~ → both have queue entries
+- ~~Queue entry not assigned to test.area~~ → both assigned to test.area
+- ~~`get_order_review_queue` SQL filter excludes the order~~ → both returned
+
+## What's left
+
+The UI times out waiting for the order text (`getByText(orderId).first()`) to become visible. Backend confirms the order IS in the list returned to test.area. So either:
+
+1. **UI pagination/slicing** — the approval page renders only N rows; FESTIVAL MALL's order might be past the visible slice
+2. **UI sorting/filtering** — a client-side filter on the page might hide the order
+3. **UI hydration race** — the order IS eventually rendered but after the 30s waitFor
+4. **Text match failure** — the order ID text appears differently in DOM (inside a code-block, a tooltip, a different case)
+
+## Next step required: Playwright trace-zip inspection
+
+This is S221 scope. The direct API probe has reached its limit — we know the problem is client-side rendering, not backend. A Playwright trace will show:
+- What the UI page looked like at the moment of timeout
+- What DOM text was actually present
+- Whether the order was off-screen / paginated / filtered out
+- Whether a client-side filter is applied by default
+
+## Remaining 7-store DEFECT-11 cluster
+
+Based on this finding, all 7 stores (FESTIVAL MALL, MEGAWIDE PITX, MEGAWORLD VENICE, NAIA T3, ORTIGAS ESTANCIA, ROBINSONS ANTIPOLO, SM STA. ROSA) likely share the same UI-rendering bottleneck. A single fix in how the approval page renders/paginates could unblock all 7.
+
+## Evidence artifacts
+
+- `output/l3/s220/direct_submit_probe.json` — full field-by-field comparison
+- `scripts/s220_compare_pass_vs_fail.py` — reusable comparison probe
+- `scripts/s220_direct_submit.py` — fresh-order submit probe
+
+## Recommendation
+
+**STOP** test-side iteration of the sweep. The 3 recent iterations (S217/S218/S219) hit 63% plateau because:
+- S217 removed Playwright's maxFailures (made the full sweep possible)
+- S218/S219 patched the wrong root cause
+
+**Next productive move: inspect Playwright trace-zip** for one failing DEFECT-11 store to find the actual UI rendering bug. That's genuinely S221 scope — not something that can be done here without the trace artifact.

--- a/output/l3/s220/direct_submit_probe.json
+++ b/output/l3/s220/direct_submit_probe.json
@@ -1,0 +1,241 @@
+{
+  "aranete_submit": {
+    "picks": [
+      {
+        "item_code": "FG001",
+        "qty_requested": 768,
+        "suggested_qty": 1536.4,
+        "recommended_qty": 1536.4,
+        "unit_price": 14.78,
+        "deviation_reason": "Stock Correction"
+      },
+      {
+        "item_code": "PM001",
+        "qty_requested": 534,
+        "suggested_qty": 1069.47,
+        "recommended_qty": 1069.47,
+        "unit_price": 3.92,
+        "deviation_reason": "Stock Correction"
+      },
+      {
+        "item_code": "PM002",
+        "qty_requested": 577,
+        "suggested_qty": 1154.47,
+        "recommended_qty": 1154.47,
+        "unit_price": 0.9,
+        "deviation_reason": "Stock Correction"
+      }
+    ],
+    "result": {
+      "success": true,
+      "name": "BEI-ORD-2026-00398",
+      "status": "Pending Approval",
+      "requires_area_supervisor_review": true,
+      "requires_regional_manager_review": false,
+      "requires_fallback_approval": false,
+      "edited_lines_count": 3,
+      "message": "Order BEI-ORD-2026-00398 submitted successfully",
+      "approval_queue_status": "created",
+      "approval_queue_name": "BEI-APQ-2026-00737",
+      "approval_approver_source": "area_supervisor",
+      "approval_assigned_approver": "test.area@bebang.ph",
+      "fallback_approver": null,
+      "submitted_after_cutoff": true,
+      "requires_dual_approval": true,
+      "approval_stage": "Pending Area Supervisor",
+      "is_emergency": false,
+      "cargo_category": "DRY",
+      "dropped_invalid_lines": 0
+    },
+    "wh": "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC"
+  },
+  "festival_submit": {
+    "picks": [
+      {
+        "item_code": "FG001",
+        "qty_requested": 575,
+        "suggested_qty": 1151.85,
+        "recommended_qty": 1151.85,
+        "unit_price": 14.78,
+        "deviation_reason": "Stock Correction"
+      },
+      {
+        "item_code": "PM007",
+        "qty_requested": 580,
+        "suggested_qty": 1160.93,
+        "recommended_qty": 1160.93,
+        "unit_price": 98.21,
+        "deviation_reason": "Stock Correction"
+      }
+    ],
+    "result": {
+      "success": true,
+      "name": "BEI-ORD-2026-00399",
+      "status": "Pending Approval",
+      "requires_area_supervisor_review": true,
+      "requires_regional_manager_review": false,
+      "requires_fallback_approval": false,
+      "edited_lines_count": 2,
+      "message": "Order BEI-ORD-2026-00399 submitted successfully",
+      "approval_queue_status": "created",
+      "approval_queue_name": "BEI-APQ-2026-00738",
+      "approval_approver_source": "area_supervisor",
+      "approval_assigned_approver": "test.area@bebang.ph",
+      "fallback_approver": null,
+      "submitted_after_cutoff": true,
+      "requires_dual_approval": true,
+      "approval_stage": "Pending Area Supervisor",
+      "is_emergency": false,
+      "cargo_category": "DRY",
+      "dropped_invalid_lines": 0
+    },
+    "wh": "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC."
+  },
+  "aranete_backend_state": {
+    "order": "BEI-ORD-2026-00398",
+    "status": "Pending Approval",
+    "approval_stage": "Pending Area Supervisor",
+    "requires_dual_approval": 1,
+    "queue_entries": [
+      {
+        "name": "BEI-APQ-2026-00525",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00526",
+        "status": "Approved",
+        "assigned_approver": "ian@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00527",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00535",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00565",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00566",
+        "status": "Approved",
+        "assigned_approver": "ian@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00593",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00639",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00685",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00737",
+        "status": "Pending",
+        "assigned_approver": "test.area@bebang.ph"
+      }
+    ],
+    "items": [
+      {
+        "item_code": "PM002",
+        "qty_requested": 577.0,
+        "suggested_qty": 1154.47,
+        "is_edited": 1
+      },
+      {
+        "item_code": "FG001",
+        "qty_requested": 768.0,
+        "suggested_qty": 1536.4,
+        "is_edited": 1
+      },
+      {
+        "item_code": "PM001",
+        "qty_requested": 534.0,
+        "suggested_qty": 1069.47,
+        "is_edited": 1
+      }
+    ],
+    "edited_count": 3
+  },
+  "festival_backend_state": {
+    "order": "BEI-ORD-2026-00399",
+    "status": "Pending Approval",
+    "approval_stage": "Pending Area Supervisor",
+    "requires_dual_approval": 1,
+    "queue_entries": [
+      {
+        "name": "BEI-APQ-2026-00528",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00536",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00567",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00568",
+        "status": "Approved",
+        "assigned_approver": "ian@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00594",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00640",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00686",
+        "status": "Approved",
+        "assigned_approver": "test.area@bebang.ph"
+      },
+      {
+        "name": "BEI-APQ-2026-00738",
+        "status": "Pending",
+        "assigned_approver": "test.area@bebang.ph"
+      }
+    ],
+    "items": [
+      {
+        "item_code": "PM007",
+        "qty_requested": 580.0,
+        "suggested_qty": 1160.93,
+        "is_edited": 1
+      },
+      {
+        "item_code": "FG001",
+        "qty_requested": 575.0,
+        "suggested_qty": 1151.85,
+        "is_edited": 1
+      }
+    ],
+    "edited_count": 2
+  },
+  "ui_visible_to_test_area": {
+    "total": 2,
+    "aranete_visible": true,
+    "festival_visible": true
+  }
+}

--- a/output/l3/s220/pass_vs_fail_probe.json
+++ b/output/l3/s220/pass_vs_fail_probe.json
@@ -1,0 +1,6 @@
+{
+  "pass_example": null,
+  "fail_example": null,
+  "ui_filter_visible_to_test_area": [],
+  "ui_filter_total_orders_visible": 0
+}

--- a/scripts/s220_compare_pass_vs_fail.py
+++ b/scripts/s220_compare_pass_vs_fail.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""S220 — compare one PASSING vs one FAILING order's backend state to find UI filter divergence."""
+import base64, gzip, json, pathlib, sys, time
+
+AWS_REGION = "ap-southeast-1"
+INSTANCE_ID = "i-026b7477d27bd46d6"
+OUT = pathlib.Path(__file__).resolve().parent.parent / "output" / "l3" / "s220" / "pass_vs_fail_probe.json"
+OUT.parent.mkdir(parents=True, exist_ok=True)
+
+# Fresh orders from the most recent sweep (S219). Check the pass/fail state.
+SCRIPT = '''
+import json, base64, gzip
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+
+# Find recent orders matching known PASS (ARANETA) and FAIL (FESTIVAL MALL) stores
+def last_order_for_store_name_like(pattern):
+    rows = frappe.db.sql(
+        """SELECT name, store, status, approval_stage, owner, creation, is_bulk_order,
+                  is_emergency, submitted_by, approved_by, approved_at
+           FROM `tabBEI Store Order`
+           WHERE store LIKE %s AND creation >= '2026-04-22 09:00:00'
+           ORDER BY creation DESC LIMIT 1""",
+        (f"%{pattern}%",), as_dict=True,
+    )
+    return rows[0] if rows else None
+
+pass_order = last_order_for_store_name_like("ARANETA GATEWAY")
+fail_order = last_order_for_store_name_like("FESTIVAL MALL ALABANG")
+
+def enrich(order):
+    if not order:
+        return None
+    # Full order doc
+    doc = frappe.get_doc("BEI Store Order", order["name"])
+    # Approval queue entries
+    queue = frappe.db.sql(
+        """SELECT name, status, assigned_approver, submitted_at, reference_name
+           FROM `tabBEI Approval Queue`
+           WHERE reference_doctype='BEI Store Order' AND reference_name=%s""",
+        (order["name"],), as_dict=True,
+    )
+    # ToDo assignments
+    todos = frappe.db.sql(
+        """SELECT name, allocated_to, description, status
+           FROM `tabToDo` WHERE reference_type='BEI Store Order' AND reference_name=%s""",
+        (order["name"],), as_dict=True,
+    )
+    # Items with is_edited status
+    items = frappe.db.sql(
+        """SELECT item_code, qty_requested, suggested_qty, is_edited, deviation_reason
+           FROM `tabBEI Store Order Item` WHERE parent=%s""",
+        (order["name"],), as_dict=True,
+    )
+    return {
+        "order": order,
+        "docstatus": doc.docstatus,
+        "requires_dual_approval": getattr(doc, "requires_dual_approval", None),
+        "approval_stage": doc.approval_stage,
+        "queue_entries": queue,
+        "todos": todos,
+        "items": items,
+    }
+
+payload = {
+    "pass_example": enrich(pass_order),
+    "fail_example": enrich(fail_order),
+}
+
+# Also run the UI filter query as test.area would see it
+from hrms.api.ordering import get_order_review_queue as queue_fn
+frappe.set_user("test.area@bebang.ph")
+try:
+    result = queue_fn(date=None, status=None)
+    # Filter to just these two orders
+    both_names = [o["name"] for o in [pass_order, fail_order] if o]
+    payload["ui_filter_visible_to_test_area"] = [
+        {"name": o["name"], "status": o["status"], "approval_stage": o.get("approval_stage"),
+         "current_approver": o.get("current_approver"), "approval_queue_name": o.get("approval_queue_name")}
+        for o in result.get("orders", [])
+        if o["name"] in both_names
+    ]
+    payload["ui_filter_total_orders_visible"] = len(result.get("orders", []))
+except Exception as e:
+    payload["ui_filter_error"] = repr(e)
+finally:
+    frappe.set_user("Administrator")
+
+compressed = gzip.compress(json.dumps(payload, default=str).encode())
+print("__B64_START__")
+print(base64.b64encode(compressed).decode())
+print("__B64_END__")
+frappe.destroy()
+'''
+
+
+def run(timeout=120):
+    import boto3
+    ssm = boto3.client("ssm", region_name=AWS_REGION)
+    enc = base64.b64encode(SCRIPT.encode()).decode()
+    cmds = [
+        "BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+        f"echo '{enc}' | base64 -d > /tmp/s220.py",
+        "docker cp /tmp/s220.py $BACKEND:/tmp/s220.py",
+        "docker exec $BACKEND /home/frappe/frappe-bench/env/bin/python /tmp/s220.py",
+    ]
+    r = ssm.send_command(InstanceIds=[INSTANCE_ID], DocumentName="AWS-RunShellScript",
+        Parameters={"commands": cmds, "executionTimeout": [str(timeout)]})
+    cid = r["Command"]["CommandId"]; print(f"CommandId: {cid}")
+    deadline = time.time() + timeout + 30
+    while time.time() < deadline:
+        time.sleep(3)
+        inv = ssm.get_command_invocation(CommandId=cid, InstanceId=INSTANCE_ID)
+        if inv["Status"] in ("Success", "Failed", "TimedOut", "Cancelled"):
+            out = inv.get("StandardOutputContent", "")
+            if inv["Status"] != "Success":
+                sys.stderr.write(inv.get("StandardErrorContent", ""))
+            return out
+    raise TimeoutError()
+
+out = run()
+s = out.find("__B64_START__"); e = out.find("__B64_END__")
+if s < 0:
+    print(out); sys.exit(1)
+b64 = out[s+len("__B64_START__"):e].strip()
+data = json.loads(gzip.decompress(base64.b64decode(b64)).decode())
+OUT.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+print(f"Wrote {OUT}")
+print()
+print("=== PASS EXAMPLE (ARANETA) ===")
+if data.get("pass_example"):
+    p = data["pass_example"]
+    print(f"  Order: {p['order']['name']} | status={p['order']['status']} | stage={p['order']['approval_stage']}")
+    print(f"  owner={p['order']['owner']} | approved_by={p['order'].get('approved_by')}")
+    print(f"  Queue entries: {len(p['queue_entries'])}")
+    for q in p["queue_entries"]:
+        print(f"    - {q['name']} | status={q['status']} | approver={q['assigned_approver']}")
+    print(f"  Items (first 2):")
+    for i in p["items"][:2]:
+        print(f"    - {i['item_code']}: qty_req={i['qty_requested']} sug={i['suggested_qty']} edited={i['is_edited']}")
+print()
+print("=== FAIL EXAMPLE (FESTIVAL MALL) ===")
+if data.get("fail_example"):
+    f = data["fail_example"]
+    print(f"  Order: {f['order']['name']} | status={f['order']['status']} | stage={f['order']['approval_stage']}")
+    print(f"  owner={f['order']['owner']} | approved_by={f['order'].get('approved_by')}")
+    print(f"  Queue entries: {len(f['queue_entries'])}")
+    for q in f["queue_entries"]:
+        print(f"    - {q['name']} | status={q['status']} | approver={q['assigned_approver']}")
+    print(f"  Items (first 2):")
+    for i in f["items"][:2]:
+        print(f"    - {i['item_code']}: qty_req={i['qty_requested']} sug={i['suggested_qty']} edited={i['is_edited']}")
+print()
+print(f"=== UI FILTER (test.area) ===")
+print(f"  Total orders visible: {data.get('ui_filter_total_orders_visible')}")
+for o in data.get("ui_filter_visible_to_test_area", []):
+    print(f"  - {o['name']} | status={o['status']} | stage={o.get('approval_stage')} | approver={o.get('current_approver')}")

--- a/scripts/s220_direct_submit.py
+++ b/scripts/s220_direct_submit.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""S220 direct-compare — submit fresh orders to ARANETA + FESTIVAL MALL, inspect backend state."""
+import base64, gzip, json, pathlib, sys, time
+
+AWS_REGION = "ap-southeast-1"
+INSTANCE_ID = "i-026b7477d27bd46d6"
+OUT = pathlib.Path(__file__).resolve().parent.parent / "output" / "l3" / "s220" / "direct_submit_probe.json"
+OUT.parent.mkdir(parents=True, exist_ok=True)
+
+SCRIPT = '''
+import json, base64, gzip
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("test.area@bebang.ph")
+
+from hrms.api.store import submit_order, get_orderable_items
+
+def submit_for_wh(wh_name):
+    # Get orderable items
+    items_resp = get_orderable_items(wh_name, None, 0)
+    picks = []
+    # Filter to DRY items only
+    dry = [i for i in (items_resp.get("items") or []) if (i.get("cargo_category") or i.get("delivery_lane", "")) in ("DRY", "Dry")]
+    for i in dry[:3]:
+        sug = float(i.get("suggested_qty") or 0)
+        if sug <= 0:
+            continue
+        # Force deviation: pick qty != suggested
+        qty = max(1, int(sug / 2))
+        if qty == int(sug):
+            qty = max(1, qty - 1)
+        picks.append({
+            "item_code": i["item_code"],
+            "qty_requested": qty,
+            "suggested_qty": sug,
+            "recommended_qty": sug,
+            "unit_price": i.get("unit_price", 0),
+            "deviation_reason": "Stock Correction" if qty != sug else "",
+        })
+    if not picks:
+        return {"error": "no picks available", "wh": wh_name}
+    result = submit_order(
+        store=wh_name, cargo_category="DRY", notes="S220 probe",
+        delivery_date=None, items=picks,
+    )
+    return {"picks": picks, "result": result, "wh": wh_name}
+
+
+def inspect(order_name):
+    if not order_name:
+        return None
+    doc = frappe.get_doc("BEI Store Order", order_name)
+    queue = frappe.db.sql(
+        """SELECT name, status, assigned_approver FROM `tabBEI Approval Queue`
+           WHERE reference_doctype='BEI Store Order' AND reference_name=%s""",
+        (order_name,), as_dict=True,
+    )
+    items = frappe.db.sql(
+        """SELECT item_code, qty_requested, suggested_qty, is_edited
+           FROM `tabBEI Store Order Item` WHERE parent=%s""",
+        (order_name,), as_dict=True,
+    )
+    return {
+        "order": order_name,
+        "status": doc.status,
+        "approval_stage": doc.approval_stage,
+        "requires_dual_approval": doc.requires_dual_approval,
+        "queue_entries": queue,
+        "items": items,
+        "edited_count": sum(1 for i in items if i["is_edited"]),
+    }
+
+
+aranete_result = submit_for_wh("ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC")
+festival_result = submit_for_wh("FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.")
+
+frappe.db.commit()
+
+aranete_order = (aranete_result.get("result") or {}).get("name")
+festival_order = (festival_result.get("result") or {}).get("name")
+
+# Now check UI filter from test.area perspective
+from hrms.api.ordering import get_order_review_queue
+ui = get_order_review_queue(date=None, status=None)
+visible = {o["name"] for o in ui.get("orders", [])}
+
+payload = {
+    "aranete_submit": aranete_result,
+    "festival_submit": festival_result,
+    "aranete_backend_state": inspect(aranete_order),
+    "festival_backend_state": inspect(festival_order),
+    "ui_visible_to_test_area": {
+        "total": len(ui.get("orders", [])),
+        "aranete_visible": aranete_order in visible if aranete_order else False,
+        "festival_visible": festival_order in visible if festival_order else False,
+    },
+}
+
+# Cleanup
+frappe.set_user("Administrator")
+for name in (aranete_order, festival_order):
+    if name:
+        try:
+            doc = frappe.get_doc("BEI Store Order", name)
+            if doc.docstatus == 0:
+                frappe.delete_doc("BEI Store Order", name, force=1)
+            elif doc.docstatus == 1:
+                doc.cancel()
+            frappe.db.commit()
+        except Exception:
+            pass
+
+compressed = gzip.compress(json.dumps(payload, default=str).encode())
+print("__B64_START__")
+print(base64.b64encode(compressed).decode())
+print("__B64_END__")
+frappe.destroy()
+'''
+
+
+def run(timeout=180):
+    import boto3
+    ssm = boto3.client("ssm", region_name=AWS_REGION)
+    enc = base64.b64encode(SCRIPT.encode()).decode()
+    cmds = [
+        "BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+        f"echo '{enc}' | base64 -d > /tmp/s220d.py",
+        "docker cp /tmp/s220d.py $BACKEND:/tmp/s220d.py",
+        "docker exec $BACKEND /home/frappe/frappe-bench/env/bin/python /tmp/s220d.py",
+    ]
+    r = ssm.send_command(InstanceIds=[INSTANCE_ID], DocumentName="AWS-RunShellScript",
+        Parameters={"commands": cmds, "executionTimeout": [str(timeout)]})
+    cid = r["Command"]["CommandId"]; print(f"CommandId: {cid}")
+    deadline = time.time() + timeout + 30
+    while time.time() < deadline:
+        time.sleep(4)
+        inv = ssm.get_command_invocation(CommandId=cid, InstanceId=INSTANCE_ID)
+        if inv["Status"] in ("Success", "Failed", "TimedOut", "Cancelled"):
+            out = inv.get("StandardOutputContent", "")
+            if inv["Status"] != "Success":
+                sys.stderr.write(inv.get("StandardErrorContent", ""))
+            return out
+    raise TimeoutError()
+
+
+out = run()
+s = out.find("__B64_START__"); e = out.find("__B64_END__")
+if s < 0:
+    print(out); sys.exit(1)
+b64 = out[s+len("__B64_START__"):e].strip()
+data = json.loads(gzip.decompress(base64.b64decode(b64)).decode())
+OUT.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+print(f"Wrote {OUT}")
+print()
+print("=== ARANETA (PASS-pattern) ===")
+ar = data.get("aranete_backend_state") or {}
+print(f"  Order={ar.get('order')} status={ar.get('status')} stage={ar.get('approval_stage')}")
+print(f"  requires_dual={ar.get('requires_dual_approval')} edited_lines={ar.get('edited_count')}")
+print(f"  Queue entries: {len(ar.get('queue_entries') or [])}")
+for q in ar.get("queue_entries") or []:
+    print(f"    - {q['name']} | status={q['status']} | approver={q['assigned_approver']}")
+print()
+print("=== FESTIVAL MALL (FAIL-pattern) ===")
+fs = data.get("festival_backend_state") or {}
+print(f"  Order={fs.get('order')} status={fs.get('status')} stage={fs.get('approval_stage')}")
+print(f"  requires_dual={fs.get('requires_dual_approval')} edited_lines={fs.get('edited_count')}")
+print(f"  Queue entries: {len(fs.get('queue_entries') or [])}")
+for q in fs.get("queue_entries") or []:
+    print(f"    - {q['name']} | status={q['status']} | approver={q['assigned_approver']}")
+print()
+ui = data.get("ui_visible_to_test_area") or {}
+print(f"=== UI FILTER (test.area view) ===")
+print(f"  Total orders visible: {ui.get('total')}")
+print(f"  ARANETA visible: {ui.get('aranete_visible')}")
+print(f"  FESTIVAL visible: {ui.get('festival_visible')}")


### PR DESCRIPTION
# S220 — Backend investigation finding

Direct-API probe submitting fresh orders as test.area to both a PASSING
store (ARANETA GATEWAY) and a FAILING store (FESTIVAL MALL ALABANG),
then inspecting full backend state + \`get_order_review_queue\` output.

## Conclusion

**The 7-store DEFECT-11 cluster is NOT a backend-filter problem.**
Backend treats both stores identically — same status, same approval
stage, same queue entries, same UI-visible state.

| Field | ARANETA (pass) | FESTIVAL MALL (fail) |
|---|---|---|
| status | Pending Approval | Pending Approval |
| approval_stage | Pending Area Supervisor | Pending Area Supervisor |
| requires_dual_approval | 1 | 1 |
| queue entries (recent) | 10 (1 Pending) | 8 (1 Pending) |
| latest queue approver | test.area@bebang.ph | test.area@bebang.ph |
| \`get_order_review_queue\` visible | ✓ Yes | ✓ Yes |

## What this rules out

- ❌ \`requires_manual_approval=False\` leaves orders without queue entries
- ❌ Queue entry not assigned to test.area
- ❌ SQL filter excludes the order

S219's "force is_edited" fix was addressing a non-problem.

## What's left (S221)

The UI rendering path. When the Playwright test's
\`getByText(orderId).waitFor({timeout: 30_000})\` times out, the order
IS in the backend result list but the DOM text is not visible to
Playwright within 30s.

Possibilities:
- Approval page paginates / scrolls and the order is off-screen
- A default client-side filter (date, store, user) hides it
- Hydration race — the order text renders AFTER the 30s window
- Text rendered in a DOM element Playwright's text query doesn't match

**Next step:** \`npx playwright show-trace\` on one failing FESTIVAL MALL
test run to see the actual DOM state at timeout moment. That's S221
scope and needs a fresh session.

## Files

- \`scripts/s220_compare_pass_vs_fail.py\` — find + compare latest orders
  for two stores (useful for future side-by-side diagnosis)
- \`scripts/s220_direct_submit.py\` — submit fresh order via API (bypass
  Playwright), inspect backend state + UI filter output
- \`output/l3/s220/direct_submit_probe.json\` — full field-by-field data
- \`output/l3/s220/BACKEND_INVESTIGATION_FINDINGS.md\` — narrative

## Progress to date

| Sprint | Pass | Key finding |
|---|---|---|
| S209 | 20/49 | baseline |
| S212-S216 | 3-9 / up to 17 | early kills |
| S217 | 31/49 | full run at 63% |
| S218-S219 | 31/49 | wrong hypotheses |
| **S220** | **—** | **backend ruled out → UI investigation needed (S221)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)