### PR TITLE
feat(S233): Create Store helper + API + RBAC + 7 unit tests + SSM seed/teardown (build per v3 plan)

### DIFF
--- a/hrms/api/company_master.py
+++ b/hrms/api/company_master.py
@@ -2259,3 +2259,103 @@ def get_orderable_store_warehouses(include_commissary: bool = True) -> list[dict
 		})
 
 	return result
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# S233: Create-New-Store BD UI endpoints (v3 amendments)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@frappe.whitelist()
+def create_store_company(
+	store_label: str,
+	parent_company: str,
+	abbr: str,
+	store_ownership_type: str,
+	tax_id: str | None = None,
+	region: str | None = None,
+	province: str | None = None,
+	city: str | None = None,
+) -> dict:
+	"""S233: BD UI endpoint — wraps hrms/api/create_new_store.py.
+
+	Permission: requires Frappe `create` perm on Company doctype +
+	one of [Business Development, BD Manager, Accounts Manager, HQ User,
+	System Manager, Administrator] roles. The role union MUST match
+	bei-tasks/lib/roles.ts MODULE_ACCESS[MODULES.COMPANY_MASTER] exactly
+	to prevent false-affordance dead-CTA bugs (S233 v1 audit Blocker B-05).
+
+	Defense-in-depth — UI hides the button for unauthorized roles too via
+	useRoleCheck({ module: MODULES.COMPANY_MASTER }).
+	"""
+	set_backend_observability_context(
+		module="company",
+		action="create_store_company",
+		mutation_type="create",
+		extras={
+			"store_label": store_label,
+			"parent_company": parent_company,
+			"abbr": abbr,
+			"store_ownership_type": store_ownership_type,
+		},
+	)
+
+	if not frappe.has_permission("Company", "create"):
+		frappe.throw(_("Not permitted to create Company"))
+
+	# v3 A5: RBAC roles MUST match bei-tasks/lib/roles.ts MODULE_ACCESS[MODULES.COMPANY_MASTER].
+	# Removed nonexistent "BD User" (zero occurrences in repo). Added "Business Development",
+	# "Accounts Manager", "HQ User" to mirror the frontend grant list. Keep both ends in sync;
+	# divergence creates false-affordance dead-CTA bugs (S233 audit Blocker B-05).
+	allowed_roles = {
+		"Business Development",
+		"BD Manager",
+		"Accounts Manager",
+		"HQ User",
+		"System Manager",
+		"Administrator",
+	}
+	user_roles = set(frappe.get_roles())
+	if not (allowed_roles & user_roles):
+		frappe.throw(_(
+			"S233: create_store_company requires one of: {0}. You have: {1}"
+		).format(", ".join(sorted(allowed_roles)), ", ".join(sorted(user_roles))))
+
+	# v3 A1: helper now lives in hrms/api/ (importable from Frappe HTTP context).
+	# `scripts/` is not on Frappe's sys.path — see HOTFIX4 at company_master.py:939.
+	from hrms.api.create_new_store import create_new_store
+	return create_new_store(
+		store_label=store_label,
+		parent_company=parent_company,
+		abbr=abbr,
+		store_ownership_type=store_ownership_type,
+		tax_id=tax_id,
+		region=region,
+		province=province,
+		city=city,
+	)
+
+
+@frappe.whitelist()
+def list_eligible_parent_companies() -> list[dict]:
+	"""S233: returns Companies that can be parent_company for a new store.
+
+	Filters: is_group=1 AND entity_category in canonical non-store types.
+	Used by the CreateStoreDialog parent picker combobox.
+	"""
+	set_backend_observability_context(
+		module="company",
+		action="list_eligible_parent_companies",
+		mutation_type="read",
+	)
+	rows = frappe.db.sql(
+		"""
+		SELECT name, abbr, entity_category, tax_id
+		FROM `tabCompany`
+		WHERE is_group = 1
+		  AND entity_category IN ('Head Office', 'Holding Company', 'Franchisor', 'Commissary')
+		ORDER BY name
+		""",
+		as_dict=True,
+	)
+	return rows

--- a/hrms/api/company_master.py
+++ b/hrms/api/company_master.py
@@ -496,7 +496,10 @@ def retry_provision(company: str) -> dict:
 # never cloned by GitHub Actions when it builds the bench image, so
 # `_load_s037_rows()` returned an empty list and the entire feature
 # silently produced 0 store rows. L3 testing caught this on first run.
-_S037_RELPATH = ("data_seed", "store_entity_mapping_2026-04-13.csv")
+# S233 v2 A7 + v3 A16: extracted to hrms/utils/bei_config.py to break circular
+# import that emerges when hrms/api/create_new_store.py also needs to read this CSV.
+# Back-compat alias preserved (existing references to `_S037_RELPATH` keep working).
+from hrms.utils.bei_config import STORE_ENTITY_MAPPING_RELPATH as _S037_RELPATH  # noqa: E402
 
 # Non-store legal entities that don't appear in S037 but should still
 # appear in the list. Category maps to the S181 entity_category field.

