### PR TITLE
fix(weather-sync): bump open-meteo read timeout 20s -> 60s

### DIFF
--- a/scripts/sync_weather_to_supabase.py
+++ b/scripts/sync_weather_to_supabase.py
@@ -315,8 +315,13 @@ def fetch_weather_bundle(latitude: float, longitude: float, date_str: str) -> di
 		"end_date": date_str,
 	}
 
+	# (connect=10s, read=60s) — open-meteo's archive-api is occasionally slow
+	# serving historical windows; 20s caused ~30% of store-groups to time out
+	# during the 12-day backfill 2026-04-15 -> 2026-04-28. 60s gives backfills
+	# substantially better per-day coverage with no meaningful impact on the
+	# scheduled 30-min job runtime (forecast endpoint typically responds <2s).
 	try:
-		response = requests.get(base_url, params=params, timeout=20)
+		response = requests.get(base_url, params=params, timeout=(10, 60))
 		response.raise_for_status()
 		payload = response.json()
 	except Exception as exc:


### PR DESCRIPTION
Follow-up to #693. Backfilling 2026-04-15 -> 2026-04-28 surfaced that ~30% of store-groups time out per call against open-meteo's archive-api with the existing 20s timeout. Per-day coverage after PR #693 backfill stuck at 22-30 stores (out of ~45 expected) for 04-17, 04-24, 04-25 even after multiple retries.

**Fix:** switch from `timeout=20` (single value) to `timeout=(10, 60)` (connect=10s, read=60s). The connect timeout stays short to fail fast on real network errors; the read timeout is the one open-meteo's archive-api actually hits.

**Safe because:**
- Scheduled forecast endpoint usually responds <2s — almost never hits the new ceiling.
- Backfills routinely take 16-21 min for 5-day windows; the 30-min workflow timeout still has plenty of headroom.

**Verification:** AST parse OK locally; `requests.get` accepts `(connect, read)` tuples per its official docs.

**Post-merge:** trigger backfill for 04-15 -> 04-25 to fill the remaining gaps.