### PR TITLE
fix(S233): Customer territory = All Territories (Philippines doesn't exist in prod)

### DIFF
--- a/hrms/api/create_new_store.py
+++ b/hrms/api/create_new_store.py
@@ -231,7 +231,7 @@ def create_new_store(
 		bc.customer_name = company_name
 		bc.customer_type = "Company"
 		bc.customer_group = "BKI Store"      # canonical pattern from company.py:574
-		bc.territory = "Philippines"          # canonical pattern from company.py:575
+		bc.territory = "All Territories"      # v3 hotfix #722: matches existing canonical Customers; "Philippines" doesn't exist in production tabTerritory
 		bc.tax_id = resolved_tax_id
 		bc.is_internal_customer = 0
 		bc.flags.ignore_permissions = True
@@ -244,7 +244,7 @@ def create_new_store(
 		ic.customer_name = f"{store_label} (Internal)"
 		ic.customer_type = "Company"
 		ic.customer_group = "BKI Store"
-		ic.territory = "Philippines"
+		ic.territory = "All Territories"  # v3 hotfix #722: matches existing canonical Internal Customers
 		ic.represents_company = company_name
 		ic.is_internal_customer = 1
 		ic.tax_id = None  # internal — no TIN


### PR DESCRIPTION
## Summary

L3 captured another runtime error post-#721 deploy (the rename now succeeds — visible in the response payload `Document renamed from L3 Test Store 233 - L3T233 to L3 Test Store 233 - BEBANG FT INC.`):

```
LinkValidationError: Could not find Territory: Philippines
  at hrms/api/create_new_store.py:238 bc.insert()
```

## Root cause

Production probe of `tabTerritory`:
- 4 territory records, **Philippines is NOT one of them**
- All existing canonical Customers (e.g. `ARANETA GATEWAY (Internal)`, `AYALA EVO CITY - BEBANG MEGA INC.`) use `territory = "All Territories"`
- One legacy Customer `Araneta Gateway` does have `territory = "Philippines"` — looks like a stale orphan from before the territory was removed

The v3 plan + helper hardcoded "Philippines" based on `hrms/overrides/company.py:575`, which is older code running in a hook context with `ignore_validate`. My fresh helper triggered link validation that fails.

## Fix

Change both Customer inserts to use `"All Territories"` (the always-existing Frappe root territory). Matches the canonical S206 Internal Customer pattern observed in production.

## Test plan

- [x] Production probe confirms Philippines absent + All Territories present + existing canonical pattern uses All Territories
- [ ] Sam merges + deploys → re-run `/l3-v2-bei-erp s233`

## Hotfix sequence so far for S233 build
- #719 — initial build
- #720 — `rename_doc(force=True, ignore_permissions=True)` — wrong: top-level wrapper rejects kwarg
- #721 — call `frappe.model.rename_doc.rename_doc` directly — works
- **#722 (this) — territory = "All Territories"**

Each hotfix exposed the next blocking issue. The L3 spec is doing exactly what real BD users would hit on first store create. Without these, the feature fails for every real user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)