### PR TITLE
fix(S205): persist or_variance_flagged + bump test item rate (S194-21)

### DIFF
--- a/hrms/api/procurement.py
+++ b/hrms/api/procurement.py
@@ -5006,6 +5006,13 @@ def upload_official_receipt(name, or_number, or_date, or_amount, or_attachment=N
     pay_req.or_uploaded_date = _now_dt()
     pay_req.or_status = "OR Received"
     pay_req.status = "Closed"
+    # Persist variance for downstream review (S194-21 cert + AP dashboard).
+    # Frappe silently drops fields not in the DocType; the schema migration
+    # in this PR adds or_variance_pct + or_variance_flagged.
+    if hasattr(pay_req, "or_variance_pct"):
+        pay_req.or_variance_pct = round(variance_pct, 2)
+    if hasattr(pay_req, "or_variance_flagged"):
+        pay_req.or_variance_flagged = 0 if amount_match else 1
     pay_req.save(ignore_permissions=True)
 
     msg = _("Official Receipt uploaded successfully. Transaction closed.")

--- a/hrms/hr/doctype/bei_payment_request/bei_payment_request.json
+++ b/hrms/hr/doctype/bei_payment_request/bei_payment_request.json
@@ -91,6 +91,8 @@
     "or_number",
     "or_date",
     "or_amount",
+    "or_variance_pct",
+    "or_variance_flagged",
     "or_attachment_section",
     "or_attachment",
     "or_uploaded_by",
@@ -625,6 +627,21 @@
       "fieldname": "or_amount",
       "fieldtype": "Currency",
       "label": "OR Amount"
+    },
+    {
+      "fieldname": "or_variance_pct",
+      "fieldtype": "Percent",
+      "label": "OR Variance %",
+      "read_only": 1,
+      "description": "abs(payment_amount - or_amount) / payment_amount * 100"
+    },
+    {
+      "default": "0",
+      "fieldname": "or_variance_flagged",
+      "fieldtype": "Check",
+      "label": "OR Variance Flagged",
+      "read_only": 1,
+      "description": "Set to 1 by upload_official_receipt when variance > 5%"
     },
     {
       "fieldname": "or_attachment_section",

--- a/scripts/s194_preflight_setup.py
+++ b/scripts/s194_preflight_setup.py
@@ -182,7 +182,14 @@ def cmd_create_item(args: argparse.Namespace) -> None:
         "item_name": args.name,
         "stock_uom": "Nos",  # Frappe-default UoM; required field on Item
         "is_stock_item": 0,  # tests don't need stock-tracked items
-        "standard_rate": 50000,  # PR form gates submit on non-zero rate
+        # Rate authorized by Sam (CEO) on 2026-04-22 to make S194-21
+        # mathematically satisfiable (qty=1 invoice = 100K + 12% VAT = 112K
+        # >= test's paymentAmount=100K). Other tests verified safe at 100K:
+        # - Boundary tests (S194-13/14) still trigger their thresholds
+        # - TIN gate (S194-15) still > 250K threshold at qty=6
+        # - Match-passing tests still chain (po=gr=invoice)
+        # - Variance tests already exceed thresholds; behaviour preserved
+        "standard_rate": 100000,
     }
     if args.group:
         fields["item_group"] = args.group


### PR DESCRIPTION
## Summary
Two changes to make S194-21 pass end-to-end:

### 1. scripts/s194_preflight_setup.py — bump standard_rate 50K→100K
CEO-authorized (2026-04-22). qty=1 invoice now lands at 112K (vs prior 56K) so the test's paymentAmount=100K passes the balance check. All other S194 tests verified safe at the higher rate (boundary tests still trigger thresholds, TIN gate still > 250K, match-passing scenarios still chain, variance tests already exceed thresholds).

### 2. hrms — persist OR variance on Payment Request
- Add or_variance_pct + or_variance_flagged fields to BEI Payment Request DocType
- Persist them in upload_official_receipt when variance > 5%

Without this the variance signal lives only in the API response, never in the doc — neither the UI nor downstream consumers can read it. S194-21 cert needs both the doc field (for assertORClosesRFP) and the UI badge (for assertORVarianceFlagged).

## Test plan
- [ ] Deploy
- [ ] Re-run S194 sweep with bei-tasks PR (UI variance badge) merged
- [ ] Expect S194-21 PASS (was failing on assertORVarianceFlagged after rate fix exposed the missing variance field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)