### PR TITLE
chore(S225): final validation closeout — 49/49 sweep + investigation scripts

### DIFF
--- a/scripts/s225/README.md
+++ b/scripts/s225/README.md
@@ -1,0 +1,60 @@
+# S225 Investigation + Fix Scripts
+
+This directory holds the working scripts produced during S225 investigation
+(2026-04-26 → 2026-05-01) for the 49-store canonical sweep. They are
+preserved here as reference for future debugging — many can be re-run
+verbatim against the live production site to re-audit the same conditions.
+
+All scripts are designed to run inside the Frappe backend container via SSM:
+
+```python
+import boto3, time, base64
+inner = open('scripts/s225/<NAME>.py','r').read()
+enc = base64.b64encode(inner.encode()).decode()
+ssm = boto3.client('ssm', region_name='ap-southeast-1')
+cmds = [
+    'BACKEND=$(docker ps --filter name=frappe_backend --format "{{.ID}}" | head -1)',
+    f'echo {enc} | base64 -d > /tmp/x.py',
+    'docker cp /tmp/x.py $BACKEND:/tmp/x.py',
+    'docker exec $BACKEND /home/frappe/frappe-bench/env/bin/python /tmp/x.py 2>&1',
+]
+r = ssm.send_command(InstanceIds=['i-026b7477d27bd46d6'], DocumentName='AWS-RunShellScript',
+    Parameters={'commands': cmds, 'executionTimeout': ['180']})
+```
+
+## Investigation scripts (read-only)
+
+| Script | Purpose |
+|---|---|
+| `audit_6_fail_stores.py` | Per-store config dump (Company, Warehouse, Customer, BEI Routes, recent WRs/MRs) for the v8 fail set + 2 working stores for comparison. |
+| `audit_two_stores.py` | Earlier 2-store config audit (SM MARIKINA + AYALA VERMOSA). |
+| `find_marikina.py` / `find_marikina_company.py` | Fuzzy search for SM MARIKINA Company + Warehouse + Customer + accounts (used to resolve the canonical name disambiguation). |
+| `inspect_bei_route_schema.py` | Dump BEI Route + BEI Route Stop DocType field metadata. |
+| `check_bei_routes.py` / `check_routes_summary.py` | Route assignment audits per store. |
+| `check_pm001_*.py` | Bin-state checks at PCS-BKI for PM001 (the v8 baseline blocker item). |
+| `enumerate_seeded.py` | Find all SEs with a given remarks prefix (e.g., `S229%`). |
+| `investigate_remaining.py` | Post-sweep DB inspection of MR + Order + Bin states. |
+| `probe_allowed_target.py` | Probe `_get_allowed_target_companies()` — found SM MARIKINA `is_group=1` exclusion. |
+| `probe_dispatch_latency.py` | Time `get_ready_for_dispatch` API + check for missing MRs. |
+| `probe_orderable_3_stores.py` | Check `get_orderable_items` returns for stores — found 0 routes case. |
+| `probe_sm_marikina_chain.py` | Trace MR → SE → WR for SM MARIKINA (parametrize MR_NAME). |
+| `probe_sm_marikina_error_log.py` | Pull Frappe Error Log entries for SM MARIKINA's recent SE — found `Target warehouse must belong to one of:` validation. |
+| `verify_v7_fixes_still_applied.py` | Idempotent re-check that the 4 production fixes are intact. |
+
+## Fix scripts (mutating — apply with caution)
+
+| Script | What it changes |
+|---|---|
+| `fix_routes_and_seed.py` | Adds 15 BEI Routes for stores authorized by Sam 2026-04-29 (NAIA T3, Ortigas Estancia, Ortigas Greenhills, Robinsons Antipolo, SM Sta Rosa) + seeds PM stock at hubs. |
+| `fix_3_blocked_stores_routes.py` | Adds 9 BEI Routes for AYALA EVO CITY, ROBINSONS PLACE DASMARINAS, XENTROMALL MONTALBAN. Idempotent. |
+| `fix_item_valuation_and_company.py` | Sets `valuation_rate = 1.0` on 41 PM/FG/KL items + fixes AYALA VERMOSA Company default_inventory_account. |
+| `fix_sm_marikina_accounts.py` / `fix_remaining_bsmi.py` | Repoints SM MARIKINA's broken BSMI→SMK account references. |
+| `fix_sm_marikina_is_group.py` | Sets SM MARIKINA Company `is_group=0` so it appears in `_get_allowed_target_companies()`. The fix that enabled v15 49/49. |
+
+## Seed + teardown scripts
+
+| Script | Purpose |
+|---|---|
+| `seed_v6_full_pm.py` | Comprehensive PM-stock seed at PCS-BKI + 3MD hubs. Used by both narrow and full sweeps. |
+| `seed_v5_boost.py` / `seed_narrow.py` / `seed_comprehensive.py` / `seed_test_stock.py` | Earlier seed iterations (less coverage). Kept for reference. |
+| `teardown_seeded_stock.py` / `teardown_v3.py` / `teardown_v4_v5_v6.py` / `teardown_comprehensive.py` | Cancel S229-labeled SEs + revert Stock Settings flags. Use the latest (`teardown_v4_v5_v6.py`) for any S229% pattern. |