--- a/hrms/api/create_new_store.py
+++ b/hrms/api/create_new_store.py
@@ -1,0 +1,319 @@
+# Copyright (c) 2026, Bebang Enterprise Inc.
+# License: MIT
+"""S233: canonical Create-New-Store helper.
+
+Creates the 4 canonical records for a new BEI store atomically:
+  1. Per-store Company (entity_category="Store", parent linked)
+  2. Warehouse (docname == company name; company == per-store Company)
+  3. Billing Customer (customer_name == company name; is_internal_customer=0)
+  4. Internal Customer (name = "<store_label> (Internal)"; represents_company == per-store Company; is_internal_customer=1)
+
+Plus appends one row to the S037 register CSV (atomic file write
+post-savepoint per v2 A3).
+
+v2 A1: this file lives in hrms/api/ (NOT scripts/canonical/) so it
+imports cleanly from Frappe's HTTP request handler. HOTFIX4 at
+company_master.py:939 documents the `from scripts/...` trap.
+
+Wraps:
+- v2 A2: release_savepoint inside try, no manual commit (Frappe HTTP cycle commits)
+- v2 A3: CSV write AFTER savepoint released (no DB↔file split-brain)
+- v2 A4: Customer inserts set customer_type/customer_group/territory (mandatory ERPNext fields)
+- v3 A18: abbr regex enforced in _validate_preconditions (savepoint name SQL safety)
+- v3 A16: imports STORE_ENTITY_MAPPING_RELPATH from hrms.utils.bei_config (no circular import)
+"""
+from __future__ import annotations
+import argparse
+import csv
+import json
+import os
+import re
+import sys
+import tempfile
+from typing import Optional
+
+import frappe
+from frappe import _
+
+# v3 A18: abbr regex — uppercase letters and digits only, 3-6 chars.
+# Prevents savepoint-name SQL injection (hyphenated abbr like "SM-T" would
+# produce invalid SAVEPOINT identifier per MariaDB syntax) AND aligns with
+# the UI label "Abbreviation (3-6 chars)".
+ABBR_PATTERN = re.compile(r"^[A-Z0-9]{3,6}$")
+
+# Canonical operational status values per Company custom field options
+ALLOWED_OPERATIONAL_STATUSES = {"Pre-Opening"}  # only Pre-Opening on create — operator transitions later
+
+# Canonical store_ownership_type values per BEI design
+ALLOWED_OWNERSHIP_TYPES = {"JV", "Managed Franchise", "Full Franchise", "Company Owned"}
+
+# Per-store-Company entity_category — always "Store" for net-new stores
+STORE_ENTITY_CATEGORY = "Store"
+
+
+def _validate_preconditions(
+	store_label: str,
+	parent_company: str,
+	abbr: str,
+	store_ownership_type: str,
+	operational_status: str,
+) -> str:
+	"""Validate all preconditions BEFORE any DB write.
+
+	Returns the canonical company_name on success.
+	Raises frappe.ValidationError with a specific message on any failure.
+	"""
+	# v3 A18 — cheapest check first
+	if not isinstance(abbr, str) or not ABBR_PATTERN.match(abbr):
+		frappe.throw(_("Abbreviation must be 3-6 uppercase letters or digits (got: {0})").format(abbr or ""))
+
+	if not store_label or not store_label.strip():
+		frappe.throw(_("Store Label is required"))
+	if " - " in store_label:
+		frappe.throw(_("Store Label cannot contain ' - ' (it conflicts with the canonical naming convention)"))
+
+	if store_ownership_type not in ALLOWED_OWNERSHIP_TYPES:
+		frappe.throw(_("Ownership Type must be one of: {0}").format(", ".join(sorted(ALLOWED_OWNERSHIP_TYPES))))
+	if operational_status not in ALLOWED_OPERATIONAL_STATUSES:
+		frappe.throw(_("Operational Status must be 'Pre-Opening' on create (got: {0})").format(operational_status))
+
+	# Parent company existence + canonical-parent shape
+	parent = frappe.db.get_value(
+		"Company", parent_company,
+		["is_group", "entity_category", "tax_id"], as_dict=True,
+	)
+	if not parent:
+		frappe.throw(_("Parent Company {0!r} does not exist").format(parent_company))
+	if not parent.get("is_group"):
+		frappe.throw(_("Parent Company {0!r} must be a group company (is_group=1) to host child stores").format(parent_company))
+	allowed_parent_categories = {"Head Office", "Holding Company", "Franchisor", "Commissary"}
+	if parent.get("entity_category") not in allowed_parent_categories:
+		frappe.throw(_(
+			"Parent Company {0!r} entity_category is {1!r}; must be one of: {2}"
+		).format(parent_company, parent.get("entity_category") or "(unset)", ", ".join(sorted(allowed_parent_categories))))
+
+	# Abbr uniqueness
+	if frappe.db.exists("Company", {"abbr": abbr}):
+		frappe.throw(_("Abbreviation {0!r} is already used by another Company").format(abbr))
+
+	# Canonical company_name uniqueness (must not already exist)
+	company_name = f"{store_label} - {parent_company}"
+	if frappe.db.exists("Company", company_name):
+		frappe.throw(_("Company {0!r} already exists").format(company_name))
+
+	return company_name
+
+
+def _append_s037_row(
+	store_label: str,
+	parent_company: str,
+	store_ownership_type: str,
+	company_name: str,
+) -> None:
+	"""Append one row to the S037 register CSV. Atomic via tempfile + os.replace.
+
+	v3 A16: imports STORE_ENTITY_MAPPING_RELPATH from hrms.utils.bei_config
+	(NOT from hrms.api.company_master — circular import trap).
+	"""
+	from hrms.utils.bei_config import STORE_ENTITY_MAPPING_RELPATH
+	s037_path = os.path.normpath(os.path.join(frappe.get_app_path("hrms"), *STORE_ENTITY_MAPPING_RELPATH))
+	with open(s037_path, encoding="utf-8-sig", newline="") as f:
+		rows = list(csv.reader(f))
+	rows.append([
+		store_label,
+		parent_company,
+		store_ownership_type,
+		company_name,
+		"BKI_TO_STORE_INTERCOMPANY",
+		"active",
+	])
+	fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(s037_path), text=True)
+	os.close(fd)
+	with open(tmp_path, "w", encoding="utf-8", newline="") as f:
+		csv.writer(f).writerows(rows)
+	os.replace(tmp_path, s037_path)
+
+
+def create_new_store(
+	store_label: str,
+	parent_company: str,
+	abbr: str,
+	store_ownership_type: str,
+	tax_id: Optional[str] = None,
+	operational_status: str = "Pre-Opening",
+	region: Optional[str] = None,
+	province: Optional[str] = None,
+	city: Optional[str] = None,
+) -> dict:
+	"""Create the 4 canonical records for a new BEI store atomically.
+
+	Returns:
+		{
+			"company": "<store_label> - <parent_company>",
+			"warehouse": "<store_label> - <parent_company>",
+			"billing_customer": "<store_label> - <parent_company>",
+			"internal_customer": "<store_label> (Internal)",
+			"s037_row_added": True | False,
+			"first_provision_done": 0,
+		}
+
+	Raises:
+		frappe.ValidationError: any precondition failure
+		Any DB exception after savepoint entry: triggers rollback of all 4
+		records; the caller observes a clean failure (zero orphans).
+	"""
+	company_name = _validate_preconditions(
+		store_label=store_label,
+		parent_company=parent_company,
+		abbr=abbr,
+		store_ownership_type=store_ownership_type,
+		operational_status=operational_status,
+	)
+
+	parent_tax_id = frappe.db.get_value("Company", parent_company, "tax_id")
+	resolved_tax_id = tax_id or parent_tax_id  # may still be None for standalone OPCs
+
+	sp = "create_new_store_" + abbr.lower()  # safe per v3 A18 regex (alnum only)
+	frappe.db.savepoint(sp)
+	s037_row_added = False
+	try:
+		# 1. Per-store Company — defect handling for ERPNext CoA importer + auto_provision
+		#    bypass via flags (v2 A1 + S231 known traps)
+		frappe.local.flags.ignore_chart_of_accounts = True
+		frappe.flags.in_install = True  # skip auto_provision_company on first save
+		try:
+			co = frappe.new_doc("Company")
+			co.company_name = company_name
+			co.abbr = abbr
+			co.country = "Philippines"
+			co.default_currency = "PHP"
+			co.tax_id = resolved_tax_id
+			co.parent_company = parent_company
+			co.entity_category = STORE_ENTITY_CATEGORY
+			co.store_ownership_type = store_ownership_type
+			co.operational_status = operational_status
+			co.is_group = 0
+			if region:
+				co.region = region
+			if province:
+				co.province = province
+			if city:
+				co.city = city
+			co.flags.ignore_permissions = True
+			co.insert()
+		finally:
+			frappe.local.flags.ignore_chart_of_accounts = False
+			frappe.flags.in_install = False
+
+		# 2. Warehouse — docname = company_name, warehouse_name = store_label
+		wh = frappe.new_doc("Warehouse")
+		wh.warehouse_name = store_label
+		wh.company = company_name  # links to per-store Company (NOT parent)
+		wh.is_group = 0
+		wh.disabled = 0
+		wh.flags.ignore_permissions = True
+		wh.insert()
+		# Frappe may auto-rename to add suffix; force the canonical docname:
+		if wh.name != company_name:
+			frappe.rename_doc("Warehouse", wh.name, company_name, force=True)
+
+		# 3. Billing Customer (v2 A4: mandatory ERPNext fields)
+		bc = frappe.new_doc("Customer")
+		bc.customer_name = company_name
+		bc.customer_type = "Company"
+		bc.customer_group = "BKI Store"      # canonical pattern from company.py:574
+		bc.territory = "Philippines"          # canonical pattern from company.py:575
+		bc.tax_id = resolved_tax_id
+		bc.is_internal_customer = 0
+		bc.flags.ignore_permissions = True
+		bc.insert()
+		if bc.name != company_name:
+			frappe.rename_doc("Customer", bc.name, company_name, force=True)
+
+		# 4. Internal Customer (S206 labor cost-sharing; v2 A4: same mandatory fields)
+		ic = frappe.new_doc("Customer")
+		ic.customer_name = f"{store_label} (Internal)"
+		ic.customer_type = "Company"
+		ic.customer_group = "BKI Store"
+		ic.territory = "Philippines"
+		ic.represents_company = company_name
+		ic.is_internal_customer = 1
+		ic.tax_id = None  # internal — no TIN
+		ic.flags.ignore_permissions = True
+		ic.insert()
+
+		# v2 A2: release savepoint INSIDE try, BEFORE returning. Do NOT call
+		# frappe.db.commit() here — Frappe's HTTP request handler commits on
+		# successful return. Calling commit() here would end the transaction
+		# before release_savepoint and make the except-block rollback ineffective.
+		frappe.db.release_savepoint(sp)
+	except Exception:
+		# v2 A2: rollback is reachable because we did NOT manually commit
+		frappe.db.rollback(save_point=sp)
+		raise
+
+	# v2 A3: CSV write happens AFTER savepoint released. Filesystem I/O is
+	# non-transactional — keeping it inside the savepoint creates a DB↔file
+	# split-brain on commit failure. DB-atomic + CSV-best-effort:
+	# if CSV write fails here, surface the exception (DB is already
+	# consistent; operator runs scripts/canonical/repair_s037_for_company.py).
+	try:
+		_append_s037_row(
+			store_label=store_label,
+			parent_company=parent_company,
+			store_ownership_type=store_ownership_type,
+			company_name=company_name,
+		)
+		s037_row_added = True
+	except Exception as csv_exc:
+		frappe.log_error(
+			title="S233: Company created but S037 CSV append failed",
+			message=(
+				f"Company {company_name!r} created in DB but CSV append failed: {csv_exc}\n"
+				f"Operator must run scripts/canonical/repair_s037_for_company.py "
+				f"--company-name '{company_name}' to fix."
+			),
+		)
+		raise
+
+	return {
+		"company": company_name,
+		"warehouse": company_name,
+		"billing_customer": company_name,
+		"internal_customer": f"{store_label} (Internal)",
+		"s037_row_added": s037_row_added,
+		"first_provision_done": 0,  # operator clicks "Run First Provisioning" pill afterwards
+	}
+
+
+# CLI wrapper for SSM use (bench execute or direct standalone)
+if __name__ == "__main__":  # pragma: no cover — CLI only
+	p = argparse.ArgumentParser(description="S233 canonical create-new-store helper")
+	p.add_argument("--store-label", required=True)
+	p.add_argument("--parent-company", required=True)
+	p.add_argument("--abbr", required=True)
+	p.add_argument(
+		"--store-ownership-type",
+		required=True,
+		choices=["JV", "Managed Franchise", "Full Franchise", "Company Owned"],
+	)
+	p.add_argument("--tax-id", default=None)
+	p.add_argument("--operational-status", default="Pre-Opening")
+	p.add_argument("--region", default=None)
+	p.add_argument("--province", default=None)
+	p.add_argument("--city", default=None)
+	args = p.parse_args()
+	# Frappe init expected (script run via bench execute or from container)
+	out = create_new_store(
+		store_label=args.store_label,
+		parent_company=args.parent_company,
+		abbr=args.abbr,
+		store_ownership_type=args.store_ownership_type,
+		tax_id=args.tax_id,
+		operational_status=args.operational_status,
+		region=args.region,
+		province=args.province,
+		city=args.city,
+	)
+	print(json.dumps(out, indent=2))
+	sys.exit(0)

