### PR TITLE
fix(sales_dashboard): drop Franchisor name-collision rows in resolver (54 -> 48)

### DIFF
--- a/hrms/api/sales_dashboard.py
+++ b/hrms/api/sales_dashboard.py
@@ -541,6 +541,20 @@ def _filter_sales_warehouses(rows: list[dict[str, Any]]) -> list[dict[str, Any]]
 					),
 				)
 			continue
+		# 2026-04-28 fix: lookup_sales_location matches by normalized warehouse
+		# name only, so a Franchisor-entity warehouse (e.g. "SM Megamall - BFC"
+		# under a Franchisor Company) whose warehouse_name happens to match a
+		# canonical Store warehouse_name (e.g. "SM Megamall") inherits the
+		# canonical mapping payload. That lets non-canonical warehouses leak
+		# into the admin/HQ resolver's all-stores view (Sam previously saw 54
+		# stores while only 48 are canonical Active stores; the 6 extras were
+		# all "- BFC" Franchisor duplicates). Reject mismatches: the row's
+		# company must equal the canonical match's company. Stakeholder /
+		# Partner branches are unaffected because their warehouses are pre-
+		# filtered by the access-row warehouse name (only canonical names live
+		# in BEI Sales Dashboard Store Access).
+		if row.get("company") and match.get("company") and row.get("company") != match.get("company"):
+			continue
 		# S200: Use warehouse_name from mapping (derived from Company store prefix)
 		# instead of the raw Warehouse.warehouse_name field which may be stale.
 		filtered.append(


### PR DESCRIPTION
Sam reported his Sales Dashboard says '54 stores in scope' while production has only 48 active canonical Stores. Diagnosed via SSM-replay:

**Root cause:** _resolve_allowed_store_scope() Admin / HQ branches use _get_warehouse_rows({is_group: 0, disabled: 0}) (no entity_category filter), then _filter_sales_warehouses, which uses lookup_sales_location(warehouse_name, name) matching by NORMALIZED warehouse_name only. Franchisor (BFC) Companies have leaf warehouses whose warehouse_name (e.g. 'SM Megamall') collides with canonical Store mapping keys, so the Franchisor row inherits the canonical mapping payload and gets included.

**6 colliding Franchisor warehouses identified:**
- Megaworld Paseo Center - BFC
- Robinsons Antipolo - BFC
- SM  Manila - BFC
- SM Megamall - BFC
- SM Southmall - BFC
- Sta. Lucia East Grand Mall - BFC

**Fix:** After lookup_sales_location returns a match in _filter_sales_warehouses, verify row.company equals match.company. If not (Franchisor collision), drop. Stakeholder / Store Partner branches unaffected because their warehouses are pre-filtered by access-row warehouse name (only canonical 'STORE - ENTITY' names live in BEI Sales Dashboard Store Access).

**Verified:** AST parse OK locally. Post-deploy expectation: Sam's badge flips 54 -> 48; drew@/dave@ remain 48 each (already cleaned up via SSM data fix earlier today).

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>