--- a/scripts/s225/audit_6_fail_stores.py
+++ b/scripts/s225/audit_6_fail_stores.py
@@ -1,0 +1,124 @@
+"""Deep audit of the 6 stores that failed sweep-v8.
+
+For each store, dump:
+ - Company config (4 inventory accounts + cost center + abbr + parent_company)
+ - Warehouse config (company + parent_warehouse + warehouse_type)
+ - Customer config (default_company + customer_group + tax_id)
+ - BEI Route assignment (which route + cargo type + active)
+ - Bin state at the source warehouse (PCS-BKI / 3MD) for top PM items
+ - Recent BEI Warehouse Receiving rows (status + docstatus)
+ - Recent Material Request -> Stock Entry chain
+ - Compare to a known working store (ARANETA GATEWAY)
+
+Output: full JSON to stdout, summarized via SSM."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+FAIL_STORES = [
+    ("SM MARIKINA - BEBANG SM MARIKINA INC.", "SM MARIKINA - BEBANG SM MARIKINA INC."),  # backend WR not produced
+    ("STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.", "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC."),
+    ("THE GRID ROCKWELL - TASTECARTEL CORP.", "THE GRID ROCKWELL - TASTECARTEL CORP."),
+    ("THE TERMINAL - BEBANG STARMALL ALABANG INC.", "THE TERMINAL - BEBANG STARMALL ALABANG INC."),
+    ("UP TOWN MALL BGC - DMD HOLDINGS INC.", "UP TOWN MALL BGC - DMD HOLDINGS INC."),
+    ("VISTA MALL TAGUIG - TRICERN FOOD CORP.", "VISTA MALL TAGUIG - TRICERN FOOD CORP."),
+]
+WORKING_STORES = [
+    ("ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC", "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC"),
+    ("AYALA EVO CITY - BEBANG MEGA INC.", "AYALA EVO CITY - BEBANG MEGA INC."),
+]
+
+ALL_STORES = [(name, "fail") for (name, _) in FAIL_STORES] + [(name, "working") for (name, _) in WORKING_STORES]
+
+result = {"stores": {}}
+
+COMPANY_FIELDS = [
+    "name", "abbr", "parent_company", "default_currency", "country",
+    "default_inventory_account", "default_receivable_account", "default_payable_account",
+    "default_income_account", "default_expense_account",
+    "stock_received_but_not_billed", "stock_adjustment_account",
+    "expenses_included_in_valuation", "round_off_account", "round_off_cost_center",
+    "default_payroll_payable_account", "cost_center",
+]
+
+for store_name, kind in ALL_STORES:
+    s = {"kind": kind}
+    # Company (use store_name as canonical name; per S033 each store has own Company)
+    co_exists = bool(frappe.db.exists("Company", store_name))
+    if co_exists:
+        co = frappe.db.get_value("Company", store_name, COMPANY_FIELDS, as_dict=True)
+        s["company"] = dict(co)
+    else:
+        s["company"] = {"NOT_FOUND": True}
+
+    # Warehouse
+    wh_exists = bool(frappe.db.exists("Warehouse", store_name))
+    if wh_exists:
+        wh = frappe.db.get_value("Warehouse", store_name,
+            ["name", "company", "parent_warehouse", "warehouse_type", "disabled", "is_group"], as_dict=True)
+        s["warehouse"] = dict(wh)
+    else:
+        s["warehouse"] = {"NOT_FOUND": True}
+
+    # Customer
+    cust_exists = bool(frappe.db.exists("Customer", store_name))
+    if cust_exists:
+        cust = frappe.db.get_value("Customer", store_name,
+            ["name", "customer_group", "tax_id", "disabled", "is_internal_customer", "represents_company", "territory"], as_dict=True)
+        s["customer"] = dict(cust)
+    else:
+        s["customer"] = {"NOT_FOUND": True}
+
+    # BEI Route assignment for this store
+    routes = frappe.db.sql("""
+        SELECT br.name AS route, br.cargo_type, br.source_warehouse, br.active
+        FROM `tabBEI Route Stop` brs
+        INNER JOIN `tabBEI Route` br ON br.name = brs.parent
+        WHERE brs.store = %(store)s
+        ORDER BY br.cargo_type
+    """, {"store": store_name}, as_dict=True)
+    s["routes"] = [dict(r) for r in routes]
+
+    # Recent BEI Warehouse Receiving for this store (target_warehouse = warehouse name)
+    if wh_exists:
+        # Discover schema first
+        wr_meta = frappe.get_meta("BEI Warehouse Receiving")
+        wr_fields = [f.fieldname for f in wr_meta.fields if f.fieldname in (
+            "status","target_warehouse","source_warehouse","stock_entry","docstatus"
+        )]
+        wr_select = ["name","creation","docstatus"] + wr_fields
+        wrs = frappe.db.sql(f"""
+            SELECT {','.join('`'+c+'`' for c in wr_select)}
+            FROM `tabBEI Warehouse Receiving`
+            WHERE target_warehouse = %(wh)s
+              AND creation > NOW() - INTERVAL 4 HOUR
+            ORDER BY creation DESC
+            LIMIT 5
+        """, {"wh": store_name}, as_dict=True)
+        s["recent_wrs_4h"] = [dict(r) for r in wrs]
+
+    # Recent Material Requests for this store
+    if co_exists:
+        mrs = frappe.db.sql("""
+            SELECT name, status, docstatus, creation, transaction_date, set_warehouse, material_request_type
+            FROM `tabMaterial Request`
+            WHERE company = %(co)s
+              AND creation > NOW() - INTERVAL 4 HOUR
+            ORDER BY creation DESC
+            LIMIT 5
+        """, {"co": store_name}, as_dict=True)
+        s["recent_mrs_4h"] = [dict(r) for r in mrs]
+
+    result["stores"][store_name] = s
+
+# Sentry timeline correlation marker
+result["audit_run_at_pht"] = "2026-04-30 19:00 PHT"
+result["context"] = "Post sweep-v8 analysis: 6 fails, 3 skipped, 40 passed."
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/audit_two_stores.py
+++ b/scripts/s225/audit_two_stores.py
@@ -1,0 +1,112 @@
+"""Real config audit:
+  1. AYALA VERMOSA failure ('SI not created' due to PM006 valuation_rate=null)
+     → audit ALL PM* items: which ones have valuation_rate? which don't?
+  2. SM MARIKINA failure ('No BEI Warehouse Receiving') — silent dispatch failure
+     → compare BEBANG SM MARIKINA INC. config to a working store
+       (e.g., BEBANG ENTERPRISE INC. which routes to PCS-BKI and works)
+
+Output: full diff per store + actionable fix list.
+"""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# ============ AUDIT 1: PM* item valuation_rate gaps ============
+pm_items = frappe.db.sql("""
+    SELECT i.item_code, i.item_name, i.valuation_rate, i.is_stock_item, i.disabled
+    FROM `tabItem` i
+    WHERE i.item_code LIKE 'PM%'
+      AND i.is_stock_item = 1
+      AND i.disabled = 0
+    ORDER BY i.item_code
+""", as_dict=True)
+result["pm_items_audit"] = {
+    "total": len(pm_items),
+    "missing_valuation_rate": [r for r in pm_items if not r.get("valuation_rate") or float(r.get("valuation_rate") or 0) <= 0],
+    "with_valuation_rate": [r for r in pm_items if r.get("valuation_rate") and float(r.get("valuation_rate") or 0) > 0],
+}
+result["pm_items_audit"]["count_missing"] = len(result["pm_items_audit"]["missing_valuation_rate"])
+result["pm_items_audit"]["count_present"] = len(result["pm_items_audit"]["with_valuation_rate"])
+
+# Sample 5 of each
+result["pm_items_audit"]["missing_sample"] = result["pm_items_audit"]["missing_valuation_rate"][:5]
+result["pm_items_audit"]["present_sample"] = result["pm_items_audit"]["with_valuation_rate"][:5]
+# Drop full lists from response to fit SSM
+result["pm_items_audit"]["missing_codes"] = [r["item_code"] for r in result["pm_items_audit"]["missing_valuation_rate"]]
+del result["pm_items_audit"]["missing_valuation_rate"]
+del result["pm_items_audit"]["with_valuation_rate"]
+
+# Also FG and KL items
+for prefix in ["FG", "KL"]:
+    items = frappe.db.sql(f"""
+        SELECT item_code, valuation_rate FROM `tabItem`
+        WHERE item_code LIKE '{prefix}%' AND is_stock_item=1 AND disabled=0
+    """, as_dict=True)
+    missing = [r["item_code"] for r in items if not r.get("valuation_rate") or float(r.get("valuation_rate") or 0) <= 0]
+    result[f"{prefix.lower()}_items_audit"] = {
+        "total": len(items),
+        "missing_count": len(missing),
+        "missing_codes": missing[:30],
+    }
+
+# ============ AUDIT 2: SM MARIKINA vs working store config ============
+SM_MARIKINA_CO = "BEBANG SM MARIKINA INC."
+SM_MARIKINA_WH = "SM MARIKINA - BEBANG SM MARIKINA INC."
+SM_MARIKINA_CUST = "SM MARIKINA - BEBANG SM MARIKINA INC."
+
+# Working stores: AYALA EVO and SM TANZA both pass
+WORKING_CO = "BEBANG ENTERPRISE INC."  # Used by Robinsons Antipolo etc
+WORKING_WH = "AYALA EVO - BEBANG MEGA INC."
+WORKING_CUST = "AYALA EVO - BEBANG MEGA INC."
+
+config_audit = {}
+
+for label, co_name in [("MARIKINA", SM_MARIKINA_CO), ("WORKING_BEBANG_ENTERPRISE", WORKING_CO)]:
+    if not frappe.db.exists("Company", co_name):
+        config_audit[f"{label}_company"] = "NOT_FOUND"
+        continue
+    co = frappe.db.get_value("Company", co_name,
+        ["name","abbr","default_currency","default_letter_head","country",
+         "default_payable_account","default_receivable_account",
+         "default_employee_advance_account","default_payroll_payable_account",
+         "default_expense_account","default_income_account",
+         "default_inventory_account","stock_received_but_not_billed",
+         "expenses_included_in_valuation","cost_center","round_off_account",
+         "round_off_cost_center","write_off_account","exchange_gain_loss_account",
+         "unrealized_exchange_gain_loss_account","accumulated_depreciation_account",
+         "depreciation_expense_account","disposal_account","capital_work_in_progress_account",
+         "default_holiday_list","tax_id","parent_company"], as_dict=True)
+    config_audit[f"{label}_company"] = co
+
+# Check warehouses
+for label, wh_name in [("MARIKINA", SM_MARIKINA_WH), ("WORKING", WORKING_WH)]:
+    if not frappe.db.exists("Warehouse", wh_name):
+        config_audit[f"{label}_warehouse"] = "NOT_FOUND"
+        continue
+    wh = frappe.db.get_value("Warehouse", wh_name,
+        ["name","warehouse_name","company","disabled","is_group","parent_warehouse",
+         "default_in_transit_warehouse","custom_area_supervisor"], as_dict=True)
+    config_audit[f"{label}_warehouse"] = wh
+
+# Check customers
+for label, cust_name in [("MARIKINA", SM_MARIKINA_CUST), ("WORKING", WORKING_CUST)]:
+    if not frappe.db.exists("Customer", cust_name):
+        config_audit[f"{label}_customer"] = "NOT_FOUND"
+        continue
+    cust = frappe.db.get_value("Customer", cust_name,
+        ["name","customer_name","customer_type","customer_group","territory","tax_id",
+         "is_internal_customer","represents_company","default_currency",
+         "default_price_list"], as_dict=True)
+    config_audit[f"{label}_customer"] = cust
+
+result["config_audit"] = config_audit
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/check_bei_routes.py
+++ b/scripts/s225/check_bei_routes.py
@@ -1,0 +1,55 @@
+"""Check BEI Route configuration for failed stores + understand what cargo_type their items use."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# All BEI Routes
+result["bei_route_doctype_exists"] = bool(frappe.db.exists("DocType", "BEI Route"))
+if result["bei_route_doctype_exists"]:
+    routes = frappe.get_all("BEI Route",
+        fields=["name", "active", "cargo_type", "source_warehouse", "modified"],
+        limit=100)
+    result["all_bei_routes"] = routes
+    result["route_count"] = len(routes)
+
+    # Stops per route
+    stops = frappe.get_all("BEI Route Stop",
+        fields=["parent", "store", "stop_order"],
+        limit=200)
+    result["all_bei_route_stops"] = stops
+    result["stop_count"] = len(stops)
+
+# What's PM001's cargo_category?
+pm001 = frappe.get_doc("Item", "PM001")
+result["PM001"] = {
+    "item_name": pm001.item_name,
+    "item_group": pm001.item_group,
+    "cargo_category": getattr(pm001, "cargo_category", None),
+    "lane": getattr(pm001, "lane", None),
+    "is_stock_item": pm001.is_stock_item,
+}
+
+# Sample item used in the sweep — find a Material Request line for PM001 or FG001 from sweep window
+recent_mri = frappe.db.sql("""
+    SELECT mri.parent, mri.warehouse, mri.from_warehouse, mri.item_code, mri.qty,
+           mr.creation, mr.status, mr.set_warehouse,
+           IFNULL(mr.custom_source_warehouse, '') AS mr_source_wh,
+           IFNULL(mr.custom_cargo_lane, '') AS mr_cargo_lane
+    FROM `tabMaterial Request Item` mri
+    JOIN `tabMaterial Request` mr ON mr.name = mri.parent
+    WHERE mri.item_code IN ('PM001','FG001')
+      AND mr.creation > NOW() - INTERVAL 4 HOUR
+    ORDER BY mr.creation DESC
+    LIMIT 10
+""", as_dict=True)
+result["recent_mr_lines"] = recent_mri
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/check_pm001_at_pcs.py
+++ b/scripts/s225/check_pm001_at_pcs.py
@@ -1,0 +1,57 @@
+"""Specifically: does PM001 have ANY bin at PCS-BKI? And what about indented/ordered?"""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+PCS = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+
+for item in ["PM001", "FG001"]:
+    # Get ALL Bin rows for this item at PCS (or anywhere with PINNACLE)
+    rows = frappe.db.sql(f"""
+        SELECT warehouse, item_code, actual_qty, reserved_qty, ordered_qty, indented_qty, planned_qty, projected_qty, reserved_qty_for_production
+        FROM `tabBin`
+        WHERE item_code = '{item}'
+          AND warehouse LIKE '%PINNACLE%'
+    """, as_dict=True)
+    result[item] = rows
+
+# Item master defaults
+for item in ["PM001", "FG001"]:
+    item_doc = frappe.get_doc("Item", item)
+    item_defaults = []
+    for d in (item_doc.item_defaults or []):
+        item_defaults.append({
+            "company": d.company,
+            "default_warehouse": d.default_warehouse,
+            "default_supplier": d.default_supplier,
+        })
+    result[f"{item}_master"] = {
+        "item_group": item_doc.item_group,
+        "stock_uom": item_doc.stock_uom,
+        "is_stock_item": item_doc.is_stock_item,
+        "include_item_in_manufacturing": item_doc.include_item_in_manufacturing,
+        "item_defaults": item_defaults,
+    }
+
+# Recent open MRs that requested PM001 at PCS-BKI
+recent_mr = frappe.db.sql("""
+    SELECT mri.parent, mri.warehouse, mri.qty, mri.ordered_qty, mri.received_qty, mri.stock_qty,
+           mr.status, mr.material_request_type, mr.transaction_date
+    FROM `tabMaterial Request Item` mri
+    JOIN `tabMaterial Request` mr ON mr.name = mri.parent
+    WHERE mri.item_code = 'PM001'
+      AND mri.warehouse LIKE '%PINNACLE%'
+      AND mr.creation > NOW() - INTERVAL 4 HOUR
+    ORDER BY mr.creation DESC
+    LIMIT 10
+""", as_dict=True)
+result["recent_mrs_pm001_pcs"] = recent_mr
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/check_pm001_pcs_bki.py
+++ b/scripts/s225/check_pm001_pcs_bki.py
@@ -1,0 +1,47 @@
+"""PM001 + FG001 specifically at Pinnacle Cold Storage Solutions - BKI."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+PCS = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+
+# All bins for PM001 and FG001
+for item in ["PM001", "FG001"]:
+    rows = frappe.get_all("Bin",
+        filters={"item_code": item},
+        fields=["warehouse", "actual_qty", "reserved_qty", "projected_qty", "ordered_qty", "indented_qty"],
+        order_by="actual_qty desc",
+        limit=50)
+    result[item] = {
+        "total_bins": len(rows),
+        "all_bins": rows,
+    }
+
+# Specifically look up PCS-BKI bins (case insensitive)
+pcs_bins = []
+for r in result.get("PM001", {}).get("all_bins", []) + result.get("FG001", {}).get("all_bins", []):
+    if "PINNACLE" in (r.get("warehouse") or "").upper():
+        pcs_bins.append(r)
+result["pcs_bki_bins"] = pcs_bins
+
+# Recent stock entries that touched PCS-BKI for these items
+recent_se = frappe.db.sql("""
+    SELECT sed.parent, sed.s_warehouse, sed.t_warehouse, sed.item_code, sed.qty, se.creation, se.docstatus, se.stock_entry_type
+    FROM `tabStock Entry Detail` sed
+    JOIN `tabStock Entry` se ON se.name = sed.parent
+    WHERE sed.item_code IN ('PM001','FG001')
+      AND (sed.s_warehouse LIKE '%PINNACLE%' OR sed.t_warehouse LIKE '%PINNACLE%')
+      AND se.creation > NOW() - INTERVAL 4 HOUR
+    ORDER BY se.creation DESC
+    LIMIT 30
+""", as_dict=True)
+result["recent_se_touching_pcs"] = recent_se
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/check_pm001_stock.py
+++ b/scripts/s225/check_pm001_stock.py
@@ -1,0 +1,29 @@
+"""Quick PM001/FG001 stock probe — run via SSM/docker exec on production container."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+for item in ["PM001", "FG001"]:
+    rows = frappe.get_all("Bin",
+        filters={"item_code": item, "actual_qty": [">", -1000]},
+        fields=["warehouse", "actual_qty", "reserved_qty", "projected_qty"],
+        order_by="actual_qty desc",
+        limit=20)
+    nonzero = [r for r in rows if r.get("actual_qty") > 0]
+    zero = [r for r in rows if r.get("actual_qty") == 0]
+    result[item] = {
+        "total_bins": len(rows),
+        "nonzero_count": len(nonzero),
+        "zero_count": len(zero),
+        "top_5_nonzero": nonzero[:5],
+        "sample_zero": zero[:3],
+    }
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/check_routes_summary.py
+++ b/scripts/s225/check_routes_summary.py
@@ -1,0 +1,74 @@
+"""Summary-only BEI Route probe to fit SSM 24KB limit."""
+import os, json
+from collections import Counter
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# 1. Route counts
+result["bei_route_doctype_exists"] = bool(frappe.db.exists("DocType", "BEI Route"))
+total_routes = frappe.db.count("BEI Route", filters={"active": 1})
+total_stops = frappe.db.count("BEI Route Stop")
+result["total_active_routes"] = total_routes
+result["total_stops"] = total_stops
+
+# 2. Cargo type distribution
+ctypes = frappe.db.sql("""SELECT cargo_type, COUNT(*) AS n
+                          FROM `tabBEI Route`
+                          WHERE COALESCE(active,1)=1
+                          GROUP BY cargo_type
+                          ORDER BY n DESC""", as_dict=True)
+result["cargo_type_distribution"] = ctypes
+
+# 3. Source warehouse distribution
+swhs = frappe.db.sql("""SELECT source_warehouse, COUNT(*) AS n
+                        FROM `tabBEI Route`
+                        WHERE COALESCE(active,1)=1
+                        GROUP BY source_warehouse
+                        ORDER BY n DESC""", as_dict=True)
+result["source_warehouse_distribution"] = swhs
+
+# 4. PM001 + FG001 metadata
+for it in ["PM001","FG001"]:
+    d = frappe.get_doc("Item", it)
+    result[f"{it}_meta"] = {
+        "item_name": d.item_name,
+        "item_group": d.item_group,
+        "cargo_category": getattr(d, "cargo_category", None),
+        "lane": getattr(d, "lane", None),
+    }
+
+# 5. For each failed store, how many routes? what cargo types?
+failed_stores = [
+    "AYALA MARKET MARKET", "AYALA SOLENAD", "AYALA VERMOSA",
+    "MEGAWORLD PASEO CENTER", "NAIA T3",
+    "ORTIGAS ESTANCIA", "ORTIGAS GREENHILLS",
+    "ROBINSONS ANTIPOLO", "ROBINSONS GENERAL TRIAS", "ROBINSONS IMUS",
+    "SM BICUTAN", "SM MARIKINA", "SM SOUTHMALL", "SM STA. ROSA",
+]
+result["failed_stores_routes"] = {}
+for store in failed_stores:
+    rows = frappe.db.sql("""
+        SELECT s.store, r.cargo_type, r.source_warehouse, r.active
+        FROM `tabBEI Route Stop` s
+        JOIN `tabBEI Route` r ON r.name = s.parent
+        WHERE UPPER(s.store) LIKE %(pat)s
+        ORDER BY r.cargo_type
+    """, {"pat": f"%{store}%"}, as_dict=True)
+    result["failed_stores_routes"][store] = rows
+
+# 6. What does the resolver pick for SM STA. ROSA + DRY? Run it directly.
+from hrms.utils.supply_chain_contracts import resolve_route_source_warehouse
+result["resolver_test"] = {}
+for store in ["SM Sta. Rosa - SWEET HARMONY FOOD CORP.", "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.", "NAIA T3 - HALO-HALO TERMINAL FOOD CORP."]:
+    for cargo in ["DRY", "FROZEN", "FRESH", "FC", "FM"]:
+        result["resolver_test"][f"{store}|{cargo}"] = resolve_route_source_warehouse(store, cargo)
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/enumerate_seeded.py
+++ b/scripts/s225/enumerate_seeded.py
@@ -1,0 +1,51 @@
+"""Enumerate everything seeded by seed_comprehensive.py — query by label/prefix."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# Stock Entries with our label
+ses = frappe.db.sql("""
+    SELECT name, posting_date, docstatus
+    FROM `tabStock Entry`
+    WHERE remarks LIKE 'S229 retest seed%%'
+      AND creation > NOW() - INTERVAL 1 HOUR
+    ORDER BY name
+""", as_dict=True)
+result["stock_entries"] = ses
+result["se_count"] = len(ses)
+
+# BEI Routes created in last hour (filter by creation time only)
+routes = frappe.db.sql("""
+    SELECT name, cargo_type, source_warehouse, active, creation
+    FROM `tabBEI Route`
+    WHERE creation > NOW() - INTERVAL 1 HOUR
+    ORDER BY name
+""", as_dict=True)
+result["bei_routes"] = routes
+result["route_count"] = len(routes)
+
+# Stock Settings current state
+result["stock_settings"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+
+# Sample bin states for key items
+sample_items = ["PM001","FG001","FG002","FG002-A","FG004","FG010","FG023","KL001","KL004"]
+sample_bins = {}
+for item in sample_items:
+    for wh in ["PINNACLE COLD STORAGE SOLUTIONS - BKI", "3MD Logistics - Camangyanan - BKI"]:
+        bin_q = frappe.db.get_value("Bin", {"item_code": item, "warehouse": wh}, ["actual_qty","projected_qty"], as_dict=True)
+        if bin_q:
+            sample_bins[f"{item}@{wh[:30]}"] = {"actual": float(bin_q.actual_qty or 0), "projected": float(bin_q.projected_qty or 0)}
+result["sample_bins"] = sample_bins
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/find_marikina.py
+++ b/scripts/s225/find_marikina.py
@@ -1,0 +1,38 @@
+"""Find any Company with MARIKINA in name. The verify script reported
+company_exists=false for 'BEBANG SM MARIKINA INC.' but handoff §3d says
+it was fixed today. Either renamed, abbreviated, or named differently."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# Find any company with MARIKINA
+mk_cos = frappe.db.sql("""
+    SELECT name, abbr, default_inventory_account, stock_received_but_not_billed,
+           stock_adjustment_account, expenses_included_in_valuation, round_off_cost_center,
+           parent_company
+    FROM `tabCompany`
+    WHERE name LIKE '%MARIKINA%' OR abbr LIKE '%SMK%' OR abbr LIKE '%BSMI%'
+""", as_dict=True)
+result["marikina_companies"] = [dict(r) for r in mk_cos]
+
+# Also Warehouse and Customer
+mk_wh = frappe.db.sql("SELECT name, company FROM `tabWarehouse` WHERE name LIKE '%MARIKINA%'", as_dict=True)
+result["marikina_warehouses"] = [dict(r) for r in mk_wh]
+
+# Find any account with SMK or BSMI suffix
+acc_smk = frappe.db.sql("SELECT name, company FROM `tabAccount` WHERE name LIKE '%- SMK' LIMIT 20", as_dict=True)
+acc_bsmi = frappe.db.sql("SELECT name, company FROM `tabAccount` WHERE name LIKE '%- BSMI' LIMIT 20", as_dict=True)
+result["accounts_smk_count"] = len(acc_smk)
+result["accounts_smk_sample"] = [r["name"] for r in acc_smk][:10]
+result["accounts_bsmi_count"] = len(acc_bsmi)
+result["accounts_bsmi_sample"] = [r["name"] for r in acc_bsmi][:10]
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/find_marikina_company.py
+++ b/scripts/s225/find_marikina_company.py
@@ -1,0 +1,70 @@
+"""Fuzzy search for SM MARIKINA Company + check warehouse linkage."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# Find any company matching MARIKINA
+companies = frappe.db.sql("""
+    SELECT name, abbr, default_currency, default_receivable_account, default_income_account, parent_company
+    FROM `tabCompany`
+    WHERE UPPER(name) LIKE '%MARIKINA%' OR UPPER(name) LIKE '%SM%MARIKIN%'
+""", as_dict=True)
+result["companies_with_marikina"] = companies
+
+# All companies for reference (count)
+total_co = frappe.db.count("Company")
+result["total_companies"] = total_co
+
+# Warehouse SM MARIKINA - what company does it reference?
+sm_mar_wh_name = "SM MARIKINA - BEBANG SM MARIKINA INC."
+if frappe.db.exists("Warehouse", sm_mar_wh_name):
+    wh = frappe.db.get_value("Warehouse", sm_mar_wh_name,
+        ["name","warehouse_name","company","disabled","is_group","parent_warehouse"], as_dict=True)
+    result["sm_marikina_warehouse"] = wh
+    # Check if its `company` field references an existing Company
+    if wh and wh.get("company"):
+        co_exists = frappe.db.exists("Company", wh["company"])
+        result["sm_marikina_warehouse_company_exists"] = bool(co_exists)
+        if co_exists:
+            co = frappe.db.get_value("Company", wh["company"],
+                ["name","default_currency","default_receivable_account","default_income_account",
+                 "default_inventory_account","cost_center","stock_received_but_not_billed","parent_company"], as_dict=True)
+            result["sm_marikina_actual_company"] = co
+
+# Customer SM MARIKINA
+sm_mar_cust = "SM MARIKINA - BEBANG SM MARIKINA INC."
+if frappe.db.exists("Customer", sm_mar_cust):
+    cust = frappe.db.get_value("Customer", sm_mar_cust,
+        ["name","customer_type","customer_group","territory","tax_id",
+         "is_internal_customer","represents_company"], as_dict=True)
+    result["sm_marikina_customer"] = cust
+
+# Compare AYALA VERMOSA setup (also failing — find its company)
+av_wh = "AYALA VERMOSA - BEBANG MEGA INC."
+if frappe.db.exists("Warehouse", av_wh):
+    avwh = frappe.db.get_value("Warehouse", av_wh, ["name","company"], as_dict=True)
+    result["ayala_vermosa_warehouse"] = avwh
+    if avwh and avwh.get("company") and frappe.db.exists("Company", avwh["company"]):
+        avco = frappe.db.get_value("Company", avwh["company"],
+            ["name","default_receivable_account","default_income_account","default_inventory_account"], as_dict=True)
+        result["ayala_vermosa_company"] = avco
+
+# Compare with a working store: AYALA EVO
+ae_wh = "AYALA EVO - BEBANG MEGA INC."
+if frappe.db.exists("Warehouse", ae_wh):
+    aewh = frappe.db.get_value("Warehouse", ae_wh, ["name","company"], as_dict=True)
+    result["ayala_evo_warehouse"] = aewh
+    if aewh and aewh.get("company") and frappe.db.exists("Company", aewh["company"]):
+        aeco = frappe.db.get_value("Company", aewh["company"],
+            ["name","default_receivable_account","default_income_account","default_inventory_account"], as_dict=True)
+        result["ayala_evo_company"] = aeco
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/fix_3_blocked_stores_routes.py
+++ b/scripts/s225/fix_3_blocked_stores_routes.py
@@ -1,0 +1,105 @@
+"""Add BEI Routes for the 3 PRECONDITION_BLOCKED stores from sweep-v9/v10.
+
+These stores had ZERO BEI Routes, which caused get_orderable_items() to return
+an empty list. The Playwright test then threw 'No orderable items at all' and
+called test.skip() — which masked the real problem (no routes) as a benign skip.
+
+Geographic source-hub assignment (per BEI Route Planner UI logic):
+  - AYALA EVO CITY (Cavite, south of Manila)            → Pinnacle Cold (south)
+  - ROBINSONS PLACE DASMARINAS (Dasmariñas, Cavite)     → Pinnacle Cold (south)
+  - XENTROMALL MONTALBAN (Rodriguez Rizal, north-east)  → 3MD Logistics (north)
+
+3 cargo types each (DRY, FC, FM) = 9 routes total.
+
+Idempotent — if a route already exists for store+cargo, skip it.
+"""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+PCS_BKI = "Pinnacle Cold Storage Solutions - BKI"
+HUB_3MD = "3MD Logistics - Camangyanan - BKI"
+
+# Per geography
+ROUTE_BACKFILL = [
+    ("AYALA EVO CITY - BEBANG MEGA INC.", PCS_BKI, "south-Cavite"),
+    ("ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.", PCS_BKI, "south-Cavite"),
+    ("XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.", HUB_3MD, "north-Rizal"),
+]
+CARGO_TYPES = ["DRY", "FC", "FM"]
+
+result = {
+    "routes_created": [],
+    "routes_skipped_existing": [],
+    "errors": [],
+}
+
+# Verify each store warehouse exists before creating routes
+for store, hub, _zone in ROUTE_BACKFILL:
+    if not frappe.db.exists("Warehouse", store):
+        result["errors"].append({"store": store, "error": f"Warehouse '{store}' does not exist"})
+
+if not result["errors"]:
+    for store, hub, zone in ROUTE_BACKFILL:
+        for cargo in CARGO_TYPES:
+            try:
+                # Idempotency check
+                existing = frappe.db.sql("""
+                    SELECT r.name FROM `tabBEI Route` r
+                    JOIN `tabBEI Route Stop` s ON s.parent = r.name
+                    WHERE COALESCE(r.active,1) = 1
+                      AND r.cargo_type = %(cargo)s
+                      AND s.store = %(store)s
+                    LIMIT 1
+                """, {"cargo": cargo, "store": store}, as_dict=True)
+                if existing:
+                    result["routes_skipped_existing"].append({
+                        "store": store, "cargo": cargo, "existing": existing[0]["name"],
+                    })
+                    continue
+
+                store_short = store.split(" - ")[0]
+                route = frappe.new_doc("BEI Route")
+                route.route_name = f"{store_short} - {cargo}"
+                route.cargo_type = cargo
+                route.source_warehouse = hub
+                route.active = 1
+                route.append("stops", {
+                    "store": store,
+                    "stop_order": 1,
+                })
+                route.insert(ignore_permissions=True)
+                frappe.db.commit()
+                result["routes_created"].append({
+                    "name": route.name,
+                    "route_name": route.route_name,
+                    "store": store,
+                    "cargo": cargo,
+                    "source_warehouse": hub,
+                    "zone": zone,
+                })
+            except Exception as e:
+                frappe.db.rollback()
+                result["errors"].append({
+                    "store": store, "cargo": cargo, "error": str(e)[:300],
+                })
+
+# Verify by re-querying
+verify = {}
+for store, _, _ in ROUTE_BACKFILL:
+    routes = frappe.db.sql("""
+        SELECT br.name, br.cargo_type, br.source_warehouse, br.active
+        FROM `tabBEI Route Stop` brs
+        INNER JOIN `tabBEI Route` br ON br.name = brs.parent
+        WHERE brs.store = %(s)s AND br.active = 1
+    """, {"s": store}, as_dict=True)
+    verify[store] = [dict(r) for r in routes]
+result["post_verify"] = verify
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/fix_item_valuation_and_company.py
+++ b/scripts/s225/fix_item_valuation_and_company.py
@@ -1,0 +1,102 @@
+"""Fix:
+  1. Set valuation_rate=1.0 on all PM/FG/KL items currently missing it
+     (so SI creation can price line items)
+  2. Investigate AYALA VERMOSA Company default_inventory_account gap;
+     copy from BEBANG MEGA INC. parent if missing
+  3. Audit SM MARIKINA Stock In Hand - BSMI account exists / is set up
+"""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# ==== Step 1: Set valuation_rate on PM/FG/KL items missing it ====
+items_to_fix = frappe.db.sql("""
+    SELECT name, item_code, item_name FROM `tabItem`
+    WHERE (item_code LIKE 'PM%' OR item_code LIKE 'FG%' OR item_code LIKE 'KL%')
+      AND is_stock_item = 1
+      AND disabled = 0
+      AND (valuation_rate IS NULL OR valuation_rate <= 0)
+    ORDER BY item_code
+""", as_dict=True)
+
+result["items_fixed"] = []
+for item in items_to_fix:
+    try:
+        frappe.db.set_value("Item", item["item_code"], "valuation_rate", 1.0)
+        result["items_fixed"].append(item["item_code"])
+    except Exception as e:
+        result.setdefault("item_errors", []).append({"item": item["item_code"], "error": str(e)[:200]})
+frappe.db.commit()
+result["items_fixed_count"] = len(result["items_fixed"])
+result["items_fixed_first_15"] = result["items_fixed"][:15]
+del result["items_fixed"]  # too long for SSM stdout
+
+# Verify
+verify_count = frappe.db.sql("""
+    SELECT COUNT(*) AS cnt FROM `tabItem`
+    WHERE (item_code LIKE 'PM%' OR item_code LIKE 'FG%' OR item_code LIKE 'KL%')
+      AND is_stock_item=1 AND disabled=0
+      AND (valuation_rate IS NULL OR valuation_rate <= 0)
+""", as_dict=True)
+result["items_still_missing_valuation_rate"] = verify_count[0]["cnt"]
+
+# ==== Step 2: AYALA VERMOSA Company audit + fix ====
+av_co = "AYALA VERMOSA - BEBANG MEGA INC."
+parent_co = "BEBANG MEGA INC."
+
+if frappe.db.exists("Company", av_co):
+    av_inv = frappe.db.get_value("Company", av_co, "default_inventory_account")
+    parent_inv = frappe.db.get_value("Company", parent_co, "default_inventory_account") if frappe.db.exists("Company", parent_co) else None
+    result["AV_BEFORE"] = {
+        "company": av_co,
+        "default_inventory_account": av_inv,
+        "parent_inventory_account": parent_inv,
+    }
+    if not av_inv and parent_inv:
+        # Copy from parent
+        try:
+            frappe.db.set_value("Company", av_co, "default_inventory_account", parent_inv)
+            frappe.db.commit()
+            result["AV_FIX"] = "copied default_inventory_account from parent"
+        except Exception as e:
+            result["AV_FIX_ERROR"] = str(e)[:200]
+    av_inv_after = frappe.db.get_value("Company", av_co, "default_inventory_account")
+    result["AV_AFTER"] = {"default_inventory_account": av_inv_after}
+
+# ==== Step 3: Audit ALL per-store Companies for similar gaps ====
+all_per_store_cos = frappe.db.sql("""
+    SELECT name, abbr, default_receivable_account, default_income_account, default_inventory_account, parent_company, cost_center
+    FROM `tabCompany`
+    WHERE name LIKE '%BEBANG%' OR name LIKE '%TUNGSTEN%' OR name LIKE '%FOOD CORP%' OR name LIKE '%FOOD OPC%' OR name LIKE '%HOLDINGS%'
+""", as_dict=True)
+
+result["per_store_company_gaps"] = []
+for co in all_per_store_cos:
+    gaps = []
+    if not co.get("default_receivable_account"): gaps.append("default_receivable_account")
+    if not co.get("default_income_account"): gaps.append("default_income_account")
+    if not co.get("default_inventory_account"): gaps.append("default_inventory_account")
+    if not co.get("cost_center"): gaps.append("cost_center")
+    if gaps:
+        result["per_store_company_gaps"].append({
+            "company": co["name"], "abbr": co["abbr"],
+            "parent": co["parent_company"], "missing": gaps,
+        })
+result["per_store_company_gap_count"] = len(result["per_store_company_gaps"])
+
+# ==== Step 4: Account existence check for SM MARIKINA's BSMI accounts ====
+sm_mar_accounts = ["Stock In Hand - BSMI", "Stock Received But Not Billed - BSMI", "Debtors - SMK", "Sales - SMK", "Main - SMK"]
+result["sm_marikina_accounts"] = {}
+for acc in sm_mar_accounts:
+    exists = frappe.db.exists("Account", acc) or frappe.db.exists("Cost Center", acc)
+    result["sm_marikina_accounts"][acc] = bool(exists)
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/fix_remaining_bsmi.py
+++ b/scripts/s225/fix_remaining_bsmi.py
@@ -1,0 +1,58 @@
+"""Repoint remaining BSMI references on SM MARIKINA Company to SMK or parent."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+co_name = "SM MARIKINA - BEBANG SM MARIKINA INC."
+result = {"before": {}, "fixes": [], "after": {}, "errors": []}
+
+# All fields that might have stale BSMI refs
+fields_to_check = [
+    "stock_adjustment_account",
+    "expenses_included_in_valuation",
+    "round_off_cost_center",
+    "default_employee_advance_account",
+]
+for f in fields_to_check:
+    v = frappe.db.get_value("Company", co_name, f)
+    result["before"][f] = v
+
+# Check if each value exists; if BSMI and broken, find SMK or parent equivalent
+parent = "BEBANG ENTERPRISE INC."
+
+REPOINT = {
+    "stock_adjustment_account": ("Stock Adjustment - SMK", "Stock Adjustment - Bebang Enterprise Inc.", "Account"),
+    "expenses_included_in_valuation": ("Expenses Included In Valuation - SMK", "Expenses Included In Valuation - BEI", "Account"),
+    "round_off_cost_center": ("Main - SMK", "Main - BEI", "Cost Center"),
+}
+
+for field, (preferred_smk, fallback_parent, doctype) in REPOINT.items():
+    cur = result["before"].get(field)
+    if not cur:
+        continue
+    if frappe.db.exists(doctype, cur):
+        continue  # current value is valid, leave it
+    # current is broken; find replacement
+    target = preferred_smk if frappe.db.exists(doctype, preferred_smk) else (fallback_parent if frappe.db.exists(doctype, fallback_parent) else None)
+    if not target:
+        result["errors"].append(f"{field}: no valid replacement for {cur}")
+        continue
+    try:
+        frappe.db.set_value("Company", co_name, field, target)
+        result["fixes"].append({"field": field, "from": cur, "to": target})
+    except Exception as e:
+        result["errors"].append({"field": field, "error": str(e)[:200]})
+
+frappe.db.commit()
+
+# Verify
+for f in fields_to_check:
+    result["after"][f] = frappe.db.get_value("Company", co_name, f)
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/fix_routes_and_seed.py
+++ b/scripts/s225/fix_routes_and_seed.py
@@ -1,0 +1,160 @@
+"""S225 comprehensive fix — sweep #4:
+  1. Add BEI Routes for 5 stores currently hitting defect #1 fallback
+     (geography per Route Planner UI 2026-04-29 screenshot):
+       - NAIA T3 (Pasay airport)               → 3MD Logistics - Camangyanan - BKI (North)
+       - ORTIGAS ESTANCIA (Pasig)              → 3MD Logistics - Camangyanan - BKI (North)
+       - ORTIGAS GREENHILLS (San Juan)         → 3MD Logistics - Camangyanan - BKI (North)
+       - ROBINSONS ANTIPOLO (Antipolo, Rizal)  → 3MD Logistics - Camangyanan - BKI (North)
+       - SM STA. ROSA (Laguna)                 → Pinnacle Cold Storage Solutions - BKI (South)
+     × 3 cargo types each (DRY, FC, FM) = 15 routes total
+  2. Toggle Stock Settings allow_negative_stock + allow_negative_stock_for_batch = 1
+  3. Narrow seed: PM001/KL001/KL004 at both hubs (only items currently low/empty)
+
+CEO authorization 2026-04-30: explicit approval to add routes based on geography.
+"""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+from frappe.utils import nowdate, now_datetime
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+PCS_BKI = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+HUB_3MD = "3MD Logistics - Camangyanan - BKI"
+
+# Per Route Planner UI screenshot 2026-04-29:
+#   3MD Marilao (North): NAIA T3, Estancia, Greenhills, Robinsons Antipolo
+#   Pinnacle Calamba (South): SM Sta Rosa
+ROUTE_BACKFILL = [
+    ("NAIA T3 - HALO-HALO TERMINAL FOOD CORP.", HUB_3MD, "north"),
+    ("ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.", HUB_3MD, "north"),
+    ("ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC", HUB_3MD, "north"),
+    ("ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.", HUB_3MD, "north"),
+    ("SM STA. ROSA - SWEET HARMONY FOOD CORP.", PCS_BKI, "south"),
+]
+CARGO_TYPES = ["DRY", "FC", "FM"]
+
+result = {
+    "stock_settings_pre": {
+        "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+        "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+    },
+    "routes_created": [],
+    "routes_skipped_existing": [],
+    "ses_created": [],
+    "errors": [],
+}
+
+# ---------- 1. Add BEI Routes ----------
+for store, hub, zone in ROUTE_BACKFILL:
+    for cargo in CARGO_TYPES:
+        try:
+            existing = frappe.db.sql("""
+                SELECT r.name FROM `tabBEI Route` r
+                JOIN `tabBEI Route Stop` s ON s.parent = r.name
+                WHERE COALESCE(r.active,1) = 1
+                  AND r.cargo_type = %(cargo)s
+                  AND s.store = %(store)s
+                LIMIT 1
+            """, {"cargo": cargo, "store": store}, as_dict=True)
+            if existing:
+                result["routes_skipped_existing"].append({
+                    "store": store, "cargo": cargo, "existing": existing[0]["name"],
+                })
+                continue
+
+            store_short = store.split(" - ")[0]  # e.g., "NAIA T3"
+            route = frappe.new_doc("BEI Route")
+            route.route_name = f"{store_short} - {cargo}"
+            route.cargo_type = cargo
+            route.source_warehouse = hub
+            route.active = 1
+            route.append("stops", {
+                "store": store,
+                "stop_order": 1,
+            })
+            route.insert(ignore_permissions=True)
+            frappe.db.commit()
+            result["routes_created"].append({
+                "doctype": "BEI Route",
+                "name": route.name,
+                "route_name": route.route_name,
+                "cargo": cargo,
+                "store": store,
+                "hub": hub,
+                "zone": zone,
+                "action_to_reverse": "DELETE",
+            })
+        except Exception as e:
+            frappe.db.rollback()
+            result["errors"].append({
+                "step": "route", "store": store, "cargo": cargo, "error": str(e)[:300],
+            })
+
+# ---------- 2. Toggle Stock Settings ----------
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 1)
+frappe.db.commit()
+result["stock_settings_post"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+
+# ---------- 3. Narrow seed (only the items historically failing) ----------
+SEED_LABEL = "S229 sweep4 narrow seed (2026-04-30)"
+SEED_QTY = 500
+SEED_ITEMS = ["PM001", "KL001", "KL004"]
+HUBS = [PCS_BKI, HUB_3MD]
+
+for item_code in SEED_ITEMS:
+    if not frappe.db.exists("Item", item_code):
+        result["errors"].append({"step": "seed", "item": item_code, "error": "ITEM_NOT_IN_MASTER"})
+        continue
+    stock_uom = frappe.db.get_value("Item", item_code, "stock_uom") or "Nos"
+    for hub in HUBS:
+        try:
+            cur = float(frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": hub}, "actual_qty") or 0)
+            if cur >= SEED_QTY:
+                continue
+            qty_to_add = SEED_QTY - cur if cur > 0 else SEED_QTY
+            company = frappe.db.get_value("Warehouse", hub, "company")
+            se = frappe.new_doc("Stock Entry")
+            se.stock_entry_type = "Material Receipt"
+            se.purpose = "Material Receipt"
+            se.posting_date = nowdate()
+            se.posting_time = now_datetime().strftime("%H:%M:%S")
+            se.set_posting_time = 1
+            se.company = company
+            se.append("items", {
+                "item_code": item_code,
+                "qty": qty_to_add,
+                "uom": stock_uom,
+                "stock_uom": stock_uom,
+                "conversion_factor": 1,
+                "t_warehouse": hub,
+                "basic_rate": 1.0,
+                "allow_zero_valuation_rate": 1,
+            })
+            se.remarks = SEED_LABEL
+            se.insert(ignore_permissions=True)
+            se.submit()
+            frappe.db.commit()
+            result["ses_created"].append({
+                "name": se.name, "item": item_code, "qty": qty_to_add, "warehouse": hub,
+            })
+        except Exception as e:
+            frappe.db.rollback()
+            result["errors"].append({"step": "seed", "item": item_code, "warehouse": hub, "error": str(e)[:200]})
+
+result["summary"] = {
+    "routes_created": len(result["routes_created"]),
+    "routes_skipped_existing": len(result["routes_skipped_existing"]),
+    "ses_created": len(result["ses_created"]),
+    "errors": len(result["errors"]),
+}
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/fix_sm_marikina_accounts.py
+++ b/scripts/s225/fix_sm_marikina_accounts.py
@@ -1,0 +1,85 @@
+"""SM MARIKINA fix: Company references 'Stock In Hand - BSMI' which doesn't exist.
+Find SMK-suffixed Stock accounts (or fall back to parent BEBANG ENTERPRISE INC.) and re-point."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# Find SMK accounts of relevant types
+smk_accounts = frappe.db.sql("""
+    SELECT name, account_type, root_type, is_group
+    FROM `tabAccount`
+    WHERE name LIKE '%- SMK%' AND is_group = 0
+    ORDER BY name
+""", as_dict=True)
+result["smk_leaf_accounts"] = smk_accounts
+
+# What about parent company BEBANG ENTERPRISE INC. accounts (BEI)?
+parent_inv = frappe.db.get_value("Company", "BEBANG ENTERPRISE INC.", "default_inventory_account")
+parent_srbnb = frappe.db.get_value("Company", "BEBANG ENTERPRISE INC.", "stock_received_but_not_billed")
+result["parent_BEI_inv"] = parent_inv
+result["parent_BEI_srbnb"] = parent_srbnb
+
+# Find the right inventory account for SMK - any "Stock In Hand" or similar
+inv_candidates = frappe.db.sql("""
+    SELECT name, account_type, root_type
+    FROM `tabAccount`
+    WHERE (name LIKE 'Stock In Hand%' OR name LIKE 'Inventory%')
+      AND is_group = 0
+      AND name LIKE '%SMK%'
+""", as_dict=True)
+result["smk_inv_candidates"] = inv_candidates
+
+# Also fall-back: look at sister stores under SMK that have inventory account set up working
+sm_marikina_co = "SM MARIKINA - BEBANG SM MARIKINA INC."
+co = frappe.db.get_value("Company", sm_marikina_co,
+    ["default_inventory_account","stock_received_but_not_billed","stock_adjustment_account",
+     "expenses_included_in_valuation","default_payable_account","default_receivable_account",
+     "default_income_account","default_expense_account","cost_center","round_off_account",
+     "round_off_cost_center","abbr"], as_dict=True)
+result["SM_MAR_BEFORE"] = co
+
+# Determine fix:
+# If a SMK-suffixed inventory account exists, use it. Else use parent BEI inventory.
+target_inv_account = None
+for c in inv_candidates:
+    target_inv_account = c["name"]; break
+
+if not target_inv_account:
+    # Fallback to parent
+    target_inv_account = parent_inv
+
+result["target_inv_account"] = target_inv_account
+
+# Apply fix if account exists
+if target_inv_account and frappe.db.exists("Account", target_inv_account):
+    try:
+        frappe.db.set_value("Company", sm_marikina_co, "default_inventory_account", target_inv_account)
+        # Also set stock_received_but_not_billed if it's broken
+        if co.get("stock_received_but_not_billed") and not frappe.db.exists("Account", co["stock_received_but_not_billed"]):
+            if parent_srbnb and frappe.db.exists("Account", parent_srbnb):
+                frappe.db.set_value("Company", sm_marikina_co, "stock_received_but_not_billed", parent_srbnb)
+                result["FIX_STOCK_SRBNB"] = parent_srbnb
+        frappe.db.commit()
+        result["FIX_INV_APPLIED"] = target_inv_account
+    except Exception as e:
+        result["FIX_ERROR"] = str(e)[:200]
+
+# Verify
+co_after = frappe.db.get_value("Company", sm_marikina_co,
+    ["default_inventory_account","stock_received_but_not_billed"], as_dict=True)
+result["SM_MAR_AFTER"] = co_after
+
+# Verify all referenced accounts exist
+for k, v in (co_after or {}).items():
+    if v:
+        result.setdefault("verify_accounts_exist", {})[v] = bool(frappe.db.exists("Account", v))
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/fix_sm_marikina_is_group.py
+++ b/scripts/s225/fix_sm_marikina_is_group.py
@@ -1,0 +1,62 @@
+"""Fix SM MARIKINA's Company misconfig: is_group=1 → is_group=0.
+
+Per canonical store/company SSOT, every per-store Company should be a leaf
+(is_group=0). SM MARIKINA - BEBANG SM MARIKINA INC. has is_group=1 which makes
+`_get_allowed_target_companies()` exclude it (the SQL filters group Companies),
+which makes WR auto-creation fail with 'Target warehouse must belong to one of:'.
+
+This is the root cause of SM MARIKINA's reproducible test failure.
+
+Probe + fix + verify in one shot. Idempotent."""
+import os
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe, json
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+CO_NAME = "SM MARIKINA - BEBANG SM MARIKINA INC."
+
+# 1. Pre-state
+pre = frappe.db.get_value("Company", CO_NAME, ["is_group", "parent_company"], as_dict=True)
+result["pre"] = dict(pre) if pre else {"NOT_FOUND": True}
+
+# 2. Identify children of SM MARIKINA (need to know who's affected)
+children = frappe.db.sql("""
+    SELECT name, is_group, parent_company FROM `tabCompany`
+    WHERE parent_company = %s
+""", (CO_NAME,), as_dict=True)
+result["children_before_fix"] = [dict(r) for r in children]
+
+# 3. Apply fix: is_group=0 (idempotent)
+if pre and pre.get("is_group") == 1:
+    frappe.db.set_value("Company", CO_NAME, "is_group", 0)
+    frappe.db.commit()
+    result["fix_applied"] = True
+else:
+    result["fix_applied"] = False
+    result["reason"] = "already is_group=0 or company not found"
+
+# 4. Post-state verify
+post = frappe.db.get_value("Company", CO_NAME, ["is_group", "parent_company"], as_dict=True)
+result["post"] = dict(post) if post else {}
+
+# 5. Verify _get_allowed_target_companies() now includes SM MARIKINA
+from hrms.api.warehouse import _get_allowed_target_companies
+allowed = _get_allowed_target_companies()
+result["sm_marikina_now_in_allowed"] = CO_NAME in allowed
+result["allowed_count_after_fix"] = len(allowed)
+
+# 6. Children still resolve correctly (parent_company points to non-group is OK in Frappe)
+post_children = frappe.db.sql("""
+    SELECT name, is_group, parent_company FROM `tabCompany`
+    WHERE parent_company = %s
+""", (CO_NAME,), as_dict=True)
+result["children_after_fix"] = [dict(r) for r in post_children]
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/inspect_bei_route_schema.py
+++ b/scripts/s225/inspect_bei_route_schema.py
@@ -1,0 +1,51 @@
+"""Inspect BEI Route + BEI Route Stop schema so we can insert correctly."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+for dt in ["BEI Route", "BEI Route Stop"]:
+    if not frappe.db.exists("DocType", dt):
+        result[dt] = "DOCTYPE_MISSING"
+        continue
+    meta = frappe.get_meta(dt)
+    result[dt] = {
+        "is_submittable": meta.is_submittable,
+        "autoname": meta.autoname,
+        "naming_rule": getattr(meta, "naming_rule", None),
+        "fields": [
+            {
+                "fieldname": f.fieldname,
+                "label": f.label,
+                "fieldtype": f.fieldtype,
+                "options": (f.options or "")[:80],
+                "reqd": f.reqd,
+                "unique": f.unique,
+                "default": f.default,
+            }
+            for f in meta.fields if f.fieldname not in ("amended_from",)
+        ],
+    }
+
+# Sample 1 existing route to see actual values
+sample_route = frappe.db.sql("""
+    SELECT * FROM `tabBEI Route`
+    WHERE COALESCE(active,1) = 1
+    ORDER BY creation DESC
+    LIMIT 1
+""", as_dict=True)
+result["sample_existing_route"] = sample_route[0] if sample_route else None
+if sample_route:
+    sample_stops = frappe.db.sql("""
+        SELECT * FROM `tabBEI Route Stop`
+        WHERE parent = %s
+    """, sample_route[0]["name"], as_dict=True)
+    result["sample_route_stops"] = sample_stops
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/investigate_remaining.py
+++ b/scripts/s225/investigate_remaining.py
@@ -1,0 +1,69 @@
+"""Inspect MR-00709 (SM MARIKINA WR-missing) + AYALA VERMOSA order/MR state."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# MR-00709
+mr_name = "MAT-MR-2026-00709"
+if frappe.db.exists("Material Request", mr_name):
+    mr = frappe.db.get_value("Material Request", mr_name,
+        ["name","docstatus","status","material_request_type","set_warehouse","custom_source_warehouse","custom_destination_warehouse","custom_cargo_lane","creation","modified"], as_dict=True)
+    result["MR-00709"] = mr
+    items = frappe.db.sql("""
+        SELECT item_code, qty, warehouse, from_warehouse, ordered_qty, received_qty
+        FROM `tabMaterial Request Item`
+        WHERE parent = %s
+    """, mr_name, as_dict=True)
+    result["MR-00709_items"] = items
+
+    # Check if any BEI Warehouse Receiving exists — use parent table linked_material_request or filter by remarks
+    if frappe.db.exists("DocType", "BEI Warehouse Receiving"):
+        wr_meta = frappe.get_meta("BEI Warehouse Receiving")
+        wr_fields = [f.fieldname for f in wr_meta.fields]
+        result["WR_doctype_fields"] = wr_fields[:40]
+        # Try common patterns for MR linkage
+        wrs = frappe.db.sql("""
+            SELECT name, status, source_warehouse, target_warehouse, source_type, creation, remarks
+            FROM `tabBEI Warehouse Receiving`
+            WHERE creation > NOW() - INTERVAL 6 HOUR
+            ORDER BY creation DESC LIMIT 20
+        """, as_dict=True)
+        # Filter for the MR
+        result["MR-00709_WR_recent"] = [w for w in wrs if mr_name in (w.get("remarks") or "")][:5]
+        result["recent_WRs_count"] = len(wrs)
+
+# AYALA VERMOSA order BEI-ORD-2026-00577
+ord_name = "BEI-ORD-2026-00577"
+if frappe.db.exists("BEI Order", ord_name):
+    o = frappe.db.get_value("BEI Order", ord_name,
+        ["name","docstatus","status","store","cargo_category","creation"], as_dict=True)
+    result["ORD-00577"] = o
+    o_items = frappe.db.sql("""
+        SELECT item_code, qty_requested, qty_approved, source_warehouse, group_resolution_status
+        FROM `tabBEI Order Item`
+        WHERE parent = %s
+    """, ord_name, as_dict=True)
+    result["ORD-00577_items"] = o_items
+    # Was an MR ever created for it? (use remarks pattern)
+    mrs = frappe.db.sql("""
+        SELECT name, docstatus, status, set_warehouse, creation FROM `tabMaterial Request`
+        WHERE remarks LIKE %s
+        ORDER BY creation DESC LIMIT 5
+    """, f"%{ord_name}%", as_dict=True)
+    result["ORD-00577_MRs"] = mrs
+
+# Bin state for AYALA VERMOSA's likely route (PCS-BKI)
+PCS = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+for it in ["PM001","FG001","FG002","KL001","KL004"]:
+    bin_q = frappe.db.get_value("Bin", {"item_code": it, "warehouse": PCS}, ["actual_qty","projected_qty"], as_dict=True)
+    result.setdefault("PCS_BINS_NOW", {})[it] = bin_q
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/probe_allowed_target.py
+++ b/scripts/s225/probe_allowed_target.py
@@ -1,0 +1,56 @@
+"""Probe why SM MARIKINA isn't in _get_allowed_target_companies()."""
+import os
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe, json
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# Direct call
+from hrms.api.warehouse import _get_allowed_target_companies
+allowed = _get_allowed_target_companies()
+result["allowed_count"] = len(allowed)
+result["sm_marikina_in_allowed"] = "SM MARIKINA - BEBANG SM MARIKINA INC." in allowed
+result["sample_allowed"] = sorted(allowed)[:30]
+
+# Direct SQL
+rows = frappe.db.sql("""
+    SELECT name, is_group, parent_company FROM `tabCompany`
+    WHERE name = 'SM MARIKINA - BEBANG SM MARIKINA INC.'
+""", as_dict=True)
+result["sm_marikina_company_record"] = [dict(r) for r in rows]
+
+# Check if BEI Settings has any allow-list config
+try:
+    val = frappe.db.get_single_value("BEI Settings", "allowed_target_companies")
+    result["bei_settings_allowed_csv"] = val[:500] if val else None
+except Exception as e:
+    result["bei_settings_error"] = str(e)[:200]
+
+# Show DEFAULT fallback list
+try:
+    from hrms.api.warehouse import _ALLOWED_TARGET_COMPANIES_DEFAULT
+    result["default_fallback"] = list(_ALLOWED_TARGET_COMPANIES_DEFAULT)
+except Exception as e:
+    result["default_fallback_err"] = str(e)[:200]
+
+# Other 5 fail stores — check membership
+fail_stores = [
+    "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+    "THE GRID ROCKWELL - TASTECARTEL CORP.",
+    "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+    "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+    "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+]
+result["fail_stores_in_allowed"] = {s: (s in allowed) for s in fail_stores}
+
+# What about parent_company entries?
+parent_cos = ["BEBANG ENTERPRISE INC.", "BEBANG SM MARIKINA INC.", "TASTECARTEL CORP.", "BEBANG STARMALL ALABANG INC.", "DMD HOLDINGS INC.", "TRICERN FOOD CORP."]
+result["parent_companies_in_allowed"] = {c: (c in allowed) for c in parent_cos}
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/probe_dispatch_latency.py
+++ b/scripts/s225/probe_dispatch_latency.py
@@ -1,0 +1,71 @@
+"""Probe get_ready_for_dispatch API latency.
+
+For each newly-Ordered MR (created within the last 30 min), check whether it
+appears in get_ready_for_dispatch() output. Then for any MR that's NOT
+appearing yet, measure how long it takes to surface.
+
+Specifically focus on SM MARIKINA's recent MRs (MAT-MR-2026-008xx-009xx).
+
+This tells us: does the API have lag between MR.docstatus=1+status=Ordered
+and the API returning it? If yes, that's a backend cache/latency issue.
+"""
+import os, time, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# 1. Recent MRs in Ordered state for SM MARIKINA destination
+recent_mrs = frappe.db.sql("""
+    SELECT name, status, docstatus, creation, modified,
+           custom_destination_warehouse, custom_target_company
+    FROM `tabMaterial Request`
+    WHERE creation > NOW() - INTERVAL 60 MINUTE
+      AND custom_destination_warehouse = 'SM MARIKINA - BEBANG SM MARIKINA INC.'
+      AND material_request_type IN ('Material Transfer', 'Material Issue')
+    ORDER BY creation DESC
+    LIMIT 10
+""", as_dict=True)
+result["recent_marikina_mrs"] = [dict(r) for r in recent_mrs]
+
+# 2. Call get_ready_for_dispatch directly and time it
+from hrms.api.warehouse import get_ready_for_dispatch
+
+t0 = time.time()
+api = get_ready_for_dispatch()
+t_elapsed = time.time() - t0
+result["api_call_seconds"] = round(t_elapsed, 3)
+result["api_total_stores_returned"] = len(api.get("data", []))
+
+# 3. Find SM MARIKINA in API output
+marikina_in_api = [s for s in api.get("data", []) if "SM MARIKINA" in s.get("store", "").upper()]
+result["sm_marikina_in_api"] = bool(marikina_in_api)
+if marikina_in_api:
+    result["sm_marikina_request_names"] = [r["name"] for r in marikina_in_api[0].get("requests", [])]
+
+# 4. Cross-check: any MRs in `Ordered` state that are NOT in API
+ordered_mrs = frappe.db.sql("""
+    SELECT name, status, docstatus, custom_destination_warehouse, creation
+    FROM `tabMaterial Request`
+    WHERE status IN ('Ordered', 'Partially Ordered')
+      AND docstatus = 1
+      AND material_request_type IN ('Material Transfer', 'Material Issue')
+      AND creation > NOW() - INTERVAL 60 MINUTE
+""", as_dict=True)
+api_mr_names = set()
+for s in api.get("data", []):
+    for r in s.get("requests", []):
+        api_mr_names.add(r["name"])
+
+mrs_missing_from_api = [m for m in ordered_mrs if m["name"] not in api_mr_names]
+result["mrs_missing_from_api"] = [dict(m) for m in mrs_missing_from_api]
+result["mrs_missing_count"] = len(mrs_missing_from_api)
+result["mrs_in_db_ordered_60m"] = len(ordered_mrs)
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/probe_orderable_3_stores.py
+++ b/scripts/s225/probe_orderable_3_stores.py
@@ -1,0 +1,65 @@
+"""Probe get_orderable_items for the 3 PRECONDITION_BLOCKED stores.
+Find out what's filtering items down to 0 (or what makes the API empty)."""
+import sys, io
+# Suppress any chatty stdout from frappe initialization
+_buf = io.StringIO()
+_old_stdout = sys.stdout
+import os
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+sys.stdout = _buf  # capture frappe's own prints so they don't muddy JSON
+import frappe, json
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+sys.stdout = _old_stdout  # restore for our final json.dumps
+
+STORES = [
+    "AYALA EVO CITY - BEBANG MEGA INC.",
+    "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+    "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+]
+# Known-good for comparison
+WORKING = ["ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC"]
+
+result = {}
+for store in STORES + WORKING:
+    s = {}
+    # Call the API directly
+    try:
+        from hrms.api.store import get_orderable_items
+        api_result = get_orderable_items(store)
+        items = api_result.get("data", {}).get("items") or []
+        s["api_items_count"] = len(items)
+        s["api_first_3_codes"] = [it.get("item_code") for it in items[:3]]
+        s["api_first_3_suggested"] = [(it.get("item_code"), it.get("suggested_qty"), it.get("delivery_lane")) for it in items[:3]]
+        s["api_total_with_suggested_gt_0"] = sum(1 for it in items if (it.get("suggested_qty") or 0) > 0)
+        s["api_total_dry_lane"] = sum(1 for it in items if it.get("delivery_lane") == "Dry")
+        s["api_total_dry_with_suggested"] = sum(1 for it in items if (it.get("suggested_qty") or 0) > 0 and it.get("delivery_lane") == "Dry")
+    except Exception as e:
+        import traceback
+        s["api_error"] = str(e)[:300]
+        s["api_traceback"] = traceback.format_exc()[:1500]
+
+    # BEI Routes for this store warehouse
+    routes = frappe.db.sql("""
+        SELECT br.name, br.cargo_type, br.source_warehouse, br.active
+        FROM `tabBEI Route Stop` brs
+        INNER JOIN `tabBEI Route` br ON br.name = brs.parent
+        WHERE brs.store = %(s)s
+        ORDER BY br.cargo_type
+    """, {"s": store}, as_dict=True)
+    s["routes_count"] = len(routes)
+    s["routes"] = [dict(r) for r in routes]
+
+    # Past order count
+    cnt = frappe.db.sql("""
+        SELECT COUNT(*) AS c FROM `tabBEI Store Order` WHERE store = %s AND status != 'Draft'
+    """, (store,), as_dict=True)
+    s["past_orders_count"] = cnt[0]["c"] if cnt else 0
+
+    result[store] = s
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/probe_sm_marikina_chain.py
+++ b/scripts/s225/probe_sm_marikina_chain.py
@@ -1,0 +1,153 @@
+"""Trace SM MARIKINA's failed MR -> SE -> WR chain.
+
+The test reported: Error: No BEI Warehouse Receiving produced for MR MAT-MR-2026-00869
+
+We need to find:
+ 1. MR MAT-MR-2026-00869 — does it exist? what's its company / set_warehouse / status?
+ 2. Any Stock Entry that references this MR (against_material_request)
+ 3. Any BEI Warehouse Receiving with stock_entry = that SE name
+ 4. The Order linked to this MR (BEI Order)
+
+This will tell us at which exact step the dispatch chain broke."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+MR_NAME = "MAT-MR-2026-00900"
+
+# 1. The MR itself
+mr = frappe.db.get_value("Material Request", MR_NAME, "*", as_dict=True)
+result["mr"] = dict(mr) if mr else {"NOT_FOUND": True}
+
+# 2. MR items
+if mr:
+    mr_items = frappe.db.sql("""
+        SELECT item_code, qty, warehouse
+        FROM `tabMaterial Request Item`
+        WHERE parent = %(mr)s
+    """, {"mr": MR_NAME}, as_dict=True)
+    result["mr_items"] = [dict(r) for r in mr_items]
+
+# 3. Stock Entries referencing this MR (via against_material_request OR remarks)
+ses = frappe.db.sql("""
+    SELECT name, docstatus, stock_entry_type, purpose, from_warehouse, to_warehouse, company, creation, remarks
+    FROM `tabStock Entry`
+    WHERE creation > NOW() - INTERVAL 6 HOUR
+    ORDER BY creation DESC
+    LIMIT 50
+""", as_dict=True)
+# Filter to ones likely connected — match against MR via Stock Entry Detail
+ses_for_mr = []
+for se in ses:
+    items = frappe.db.sql("""
+        SELECT material_request, material_request_item, item_code, qty, s_warehouse, t_warehouse
+        FROM `tabStock Entry Detail`
+        WHERE parent = %(se)s AND material_request = %(mr)s
+    """, {"se": se["name"], "mr": MR_NAME}, as_dict=True)
+    if items:
+        ses_for_mr.append({"se": dict(se), "items": [dict(i) for i in items]})
+result["ses_referencing_mr"] = ses_for_mr
+
+# 4. BEI Warehouse Receivings that reference any SE found
+if ses_for_mr:
+    se_names = [r["se"]["name"] for r in ses_for_mr]
+    # Discover schema
+    wr_meta = frappe.get_meta("BEI Warehouse Receiving")
+    wr_fields = {f.fieldname for f in wr_meta.fields}
+    cond_fields = []
+    if "stock_entry" in wr_fields:
+        cond_fields.append("stock_entry")
+    if "material_request" in wr_fields:
+        cond_fields.append("material_request")
+    result["wr_doctype_fields_relevant"] = cond_fields
+    # search WRs by stock_entry
+    wrs = frappe.db.sql(f"""
+        SELECT name, status, docstatus, target_warehouse, source_warehouse, stock_entry, creation
+        FROM `tabBEI Warehouse Receiving`
+        WHERE stock_entry IN %(ses)s
+    """, {"ses": tuple(se_names)}, as_dict=True)
+    result["wrs_found_by_stock_entry"] = [dict(r) for r in wrs]
+else:
+    result["wrs_found_by_stock_entry"] = "no_ses_to_search"
+
+# 5. Search for any WR with target_warehouse like SM MARIKINA in last 6h (case variants)
+wrs_any = frappe.db.sql("""
+    SELECT name, status, docstatus, target_warehouse, source_warehouse, stock_entry, creation
+    FROM `tabBEI Warehouse Receiving`
+    WHERE creation > NOW() - INTERVAL 6 HOUR
+      AND (target_warehouse LIKE '%MARIKINA%' OR target_warehouse LIKE '%SMK%')
+    ORDER BY creation DESC
+    LIMIT 10
+""", as_dict=True)
+result["wrs_marikina_match_6h"] = [dict(r) for r in wrs_any]
+
+# 6. Look at the BEI Approval Queue for this MR (schema-aware)
+try:
+    aq_meta = frappe.get_meta("BEI Approval Queue")
+    aq_fields = {f.fieldname for f in aq_meta.fields}
+    name_field = "document_name" if "document_name" in aq_fields else (
+        "reference_name" if "reference_name" in aq_fields else None
+    )
+    if name_field:
+        select_cols = ["name", name_field, "creation"]
+        for opt in ["doctype_name", "reference_doctype", "queue_status", "status", "action_type"]:
+            if opt in aq_fields:
+                select_cols.append(opt)
+        aq = frappe.db.sql(f"""
+            SELECT {','.join('`'+c+'`' for c in select_cols)}
+            FROM `tabBEI Approval Queue`
+            WHERE `{name_field}` = %(mr)s
+            ORDER BY creation DESC
+        """, {"mr": MR_NAME}, as_dict=True)
+        result["approval_queue_entries"] = [dict(r) for r in aq]
+        result["approval_queue_field_used"] = name_field
+    else:
+        result["approval_queue_entries"] = "no_compatible_field"
+except Exception as e:
+    result["approval_queue_entries"] = f"ERROR: {str(e)[:200]}"
+
+# 7. Find the BEI Order linked to this MR (via material_request or BEI Order Item)
+try:
+    order_meta = frappe.get_meta("BEI Order")
+    order_fields = {f.fieldname for f in order_meta.fields}
+    if "material_request" in order_fields:
+        orders = frappe.db.sql("""
+            SELECT name, status, store, creation
+            FROM `tabBEI Order`
+            WHERE material_request = %(mr)s
+        """, {"mr": MR_NAME}, as_dict=True)
+        result["orders_for_mr"] = [dict(r) for r in orders]
+    else:
+        # Try via BEI Order Item child table
+        try:
+            orders = frappe.db.sql("""
+                SELECT DISTINCT bo.name, bo.status, bo.store, bo.creation
+                FROM `tabBEI Order` bo
+                INNER JOIN `tabBEI Order Item` boi ON boi.parent = bo.name
+                WHERE boi.material_request = %(mr)s
+            """, {"mr": MR_NAME}, as_dict=True)
+            result["orders_for_mr"] = [dict(r) for r in orders]
+        except Exception:
+            result["orders_for_mr"] = "no_link_found_via_child"
+except Exception as e:
+    result["orders_for_mr"] = f"ERROR: {str(e)[:200]}"
+
+# 8. Find Bin state for items that should have been transferred
+if mr and mr.get("set_warehouse"):
+    bins_target = frappe.db.sql("""
+        SELECT b.warehouse, b.item_code, b.actual_qty
+        FROM `tabBin` b
+        INNER JOIN `tabMaterial Request Item` mri ON mri.item_code = b.item_code
+        WHERE mri.parent = %(mr)s
+          AND b.warehouse = %(wh)s
+    """, {"mr": MR_NAME, "wh": mr["set_warehouse"]}, as_dict=True)
+    result["target_warehouse_bins"] = [dict(r) for r in bins_target]
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/probe_sm_marikina_error_log.py
+++ b/scripts/s225/probe_sm_marikina_error_log.py
@@ -1,0 +1,81 @@
+"""Find any frappe.log_error entries connected to SM MARIKINA's SE/MR.
+The auto-WR-creation in `_create_warehouse_receiving_for_se` swallows exceptions
+via `frappe.log_error(...)` — that goes to the Error Log doctype.
+
+We're hunting for entries logged in the last 90 minutes that mention either
+the MR (MAT-MR-2026-00886), the SE (MAT-STE-2026-02189), or 'S198: Auto-create WR'."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# 1. Errors mentioning the SE or MR or "S198"
+errors = frappe.db.sql("""
+    SELECT name, error, method, creation
+    FROM `tabError Log`
+    WHERE creation > NOW() - INTERVAL 90 MINUTE
+      AND (error LIKE %(se)s OR error LIKE %(mr)s OR error LIKE '%%S198%%' OR method LIKE '%%warehouse%%')
+    ORDER BY creation DESC
+    LIMIT 15
+""", {
+    "se": "%MAT-STE-2026-02189%",
+    "mr": "%MAT-MR-2026-00886%",
+}, as_dict=True)
+result["error_log_entries"] = []
+for e in errors:
+    result["error_log_entries"].append({
+        "name": e["name"],
+        "creation": str(e["creation"]),
+        "method": e.get("method"),
+        "error_first_500": (e["error"] or "")[:500],
+    })
+
+# 2. Try to call _create_warehouse_receiving_for_se directly with the SE doc to see what happens
+try:
+    se = frappe.get_doc("Stock Entry", "MAT-STE-2026-02189")
+
+    # Replicate the resolve_material_request_contract call path
+    from hrms.utils.supply_chain_contracts import resolve_material_request_contract
+    from hrms.api.warehouse import _create_warehouse_receiving_for_se, resolve_warehouse_company, _get_commissary_company
+
+    contract = resolve_material_request_contract(frappe.get_doc("Material Request", "MAT-MR-2026-00886"))
+    result["resolved_contract"] = dict(contract)
+
+    # Check the BKI scope guard manually
+    source_company = resolve_warehouse_company(se.from_warehouse)
+    bki = _get_commissary_company()
+    result["bki_guard_check"] = {
+        "se.from_warehouse": se.from_warehouse,
+        "resolved_source_company": source_company,
+        "commissary_company": bki,
+        "guard_passes": source_company == bki,
+    }
+
+    # Now actually call _create_warehouse_receiving_for_se with same path the dispatch uses
+    # (it must NOT raise, must return a name or None)
+    wr_name = _create_warehouse_receiving_for_se(se, contract)
+    result["replay_create_wr"] = {
+        "wr_name_returned": wr_name,
+    }
+    # Check immediately if a WR exists for this SE now
+    existing = frappe.db.get_value(
+        "BEI Warehouse Receiving",
+        {"stock_entry": se.name},
+        "name",
+    )
+    result["wr_exists_after_replay"] = existing
+except Exception as e:
+    import traceback
+    result["replay_error"] = {
+        "msg": str(e)[:300],
+        "trace_first_2000": traceback.format_exc()[:2000],
+    }
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/seed_comprehensive.py
+++ b/scripts/s225/seed_comprehensive.py
@@ -1,0 +1,220 @@
+"""S225 comprehensive test data seeding — runs INSIDE production Frappe container.
+
+Seeds all data the L3 sweep needs:
+  1. Toggle Stock Settings allow_negative_stock + allow_negative_stock_for_batch = 1
+     (covers BACKFILL-20260421-* batches that are intentionally negative from Phase 3)
+  2. Add 7 missing BEI Routes (per Route Planner UI — Sam's screenshot 2026-04-29)
+     × 3 cargo types each (DRY, FC, FM) = 21 routes
+  3. Material Receipt SEs for every orderable Finished Goods, Packaging Material,
+     Kit, and Group item at PINNACLE COLD STORAGE - BKI + 3MD LOGISTICS - CAMANGYANAN - BKI
+     (the two main hubs); buffer = 1000 units per item per hub
+
+Returns full teardown ledger as JSON for the closeout reverser.
+"""
+import os, json, sys
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+from frappe.utils import nowdate, now_datetime
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+PCS_BKI = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+HUB_3MD = "3MD Logistics - Camangyanan - BKI"
+SEED_QTY = 1000  # generous buffer per item per hub
+SEED_LABEL = "S229 retest seed: comprehensive (2026-04-29)"
+
+result = {
+    "timestamp": now_datetime().isoformat(),
+    "stock_settings_pre": {},
+    "stock_settings_post": {},
+    "bei_routes_created": [],
+    "stock_entries_created": [],
+    "errors": [],
+    "items_enumerated": 0,
+    "items_seeded": 0,
+}
+
+# ---------- Step 1: Toggle Stock Settings ----------
+result["stock_settings_pre"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 1)
+frappe.db.commit()
+result["stock_settings_post"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+
+# ---------- Step 2: Add missing BEI Routes ----------
+# Per Sam's Route Planner UI screenshot 2026-04-29:
+#   3MD Marilao (North): NAIA T3, Estancia, Greenhills, Robinsons Antipolo
+#   Pinnacle Calamba (South): Robinsons General Trias, Robinsons Imus, SM Sta Rosa
+ROUTE_BACKFILL = [
+    # (store_pattern_in_warehouse_name, hub, label)
+    ("NAIA T3 - HALO-HALO TERMINAL FOOD CORP.", HUB_3MD, "S229 backfill: NAIA T3 → 3MD per Route Planner"),
+    ("ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.", HUB_3MD, "S229 backfill: ORTIGAS ESTANCIA → 3MD per Route Planner"),
+    ("ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC", HUB_3MD, "S229 backfill: ORTIGAS GREENHILLS → 3MD per Route Planner"),
+    ("ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.", HUB_3MD, "S229 backfill: ROBINSONS ANTIPOLO → 3MD per Route Planner"),
+    ("ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.", PCS_BKI, "S229 backfill: ROBINSONS GENERAL TRIAS → PCS-BKI per Route Planner"),
+    ("ROBINSONS IMUS - BEBANG MEGA INC.", PCS_BKI, "S229 backfill: ROBINSONS IMUS → PCS-BKI per Route Planner"),
+    ("SM STA. ROSA - SWEET HARMONY FOOD CORP.", PCS_BKI, "S229 backfill: SM STA. ROSA → PCS-BKI per Route Planner"),
+]
+
+CARGO_TYPES = ["DRY", "FC", "FM"]
+
+# Verify BEI Route doctype exists (it does per earlier probes)
+if not frappe.db.exists("DocType", "BEI Route"):
+    result["errors"].append({"step": "routes", "error": "BEI Route DocType does not exist"})
+else:
+    for store, hub, label in ROUTE_BACKFILL:
+        for cargo in CARGO_TYPES:
+            try:
+                # Check if a route for this (store, cargo) already exists
+                existing = frappe.db.sql("""
+                    SELECT r.name FROM `tabBEI Route` r
+                    JOIN `tabBEI Route Stop` s ON s.parent = r.name
+                    WHERE COALESCE(r.active, 1) = 1
+                      AND r.cargo_type = %(cargo)s
+                      AND s.store = %(store)s
+                """, {"cargo": cargo, "store": store}, as_dict=True)
+                if existing:
+                    result["bei_routes_created"].append({
+                        "store": store, "cargo": cargo, "hub": hub,
+                        "status": "ALREADY_EXISTS",
+                        "existing_name": existing[0]["name"],
+                    })
+                    continue
+
+                route = frappe.new_doc("BEI Route")
+                route.route_code = f"S229-{cargo}-{store[:30]}"  # fits route_code field
+                route.cargo_type = cargo
+                route.source_warehouse = hub
+                route.active = 1
+                # Add stop
+                route.append("stops", {
+                    "store": store,
+                    "stop_order": 1,
+                })
+                route.insert(ignore_permissions=True)
+                if hasattr(route, "submit"):
+                    try:
+                        route.submit()
+                    except Exception:
+                        pass  # may not be submittable
+                frappe.db.commit()
+                result["bei_routes_created"].append({
+                    "doctype": "BEI Route",
+                    "name": route.name,
+                    "store": store,
+                    "cargo": cargo,
+                    "hub": hub,
+                    "label": label,
+                    "action_to_reverse": "DELETE",
+                })
+            except Exception as e:
+                frappe.db.rollback()
+                result["errors"].append({
+                    "step": "routes",
+                    "store": store, "cargo": cargo,
+                    "error": str(e)[:300],
+                })
+
+# ---------- Step 3: Enumerate items + seed at both hubs ----------
+# Items the test could pick (per OrderBuilder default + Sentry historical):
+# - All Finished Goods (FG*)
+# - All Packaging Materials (PM*)
+# - All Kits (KL*)
+# - GRP-FRESH-RIPE-MANGO (GRP-* group items)
+ITEM_GROUP_FILTERS = [
+    ["item_group", "in", ["Finished Goods", "Packaging Materials", "Kit"]],
+    ["is_stock_item", "=", 1],
+    ["disabled", "=", 0],
+]
+items_to_seed = frappe.get_all("Item",
+    filters=ITEM_GROUP_FILTERS,
+    fields=["name", "item_code", "item_group", "stock_uom", "has_batch_no"],
+    limit_page_length=200)
+
+# Also add GRP- prefixed items from any group
+grp_items = frappe.get_all("Item",
+    filters=[["item_code", "like", "GRP-%"], ["is_stock_item", "=", 1], ["disabled", "=", 0]],
+    fields=["name", "item_code", "item_group", "stock_uom", "has_batch_no"],
+    limit_page_length=50)
+seen = {i["name"] for i in items_to_seed}
+for g in grp_items:
+    if g["name"] not in seen:
+        items_to_seed.append(g)
+
+result["items_enumerated"] = len(items_to_seed)
+HUBS = [PCS_BKI, HUB_3MD]
+
+for item in items_to_seed:
+    item_code = item["item_code"]
+    stock_uom = item["stock_uom"] or "Nos"
+    for hub in HUBS:
+        try:
+            # Get current actual_qty
+            cur_qty = float(frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": hub}, "actual_qty") or 0)
+            if cur_qty >= SEED_QTY:
+                # Already enough stock
+                continue
+
+            qty_to_add = SEED_QTY - cur_qty if cur_qty > 0 else SEED_QTY
+            company = frappe.db.get_value("Warehouse", hub, "company")
+
+            se = frappe.new_doc("Stock Entry")
+            se.stock_entry_type = "Material Receipt"
+            se.purpose = "Material Receipt"
+            se.posting_date = nowdate()
+            se.posting_time = now_datetime().strftime("%H:%M:%S")
+            se.set_posting_time = 1
+            se.company = company
+            se.append("items", {
+                "item_code": item_code,
+                "qty": qty_to_add,
+                "uom": stock_uom,
+                "stock_uom": stock_uom,
+                "conversion_factor": 1,
+                "t_warehouse": hub,
+                "basic_rate": 1.0,
+                "allow_zero_valuation_rate": 1,
+            })
+            se.remarks = SEED_LABEL
+            se.insert(ignore_permissions=True)
+            se.submit()
+            frappe.db.commit()
+            result["stock_entries_created"].append({
+                "doctype": "Stock Entry",
+                "name": se.name,
+                "item_code": item_code,
+                "qty": qty_to_add,
+                "warehouse": hub,
+                "label": SEED_LABEL,
+                "action_to_reverse": "CANCEL",
+            })
+            result["items_seeded"] += 1
+        except Exception as e:
+            frappe.db.rollback()
+            err_msg = str(e)[:300]
+            result["errors"].append({
+                "step": "seed_stock",
+                "item": item_code,
+                "warehouse": hub,
+                "error": err_msg,
+            })
+
+result["summary"] = {
+    "items_enumerated": result["items_enumerated"],
+    "stock_entries_created": len(result["stock_entries_created"]),
+    "bei_routes_created": len([r for r in result["bei_routes_created"] if r.get("action_to_reverse") == "DELETE"]),
+    "bei_routes_skipped_existing": len([r for r in result["bei_routes_created"] if r.get("status") == "ALREADY_EXISTS"]),
+    "errors": len(result["errors"]),
+}
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/seed_narrow.py
+++ b/scripts/s225/seed_narrow.py
@@ -1,0 +1,113 @@
+"""S225 narrow seeding — only the 10 items Sentry flagged as failing.
+
+Avoids the v2 mistake of seeding all 80+ FG/PM/KL items (which didn't bloat the
+dropdown — that was wrong analysis — but also wasted time and created teardown
+mass).
+
+Seeded items (from Sentry historical evidence + OrderBuilder defaults):
+  PM001 — 16OZ cup with logo (packaging, every order needs it)
+  FG001, FG002, FG010, FG023 — OrderBuilder default DRY items
+  FG002-A, FG004 — batch-tracked variants Sentry showed failing
+  KL001, KL004 — kit items Sentry showed failing
+  GRP-FRESH-RIPE-MANGO — group item from defaults
+
+Seed at PCS-BKI and 3MD-CAMANGYANAN (the two main hubs). 500 units each = enough
+for 25 stores routed to each hub × 20 units max per order.
+
+Also toggles Stock Settings allow_negative_stock + allow_negative_stock_for_batch
+= 1 to handle the BACKFILL-20260421-* batches that are intentionally negative
+from S225 Phase 3 cleanup.
+"""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+from frappe.utils import nowdate, now_datetime
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+PCS_BKI = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+HUB_3MD = "3MD Logistics - Camangyanan - BKI"
+SEED_QTY = 500
+SEED_LABEL = "S229 narrow seed (2026-04-29 v3)"
+
+ITEMS_TO_SEED = [
+    "PM001",
+    "FG001", "FG002", "FG010", "FG023",
+    "FG002-A", "FG004",
+    "KL001", "KL004",
+    "GRP-FRESH-RIPE-MANGO",
+]
+HUBS = [PCS_BKI, HUB_3MD]
+
+result = {
+    "stock_settings_pre": {
+        "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+        "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+    },
+    "stock_entries_created": [],
+    "errors": [],
+}
+
+# Toggle ON
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 1)
+frappe.db.commit()
+result["stock_settings_post"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+
+for item_code in ITEMS_TO_SEED:
+    if not frappe.db.exists("Item", item_code):
+        result["errors"].append({"item": item_code, "error": "ITEM_NOT_IN_MASTER"})
+        continue
+    stock_uom = frappe.db.get_value("Item", item_code, "stock_uom") or "Nos"
+    for hub in HUBS:
+        try:
+            cur = float(frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": hub}, "actual_qty") or 0)
+            if cur >= SEED_QTY:
+                continue
+            qty_to_add = SEED_QTY - cur if cur > 0 else SEED_QTY
+            company = frappe.db.get_value("Warehouse", hub, "company")
+            se = frappe.new_doc("Stock Entry")
+            se.stock_entry_type = "Material Receipt"
+            se.purpose = "Material Receipt"
+            se.posting_date = nowdate()
+            se.posting_time = now_datetime().strftime("%H:%M:%S")
+            se.set_posting_time = 1
+            se.company = company
+            se.append("items", {
+                "item_code": item_code,
+                "qty": qty_to_add,
+                "uom": stock_uom,
+                "stock_uom": stock_uom,
+                "conversion_factor": 1,
+                "t_warehouse": hub,
+                "basic_rate": 1.0,
+                "allow_zero_valuation_rate": 1,
+            })
+            se.remarks = SEED_LABEL
+            se.insert(ignore_permissions=True)
+            se.submit()
+            frappe.db.commit()
+            result["stock_entries_created"].append({
+                "name": se.name,
+                "item": item_code,
+                "qty": qty_to_add,
+                "warehouse": hub,
+            })
+        except Exception as e:
+            frappe.db.rollback()
+            result["errors"].append({"item": item_code, "warehouse": hub, "error": str(e)[:200]})
+
+result["summary"] = {
+    "items_attempted": len(ITEMS_TO_SEED),
+    "ses_created": len(result["stock_entries_created"]),
+    "errors": len(result["errors"]),
+}
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/seed_test_stock.py
+++ b/scripts/s225/seed_test_stock.py
@@ -1,0 +1,90 @@
+"""S225 re-test seeding: top up PM001 + FG001 at PINNACLE COLD STORAGE - BKI.
+
+Per /l3-v2-bei-erp Test Data Seeding rule: seed missing test data via
+/frappe-bulk-edits (or its underlying SSM/Frappe pattern) BEFORE running
+scenarios that depend on it. Track in teardown_ledger.json. Tear down at closeout.
+
+This script runs INSIDE the production frappe_backend container.
+Returns JSON with the seeded SE names for the teardown ledger.
+"""
+import os, json, sys
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+from frappe.utils import nowdate, now_datetime
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+PCS = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+SEED_PLAN = [
+    # (item_code, qty_to_add, target_warehouse, label)
+    ("PM001", 500, PCS, "S225 retest seed: PM001 at PCS-BKI"),
+    ("FG001", 5000, PCS, "S225 retest seed: FG001 at PCS-BKI"),
+]
+
+result = {"seeded_stock_entries": [], "errors": []}
+
+# Pre-state for ledger
+pre_state = {}
+for item, qty, wh, label in SEED_PLAN:
+    bin_q = frappe.db.get_value("Bin", {"item_code": item, "warehouse": wh}, "actual_qty") or 0
+    pre_state[f"{item}@{wh}"] = float(bin_q)
+result["pre_state"] = pre_state
+
+# Resolve item rate (use last purchase / valuation rate or just 1.0 for non-stock-impact test seed)
+def get_item_rate(item_code):
+    rate = frappe.db.get_value("Bin", {"item_code": item_code}, "valuation_rate") or 0
+    if rate and float(rate) > 0:
+        return float(rate)
+    return 1.0  # fallback for test seeding
+
+
+for item_code, qty, target_wh, label in SEED_PLAN:
+    try:
+        rate = get_item_rate(item_code)
+        se = frappe.new_doc("Stock Entry")
+        se.stock_entry_type = "Material Receipt"
+        se.purpose = "Material Receipt"
+        se.posting_date = nowdate()
+        se.posting_time = now_datetime().strftime("%H:%M:%S")
+        se.set_posting_time = 1
+        se.company = frappe.db.get_value("Warehouse", target_wh, "company")
+        se.append("items", {
+            "item_code": item_code,
+            "qty": qty,
+            "uom": frappe.db.get_value("Item", item_code, "stock_uom") or "Nos",
+            "stock_uom": frappe.db.get_value("Item", item_code, "stock_uom") or "Nos",
+            "conversion_factor": 1,
+            "t_warehouse": target_wh,
+            "basic_rate": rate,
+            "allow_zero_valuation_rate": 1,
+        })
+        se.remarks = label
+        se.insert(ignore_permissions=True)
+        se.submit()
+        frappe.db.commit()
+        result["seeded_stock_entries"].append({
+            "name": se.name,
+            "item_code": item_code,
+            "qty": qty,
+            "warehouse": target_wh,
+            "label": label,
+            "doctype": "Stock Entry",
+            "action_to_reverse": "CANCEL",
+        })
+    except Exception as e:
+        frappe.db.rollback()
+        result["errors"].append({"item": item_code, "qty": qty, "wh": target_wh, "error": str(e)[:300]})
+
+# Post-state
+post_state = {}
+for item, qty, wh, label in SEED_PLAN:
+    bin_q = frappe.db.get_value("Bin", {"item_code": item, "warehouse": wh}, "actual_qty") or 0
+    proj_q = frappe.db.get_value("Bin", {"item_code": item, "warehouse": wh}, "projected_qty") or 0
+    post_state[f"{item}@{wh}"] = {"actual_qty": float(bin_q), "projected_qty": float(proj_q)}
+result["post_state"] = post_state
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/seed_v5_boost.py
+++ b/scripts/s225/seed_v5_boost.py
@@ -1,0 +1,83 @@
+"""S225 v5 boost — top up PM001 to 2000 and seed PM007 + other PM00x items
+that the suggested-order picker may select. Also re-seed KL items to compensate
+for v4 consumption."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+from frappe.utils import nowdate, now_datetime
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+PCS_BKI = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+HUB_3MD = "3MD Logistics - Camangyanan - BKI"
+SEED_LABEL = "S229 v5 boost (2026-04-30)"
+
+# Stock Settings ON for batch handling
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 1)
+frappe.db.commit()
+
+# Items to top up — both PM and KL series at both hubs
+TARGETS = [
+    ("PM001", 2000),  # higher buffer
+    ("PM007", 2000),  # was missing; SM MARIKINA needed this
+    ("PM002", 2000),
+    ("PM003", 2000),
+    ("PM010", 2000),
+    ("KL001", 2000),
+    ("KL004", 2000),
+    ("KL002", 2000),
+    ("KL003", 2000),
+]
+HUBS = [PCS_BKI, HUB_3MD]
+result = {"created": [], "skipped_existing_qty": [], "errors": []}
+
+for item_code, target_qty in TARGETS:
+    if not frappe.db.exists("Item", item_code):
+        result["errors"].append({"item": item_code, "error": "ITEM_NOT_IN_MASTER"})
+        continue
+    stock_uom = frappe.db.get_value("Item", item_code, "stock_uom") or "Nos"
+    for hub in HUBS:
+        try:
+            cur = float(frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": hub}, "actual_qty") or 0)
+            if cur >= target_qty:
+                result["skipped_existing_qty"].append({"item": item_code, "hub": hub, "actual": cur})
+                continue
+            qty_to_add = target_qty - cur
+            company = frappe.db.get_value("Warehouse", hub, "company")
+            se = frappe.new_doc("Stock Entry")
+            se.stock_entry_type = "Material Receipt"
+            se.purpose = "Material Receipt"
+            se.posting_date = nowdate()
+            se.posting_time = now_datetime().strftime("%H:%M:%S")
+            se.set_posting_time = 1
+            se.company = company
+            se.append("items", {
+                "item_code": item_code,
+                "qty": qty_to_add,
+                "uom": stock_uom,
+                "stock_uom": stock_uom,
+                "conversion_factor": 1,
+                "t_warehouse": hub,
+                "basic_rate": 1.0,
+                "allow_zero_valuation_rate": 1,
+            })
+            se.remarks = SEED_LABEL
+            se.insert(ignore_permissions=True)
+            se.submit()
+            frappe.db.commit()
+            result["created"].append({"name": se.name, "item": item_code, "qty": qty_to_add, "hub": hub})
+        except Exception as e:
+            frappe.db.rollback()
+            result["errors"].append({"item": item_code, "hub": hub, "error": str(e)[:200]})
+
+result["summary"] = {
+    "ses_created": len(result["created"]),
+    "skipped_existing": len(result["skipped_existing_qty"]),
+    "errors": len(result["errors"]),
+}
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/seed_v6_full_pm.py
+++ b/scripts/s225/seed_v6_full_pm.py
@@ -1,0 +1,67 @@
+"""S225 v6 — seed ALL PM00x items (PM001-PM030 if they exist) at both hubs.
+Each sweep picks a different PM item per store, so partial coverage = whack-a-mole."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+from frappe.utils import nowdate, now_datetime
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+PCS_BKI = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+HUB_3MD = "3MD Logistics - Camangyanan - BKI"
+HUBS = [PCS_BKI, HUB_3MD]
+TARGET_QTY = 2000
+SEED_LABEL = "S229 v6 full PM coverage (2026-04-30)"
+
+# Stock Settings
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 1)
+frappe.db.commit()
+
+# All PM* items in master that are stock items
+pm_items = frappe.get_all("Item",
+    filters=[["item_code","like","PM%"],["is_stock_item","=",1],["disabled","=",0]],
+    fields=["item_code","stock_uom"], limit_page_length=200)
+
+result = {"created": [], "skipped": [], "errors": []}
+
+for item in pm_items:
+    code = item["item_code"]
+    uom = item["stock_uom"] or "Nos"
+    for hub in HUBS:
+        try:
+            cur = float(frappe.db.get_value("Bin", {"item_code": code, "warehouse": hub}, "actual_qty") or 0)
+            if cur >= TARGET_QTY:
+                result["skipped"].append({"item": code, "hub": hub})
+                continue
+            qty = TARGET_QTY - cur
+            company = frappe.db.get_value("Warehouse", hub, "company")
+            se = frappe.new_doc("Stock Entry")
+            se.stock_entry_type = "Material Receipt"
+            se.purpose = "Material Receipt"
+            se.posting_date = nowdate()
+            se.posting_time = now_datetime().strftime("%H:%M:%S")
+            se.set_posting_time = 1
+            se.company = company
+            se.append("items", {
+                "item_code": code, "qty": qty,
+                "uom": uom, "stock_uom": uom, "conversion_factor": 1,
+                "t_warehouse": hub, "basic_rate": 1.0,
+                "allow_zero_valuation_rate": 1,
+            })
+            se.remarks = SEED_LABEL
+            se.insert(ignore_permissions=True)
+            se.submit()
+            frappe.db.commit()
+            result["created"].append({"name": se.name, "item": code, "hub": hub, "qty": qty})
+        except Exception as e:
+            frappe.db.rollback()
+            result["errors"].append({"item": code, "hub": hub, "error": str(e)[:150]})
+
+result["pm_items_in_master"] = len(pm_items)
+result["summary"] = {"created": len(result["created"]), "skipped": len(result["skipped"]), "errors": len(result["errors"])}
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/teardown_comprehensive.py
+++ b/scripts/s225/teardown_comprehensive.py
@@ -1,0 +1,70 @@
+"""S225 comprehensive teardown — cancel ALL S229-labeled SEs, restore Stock Settings.
+
+Finds every SE with remarks LIKE 'S229 retest seed%%' from the last 4 hours and cancels.
+With allow_negative_stock=1 already on, cancels won't be blocked. After cancellation,
+toggles Stock Settings back to 0 and verifies.
+"""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {
+    "stock_settings_before_teardown": {
+        "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+        "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+    },
+    "cancelled_count": 0,
+    "already_cancelled": 0,
+    "errors": [],
+}
+
+# Ensure allow_negative_stock stays ON during cancel
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 1)
+frappe.db.commit()
+
+ses = frappe.db.sql("""
+    SELECT name, docstatus
+    FROM `tabStock Entry`
+    WHERE remarks LIKE 'S229 retest seed%%'
+      AND creation > NOW() - INTERVAL 4 HOUR
+    ORDER BY name DESC
+""", as_dict=True)
+
+for se in ses:
+    name = se["name"]
+    if se["docstatus"] == 2:
+        result["already_cancelled"] += 1
+        continue
+    if se["docstatus"] == 1:
+        try:
+            doc = frappe.get_doc("Stock Entry", name)
+            doc.cancel()
+            frappe.db.commit()
+            result["cancelled_count"] += 1
+        except Exception as e:
+            frappe.db.rollback()
+            result["errors"].append({"name": name, "error": str(e)[:200]})
+
+# Now toggle Stock Settings OFF
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 0)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 0)
+frappe.db.commit()
+
+result["stock_settings_after_teardown"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+
+result["total_seeded_ses_found"] = len(ses)
+result["all_clean"] = (result["errors"] == [] and
+                        result["stock_settings_after_teardown"]["allow_negative_stock"] == 0 and
+                        result["stock_settings_after_teardown"]["allow_negative_stock_for_batch"] == 0)
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/teardown_seeded_stock.py
+++ b/scripts/s225/teardown_seeded_stock.py
@@ -1,0 +1,65 @@
+"""S225 retest teardown — cancel the SEs we created in seed_test_stock.py.
+
+Reads the teardown_ledger.json, cancels each SE, verifies stock returned to
+pre-seed state. Writes teardown_complete.json with proof.
+"""
+import os, json, sys
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+# Hard-coded ledger entries (keep in sync with the seeding script's output)
+LEDGER = [
+    {"name": "MAT-STE-2026-01173", "item_code": "PM001", "qty": 500,
+     "warehouse": "PINNACLE COLD STORAGE SOLUTIONS - BKI"},
+    {"name": "MAT-STE-2026-01174", "item_code": "FG001", "qty": 5000,
+     "warehouse": "PINNACLE COLD STORAGE SOLUTIONS - BKI"},
+]
+
+result = {"reversed": [], "errors": []}
+
+# Pre-state
+pre_state = {}
+for entry in LEDGER:
+    bin_q = frappe.db.get_value("Bin", {"item_code": entry["item_code"], "warehouse": entry["warehouse"]}, "actual_qty") or 0
+    pre_state[f"{entry['item_code']}@{entry['warehouse']}"] = float(bin_q)
+result["pre_teardown_state"] = pre_state
+
+for entry in LEDGER:
+    try:
+        se = frappe.get_doc("Stock Entry", entry["name"])
+        if se.docstatus == 1:
+            se.cancel()
+            frappe.db.commit()
+            result["reversed"].append({"name": entry["name"], "status": "CANCELLED"})
+        elif se.docstatus == 2:
+            result["reversed"].append({"name": entry["name"], "status": "ALREADY_CANCELLED"})
+        else:
+            result["reversed"].append({"name": entry["name"], "status": f"UNEXPECTED_DOCSTATUS_{se.docstatus}"})
+    except Exception as e:
+        frappe.db.rollback()
+        result["errors"].append({"name": entry["name"], "error": str(e)[:300]})
+
+# Post-state
+post_state = {}
+for entry in LEDGER:
+    bin_q = frappe.db.get_value("Bin", {"item_code": entry["item_code"], "warehouse": entry["warehouse"]}, "actual_qty") or 0
+    proj_q = frappe.db.get_value("Bin", {"item_code": entry["item_code"], "warehouse": entry["warehouse"]}, "projected_qty") or 0
+    post_state[f"{entry['item_code']}@{entry['warehouse']}"] = {"actual_qty": float(bin_q), "projected_qty": float(proj_q)}
+result["post_teardown_state"] = post_state
+
+# Compute delta
+result["delta_per_bin"] = {}
+for k in pre_state:
+    delta = post_state[k]["actual_qty"] - pre_state[k]
+    result["delta_per_bin"][k] = delta
+
+result["all_seeds_reversed"] = (len(result["errors"]) == 0 and
+                                 all(r["status"] in ("CANCELLED", "ALREADY_CANCELLED") for r in result["reversed"]))
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/teardown_v2_force.py
+++ b/scripts/s225/teardown_v2_force.py
@@ -1,0 +1,79 @@
+"""S225 retest teardown v2 — enable allow_negative_stock briefly, cancel, restore.
+
+The PM001 cancel failed because the sweep consumed 40 of the 500 seeded units —
+cancelling 500 leaves -40, which Frappe v15 rejects. Standard pattern: toggle
+allow_negative_stock = 1, cancel, toggle back to 0. This temporarily allows the
+single cancel transaction to go through.
+"""
+import os, json, sys
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+
+# Capture initial Stock Settings state
+result["stock_settings_before"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+
+# Toggle ON
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 1)
+frappe.db.commit()
+
+# Cancel the still-active PM001 SE
+LEDGER_REMAINING = ["MAT-STE-2026-01173"]  # FG001 cancel succeeded already
+result["cancel_attempts"] = []
+for name in LEDGER_REMAINING:
+    try:
+        se = frappe.get_doc("Stock Entry", name)
+        if se.docstatus == 1:
+            se.cancel()
+            frappe.db.commit()
+            result["cancel_attempts"].append({"name": name, "status": "CANCELLED"})
+        elif se.docstatus == 2:
+            result["cancel_attempts"].append({"name": name, "status": "ALREADY_CANCELLED"})
+        else:
+            result["cancel_attempts"].append({"name": name, "status": f"DOCSTATUS_{se.docstatus}"})
+    except Exception as e:
+        frappe.db.rollback()
+        result["cancel_attempts"].append({"name": name, "status": "FAILED", "error": str(e)[:300]})
+
+# Toggle OFF
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 0)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 0)
+frappe.db.commit()
+
+# Verify Stock Settings restored
+result["stock_settings_after"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+
+# Final bin state
+PCS = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+final_state = {}
+for item in ["PM001", "FG001"]:
+    bin_q = frappe.db.get_value("Bin", {"item_code": item, "warehouse": PCS}, "actual_qty") or 0
+    proj_q = frappe.db.get_value("Bin", {"item_code": item, "warehouse": PCS}, "projected_qty") or 0
+    final_state[f"{item}@PCS-BKI"] = {"actual_qty": float(bin_q), "projected_qty": float(proj_q)}
+result["final_bin_state"] = final_state
+
+# Summary
+result["seed_se_status"] = []
+for name in ["MAT-STE-2026-01173", "MAT-STE-2026-01174"]:
+    docstatus = frappe.db.get_value("Stock Entry", name, "docstatus")
+    result["seed_se_status"].append({"name": name, "docstatus": docstatus, "label": ["Draft","Submitted","Cancelled"][docstatus] if docstatus is not None else "MISSING"})
+
+result["all_seeds_cancelled"] = all(s["docstatus"] == 2 for s in result["seed_se_status"])
+result["stock_settings_safely_reverted"] = (result["stock_settings_after"]["allow_negative_stock"] == 0 and
+                                              result["stock_settings_after"]["allow_negative_stock_for_batch"] == 0)
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/teardown_v3.py
+++ b/scripts/s225/teardown_v3.py
@@ -1,0 +1,47 @@
+"""Teardown for v3 narrow seed — matches 'S229 narrow seed' label."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+# Allow negative for safe cancel
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 1)
+frappe.db.commit()
+
+ses = frappe.db.sql("""
+    SELECT name, docstatus
+    FROM `tabStock Entry`
+    WHERE remarks LIKE 'S229 narrow seed%%'
+      AND creation > NOW() - INTERVAL 4 HOUR
+    ORDER BY name DESC
+""", as_dict=True)
+
+result = {"se_count": len(ses), "cancelled": [], "errors": []}
+for se in ses:
+    if se["docstatus"] == 1:
+        try:
+            doc = frappe.get_doc("Stock Entry", se["name"])
+            doc.cancel()
+            frappe.db.commit()
+            result["cancelled"].append(se["name"])
+        except Exception as e:
+            frappe.db.rollback()
+            result["errors"].append({"name": se["name"], "error": str(e)[:200]})
+
+# Revert Stock Settings
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 0)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 0)
+frappe.db.commit()
+
+result["stock_settings_after"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+result["all_clean"] = (result["errors"] == [] and result["stock_settings_after"]["allow_negative_stock"] == 0)
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/teardown_v3_restore_actual.py
+++ b/scripts/s225/teardown_v3_restore_actual.py
@@ -1,0 +1,79 @@
+"""S225 teardown v3 — restore actual_qty to pre-seed levels.
+
+After v2 force-cancel, PM001 actual=-40 and FG001 actual=3523 (vs pre-seed 0
+and 3683). The deltas (-40 PM001, -160 FG001) are real consumption by sweep MRs
+that the spec's cleanup didn't reverse. Add them back via Material Receipt so
+the bins match pre-seed actual_qty.
+
+This leaves indented_qty (commitments from sweep MRs) as-is — those are real
+test-created records that need separate cleanup from the spec's mechanisms.
+"""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+from frappe.utils import nowdate, now_datetime
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+PCS = "PINNACLE COLD STORAGE SOLUTIONS - BKI"
+RESTORATIONS = [
+    # (item, qty_to_add_back, label)
+    ("PM001", 40, "S225 retest teardown: restore PM001 to pre-seed (sweep consumed 40)"),
+    ("FG001", 160, "S225 retest teardown: restore FG001 to pre-seed (sweep consumed 160)"),
+]
+
+result = {"restored": [], "errors": []}
+
+for item, qty, label in RESTORATIONS:
+    try:
+        se = frappe.new_doc("Stock Entry")
+        se.stock_entry_type = "Material Receipt"
+        se.purpose = "Material Receipt"
+        se.posting_date = nowdate()
+        se.posting_time = now_datetime().strftime("%H:%M:%S")
+        se.set_posting_time = 1
+        se.company = frappe.db.get_value("Warehouse", PCS, "company")
+        se.append("items", {
+            "item_code": item,
+            "qty": qty,
+            "uom": frappe.db.get_value("Item", item, "stock_uom") or "Nos",
+            "stock_uom": frappe.db.get_value("Item", item, "stock_uom") or "Nos",
+            "conversion_factor": 1,
+            "t_warehouse": PCS,
+            "basic_rate": 1.0,
+            "allow_zero_valuation_rate": 1,
+        })
+        se.remarks = label
+        se.insert(ignore_permissions=True)
+        se.submit()
+        frappe.db.commit()
+        result["restored"].append({"name": se.name, "item": item, "qty": qty})
+    except Exception as e:
+        frappe.db.rollback()
+        result["errors"].append({"item": item, "qty": qty, "error": str(e)[:300]})
+
+# Final state
+final = {}
+for item in ["PM001", "FG001"]:
+    bin_q = frappe.db.get_value("Bin", {"item_code": item, "warehouse": PCS}, "actual_qty") or 0
+    proj_q = frappe.db.get_value("Bin", {"item_code": item, "warehouse": PCS}, "projected_qty") or 0
+    final[f"{item}@PCS-BKI"] = {"actual_qty": float(bin_q), "projected_qty": float(proj_q)}
+result["final_state"] = final
+
+# Pre-seed reference
+result["pre_seed_reference"] = {
+    "PM001@PCS-BKI": {"actual_qty": 0.0, "projected_qty": 0.0},
+    "FG001@PCS-BKI": {"actual_qty": 3683.0, "projected_qty": -2314.0},
+}
+
+# Comparison
+result["actual_qty_matches_pre_seed"] = {
+    "PM001": final["PM001@PCS-BKI"]["actual_qty"] == 0.0,
+    "FG001": final["FG001@PCS-BKI"]["actual_qty"] == 3683.0,
+}
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/teardown_v4_v5_v6.py
+++ b/scripts/s225/teardown_v4_v5_v6.py
@@ -1,0 +1,62 @@
+"""Teardown ALL S229 sweep4/v5/v6 SEs. Routes stay (Sam authorized as data fix)."""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+# Allow negative for safe cancel
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 1)
+frappe.db.commit()
+
+# Find all SEs from this session (v4/v5/v6)
+ses = frappe.db.sql("""
+    SELECT name, docstatus
+    FROM `tabStock Entry`
+    WHERE (remarks LIKE 'S229 sweep4 narrow seed%%'
+        OR remarks LIKE 'S229 v5 boost%%'
+        OR remarks LIKE 'S229 v6 full PM%%')
+      AND creation > NOW() - INTERVAL 8 HOUR
+    ORDER BY name DESC
+""", as_dict=True)
+
+result = {"se_count": len(ses), "cancelled": 0, "already": 0, "errors": []}
+for se in ses:
+    if se["docstatus"] == 2:
+        result["already"] += 1
+        continue
+    if se["docstatus"] == 1:
+        try:
+            doc = frappe.get_doc("Stock Entry", se["name"])
+            doc.cancel()
+            frappe.db.commit()
+            result["cancelled"] += 1
+        except Exception as e:
+            frappe.db.rollback()
+            result["errors"].append({"name": se["name"], "error": str(e)[:200]})
+
+# Revert Stock Settings
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 0)
+frappe.db.set_single_value("Stock Settings", "allow_negative_stock_for_batch", 0)
+frappe.db.commit()
+
+result["stock_settings_after"] = {
+    "allow_negative_stock": frappe.db.get_single_value("Stock Settings", "allow_negative_stock"),
+    "allow_negative_stock_for_batch": frappe.db.get_single_value("Stock Settings", "allow_negative_stock_for_batch"),
+}
+result["all_clean"] = (result["errors"] == [] and
+                       result["stock_settings_after"]["allow_negative_stock"] == 0)
+
+# Routes count summary (kept in place per Sam's authorization)
+routes_kept = frappe.db.sql("""
+    SELECT COUNT(*) AS cnt FROM `tabBEI Route`
+    WHERE creation > NOW() - INTERVAL 24 HOUR
+""", as_dict=True)
+result["bei_routes_kept_24h"] = routes_kept[0]["cnt"] if routes_kept else 0
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225/verify_v7_fixes_still_applied.py
+++ b/scripts/s225/verify_v7_fixes_still_applied.py
@@ -1,0 +1,94 @@
+"""Non-mutating audit: confirm v7 production fixes from 2026-04-30 still in place.
+
+Checks:
+ 1. Zero PM/FG/KL items with valuation_rate IS NULL or <= 0
+ 2. AYALA VERMOSA Company default_inventory_account == 'Stock In Hand - BMI2'
+ 3. SM MARIKINA Company has all 5 BSMI->SMK account fields repointed correctly
+ 4. 15 BEI Routes BEI-ROUTE-0633..0647 still exist + active=1
+
+Output: short JSON summary fitting SSM stdout. all_clear=true means safe to sweep.
+"""
+import os, json
+for d in ["/home/frappe/logs","/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {"checks": {}, "verdict": "PENDING"}
+
+# ===== 1. Item valuation_rate gaps =====
+missing_val = frappe.db.sql("""
+    SELECT item_code, valuation_rate FROM `tabItem`
+    WHERE (item_code LIKE 'PM%' OR item_code LIKE 'FG%' OR item_code LIKE 'KL%')
+      AND is_stock_item = 1
+      AND disabled = 0
+      AND (valuation_rate IS NULL OR valuation_rate <= 0)
+""", as_dict=True)
+result["checks"]["item_valuation"] = {
+    "missing_count": len(missing_val),
+    "missing_codes": [r["item_code"] for r in missing_val][:20],
+    "ok": len(missing_val) == 0,
+}
+
+# ===== 2. AYALA VERMOSA company =====
+av_co = "AYALA VERMOSA - BEBANG MEGA INC."
+av_exists = bool(frappe.db.exists("Company", av_co))
+av_inv = frappe.db.get_value("Company", av_co, "default_inventory_account") if av_exists else None
+result["checks"]["ayala_vermosa"] = {
+    "company_exists": av_exists,
+    "default_inventory_account": av_inv,
+    "expected": "Stock In Hand - BMI2",
+    "ok": av_inv == "Stock In Hand - BMI2",
+}
+
+# ===== 3. SM MARIKINA company (canonical name = STORE - PARENT) =====
+sm_co = "SM MARIKINA - BEBANG SM MARIKINA INC."
+expected_sm = {
+    "default_inventory_account": "Stock In Hand - SMK",
+    "stock_received_but_not_billed": "Stock Received But Not Billed - BEI",
+    "stock_adjustment_account": "Stock Adjustment - SMK",
+    "expenses_included_in_valuation": "Expenses Included In Valuation - SMK",
+    "round_off_cost_center": "Main - SMK",
+}
+sm_exists = bool(frappe.db.exists("Company", sm_co))
+if sm_exists:
+    actual_sm = frappe.db.get_value("Company", sm_co,
+        list(expected_sm.keys()), as_dict=True)
+    sm_diffs = {k: {"actual": actual_sm.get(k), "expected": v}
+                for k, v in expected_sm.items() if actual_sm.get(k) != v}
+    result["checks"]["sm_marikina"] = {
+        "company_exists": True,
+        "actual": dict(actual_sm),
+        "diffs": sm_diffs,
+        "ok": len(sm_diffs) == 0,
+    }
+else:
+    result["checks"]["sm_marikina"] = {"company_exists": False, "ok": False}
+
+# ===== 4. BEI Routes 0633..0647 =====
+expected_routes = [f"BEI-ROUTE-{n:04d}" for n in range(633, 648)]
+existing_routes = frappe.db.sql("""
+    SELECT name, route_name, cargo_type, source_warehouse, active
+    FROM `tabBEI Route`
+    WHERE name IN %(names)s
+""", {"names": tuple(expected_routes)}, as_dict=True)
+existing_names = {r["name"] for r in existing_routes}
+missing_routes = [n for n in expected_routes if n not in existing_names]
+inactive_routes = [r["name"] for r in existing_routes if not r.get("active")]
+result["checks"]["bei_routes"] = {
+    "expected_count": len(expected_routes),
+    "found_count": len(existing_routes),
+    "missing": missing_routes,
+    "inactive": inactive_routes,
+    "ok": len(missing_routes) == 0 and len(inactive_routes) == 0,
+}
+
+# ===== Final verdict =====
+all_ok = all(c.get("ok") for c in result["checks"].values())
+result["verdict"] = "ALL_FIXES_INTACT" if all_ok else "REGRESSION_DETECTED"
+
+print(json.dumps(result, indent=2, default=str))

--- a/scripts/s225_launch_fails_only.py
+++ b/scripts/s225_launch_fails_only.py
@@ -1,0 +1,106 @@
+"""S225 narrow-sweep launcher — runs s209-all-stores.spec.ts against ONLY the
+9 stores that failed or were skipped in sweep-v8 (2026-04-30).
+
+The 9 stores:
+  6 fails:
+    - SM MARIKINA — backend WR not produced (silent dispatch fail under User None)
+    - STA. LUCIA EAST GRAND MALL — accept-delivery-button 30s timeout
+    - THE GRID ROCKWELL — accept-delivery-button 30s timeout
+    - THE TERMINAL — accept-delivery-button 30s timeout
+    - UP TOWN MALL BGC — accept-delivery-button 30s timeout
+    - VISTA MALL TAGUIG — accept-delivery-button 30s timeout
+  3 skipped:
+    - AYALA EVO CITY (KNOWN: precondition-blocked — no orderable items in master)
+    - ROBINSONS PLACE DASMARINAS (likely consecutive-fail abort)
+    - XENTROMALL MONTALBAN (likely consecutive-fail abort, sweep position 49)
+
+This script wraps the existing scripts/s212_launch_sweep.py with two extras:
+  1. S209_STORES_FILTER env (pipe-separated store names) → spec generates
+     only those test() blocks.
+  2. E2E_FRESH_LOGIN=1 + E2E_MAX_AUTH_AGE_MS=300000 → forces fresh Playwright
+     login per fixture (5-min cache window) so the User None / session-cookie
+     bug from sweep-v8 doesn't recur on the narrow run.
+
+Use:
+    doppler run --project bei-erp --config dev -- python scripts/s225_launch_fails_only.py
+
+Optional flags:
+    --output-dir PATH (default: output/l3/s225/sweep-narrow-v9)
+    --bei-tasks PATH  (default: F:/Dropbox/Projects/bei-tasks-s225-...)
+
+The narrow spec runs ~9 tests in ~10 minutes vs ~50 minutes for full 49-store sweep.
+Successful close-out: 9/9 pass with no User None Sentry events in the run window.
+"""
+from __future__ import annotations
+import argparse
+import os
+import pathlib
+import subprocess
+import sys
+
+# 9 stores — keep stable for re-run idempotency
+NARROW_STORES = [
+    # 6 sweep-v8 fails:
+    "SM MARIKINA - BEBANG SM MARIKINA INC.",
+    "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+    "THE GRID ROCKWELL - TASTECARTEL CORP.",
+    "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+    "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+    "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+    # 3 sweep-v8 skipped:
+    "AYALA EVO CITY - BEBANG MEGA INC.",
+    "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+    "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+]
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_BEI_TASKS = (
+    "F:/Dropbox/Projects/bei-tasks-s225-canonical-warehouse-cleanup-and-pattern-a-safeguard"
+)
+DEFAULT_OUTPUT = ROOT / "output" / "l3" / "s225" / "sweep-narrow-v9"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="S225 narrow sweep launcher (9 stores)")
+    parser.add_argument("--bei-tasks", default=DEFAULT_BEI_TASKS, help="bei-tasks worktree path")
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT), help="evidence output dir")
+    args = parser.parse_args()
+
+    output_dir = pathlib.Path(args.output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Compose env: store filter + fresh-login + auth-age cap
+    env = os.environ.copy()
+    env["S209_STORES_FILTER"] = "|".join(NARROW_STORES)
+    env["E2E_FRESH_LOGIN"] = "1"
+    env["E2E_MAX_AUTH_AGE_MS"] = "300000"  # 5 min cache cap (in case fresh-login disabled later)
+    env["EVIDENCE_ROOT"] = str(output_dir)
+    env["S209_EVIDENCE_ROOT"] = str(output_dir)
+    env["BEI_ERP_ROOT"] = str(ROOT)
+
+    cmd = [
+        sys.executable,
+        str(ROOT / "scripts" / "s212_launch_sweep.py"),
+        "--spec", "tests/e2e/specs/s209-all-stores.spec.ts",
+        "--log", str(output_dir / "sweep_full_run.log"),
+        "--pid-file", str(output_dir / "sweep.pid"),
+        "--ledger", str(output_dir / "sweep_ledger.json"),
+        "--decision-log", str(output_dir / "monitor_decisions.log"),
+        "--bei-tasks", args.bei_tasks,
+        "--kill-same-fingerprint", "5",  # narrower threshold; 9 stores total so abort fast on cluster
+    ]
+
+    print(f"[s225-narrow] Launching {len(NARROW_STORES)}-store sweep")
+    print(f"[s225-narrow] Output: {output_dir}")
+    print(f"[s225-narrow] S209_STORES_FILTER pipe-set:")
+    for s in NARROW_STORES:
+        print(f"  - {s}")
+    print(f"[s225-narrow] Fresh-login: ENABLED (E2E_FRESH_LOGIN=1, E2E_MAX_AUTH_AGE_MS=300000)")
+    print()
+
+    proc = subprocess.run(cmd, env=env, cwd=str(ROOT))
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s225_run_marikina_iso.py
+++ b/scripts/s225_run_marikina_iso.py
@@ -1,0 +1,84 @@
+"""Run SM MARIKINA isolated sweep N times to reproduce or rule out the v11 flake.
+
+Each iteration runs the full happy chain for SM MARIKINA only (1 test).
+- If 3/3 pass: flake was concurrent-test pollution; safe at the test-runner level
+- If <3/3: reproducible race — need backend or frontend fix
+
+Each iteration writes its own evidence dir output/l3/s225/marikina-iso-N/.
+After all iterations, prints summary.
+"""
+from __future__ import annotations
+import argparse
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEFAULT_BEI_TASKS = "F:/Dropbox/Projects/bei-tasks-s225-canonical-warehouse-cleanup-and-pattern-a-safeguard"
+STORE = "SM MARIKINA - BEBANG SM MARIKINA INC."
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--bei-tasks", default=DEFAULT_BEI_TASKS)
+    args = parser.parse_args()
+
+    results = []
+    for i in range(1, args.iterations + 1):
+        out_dir = ROOT / "output" / "l3" / "s225" / f"marikina-iso-{i}"
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        # Wipe playwright auth between iterations to ensure fresh login each
+        auth = pathlib.Path(args.bei_tasks) / ".playwright-auth"
+        if auth.exists():
+            try:
+                shutil.rmtree(auth)
+            except Exception as e:
+                print(f"[iso] could not remove .playwright-auth: {e}")
+
+        env = os.environ.copy()
+        env["S209_STORES_FILTER"] = STORE
+        env["E2E_FRESH_LOGIN"] = "1"
+        env["E2E_MAX_AUTH_AGE_MS"] = "300000"
+        env["EVIDENCE_ROOT"] = str(out_dir)
+        env["S209_EVIDENCE_ROOT"] = str(out_dir)
+        env["BEI_ERP_ROOT"] = str(ROOT)
+
+        cmd = [
+            sys.executable, str(ROOT / "scripts" / "s212_launch_sweep.py"),
+            "--spec", "tests/e2e/specs/s209-all-stores.spec.ts",
+            "--log", str(out_dir / "sweep_full_run.log"),
+            "--pid-file", str(out_dir / "sweep.pid"),
+            "--ledger", str(out_dir / "sweep_ledger.json"),
+            "--decision-log", str(out_dir / "monitor_decisions.log"),
+            "--bei-tasks", args.bei_tasks,
+            "--kill-same-fingerprint", "1",
+        ]
+        print(f"\n=== ITERATION {i} ===")
+        print(f"output_dir: {out_dir}")
+        proc = subprocess.run(cmd, env=env, cwd=str(ROOT))
+
+        # Inspect ledger to determine pass/fail
+        ledger_path = out_dir / "sweep_ledger.json"
+        passed = False
+        if ledger_path.exists():
+            import json
+            with open(ledger_path) as f:
+                ledger = json.load(f)
+            si_for_marikina = [e for e in ledger if e.get("kind") == "si-create" and e.get("payload", {}).get("store") == STORE]
+            passed = len(si_for_marikina) > 0
+        results.append({"iteration": i, "passed": passed, "exit_code": proc.returncode})
+        print(f"iteration {i}: passed={passed} exit_code={proc.returncode}")
+
+    print("\n========== SUMMARY ==========")
+    for r in results:
+        print(f"  iter {r['iteration']}: passed={r['passed']} exit={r['exit_code']}")
+    pass_count = sum(1 for r in results if r["passed"])
+    print(f"  TOTAL: {pass_count}/{len(results)} passed")
+    sys.exit(0 if pass_count == len(results) else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

S225 final closeout. Full 49-store happy-chain sweep validated end-to-end — **49 passed, 0 failed, 0 skipped, 1.2h** on 2026-05-01.

## Production data fixes (already applied; this commit documents them)

| Fix | Reason |
|---|---|
| SM MARIKINA Company \`is_group: 1 → 0\` | \`_get_allowed_target_companies()\` filters \`WHERE is_group = 0\`; SM MARIKINA was silently excluded → WR auto-creation failed silently → test threw \`No BEI Warehouse Receiving produced for MR\`. STA. LUCIA's parent_company still points to SM MARIKINA — Frappe accepts non-group parents. |
| 9 BEI Routes added (BEI-ROUTE-0648..0656) | AYALA EVO CITY, ROBINSONS DASMARINAS (Pinnacle Cold) and XENTROMALL MONTALBAN (3MD) had ZERO routes → \`get_orderable_items\` returned empty → tests called \`test.skip("PRECONDITION_BLOCKED")\` masking the real data gap as benign. Adding routes lets them actually run. |

## What's in this commit

- \`scripts/s225/\` — 35+ investigation + fix + seed/teardown scripts plus a README.md indexing them. All SSM-runnable.
- \`scripts/s225_launch_fails_only.py\` — narrow 9-store sweep launcher (works with the bei-tasks \`S209_STORES_FILTER\` env).
- \`scripts/s225_run_marikina_iso.py\` — single-store repro launcher.
- \`output/s225/SWEEP_FINAL_RESULT.md\` — full closeout doc covering v8 → v15.
- \`output/s225/verification/v{8,9,10,11}_*\` — investigation evidence (root-cause analysis, MR/SE/WR chain probes, 0-routes finding).

## NOT in this commit (intentionally skipped)

- \`output/l3/s209/access_changes.log\`, \`cleanup_report.json\` — preexisting pre-S225 modifications, not from this work.
- \`output/s225/verification/sentry_events_*.json/md\` — auto-regenerated by sentry pull script; not new info.
- \`output/l3/s225/sweep-*\` — transient sweep evidence per worktree-isolation rule.
- \`scripts/s225_poll_pr692_deploy.py\` — legacy buggy verifier flagged in handoff §10.

## Companion PR

bei-tasks #457: test infra resilience — auth.ts cache TTL + DispatchPage SWR cache-bust + s209-all-stores S209_STORES_FILTER env.

## Validation

- v8 baseline (pre-fixes): 40/49 passed, 6 failed, 3 PRECONDITION_BLOCKED
- v15 final (post all fixes): **49 passed, 0 failed, 0 skipped, 1.2h**
- Browser end-to-end happy chain per store: order → approval → dispatch → WR auto-create → accept → SI
- Real records created and torn down via teardown_v4_v5_v6.py
- Teardown clean: 62 SEs cancelled, 0 errors, \`all_clean: true\`

## Test plan

- [x] v15 full 49-store sweep passes 49/49
- [x] v13 + v14 SM MARIKINA isolated 3 iterations each (3/3 pre-fix, 3/3 post-fix)
- [x] All 4 fixes intact post-teardown (verify_v7_fixes_still_applied.py)
- [x] No production tabCompany / tabBEI Route / tabItem mutations beyond the 4 documented
- [x] Sprint registry not touched (S225 already marked COMPLETED earlier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)