--- a/hrms/tests/test_s233_create_store_company.py
+++ b/hrms/tests/test_s233_create_store_company.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2026, Bebang Enterprise Inc.
+# License: MIT
+"""S233 unit tests for create_store_company + list_eligible_parent_companies."""
+from __future__ import annotations
+import unittest
+
+import frappe
+
+from hrms.api.company_master import (
+	create_store_company,
+	list_eligible_parent_companies,
+)
+
+
+class TestS233CreateStoreCompany(unittest.TestCase):
+	TEST_STORE_LABEL = "S233-TEST-UNIT"
+	TEST_PARENT = "BEBANG FT INC."  # is_group=1 + entity_category="Holding Company" since v3 A14 backfill
+	TEST_ABBR = "S233UN"  # 3-6 chars uppercase + digits per v3 A18
+	TEST_COMPANY_NAME = f"{TEST_STORE_LABEL} - {TEST_PARENT}"
+	TEST_INTERNAL = f"{TEST_STORE_LABEL} (Internal)"
+
+	def setUp(self):
+		self._cleanup_records()
+
+	def tearDown(self):
+		self._cleanup_records()
+
+	def _cleanup_records(self):
+		"""Remove test records from any prior run (idempotent)."""
+		for dt, name in [
+			("Customer", self.TEST_INTERNAL),
+			("Customer", self.TEST_COMPANY_NAME),
+			("Warehouse", self.TEST_COMPANY_NAME),
+			("Company", self.TEST_COMPANY_NAME),
+		]:
+			if frappe.db.exists(dt, name):
+				try:
+					frappe.delete_doc(dt, name, force=True, ignore_permissions=True, ignore_on_trash=True)
+				except Exception:
+					pass
+		frappe.db.commit()
+
+	def _all_records_absent(self) -> bool:
+		return not any([
+			frappe.db.exists("Company", self.TEST_COMPANY_NAME),
+			frappe.db.exists("Warehouse", self.TEST_COMPANY_NAME),
+			frappe.db.exists("Customer", self.TEST_COMPANY_NAME),
+			frappe.db.exists("Customer", self.TEST_INTERNAL),
+		])
+
+	def test_happy_path_creates_4_canonical_records(self):
+		"""Plan Phase 5 S1: helper creates Company + Warehouse + 2 Customers."""
+		out = create_store_company(
+			store_label=self.TEST_STORE_LABEL,
+			parent_company=self.TEST_PARENT,
+			abbr=self.TEST_ABBR,
+			store_ownership_type="Managed Franchise",
+		)
+		self.assertEqual(out["company"], self.TEST_COMPANY_NAME)
+		self.assertEqual(out["warehouse"], self.TEST_COMPANY_NAME)
+		self.assertEqual(out["billing_customer"], self.TEST_COMPANY_NAME)
+		self.assertEqual(out["internal_customer"], self.TEST_INTERNAL)
+		self.assertEqual(out["first_provision_done"], 0)
+		# All 4 records exist in DB
+		self.assertTrue(frappe.db.exists("Company", self.TEST_COMPANY_NAME))
+		self.assertTrue(frappe.db.exists("Warehouse", self.TEST_COMPANY_NAME))
+		self.assertTrue(frappe.db.exists("Customer", self.TEST_COMPANY_NAME))
+		self.assertTrue(frappe.db.exists("Customer", self.TEST_INTERNAL))
+
+	def test_rejects_non_group_parent(self):
+		"""v2 A4 / v3 A14: parent must be is_group=1."""
+		# Find a per-store Company (is_group=0) to use as fake parent
+		non_group = frappe.db.get_value("Company", {"is_group": 0}, "name")
+		self.assertIsNotNone(non_group, "test fixture: at least one is_group=0 Company should exist")
+		with self.assertRaises(frappe.ValidationError):
+			create_store_company(
+				store_label=self.TEST_STORE_LABEL,
+				parent_company=non_group,
+				abbr=self.TEST_ABBR,
+				store_ownership_type="Managed Franchise",
+			)
+		self.assertTrue(self._all_records_absent(), "no records should be created when parent is non-group")
+
+	def test_rejects_duplicate_abbr(self):
+		"""v3 A18: abbr must be unique."""
+		# First create succeeds
+		create_store_company(
+			store_label=self.TEST_STORE_LABEL,
+			parent_company=self.TEST_PARENT,
+			abbr=self.TEST_ABBR,
+			store_ownership_type="Managed Franchise",
+		)
+		# Second create with different label but same abbr fails
+		with self.assertRaises(frappe.ValidationError):
+			create_store_company(
+				store_label="S233-TEST-DIFFERENT",
+				parent_company=self.TEST_PARENT,
+				abbr=self.TEST_ABBR,
+				store_ownership_type="JV",
+			)
+
+	def test_rejects_existing_company_name(self):
+		"""Canonical company_name uniqueness."""
+		create_store_company(
+			store_label=self.TEST_STORE_LABEL,
+			parent_company=self.TEST_PARENT,
+			abbr=self.TEST_ABBR,
+			store_ownership_type="Managed Franchise",
+		)
+		# Same label + same parent → same canonical name
+		with self.assertRaises(frappe.ValidationError):
+			create_store_company(
+				store_label=self.TEST_STORE_LABEL,
+				parent_company=self.TEST_PARENT,
+				abbr="S233UB",  # different abbr to bypass that check
+				store_ownership_type="Managed Franchise",
+			)
+
+	def test_rejects_invalid_abbr_pattern(self):
+		"""v3 A18: abbr regex ^[A-Z0-9]{3,6}$."""
+		for bad_abbr in ["AB", "TOOLONG7C", "with-hyphen", "lowercase", "WITH SPACE", ""]:
+			with self.subTest(abbr=bad_abbr):
+				with self.assertRaises(frappe.ValidationError):
+					create_store_company(
+						store_label=self.TEST_STORE_LABEL,
+						parent_company=self.TEST_PARENT,
+						abbr=bad_abbr,
+						store_ownership_type="Managed Franchise",
+					)
+
+	def test_atomicity_partial_failure_rolls_back_all_4(self):
+		"""v2 A2: savepoint rolls back all 4 records if any insert fails.
+
+		Force a failure by passing an invalid (but precondition-passing)
+		ownership type via a direct helper call AFTER preconditions pass —
+		simulated by patching one of the inner inserts to raise.
+		"""
+		from unittest.mock import patch
+		import hrms.api.create_new_store as helper
+
+		# Patch the second-to-last frappe.new_doc call to raise
+		original_new_doc = frappe.new_doc
+		call_count = {"n": 0}
+
+		def fake_new_doc(doctype, *args, **kwargs):
+			call_count["n"] += 1
+			# Allow Company + Warehouse + first Customer; fail on internal Customer
+			if call_count["n"] == 4:
+				raise frappe.ValidationError("simulated failure on internal Customer insert")
+			return original_new_doc(doctype, *args, **kwargs)
+
+		with patch.object(frappe, "new_doc", side_effect=fake_new_doc):
+			with self.assertRaises(frappe.ValidationError):
+				create_store_company(
+					store_label=self.TEST_STORE_LABEL,
+					parent_company=self.TEST_PARENT,
+					abbr=self.TEST_ABBR,
+					store_ownership_type="Managed Franchise",
+				)
+		# All 4 records absent — savepoint rolled back the partial work
+		self.assertTrue(self._all_records_absent(), "savepoint must roll back all 4 records on failure")
+
+	def test_list_eligible_parents_returns_only_group_companies(self):
+		"""list_eligible_parent_companies filters correctly."""
+		rows = list_eligible_parent_companies()
+		self.assertGreater(len(rows), 0, "at least one canonical parent must exist")
+		for row in rows:
+			# Every row must have entity_category in the allowed set
+			self.assertIn(
+				row["entity_category"],
+				{"Head Office", "Holding Company", "Franchisor", "Commissary"},
+				f"row {row} has wrong entity_category",
+			)
+			# And every parent must be is_group=1
+			is_group = frappe.db.get_value("Company", row["name"], "is_group")
+			self.assertEqual(is_group, 1, f"row {row['name']} is not is_group=1")
+		# After v3 A14 backfill, BFI2 should appear
+		names = [r["name"] for r in rows]
+		self.assertIn("BEBANG FT INC.", names, "v3 A14: BFI2 must appear after backfill")

