### PR TITLE
fix(S225 phase 6): SHIP the actual hrms code (PR #692 only shipped diagnosis artifacts)

### DIFF
--- a/hrms/api/mosaic_webhook.py
+++ b/hrms/api/mosaic_webhook.py
@@ -473,8 +473,12 @@ def _upsert_completed_order(order: dict) -> None:
     }
 
     order_row = _map_order_row(order)
+    # S225 follow-up (Phase 6 Sentry): PostgREST returns 409 when
+    # `Prefer: resolution=merge-duplicates` doesn't know which unique
+    # constraint to use. Add explicit `on_conflict` query params so
+    # merge-duplicates resolves on the intended constraint.
     r_order = requests.post(
-        f"{SUPABASE_URL}/rest/v1/pos_orders",
+        f"{SUPABASE_URL}/rest/v1/pos_orders?on_conflict=id",
         headers=headers,
         json=[order_row],
         timeout=15,
@@ -484,7 +488,7 @@ def _upsert_completed_order(order: dict) -> None:
     item_rows = _map_order_items(order)
     if item_rows:
         r_items = requests.post(
-            f"{SUPABASE_URL}/rest/v1/pos_order_items",
+            f"{SUPABASE_URL}/rest/v1/pos_order_items?on_conflict=order_id,product_id,line_number",
             headers=headers,
             json=item_rows,
             timeout=15,

--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -514,11 +514,32 @@ def _filter_sales_warehouses(rows: list[dict[str, Any]]) -> list[dict[str, Any]]
 	for row in rows:
 		match = lookup_sales_location(row.get("warehouse_name"), row.get("name"))
 		if not match:
-			wh_name = row.get("name") or row.get("warehouse_name") or "(unknown)"
-			frappe.log_error(
-				title="Sales Dashboard: unmapped warehouse dropped",
-				message=f"Warehouse {wh_name!r} (company={row.get('company')!r}) has no mosaic_location_id on its Company — excluded from Analytics scope.",
-			)
+			# S225 follow-up: stop spamming Sentry on every dashboard load for
+			# warehouses that are intentionally non-POS (commissary, cold storage,
+			# logistics hubs). They never need mosaic_location_id by design — see
+			# memory/feedback_bki_no_pos.md. Log once at info-level instead of as
+			# a Sentry error event. The drop behaviour is unchanged.
+			wh_name = (row.get("name") or row.get("warehouse_name") or "").lower()
+			# Heuristic: BKI suffix, cold-storage / logistics keywords, internal sub-warehouses
+			_non_pos_markers = ("- bki", "cold storage", "logistics", "commissary", "stores -",
+				"finished goods -", "goods in transit -", "work in progress -")
+			is_known_non_pos = any(m in wh_name for m in _non_pos_markers)
+			full_name = row.get("name") or row.get("warehouse_name") or "(unknown)"
+			if is_known_non_pos:
+				frappe.logger("sales_dashboard").info(
+					f"sales_dashboard: skipping non-POS warehouse {full_name!r} "
+					f"(company={row.get('company')!r}) — expected, no mosaic_location_id required"
+				)
+			else:
+				# Unexpected unmapped store warehouse — keep as Sentry error so it surfaces
+				frappe.log_error(
+					title="Sales Dashboard: unmapped warehouse dropped",
+					message=(
+						f"Warehouse {full_name!r} (company={row.get('company')!r}) has no "
+						f"mosaic_location_id on its Company — excluded from Analytics scope. "
+						f"If this is a real POS store, set mosaic_location_id on the Company."
+					),
+				)
 			continue
 		# S200: Use warehouse_name from mapping (derived from Company store prefix)
 		# instead of the raw Warehouse.warehouse_name field which may be stale.

--- a/hrms/api/store.py
+++ b/hrms/api/store.py
@@ -3454,6 +3454,23 @@ def approve_order(order_name: str, approved_quantities: list | str | None = None
 	user = frappe.session.user
 	order = frappe.get_doc("BEI Store Order", order_name)
 
+	# S225 follow-up (Phase 6 Sentry): mirror the S224 Pattern B idempotency fix
+	# from approve_material_request. If the order is already fully approved
+	# (single-approval auto-promote at submit time, or dual-approval already
+	# completed), return success-noop instead of throwing. This stops the
+	# "Order is not pending approval" and "currently assigned to <other user>"
+	# errors that surface when a follow-up approval call lands on an order
+	# that already passed the relevant stage.
+	if order.status == "Approved":
+		return {
+			"success": True,
+			"name": order.name,
+			"status": order.status,
+			"approval_stage": getattr(order, "approval_stage", None) or "Single Approval",
+			"message": f"Order {order.name} already approved (status=Approved) — no-op",
+			"already_approved": True,
+		}
+
 	if order.status != "Pending Approval":
 		frappe.throw(_("Order is not pending approval"))
 
@@ -3908,9 +3925,31 @@ def _create_mr_for_store_order(order):
 		if not store_warehouse:
 			frappe.throw(_("No store warehouse found on order {0}").format(order.name))
 		cargo_category = getattr(order, "cargo_category", None) or "DRY"
-		source_warehouse = _resolve_store_order_source_warehouse(store_warehouse, cargo_category)
+		# S225 follow-up (Phase 6 Sentry findings): when no commissary route is configured
+		# for this store+lane, _resolve_store_order_source_warehouse returns None.
+		# Previously source_company then fell to get_company() (BEI parent), causing
+		# InvalidWarehouseCompany on validate_warehouse_company because the doc's
+		# company didn't match any of its row warehouses' per-store companies.
+		# Match the pattern used by _build_orderable_source_stock_context: default
+		# the unresolved source to the store's own warehouse so the MR becomes a
+		# legitimate same-company Material Transfer instead of a malformed cross-
+		# company doc. Log a warning so we still see the route gap.
+		_resolved_source = _resolve_store_order_source_warehouse(store_warehouse, cargo_category)
+		if not _resolved_source:
+			frappe.log_error(
+				f"S225 follow-up: no commissary route for {store_warehouse}+{cargo_category}; "
+				f"defaulting source to store warehouse. Add a BEI Route or _CENTRAL_WAREHOUSE_ROUTE_MAP entry.",
+				"S225 Source Route Missing",
+			)
+		source_warehouse = _resolved_source or store_warehouse
 		buyer_entity_row = resolve_store_buyer_entity(warehouse_docname=store_warehouse)
-		source_company = resolve_warehouse_company(source_warehouse) or get_company()
+		# Belt and suspenders: even if source_warehouse is set, prefer the per-store
+		# Company resolution over the global default to keep canonical alignment.
+		source_company = (
+			resolve_warehouse_company(source_warehouse)
+			or resolve_warehouse_company(store_warehouse)
+			or get_company()
+		)
 		# S190: Read company from order (set at submit time) instead of guessing
 		operational_target_company = (
 			getattr(order, "company", None) or resolve_warehouse_company(store_warehouse) or get_company()

--- a/hrms/api/warehouse.py
+++ b/hrms/api/warehouse.py
@@ -1094,10 +1094,18 @@ def get_pending_material_requests():
 		action="get_pending_material_requests",
 		mutation_type="read",
 	)
+	# S225 follow-up (Phase 6 Sentry): "Ordered" MRs (auto-promoted at creation
+	# by the BEI on_submit hook for store-orders) were dropping out of this
+	# warehouse-approval queue, leaving SCM with no way to confirm/dispatch via
+	# the UI. Same root pattern as S226's order-approval queue fix. Include
+	# "Ordered" so already-promoted MRs remain visible until they are dispatched
+	# (i.e., until a Stock Entry consumes them and the status moves to
+	# "Transferred"). The S224 Pattern B idempotency fix in approve_material_request
+	# means a re-click on an Ordered MR is a no-op and won't throw.
 	mrs = frappe.get_all(
 		"Material Request",
 		filters={
-			"status": ["in", ["Pending", "Partially Ordered"]],
+			"status": ["in", ["Pending", "Partially Ordered", "Ordered"]],
 			"docstatus": 1,
 			"material_request_type": ["in", ["Material Transfer", "Material Issue"]],
 		},
@@ -1636,10 +1644,17 @@ def create_stock_transfer(
 		# functional logic.
 		_lock_wait_ms = int((_time.time() - _lock_t0) * 1000)
 		if _lock_wait_ms > 2000:
-			frappe.log_error(
-				f"S225 lock wait {_lock_wait_ms}ms for {source_warehouse}/{_lock_item_codes}",
-				"S225 Lock Contention",
-			)
+			try:
+				frappe.log_error(
+					f"S225 lock wait {_lock_wait_ms}ms for {source_warehouse}/{_lock_item_codes}",
+					"S225 Lock Contention",
+				)
+			except (RuntimeError, Exception):
+				# frappe.log_error can throw "object is not bound" when called from a
+				# non-request context (e.g., worker thread, scheduled job). The
+				# lock-wait info is best-effort — drop silently rather than break the
+				# dispatch.
+				pass
 
 	for item_data in normalized_items:
 		# Get item details

--- a/hrms/utils/sentry.py
+++ b/hrms/utils/sentry.py
@@ -285,10 +285,41 @@ def init_sentry():
 
 			_patch_log_error()
 			_patch_handle_exception()
+			_patch_frappe_set_scope_for_non_request_contexts()
 			_sentry_initialized = True
 
 		except Exception:
 			pass
+
+
+def _patch_frappe_set_scope_for_non_request_contexts():
+	"""S225 follow-up — gracefully handle non-request contexts in frappe.utils.sentry.set_scope.
+
+	Frappe's built-in set_scope accesses `frappe.request.path` directly, which raises
+	`RuntimeError: object is not bound` when called from a worker thread or
+	scheduled job. This causes spurious Sentry errors during non-request log_error
+	calls (e.g., the S225 lock-wait telemetry from concurrent dispatches).
+
+	Wrap it to skip silently when no request is bound. The error reporting still
+	flows through Frappe's other paths.
+	"""
+	try:
+		import frappe.utils.sentry as _frappe_sentry
+		if getattr(_frappe_sentry, "_bei_set_scope_patched", False):
+			return
+		_orig_set_scope = _frappe_sentry.set_scope
+
+		def _safe_set_scope(*args, **kwargs):
+			try:
+				return _orig_set_scope(*args, **kwargs)
+			except RuntimeError:
+				# "object is not bound" — no Werkzeug request context. Skip.
+				return None
+
+		_frappe_sentry.set_scope = _safe_set_scope
+		_frappe_sentry._bei_set_scope_patched = True
+	except Exception:
+		pass
 
 
 def _patch_log_error():


### PR DESCRIPTION
## Critical: PR #692 didn't actually ship the code

PR #692's description listed 7 backend fixes. Inspection of the merged commit (\`c3c65bdda\` → \`ed9bc65ad\`) reveals it shipped only the diagnosis artifacts (Sentry event JSONs + scripts/s225_*) — the actual \`hrms/*\` code changes were lost during a 'git stash + checkout -B + stash pop' workflow after a hook blocked my push to a previously-merged branch.

This PR ships the actual code. **+124 / -14 lines across 5 hrms files.**

## What's in this PR (now ACTUALLY in the diff)

| # | File | Sentry bucket fixed | Count |
|---|---|---|---|
| 1 | \`hrms/api/store.py:_create_mr_for_store_order\` | InvalidWarehouseCompany — source_company fell to BEI parent when route missing | 11 |
| 2 | \`hrms/api/store.py:approve_order\` | "Order is currently assigned to <user>" 403 — added Approved-status idempotency | 6 |
| 3 | \`hrms/api/warehouse.py:get_pending_material_requests\` | WarehouseApprovalPage button not visible — added "Ordered" status to queue filter | 8 (kill-trigger) |
| 4 | \`hrms/api/warehouse.py:create_stock_transfer\` | RuntimeError from S225 Lock Contention log — try/except wrap | 9 |
| 5 | \`hrms/utils/sentry.py\` | RuntimeError "object is not bound" — defensive monkey-patch on \`set_scope\` | systemic |
| 6 | \`hrms/api/sales_dashboard.py:_filter_sales_warehouses\` | "Sales Dashboard: unmapped warehouse dropped" — non-POS skip | 49 |
| 7 | \`hrms/api/mosaic_webhook.py:_upsert_completed_order\` | HTTPError 409 — explicit \`on_conflict\` query param | 15 |

## Verification before push

\`\`\`
hrms/api/store.py:3 matches "S225 follow-up"
hrms/api/warehouse.py:1 matches "S225 follow-up"
hrms/utils/sentry.py:2 matches "_patch_frappe_set_scope_for_non_request_contexts"
hrms/api/mosaic_webhook.py:1 matches "on_conflict=order_id"
\`\`\`

## Canonical scope: in

\`store.py\` + \`warehouse.py\`. Code-only changes. No master-data mutations. Postcheck: 49 stores / 0 violations.

## After merge + deploy

Re-run full L3 sweep with \`--kill-same-fingerprint 15\`. Target 49/49 PASS.

## Honest disclosure on band-aid risk

- Fix #1 makes the system degrade gracefully when a route is missing (store self-fulfills) — the deeper root cause is MISSING ROUTE entries for some stores. To fully fix, ADD the routes in BEI Route DocType or \`_CENTRAL_WAREHOUSE_ROUTE_MAP\`.
- Fix #2 only handles \`status=="Approved"\` cases. The 403 also fires for "Pending Approval / assigned to test.area" cases where stage 1 didn't transition. That deeper case is likely caused by the InvalidWarehouseCompany throw rolling back stage 1 — fix #1 should eliminate it transitively.
- Fix #4 is defense-in-depth; fix #5 is the systemic root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)