### PR TITLE
fix(weather-sync): tolerate missing frappe import in GitHub Actions

### DIFF
--- a/scripts/sync_weather_to_supabase.py
+++ b/scripts/sync_weather_to_supabase.py
@@ -32,14 +32,30 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def _load_lookup_sales_location():
-	spec = importlib.util.spec_from_file_location(
-		"sales_location_mapping_sync",
-		ROOT / "hrms" / "utils" / "sales_location_mapping.py",
-	)
-	module = importlib.util.module_from_spec(spec)
-	assert spec and spec.loader
-	spec.loader.exec_module(module)
-	return module.lookup_sales_location
+	"""Try to load lookup_sales_location from hrms/utils. Falls back to a no-op
+	if the module can't be imported (e.g., running outside Frappe in GitHub
+	Actions, where `import frappe` at the top of sales_location_mapping.py
+	fails with ModuleNotFoundError).
+
+	Since S191/S200 (2026-04-16), sales_location_mapping.py imports `frappe`
+	at module top-level for the live ORM-backed Company/Warehouse query. The
+	weather sync embeds all live `location_id` values inline in
+	`_STORE_COORDINATES` below — the fallback is only used for stores with
+	`location_id == 0`, which are skipped anyway. So a no-op fallback is safe.
+	"""
+	try:
+		spec = importlib.util.spec_from_file_location(
+			"sales_location_mapping_sync",
+			ROOT / "hrms" / "utils" / "sales_location_mapping.py",
+		)
+		module = importlib.util.module_from_spec(spec)
+		assert spec and spec.loader
+		spec.loader.exec_module(module)
+		return module.lookup_sales_location
+	except ModuleNotFoundError as exc:
+		# `import frappe` failed — running outside Frappe (GitHub Actions, etc.)
+		print(f"[INFO] Frappe-backed lookup unavailable ({exc}); using embedded mapping only.")
+		return lambda warehouse_name=None, warehouse_record_name=None: None
 
 
 lookup_sales_location = _load_lookup_sales_location()


### PR DESCRIPTION
## Summary

Weather sync GitHub Action has been **failing every 3 hours since 2026-04-15** (12 days). Last successful run: \`2026-04-15T21:32:59Z\` (id=24479519647). Latest failures: id=24988573708, id=24981484129, etc.

## Root cause

S191 commit \`77fe412e1\` (2026-04-16 08:27 PHT) rewired the sales-location mapping from a CSV file to live Frappe ORM. After that change, \`hrms/utils/sales_location_mapping.py\` has \`import frappe\` at module top:

\`\`\`
File '.../hrms/utils/sales_location_mapping.py', line 6, in <module>
  import frappe
ModuleNotFoundError: No module named 'frappe'
\`\`\`

The GitHub Actions runner (\`.github/workflows/weather-sync.yml\`) only installs \`requests\` and \`supabase\` — Frappe is NOT installed there. So the script crashes at import time.

## Fix

Wrap the loader in \`try/except ModuleNotFoundError\` and return a no-op stub when Frappe isn't available.

\`\`\`python
def _load_lookup_sales_location():
    try:
        # ... existing dynamic import ...
        return module.lookup_sales_location
    except ModuleNotFoundError as exc:
        print(f'[INFO] Frappe-backed lookup unavailable ({exc}); using embedded mapping only.')
        return lambda warehouse_name=None, warehouse_record_name=None: None
\`\`\`

## Why this is safe

- All live \`location_id\` values are embedded inline in \`_STORE_COORDINATES\` (line 130).
- The Frappe-backed lookup was only used as a fallback for 2 stores with \`location_id == 0\` (Estancia, Shaw BLVD), which are then skipped anyway via the existing \`[WARN] Skipping\` branch.
- Production environments (where Frappe IS importable) keep the live fallback unchanged.

## Verification

Simulated \"no frappe\" environment locally:

\`\`\`
[INFO] Frappe-backed lookup unavailable (No module named 'frappe'); using embedded mapping only.
Module loaded successfully without frappe
lookup_sales_location is: function
lookup_sales_location(\"Estancia\") returned: None
\`\`\`

After merge, the next scheduled run (every 3 hours at :15 UTC) should succeed and unblock 12 days of stuck weather data.

## Backfill recommendation (post-merge)

Once the workflow runs green, manually trigger a backfill via \`workflow_dispatch\` with:
- \`start_date\`: 2026-04-15
- \`end_date\`: 2026-04-27

That will catch up the missed window in one shot.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>