--- a/hrms/utils/bei_config.py
+++ b/hrms/utils/bei_config.py
@@ -76,3 +76,12 @@ def get_service_account_path() -> str:
 def get_company() -> str:
 	"""Return the default company name from Frappe global defaults."""
 	return frappe.defaults.get_global_default("company") or "Bebang Enterprise Inc."
+
+
+# ── S037 store/entity register CSV (S233 v2 A7 + v3 A16) ─────────────────
+# Extracted from hrms/api/company_master.py to break the circular import
+# that emerges when hrms/api/create_new_store.py needs to read it.
+# v3 A16: name is STORE_ENTITY_MAPPING_RELPATH (descriptive) to avoid
+# confusion with hrms/overrides/company.py::_S037_REGISTER_RELPATH which
+# points to a DIFFERENT CSV (store_buyer_entity_register_2026-03-12.csv).
+STORE_ENTITY_MAPPING_RELPATH = ("data_seed", "store_entity_mapping_2026-04-13.csv")

--- a/scripts/canonical/repair_s037_for_company.py
+++ b/scripts/canonical/repair_s037_for_company.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Bebang Enterprise Inc.
+# License: MIT
+"""S233 v3 A15: repair the S037 register CSV after a post-savepoint append failed.
+
+Called manually after Sentry alert raised by hrms/api/create_new_store.py
+when DB-side 4-record creation succeeded but the subsequent CSV append
+raised. Idempotent — checks for existing row before appending.
+
+Usage (inside Frappe container):
+    bench --site hq.bebang.ph execute scripts.canonical.repair_s037_for_company.repair \\
+        --kwargs '{"company_name": "SM Tanza - BEBANG MEGA INC."}'
+
+Or as standalone CLI:
+    python scripts/canonical/repair_s037_for_company.py \\
+        --company-name "SM Tanza - BEBANG MEGA INC."
+"""
+from __future__ import annotations
+import argparse
+import csv
+import json
+import os
+import sys
+import tempfile
+from typing import Optional
+
+
+def repair(company_name: str) -> dict:
+	"""Append the missing S037 row for an already-created Company. Idempotent.
+
+	Reads Company doc, derives store_label/parent/ownership from the canonical
+	docname pattern + DB row, checks if S037 already has the row, appends if not.
+
+	Returns:
+		{"status": "OK", "action": "appended" | "noop", "company_name": ..., ...}
+		{"status": "ERROR", "reason": ...}
+	"""
+	import frappe  # late import (so CLI mode without frappe.init still parses args)
+
+	# Load Company DB row
+	co = frappe.db.get_value(
+		"Company", company_name,
+		["abbr", "parent_company", "store_ownership_type", "country"],
+		as_dict=True,
+	)
+	if not co:
+		return {"status": "ERROR", "reason": f"Company {company_name!r} not found"}
+
+	parent = co["parent_company"]
+	if not parent:
+		return {"status": "ERROR", "reason": f"Company {company_name!r} has no parent_company set"}
+
+	# Resolve store_label (everything before " - <parent>")
+	suffix = f" - {parent}"
+	if not company_name.endswith(suffix):
+		return {
+			"status": "ERROR",
+			"reason": f"Company name {company_name!r} doesn't end with parent suffix {suffix!r}",
+		}
+	store_label = company_name[: -len(suffix)]
+
+	# Resolve canonical CSV path via the v3-renamed constant
+	from hrms.utils.bei_config import STORE_ENTITY_MAPPING_RELPATH
+	s037_path = os.path.normpath(os.path.join(frappe.get_app_path("hrms"), *STORE_ENTITY_MAPPING_RELPATH))
+
+	if not os.path.exists(s037_path):
+		return {"status": "ERROR", "reason": f"S037 CSV not found at {s037_path}"}
+
+	# Read existing rows + check if this store already there (idempotent)
+	with open(s037_path, encoding="utf-8-sig", newline="") as f:
+		rows = list(csv.reader(f))
+	for r in rows[1:]:  # skip header
+		if r and r[0].strip() == store_label:
+			return {
+				"status": "OK",
+				"action": "noop",
+				"reason": "row already present",
+				"company_name": company_name,
+				"store_label": store_label,
+			}
+
+	# Append the missing row using the canonical 6-column layout
+	rows.append([
+		store_label,
+		parent,
+		co["store_ownership_type"] or "",
+		company_name,
+		"BKI_TO_STORE_INTERCOMPANY",
+		"active",
+	])
+	fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(s037_path), text=True)
+	os.close(fd)
+	with open(tmp_path, "w", encoding="utf-8", newline="") as f:
+		csv.writer(f).writerows(rows)
+	os.replace(tmp_path, s037_path)
+	return {
+		"status": "OK",
+		"action": "appended",
+		"company_name": company_name,
+		"store_label": store_label,
+		"csv_path": s037_path,
+	}
+
+
+if __name__ == "__main__":  # pragma: no cover — CLI only
+	p = argparse.ArgumentParser(description="S233 v3 A15: repair S037 register CSV after a failed post-savepoint append")
+	p.add_argument(
+		"--company-name", required=True,
+		help="Canonical company docname (e.g. 'SM Tanza - BEBANG MEGA INC.')",
+	)
+	args = p.parse_args()
+	# Caller initializes Frappe (via bench execute or direct frappe.init+connect)
+	out = repair(args.company_name)
+	print(json.dumps(out, indent=2))
+	sys.exit(0 if out["status"] == "OK" else 1)

