### PR TITLE
fix(S233): rename_doc needs ignore_permissions=True (L3 caught this)

### DIFF
--- a/hrms/api/create_new_store.py
+++ b/hrms/api/create_new_store.py
@@ -213,9 +213,13 @@ def create_new_store(
 		wh.disabled = 0
 		wh.flags.ignore_permissions = True
 		wh.insert()
-		# Frappe may auto-rename to add suffix; force the canonical docname:
+		# Frappe may auto-rename to add suffix; force the canonical docname.
+		# v3 hotfix: force=True only handles cancelled docs; ignore_permissions=True
+		# is required to bypass the per-doc write-permission check in validate_rename.
+		# Without it, the live BD user fails on the source-doc permission check even
+		# though they had insert permission.
 		if wh.name != company_name:
-			frappe.rename_doc("Warehouse", wh.name, company_name, force=True)
+			frappe.rename_doc("Warehouse", wh.name, company_name, force=True, ignore_permissions=True)
 
 		# 3. Billing Customer (v2 A4: mandatory ERPNext fields)
 		bc = frappe.new_doc("Customer")
@@ -228,7 +232,7 @@ def create_new_store(
 		bc.flags.ignore_permissions = True
 		bc.insert()
 		if bc.name != company_name:
-			frappe.rename_doc("Customer", bc.name, company_name, force=True)
+			frappe.rename_doc("Customer", bc.name, company_name, force=True, ignore_permissions=True)
 
 		# 4. Internal Customer (S206 labor cost-sharing; v2 A4: same mandatory fields)
 		ic = frappe.new_doc("Customer")


### PR DESCRIPTION
## Summary

L3 S1 first run (post-deploy of #719) caught a real bug:

```
ValidationError: You need write permission on Warehouse L3 Test Store 233 - L3T233 to rename
  at frappe/model/rename_doc.py:383 validate_rename
  called from hrms/api/create_new_store.py:218
```

## Root cause

`frappe.rename_doc("Warehouse", wh.name, company_name, force=True)` only handles the cancelled-doc case via `force=True`. It still calls `validate_rename` which does `frappe.has_permission(doctype, "write", doc=old)` on the source doc loaded fresh from DB. The `wh.flags.ignore_permissions = True` flag we set BEFORE `wh.insert()` does not survive into the rename validation (different doc instance).

## Fix

Pass `ignore_permissions=True` to `rename_doc` for both the Warehouse and billing Customer renames. The user has already passed the earlier role-set + `frappe.has_permission("Company", "create")` gate; the rename here is just docname canonicalization (Frappe auto-suffixed with abbr; we want canonical `<store_label> - <parent_company>`).

## Test plan

- [x] Diagnosis verified by capturing the live API response (status 417, the exact stack trace above)
- [ ] Sam merges → API container restart → re-run `/l3-v2-bei-erp s233`

## How L3 caught it

Local unit tests passed because `Administrator` user is used by the test runner — has full write perm on Warehouse already. The `test.bd@bebang.ph` user (BD Manager only) lacks the source-doc write perm. The L3 race scenario S8 would have caught this too. This is exactly why we run L3 against a real BD-role user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)