### PR TITLE
fix(S233): rename_doc must be called via frappe.model.rename_doc (top wrapper rejects ignore_permissions)

### DIFF
--- a/hrms/api/create_new_store.py
+++ b/hrms/api/create_new_store.py
@@ -214,12 +214,17 @@ def create_new_store(
 		wh.flags.ignore_permissions = True
 		wh.insert()
 		# Frappe may auto-rename to add suffix; force the canonical docname.
-		# v3 hotfix: force=True only handles cancelled docs; ignore_permissions=True
-		# is required to bypass the per-doc write-permission check in validate_rename.
-		# Without it, the live BD user fails on the source-doc permission check even
-		# though they had insert permission.
+		# v3 hotfix #720 + #721: must call frappe.model.rename_doc.rename_doc directly
+		# because the top-level frappe.rename_doc wrapper has a strict typing
+		# decorator that doesn't accept `ignore_permissions` (raises TypeError at
+		# runtime). The internal rename_doc accepts both `force` (bypass cancelled-doc
+		# check) and `ignore_permissions` (bypass source-doc write-perm in
+		# validate_rename — required because wh.flags.ignore_permissions=True set
+		# before insert does NOT propagate to the rename validation, which loads a
+		# fresh doc from DB).
+		from frappe.model.rename_doc import rename_doc as _rename_doc_internal
 		if wh.name != company_name:
-			frappe.rename_doc("Warehouse", wh.name, company_name, force=True, ignore_permissions=True)
+			_rename_doc_internal("Warehouse", wh.name, company_name, force=True, ignore_permissions=True)
 
 		# 3. Billing Customer (v2 A4: mandatory ERPNext fields)
 		bc = frappe.new_doc("Customer")
@@ -232,7 +237,7 @@ def create_new_store(
 		bc.flags.ignore_permissions = True
 		bc.insert()
 		if bc.name != company_name:
-			frappe.rename_doc("Customer", bc.name, company_name, force=True, ignore_permissions=True)
+			_rename_doc_internal("Customer", bc.name, company_name, force=True, ignore_permissions=True)
 
 		# 4. Internal Customer (S206 labor cost-sharing; v2 A4: same mandatory fields)
 		ic = frappe.new_doc("Customer")


### PR DESCRIPTION
## Summary

Hotfix PR #720 added `ignore_permissions=True` to `frappe.rename_doc(...)` but it failed at runtime:

```
TypeError: rename_doc() got an unexpected keyword argument 'ignore_permissions'
  at frappe.utils.typing_validations:32 wrapper
  at hrms/api/create_new_store.py:222
```

The top-level `frappe.rename_doc` wrapper has a strict `typing_validations` decorator that rejects unknown kwargs. Its published signature does not include `ignore_permissions`.

## Fix

Import the internal function directly:
```python
from frappe.model.rename_doc import rename_doc as _rename_doc_internal
_rename_doc_internal("Warehouse", wh.name, company_name, force=True, ignore_permissions=True)
```

The internal `frappe.model.rename_doc.rename_doc` accepts both `force` and `ignore_permissions` per its full signature.

## Why this couldn't be caught locally

The issue surfaces ONLY at the typing decorator. `tsc --noEmit`, lint, and Python static analysis pass because both call sites are valid Python. Frappe v15's strict typing layer rejects the kwarg at first call.

## Test plan

- [x] L3 evidence captured the exact runtime error post-#720 deploy
- [ ] Sam merges → restart API container → re-run `/l3-v2-bei-erp s233`

🤖 Generated with [Claude Code](https://claude.com/claude-code)