--- a/scripts/s233_backfill_bfi2_entity_category.py
+++ b/scripts/s233_backfill_bfi2_entity_category.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""S233 v3 A14: conditionally backfill BFI2 entity_category.
+
+Reads output/s233/verification/bfi2_state_pre.json. If
+entity_category not in {Head Office, Holding Company, Franchisor, Commissary},
+sets it to "Holding Company" via frappe.db.set_value (no full save — avoids
+re-firing auto_provision_company hook).
+
+Idempotent — re-running after backfill is a no-op.
+"""
+from __future__ import annotations
+import json, pathlib, sys
+
+PREAMBLE = """\
+import os, sys, json, traceback
+for d in (
+    "/home/frappe/logs",
+    "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+):
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+def _emit(payload):
+    print("---S233-BACKFILL-START---")
+    print(json.dumps(payload, indent=2, default=str))
+    print("---S233-BACKFILL-END---")
+"""
+
+BACKFILL = PREAMBLE + """
+ALLOWED = {"Head Office", "Holding Company", "Franchisor", "Commissary"}
+RECOMMENDED = "Holding Company"
+result = {}
+try:
+    pre = frappe.db.get_value(
+        "Company", "BEBANG FT INC.",
+        ["entity_category", "is_group"], as_dict=True,
+    )
+    result["pre"] = pre
+    if not pre:
+        result["error"] = "BFI2 not found"
+    elif pre.get("entity_category") in ALLOWED:
+        result["action"] = "noop"
+        result["reason"] = f"entity_category already {pre['entity_category']!r}, in allowed set"
+    else:
+        # Direct SQL set_value — does NOT re-fire auto_provision_company hook
+        # (avoids the S231 chart-of-accounts importer trap if doc_save was used)
+        frappe.db.set_value("Company", "BEBANG FT INC.", "entity_category", RECOMMENDED)
+        frappe.db.commit()
+        result["action"] = "backfilled"
+        result["from"] = pre.get("entity_category")
+        result["to"] = RECOMMENDED
+    # Re-probe for evidence
+    post = frappe.db.get_value(
+        "Company", "BEBANG FT INC.",
+        ["entity_category", "is_group"], as_dict=True,
+    )
+    result["post"] = post
+    result["entity_category_in_allowed_set"] = post.get("entity_category") in ALLOWED
+    result["is_group_correct"] = post.get("is_group") == 1
+except Exception as e:
+    result["error"] = str(e)
+    result["traceback"] = traceback.format_exc()
+
+_emit(result)
+frappe.destroy()
+"""
+
+
+def main() -> int:
+    REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    try:
+        from s231_ssm_helper import run_in_container
+    except ImportError:
+        print("ERROR: s231_ssm_helper not found; expected at scripts/s231_ssm_helper.py", file=sys.stderr)
+        return 1
+
+    stdout = run_in_container(BACKFILL, timeout=120)
+    if "---S233-BACKFILL-START---" not in stdout:
+        print("ERROR: backfill output missing markers:\n" + stdout[-2000:], file=sys.stderr)
+        return 2
+    s = stdout.split("---S233-BACKFILL-START---", 1)[1].split("---S233-BACKFILL-END---", 1)[0].strip()
+    data = json.loads(s)
+    out_path = REPO_ROOT / "output" / "s233" / "verification" / "bfi2_state_after.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(data, indent=2, default=str))
+    print(json.dumps(data, indent=2, default=str))
+    if data.get("error"):
+        return 1
+    if not (data.get("entity_category_in_allowed_set") and data.get("is_group_correct")):
+        print("FAIL: post-state still not canonical", file=sys.stderr)
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s233_l3_seed_preconditions.py
+++ b/scripts/s233_l3_seed_preconditions.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""S233 v3 L3 pre-flight seeder.
+
+Idempotent. Ensures L3 spec preconditions are met BEFORE Playwright opens
+the browser:
+  1. BFI2 has is_group=1 AND entity_category in {Head Office, Holding Company,
+     Franchisor, Commissary} (delegates to s233_backfill_bfi2_entity_category.py)
+  2. test.bd@bebang.ph User exists with role "BD Manager"
+  3. test.crew@bebang.ph User exists with role "Crew" (no BD Manager — for
+     S7 negative-case button-hidden test)
+
+Output: output/l3/s233/seed_complete.json with the resolved state.
+
+Per CEO browser-only directive: this script runs BEFORE the browser opens
+(not from inside the spec body).
+"""
+from __future__ import annotations
+import json
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from s231_ssm_helper import run_in_container
+
+PREAMBLE = """\
+import os, sys, json, traceback
+for d in (
+    "/home/frappe/logs",
+    "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+):
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+def _emit(payload):
+    print("---S233-SEED-START---")
+    print(json.dumps(payload, indent=2, default=str))
+    print("---S233-SEED-END---")
+"""
+
+SEED = PREAMBLE + """
+result = {"steps": []}
+try:
+    # Step 1: BFI2 is_group + entity_category
+    bfi2 = frappe.db.get_value(
+        "Company", "BEBANG FT INC.",
+        ["is_group", "entity_category", "abbr"], as_dict=True,
+    )
+    result["steps"].append({"step": 1, "name": "bfi2_state", "value": bfi2})
+    ALLOWED = {"Head Office", "Holding Company", "Franchisor", "Commissary"}
+    if not bfi2:
+        result["error"] = "BFI2 not found — cannot seed L3"
+        _emit(result); frappe.destroy(); raise SystemExit(0)
+    if bfi2.get("is_group") != 1 or bfi2.get("entity_category") not in ALLOWED:
+        result["error"] = (
+            f"BFI2 not canonical: is_group={bfi2.get('is_group')}, "
+            f"entity_category={bfi2.get('entity_category')!r}. "
+            f"Run s233_backfill_bfi2_entity_category.py first."
+        )
+        _emit(result); frappe.destroy(); raise SystemExit(0)
+
+    # Step 2: test.bd@bebang.ph User with BD Manager role
+    BD_USER = "test.bd@bebang.ph"
+    bd_step = {"step": 2, "name": "test_bd_user"}
+    if not frappe.db.exists("User", BD_USER):
+        u = frappe.new_doc("User")
+        u.email = BD_USER
+        u.first_name = "Test"
+        u.last_name = "BD"
+        u.username = BD_USER.split("@")[0]
+        u.send_welcome_email = 0
+        u.enabled = 1
+        u.user_type = "System User"
+        u.flags.ignore_permissions = True
+        u.insert()
+        bd_step["created"] = True
+    else:
+        bd_step["created"] = False
+    # Ensure BD Manager role assigned (idempotent)
+    if not frappe.db.exists("Has Role", {"parent": BD_USER, "role": "BD Manager"}):
+        u = frappe.get_doc("User", BD_USER)
+        u.append("roles", {"role": "BD Manager"})
+        u.flags.ignore_permissions = True
+        u.save()
+        bd_step["bd_manager_role_added"] = True
+    else:
+        bd_step["bd_manager_role_added"] = False
+    # Set test password
+    from frappe.utils.password import update_password
+    update_password(BD_USER, "BeiTest2026!")
+    bd_step["password_set"] = True
+    result["steps"].append(bd_step)
+
+    # Step 3: test.crew@bebang.ph User with Crew role only (no BD Manager)
+    CREW_USER = "test.crew@bebang.ph"
+    crew_step = {"step": 3, "name": "test_crew_user"}
+    if not frappe.db.exists("User", CREW_USER):
+        u = frappe.new_doc("User")
+        u.email = CREW_USER
+        u.first_name = "Test"
+        u.last_name = "Crew"
+        u.username = CREW_USER.split("@")[0]
+        u.send_welcome_email = 0
+        u.enabled = 1
+        u.user_type = "System User"
+        u.flags.ignore_permissions = True
+        u.insert()
+        crew_step["created"] = True
+    else:
+        crew_step["created"] = False
+    # Ensure Crew role assigned (only Crew, no BD Manager — for negative test)
+    if frappe.db.exists("Has Role", {"parent": CREW_USER, "role": "Crew"}):
+        crew_step["crew_role_present"] = True
+    else:
+        u = frappe.get_doc("User", CREW_USER)
+        u.append("roles", {"role": "Crew"})
+        u.flags.ignore_permissions = True
+        u.save()
+        crew_step["crew_role_added"] = True
+    # Confirm Crew user does NOT have BD Manager (would invalidate S7 negative case)
+    has_bd = frappe.db.exists("Has Role", {"parent": CREW_USER, "role": "BD Manager"})
+    if has_bd:
+        # Strip it
+        frappe.db.delete("Has Role", {"parent": CREW_USER, "role": "BD Manager"})
+        crew_step["stripped_bd_manager_role"] = True
+    update_password(CREW_USER, "BeiTest2026!")
+    crew_step["password_set"] = True
+    result["steps"].append(crew_step)
+
+    frappe.db.commit()
+    result["status"] = "OK"
+except Exception as e:
+    result["error"] = str(e)
+    result["traceback"] = traceback.format_exc()
+    result["status"] = "ERROR"
+
+_emit(result)
+frappe.destroy()
+"""
+
+
+def main() -> int:
+	stdout = run_in_container(SEED, timeout=180)
+	if "---S233-SEED-START---" not in stdout:
+		print("ERROR: seed output missing markers:\n" + stdout[-2000:], file=sys.stderr)
+		return 2
+	s = stdout.split("---S233-SEED-START---", 1)[1].split("---S233-SEED-END---", 1)[0].strip()
+	data = json.loads(s)
+	out_path = REPO_ROOT / "output" / "l3" / "s233" / "seed_complete.json"
+	out_path.parent.mkdir(parents=True, exist_ok=True)
+	out_path.write_text(json.dumps(data, indent=2, default=str))
+	print(json.dumps(data, indent=2, default=str))
+	return 0 if data.get("status") == "OK" else 1
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/scripts/s233_l3_teardown_test_store.py
+++ b/scripts/s233_l3_teardown_test_store.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""S233 v3 L3 post-flight teardown.
+
+Reverses any L3-test-created records left behind by the spec. Targets BOTH
+test stores (S1-S5 happy/negative case AND S8 race-condition winner):
+  - "L3 Test Store 233 - BEBANG FT INC."
+  - "L3 Race Test Store - BEBANG FT INC."
+
+Order: Customer (internal) → Customer (billing) → Warehouse → Company,
+then strip the matching S037 register CSV row.
+
+Idempotent — re-running after partial cleanup is a no-op for whatever's
+already deleted. Writes output/l3/s233/teardown_complete.json with the
+final reconciliation.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from s231_ssm_helper import run_in_container
+
+PREAMBLE = """\
+import os, sys, json, traceback
+for d in (
+    "/home/frappe/logs",
+    "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+):
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+def _emit(payload):
+    print("---S233-TEARDOWN-START---")
+    print(json.dumps(payload, indent=2, default=str))
+    print("---S233-TEARDOWN-END---")
+"""
+
+TEARDOWN = PREAMBLE + """
+import csv, os, tempfile
+
+TEST_STORES = [
+    {"label": "L3 Test Store 233", "parent": "BEBANG FT INC."},
+    {"label": "L3 Race Test Store", "parent": "BEBANG FT INC."},
+]
+
+result = {"per_store": [], "csv_rows_removed": 0, "deleted_total": 0}
+try:
+    for spec in TEST_STORES:
+        store_label = spec["label"]
+        parent = spec["parent"]
+        company_name = f"{store_label} - {parent}"
+        internal = f"{store_label} (Internal)"
+        per_store = {
+            "store_label": store_label,
+            "company_name": company_name,
+            "actions": [],
+        }
+
+        # 1. Internal Customer
+        if frappe.db.exists("Customer", internal):
+            try:
+                frappe.delete_doc("Customer", internal, force=True, ignore_permissions=True, ignore_on_trash=True)
+                per_store["actions"].append({"doctype": "Customer", "name": internal, "action": "deleted"})
+                result["deleted_total"] += 1
+            except Exception as e:
+                per_store["actions"].append({"doctype": "Customer", "name": internal, "action": "failed", "error": str(e)[:200]})
+
+        # 2. Billing Customer
+        if frappe.db.exists("Customer", company_name):
+            try:
+                frappe.delete_doc("Customer", company_name, force=True, ignore_permissions=True, ignore_on_trash=True)
+                per_store["actions"].append({"doctype": "Customer", "name": company_name, "action": "deleted"})
+                result["deleted_total"] += 1
+            except Exception as e:
+                per_store["actions"].append({"doctype": "Customer", "name": company_name, "action": "failed", "error": str(e)[:200]})
+
+        # 3. Warehouse
+        if frappe.db.exists("Warehouse", company_name):
+            try:
+                frappe.delete_doc("Warehouse", company_name, force=True, ignore_permissions=True, ignore_on_trash=True)
+                per_store["actions"].append({"doctype": "Warehouse", "name": company_name, "action": "deleted"})
+                result["deleted_total"] += 1
+            except Exception as e:
+                per_store["actions"].append({"doctype": "Warehouse", "name": company_name, "action": "failed", "error": str(e)[:200]})
+
+        # 4. Company
+        if frappe.db.exists("Company", company_name):
+            try:
+                frappe.delete_doc("Company", company_name, force=True, ignore_permissions=True, ignore_on_trash=True)
+                per_store["actions"].append({"doctype": "Company", "name": company_name, "action": "deleted"})
+                result["deleted_total"] += 1
+            except Exception as e:
+                per_store["actions"].append({"doctype": "Company", "name": company_name, "action": "failed", "error": str(e)[:200]})
+
+        result["per_store"].append(per_store)
+
+    frappe.db.commit()
+
+    # 5. Strip matching rows from S037 register CSV (atomic write)
+    from hrms.utils.bei_config import STORE_ENTITY_MAPPING_RELPATH
+    s037_path = os.path.normpath(os.path.join(frappe.get_app_path("hrms"), *STORE_ENTITY_MAPPING_RELPATH))
+    if os.path.exists(s037_path):
+        with open(s037_path, encoding="utf-8-sig", newline="") as f:
+            rows = list(csv.reader(f))
+        labels_to_strip = {s["label"] for s in TEST_STORES}
+        kept = [rows[0]]  # header
+        for r in rows[1:]:
+            if r and r[0].strip() in labels_to_strip:
+                result["csv_rows_removed"] += 1
+            else:
+                kept.append(r)
+        if result["csv_rows_removed"] > 0:
+            fd, tmp = tempfile.mkstemp(dir=os.path.dirname(s037_path), text=True)
+            os.close(fd)
+            with open(tmp, "w", encoding="utf-8", newline="") as f:
+                csv.writer(f).writerows(kept)
+            os.replace(tmp, s037_path)
+
+    # Final reconciliation: confirm zero remaining
+    remaining = []
+    for spec in TEST_STORES:
+        store_label = spec["label"]
+        parent = spec["parent"]
+        company_name = f"{store_label} - {parent}"
+        for dt, name in [
+            ("Company", company_name),
+            ("Warehouse", company_name),
+            ("Customer", company_name),
+            ("Customer", f"{store_label} (Internal)"),
+        ]:
+            if frappe.db.exists(dt, name):
+                remaining.append({"doctype": dt, "name": name})
+    result["remaining"] = remaining
+    result["remaining_count"] = len(remaining)
+    result["status"] = "OK" if len(remaining) == 0 else "PARTIAL"
+except Exception as e:
+    result["error"] = str(e)
+    result["traceback"] = traceback.format_exc()
+    result["status"] = "ERROR"
+
+_emit(result)
+frappe.destroy()
+"""
+
+
+def main() -> int:
+	stdout = run_in_container(TEARDOWN, timeout=180)
+	if "---S233-TEARDOWN-START---" not in stdout:
+		print("ERROR: teardown output missing markers:\n" + stdout[-2000:], file=sys.stderr)
+		return 2
+	s = stdout.split("---S233-TEARDOWN-START---", 1)[1].split("---S233-TEARDOWN-END---", 1)[0].strip()
+	data = json.loads(s)
+	out_path = REPO_ROOT / "output" / "l3" / "s233" / "teardown_complete.json"
+	out_path.parent.mkdir(parents=True, exist_ok=True)
+	out_path.write_text(json.dumps(data, indent=2, default=str))
+	print(json.dumps(data, indent=2, default=str))
+	return 0 if data.get("status") == "OK" else 1
+
+
+if __name__ == "__main__":
+	sys.exit(main())

--- a/scripts/s233_probe_bfi2_entity_category.py
+++ b/scripts/s233_probe_bfi2_entity_category.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""S233 v3 A14: probe BEBANG FT INC. (BFI2) live entity_category + is_group state.
+
+Run via SSM inside Frappe container. Captures snapshot to
+output/s233/verification/bfi2_state_pre.json. Phase 0.4 step 1 of 2 —
+backfill (set_value) only fires if probe shows entity_category not in
+the canonical {Head Office, Holding Company, Franchisor, Commissary} set.
+"""
+from __future__ import annotations
+import json, os, pathlib, sys
+
+# SSM helper preamble — copied from scripts/s231_ssm_helper.py pattern
+PREAMBLE = """\
+import os, sys, json, traceback
+for d in (
+    "/home/frappe/logs",
+    "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+):
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+def _emit(payload):
+    print("---S233-PROBE-START---")
+    print(json.dumps(payload, indent=2, default=str))
+    print("---S233-PROBE-END---")
+"""
+
+PROBE = PREAMBLE + """
+result = {}
+try:
+    out = frappe.db.get_value(
+        "Company", "BEBANG FT INC.",
+        ["is_group", "entity_category", "abbr", "tax_id", "parent_company"],
+        as_dict=True,
+    )
+    if not out:
+        result["error"] = "BEBANG FT INC. does not exist"
+    else:
+        result["state"] = out
+        ALLOWED = {"Head Office", "Holding Company", "Franchisor", "Commissary"}
+        result["entity_category_in_allowed_set"] = (out.get("entity_category") in ALLOWED)
+        result["is_group_correct"] = (out.get("is_group") == 1)
+        result["needs_backfill"] = not result["entity_category_in_allowed_set"]
+        result["recommended_value"] = "Holding Company"  # BFI2 is a holding entity per S231 design
+except Exception as e:
+    result["error"] = str(e)
+    result["traceback"] = traceback.format_exc()
+
+_emit(result)
+frappe.destroy()
+"""
+
+
+def main() -> int:
+    # Caller (this main) writes the script payload to /tmp on the SSM host
+    # then docker execs into the backend container. We use the existing
+    # s231_ssm_helper if available; otherwise emit the script for manual exec.
+    REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    try:
+        from s231_ssm_helper import decode_output, run_in_container
+    except ImportError:
+        print("ERROR: s231_ssm_helper not found; expected at scripts/s231_ssm_helper.py", file=sys.stderr)
+        return 1
+
+    stdout = run_in_container(PROBE, timeout=120)
+    # decode_output expects START/END markers — ours are S231-PROBE-START/END.
+    # Fall back to raw JSON between our markers.
+    if "---S233-PROBE-START---" in stdout and "---S233-PROBE-END---" in stdout:
+        s = stdout.split("---S233-PROBE-START---", 1)[1].split("---S233-PROBE-END---", 1)[0].strip()
+        data = json.loads(s)
+    else:
+        try:
+            data = decode_output(stdout)
+        except Exception:
+            print("ERROR: could not decode probe output:\n" + stdout[-2000:], file=sys.stderr)
+            return 2
+
+    out_path = pathlib.Path(__file__).resolve().parent.parent / "output" / "s233" / "verification" / "bfi2_state_pre.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(data, indent=2, default=str))
+    print(json.dumps(data, indent=2, default=str))
+    return 0 if not data.get("error") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Builds the S233 backend for the v3 plan (PR #717 merged 2026-05-03 13:52 UTC). Implements the canonical `create_new_store` helper + whitelisted API + 7 unit tests + L3 SSM seed/teardown scripts. Frontend ships in companion bei-tasks PR.

**Plan**: `docs/plans/2026-05-03-sprint-233-create-store-ui-button.md` (v3)
**Audit trail**: 3 cycles (v1 → v2 → v3), all CRITICAL blockers fixed; build verified clean.

## Phases shipped (49u total)

| Phase | Units | Files |
|---|---|---|
| Phase 0 — boot + baselines + library audit | 4 | output/s233/{REMOTE_TRUTH_BASELINE.json, state/PRETOUCH_BACKUP.json, verification/{canonical_verifier_pre.txt, library_audit.md}} |
| Phase 0.4 — BFI2 entity_category backfill (v3 A14) | 1 | scripts/s233_probe_bfi2_entity_category.py + scripts/s233_backfill_bfi2_entity_category.py — backfilled BFI2 from `""` to `"Holding Company"` (was empty in production, confirmed v2 audit B-V2-04) |
| Phase 0.5 — STORE_ENTITY_MAPPING_RELPATH extracted (v2 A7 + v3 A16) | 1 | hrms/utils/bei_config.py + hrms/api/company_master.py:499 alias |
| Phase 1 — canonical helper (v2 A1/A2/A3/A4 + v3 A16/A18) | 8 | hrms/api/create_new_store.py — atomic 4-record create, savepoint inside try (no manual commit), CSV write post-savepoint, customer_type/group/territory on both Customers, abbr regex enforced |
| Phase 1.5 — repair_s037_for_company.py (v3 A15) | 2 | scripts/canonical/repair_s037_for_company.py — idempotent CSV repair |
| Phase 2 — whitelisted API + RBAC + 7 unit tests (v3 A17) | 5 | hrms/api/company_master.py — `create_store_company` + `list_eligible_parent_companies`; hrms/tests/test_s233_create_store_company.py |
| Phase 4 — SSM seed/teardown scripts | 3 | scripts/s233_l3_seed_preconditions.py + scripts/s233_l3_teardown_test_store.py |

## Canonical scope: in (verified)

- **Pre-execution:** 49/49 ALL CANONICAL — 0 violations
- **Post-execution:** 49/49 ALL CANONICAL — 0 NEW violations
- BFI2 backfill is the only production state mutation outside the worktree; fixes a hidden dependency for the new `list_eligible_parent_companies` endpoint without introducing drift.

## v3 amendments implemented

| # | Resolution |
|---|---|
| A11 | useRoleCheck (frontend, in bei-tasks PR) |
| A12 | Real-life browser-only L3 (in bei-tasks PR) |
| A13 | ssmRun reference dropped (in bei-tasks PR) |
| A14 | BFI2 backfill — DONE in this PR |
| A15 | repair_s037_for_company.py — DONE in this PR |
| A16 | STORE_ENTITY_MAPPING_RELPATH rename — DONE in this PR |
| A17 | Phase 2-1 docstring corrected — DONE in this PR |
| A18 | abbr regex `^[A-Z0-9]{3,6}$` — DONE in this PR |

## DM-7 Sentry observability

Both new whitelisted endpoints have `set_backend_observability_context()`:
- `create_store_company` → module="company", action="create_store_company", mutation_type="create"
- `list_eligible_parent_companies` → module="company", action="list_eligible_parent_companies", mutation_type="read"

## Test plan

- [x] 22 backend code-level checks pass for create_new_store.py
- [x] 6 checks pass for repair_s037_for_company.py
- [x] 8 RBAC code-level checks pass for company_master.py extensions
- [x] BFI2 entity_category live-state probed + backfilled to "Holding Company"
- [x] Canonical preflight + post both 49/49 ALL CANONICAL — 0 violations
- [ ] Sam runs `bench --site hq.bebang.ph run-tests --module hrms.tests.test_s233_create_store_company` after deploy (expects 7 PASS)
- [ ] L3 retest in fresh session per BEI execute-plan-bei-erp policy (handoff prompt in `output/s233/SUMMARY.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
