### PR TITLE
chore(S233 L3): test library + runbook + 5 probe scripts (post-L3 closeout)

### DIFF
--- a/docs/testing/S233_L3_RUNBOOK.md
+++ b/docs/testing/S233_L3_RUNBOOK.md
@@ -1,0 +1,143 @@
+# S233 L3 Runbook — Create Store UI
+
+## Verified working test pipeline (2026-05-04)
+
+Result of latest run: **7/7 PASS in 1.0m**, no orphans, canonical verifier clean post-run.
+
+```
+✓ S1  BD/CEO user creates a new store correctly (happy path)         17.6s
+✓ S2  Detail dialog opens for new store and renders correctly         4.4s
+✓ S3  Duplicate abbr is rejected with friendly toast                  3.5s
+✓ S4  Parent dropdown shows ONLY canonical parents (filter test)      3.5s
+✓ S5  Blank parent rejects submission with toast                      3.1s
+✓ S7  BD Manager sees button; Crew-only does NOT (RBAC)               8.3s
+✓ S8  Two BD users race — savepoint atomicity proven                 20.2s
+```
+
+## Quick run
+
+```bash
+# 1. Spawn fresh worktrees (or reuse if you already have them)
+cd F:/Dropbox/Projects/BEI-ERP && git fetch origin --prune
+git worktree add F:/Dropbox/Projects/BEI-ERP-l3-s233 -B l3-s233-runner-hrms origin/production
+cd F:/Dropbox/Projects/bei-tasks && git fetch origin --prune
+git worktree add F:/Dropbox/Projects/bei-tasks-l3-s233 -B l3-s233-runner origin/main
+cd F:/Dropbox/Projects/bei-tasks-l3-s233 && npm install
+
+# 2. Pre-test seed (BFI2 entity_category check, test users, missing roles)
+cd F:/Dropbox/Projects/BEI-ERP-l3-s233
+python scripts/s233_l3_seed_roles.py            # creates BD Manager + Business Development + Crew Roles if missing
+python scripts/s233_l3_seed_preconditions.py    # verifies BFI2 + creates test.bd + test.crew users
+
+# 3. Run the spec (browser-only per CEO directive)
+cd F:/Dropbox/Projects/bei-tasks-l3-s233
+npx playwright test tests/e2e/specs/s233-create-store-ui.spec.ts --reporter=list
+
+# 4. Post-test teardown (deletes 4 records × 2 stores + S037 CSV rows)
+cd F:/Dropbox/Projects/BEI-ERP-l3-s233
+python scripts/s233_l3_teardown_test_store.py
+
+# 5. Confirm clean state
+python scripts/verify_canonical_structure.py    # 49/49 ALL CANONICAL — 0 violations
+```
+
+## Test library files (reusable)
+
+### bei-tasks repo
+
+| File | Purpose |
+|---|---|
+| `tests/e2e/specs/s233-create-store-ui.spec.ts` | The 7-scenario L3 spec |
+| `tests/e2e/pages/CreateStoreDialog.ts` | Page Object with all real user actions (open, fill, pick, submit, cancel, readParentDropdownOptions) |
+| `tests/e2e/builders/store-create-payload.ts` | Test data builder with sane defaults |
+| `tests/e2e/assertions/canonicalStoreShape.ts` | Read-only API assertions via `page.evaluate(fetch)` (authenticated browser context) |
+| `tests/e2e/fixtures/cleanup.ts` | `store-company-create` cleanup kind reverses 4 records |
+| `tests/e2e/fixtures/auth.ts` | `loggedInAsBdManager` + `loggedInAsCrewOnly` fixtures |
+
+### hrms repo
+
+| Script | Purpose |
+|---|---|
+| `scripts/s233_l3_seed_roles.py` | Idempotent: creates `BD Manager`, `Business Development`, `Crew` Frappe Role DocTypes if missing (frontend declares them but no fixtures migration ever seeded them) |
+| `scripts/s233_l3_seed_preconditions.py` | Verifies BFI2 canonical + creates `test.bd@bebang.ph` (BD Manager) + `test.crew@bebang.ph` (Crew only) — both pwd `BeiTest2026!` |
+| `scripts/s233_l3_teardown_test_store.py` | Idempotent: deletes test stores (`L3 Test Store 233` + `L3 Race Test Store`) — 4 records each + 2 S037 CSV rows |
+| `scripts/s233_probe_bfi2_entity_category.py` | Read-only probe: BFI2 is_group + entity_category state |
+| `scripts/s233_backfill_bfi2_entity_category.py` | Conditional backfill: BFI2 entity_category to "Holding Company" if missing |
+| `scripts/s233_l3_probe_roles.py` | Read-only probe: which Frappe Roles exist (BD Manager, etc.) |
+| `scripts/s233_l3_probe_territories.py` | Read-only probe: tabTerritory + Customer Group state |
+| `scripts/s233_l3_probe_test_records.py` | Read-only probe: post-create canonical 4-record state |
+| `scripts/s233_l3_probe_bfc_bki.py` | Read-only probe: BFC + BKI is_group + entity_category |
+
+### scripts/canonical/repair_s037_for_company.py
+Operator runbook for post-savepoint CSV-write failures. Idempotent: reads Company, derives store_label, checks for existing S037 row, appends if missing. Used when the helper's post-savepoint CSV write fails (operator gets Sentry alert pointing here).
+
+## CEO directive — real-life browser-only
+
+The spec is written per the 2026-05-03 CEO directive:
+
+> "The test should be like real life scenarios, not just to pass, so make sure any test script we create reflects that and it should all be done in browser."
+
+### Banned anti-patterns absent from spec body
+- `ssmRun(` — not used (would mutate production)
+- `set_value("Customer Group"` — not used
+- `NONEXISTENT_GROUP` — not used (would require test-only kwarg in helper)
+- monkey-patching — not used
+- Direct REST mutations — not used (only read-only `frappe.client.get_value` GET via `page.evaluate(fetch)`)
+
+### Scenarios reflect real user actions
+- S1 happy: BD/CEO clicks Add Store → fills form → submits → verifies via authenticated read-only API
+- S2 detail: clicks new row → detail dialog opens
+- S3 duplicate abbr: real-user typo on abbr → friendly toast
+- S4 dropdown filter (NOT bypass test): verifies filter prevention works — real users cannot pick a non-canonical parent because the dropdown filters them out
+- S5 required field: blank parent → submit blocked
+- S7 RBAC: BD Manager sees button; Crew-only does NOT
+- S8 concurrent race: TWO real BD users (`loggedInAsCEO` + fresh `test.bd@bebang.ph` context) submit identical payloads via `Promise.all` — exactly one wins, savepoint atomicity holds
+
+### Setup + teardown outside the browser
+- Pre-test: `/frappe-bulk-edits` style SSM scripts run BEFORE Playwright opens
+- Post-test: SSM teardown runs AFTER Playwright closes
+- The spec body itself is pure browser interactions + read-only verification
+
+## Collateral defects discovered (long-standing data drift, NOT S233 bugs)
+
+These were discovered during L3 + don't break the S233 feature, but are recommended follow-ups:
+
+1. **Frappe Role DocTypes missing**: `BD Manager`, `Business Development`, `Crew` declared in `bei-tasks/lib/roles.ts` but no fixtures migration. Mitigated by `s233_l3_seed_roles.py` for testing.
+2. **BFC + BKI `is_group=0`**: `BEBANG FRANCHISE CORP.` (Franchisor) and `BEBANG KITCHEN INC.` (Commissary) cannot host child Companies in production. Filter correctly excludes them; if BD wants Franchisor stores under BFC, fix the master data.
+3. **Territory "Philippines" missing from `tabTerritory`**: legacy code references it; helper now uses "All Territories" (root, always exists).
+4. **BD Manager lacks Frappe `Company.create` doctype-level perm**: test.bd@bebang.ph can pass the role-based gate but fails Frappe's permission check. Sam should add `Company.create` to BD Manager via Role Permission Manager for the feature to work end-to-end for non-System-Manager users.
+
+## Hotfix sequence required to land
+
+L3 caught real bugs that local TS-only verification missed. Each hotfix exposed the next blocking issue:
+
+| PR | Issue |
+|---|---|
+| #719 | Initial S233 build (hrms backend + bei-tasks frontend) |
+| #720 | `frappe.rename_doc(force=True, ignore_permissions=True)` — wrapper rejects kwarg (didn't help) |
+| #721 | Call `frappe.model.rename_doc.rename_doc` directly — works |
+| #723 | Customer territory = `"All Territories"` (Philippines doesn't exist) |
+| #462 | Vercel TS strict-build hotfix |
+
+## Anti-patterns this spec avoids (S120/S225 lessons)
+
+- ❌ Element existence checks instead of value verification → ✅ asserts toast text via regex match
+- ❌ API shortcuts for mutations → ✅ every mutation via real button click
+- ❌ Stale records → ✅ pre-test teardown ensures fresh state
+- ❌ Selector guessing → ✅ all 7 `data-testid` attributes per Page Object pattern
+- ❌ Python `sync_playwright` → ✅ TypeScript `npx playwright test` (S231 lesson)
+- ❌ Top-level `request` fixture without cookies → ✅ `page.evaluate(fetch)` for authenticated read-only verification
+- ❌ Test-only kwargs in production helper → ✅ no back doors in the helper
+- ❌ Disabling production master records mid-test → ✅ no production state mutations from spec
+
+## Future regressions
+
+To re-run for regression testing after any change to:
+- `hrms/api/create_new_store.py`
+- `hrms/api/company_master.py::create_store_company`
+- `hrms/api/company_master.py::list_eligible_parent_companies`
+- `bei-tasks/components/company-master/create-store-dialog.tsx`
+- `bei-tasks/lib/queries/company-master.ts::useCreateStoreCompany`
+- `bei-tasks/app/dashboard/bd/companies/page.tsx` (header + RBAC guard)
+- `hrms/utils/bei_config.py::STORE_ENTITY_MAPPING_RELPATH`
+- `scripts/canonical/repair_s037_for_company.py`

--- a/scripts/s233_l3_probe_bfc_bki.py
+++ b/scripts/s233_l3_probe_bfc_bki.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""S233 L3 — probe BFC and BKI entity_category + is_group state."""
+from __future__ import annotations
+import json, pathlib, sys
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from s231_ssm_helper import run_in_container
+
+PROBE = """\
+import os, json
+for d in ("/home/frappe/logs", "/home/frappe/frappe-bench/logs", "/home/frappe/frappe-bench/hq.bebang.ph/logs", "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"):
+    try: os.makedirs(d, exist_ok=True)
+    except: pass
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+for name in ["BEBANG FRANCHISE CORP.", "BEBANG KITCHEN INC."]:
+    if frappe.db.exists("Company", name):
+        result[name] = frappe.db.get_value("Company", name, ["is_group", "entity_category", "abbr"], as_dict=True)
+    else:
+        result[name] = "NOT_FOUND"
+
+# Also list all Companies with is_group=1
+groups = frappe.db.sql("SELECT name, entity_category, abbr FROM `tabCompany` WHERE is_group=1 ORDER BY name", as_dict=True)
+result["all_is_group_companies"] = groups
+
+print("---PROBE-START---")
+print(json.dumps(result, indent=2, default=str))
+print("---PROBE-END---")
+frappe.destroy()
+"""
+
+
+def main() -> int:
+    stdout = run_in_container(PROBE, timeout=60)
+    if "---PROBE-START---" not in stdout: print("ERR:\\n" + stdout[-1500:]); return 1
+    s = stdout.split("---PROBE-START---", 1)[1].split("---PROBE-END---", 1)[0].strip()
+    print(s); return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s233_l3_probe_roles.py
+++ b/scripts/s233_l3_probe_roles.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""S233 L3 — probe existing Frappe Roles relevant to S233 RBAC."""
+from __future__ import annotations
+import json, pathlib, sys
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from s231_ssm_helper import run_in_container
+
+PREAMBLE = """\
+import os, sys, json, traceback
+for d in ("/home/frappe/logs", "/home/frappe/frappe-bench/logs", "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"):
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+def _emit(p):
+    print("---S233-ROLES-START---")
+    print(json.dumps(p, indent=2, default=str))
+    print("---S233-ROLES-END---")
+"""
+
+PROBE = PREAMBLE + """
+result = {"target_roles": {}}
+TARGETS = ["BD Manager", "Business Development", "Accounts Manager", "HQ User", "System Manager", "Administrator", "Crew", "Store Crew", "Area Supervisor"]
+for r in TARGETS:
+    result["target_roles"][r] = bool(frappe.db.exists("Role", r))
+# Sample existing BD-ish roles
+all_roles = frappe.db.sql("SELECT name, disabled FROM `tabRole` WHERE name LIKE %s OR name LIKE %s OR name LIKE %s ORDER BY name", ("%BD%", "%Business%", "%Crew%"), as_dict=True)
+result["existing_bd_or_crew_roles"] = all_roles
+_emit(result)
+frappe.destroy()
+"""
+
+
+def main() -> int:
+    stdout = run_in_container(PROBE, timeout=60)
+    if "---S233-ROLES-START---" not in stdout:
+        print("ERR:\n" + stdout[-1500:])
+        return 1
+    s = stdout.split("---S233-ROLES-START---", 1)[1].split("---S233-ROLES-END---", 1)[0].strip()
+    print(s)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s233_l3_probe_territories.py
+++ b/scripts/s233_l3_probe_territories.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""S233 L3 — probe Territory + CustomerGroup state in production."""
+from __future__ import annotations
+import json, pathlib, sys
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from s231_ssm_helper import run_in_container
+
+PROBE = """\
+import os, json, traceback
+for d in ("/home/frappe/logs", "/home/frappe/frappe-bench/logs", "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"):
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+try:
+    territories = frappe.db.sql("SELECT name FROM `tabTerritory` ORDER BY name", as_dict=True)
+    result["territories_count"] = len(territories)
+    result["territories"] = territories
+    result["territory_philippines_exists"] = bool(frappe.db.exists("Territory", "Philippines"))
+
+    cgroups = frappe.db.sql("SELECT name FROM `tabCustomer Group` WHERE name LIKE %s OR name LIKE %s ORDER BY name", ("%BKI%", "%Store%"), as_dict=True)
+    result["bki_cgroups"] = cgroups
+    result["bki_store_exists"] = bool(frappe.db.exists("Customer Group", "BKI Store"))
+
+    # Sample existing Customer to see what territory + customer_group it uses
+    sample = frappe.db.sql("SELECT name, customer_group, territory FROM `tabCustomer` LIMIT 5", as_dict=True)
+    result["sample_customers"] = sample
+except Exception as e:
+    result["error"] = str(e)
+    result["traceback"] = traceback.format_exc()
+
+print("---PROBE-START---")
+print(json.dumps(result, indent=2, default=str))
+print("---PROBE-END---")
+frappe.destroy()
+"""
+
+
+def main() -> int:
+    stdout = run_in_container(PROBE, timeout=60)
+    if "---PROBE-START---" not in stdout:
+        print("ERR:\n" + stdout[-1500:])
+        return 1
+    s = stdout.split("---PROBE-START---", 1)[1].split("---PROBE-END---", 1)[0].strip()
+    print(s)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s233_l3_probe_test_records.py
+++ b/scripts/s233_l3_probe_test_records.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""S233 L3 — probe whether the test Company + 4 records actually exist in DB."""
+from __future__ import annotations
+import json, pathlib, sys
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from s231_ssm_helper import run_in_container
+
+PROBE = """\
+import os, json
+for d in ("/home/frappe/logs", "/home/frappe/frappe-bench/logs", "/home/frappe/frappe-bench/hq.bebang.ph/logs", "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"):
+    try: os.makedirs(d, exist_ok=True)
+    except: pass
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+
+result = {}
+for dt, name in [
+    ("Company", "L3 Test Store 233 - BEBANG FT INC."),
+    ("Warehouse", "L3 Test Store 233 - BEBANG FT INC."),
+    ("Customer", "L3 Test Store 233 - BEBANG FT INC."),
+    ("Customer", "L3 Test Store 233 (Internal)"),
+]:
+    exists = bool(frappe.db.exists(dt, name))
+    result[f"{dt}::{name}"] = exists
+
+# Also dump the Company doc fields if it exists
+if frappe.db.exists("Company", "L3 Test Store 233 - BEBANG FT INC."):
+    doc = frappe.db.get_value("Company", "L3 Test Store 233 - BEBANG FT INC.",
+        ["abbr", "parent_company", "store_ownership_type", "entity_category", "operational_status", "tax_id", "first_provision_done"], as_dict=True)
+    result["company_doc"] = doc
+
+# Check S037 CSV row
+import csv
+from hrms.utils.bei_config import STORE_ENTITY_MAPPING_RELPATH
+s037 = os.path.normpath(os.path.join(frappe.get_app_path("hrms"), *STORE_ENTITY_MAPPING_RELPATH))
+with open(s037, encoding="utf-8-sig", newline="") as f:
+    rows = list(csv.reader(f))
+result["s037_test_row_present"] = any(r and r[0].strip() == "L3 Test Store 233" for r in rows[1:])
+
+print("---PROBE-START---")
+print(json.dumps(result, indent=2, default=str))
+print("---PROBE-END---")
+frappe.destroy()
+"""
+
+
+def main() -> int:
+    stdout = run_in_container(PROBE, timeout=60)
+    if "---PROBE-START---" not in stdout:
+        print("ERR:\n" + stdout[-1500:])
+        return 1
+    s = stdout.split("---PROBE-START---", 1)[1].split("---PROBE-END---", 1)[0].strip()
+    print(s)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s233_l3_seed_preconditions.py
+++ b/scripts/s233_l3_seed_preconditions.py
@@ -28,9 +28,13 @@ import os, sys, json, traceback
 for d in (
     "/home/frappe/logs",
     "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/hq.bebang.ph/logs",
     "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
 ):
-    os.makedirs(d, exist_ok=True)
+    try:
+        os.makedirs(d, exist_ok=True)
+    except Exception:
+        pass
 import frappe
 frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
 frappe.connect()

--- a/scripts/s233_l3_seed_roles.py
+++ b/scripts/s233_l3_seed_roles.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""S233 L3 — seed missing Frappe Role DocTypes (BD Manager, Business Development, Crew).
+
+These roles are declared in bei-tasks/lib/roles.ts but were never migrated
+to Frappe as Role DocTypes. Seed them so L3 can assign them to test users.
+Idempotent — if a role already exists, no-op.
+
+This is also recorded as collateral defect S233-COLLAT-1: ship a fixtures
+migration so these roles exist in production by default (separate sprint).
+"""
+from __future__ import annotations
+import json, pathlib, sys
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+from s231_ssm_helper import run_in_container
+
+PREAMBLE = """\
+import os, sys, json, traceback
+for d in ("/home/frappe/logs", "/home/frappe/frappe-bench/logs", "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"):
+    os.makedirs(d, exist_ok=True)
+import frappe
+frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+frappe.connect()
+frappe.set_user("Administrator")
+def _emit(p):
+    print("---S233-SEEDROLES-START---")
+    print(json.dumps(p, indent=2, default=str))
+    print("---S233-SEEDROLES-END---")
+"""
+
+SEED = PREAMBLE + """
+TARGETS = ["BD Manager", "Business Development", "Crew"]
+result = {"actions": []}
+try:
+    for role in TARGETS:
+        if frappe.db.exists("Role", role):
+            result["actions"].append({"role": role, "action": "noop", "reason": "already exists"})
+        else:
+            r = frappe.new_doc("Role")
+            r.role_name = role
+            r.disabled = 0
+            r.is_custom = 1
+            r.flags.ignore_permissions = True
+            r.insert()
+            result["actions"].append({"role": role, "action": "created"})
+    frappe.db.commit()
+    result["status"] = "OK"
+except Exception as e:
+    result["error"] = str(e)
+    result["traceback"] = traceback.format_exc()
+    result["status"] = "ERROR"
+_emit(result)
+frappe.destroy()
+"""
+
+
+def main() -> int:
+    stdout = run_in_container(SEED, timeout=60)
+    if "---S233-SEEDROLES-START---" not in stdout:
+        print("ERR:\n" + stdout[-1500:])
+        return 1
+    s = stdout.split("---S233-SEEDROLES-START---", 1)[1].split("---S233-SEEDROLES-END---", 1)[0].strip()
+    print(s)
+    return 0 if json.loads(s).get("status") == "OK" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/s233_l3_teardown_test_store.py
+++ b/scripts/s233_l3_teardown_test_store.py
@@ -27,9 +27,13 @@ import os, sys, json, traceback
 for d in (
     "/home/frappe/logs",
     "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/hq.bebang.ph/logs",
     "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
 ):
-    os.makedirs(d, exist_ok=True)
+    try:
+        os.makedirs(d, exist_ok=True)
+    except Exception:
+        pass
 import frappe
 frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
 frappe.connect()


### PR DESCRIPTION
## Summary

Saves the reusable S233 L3 test library + runbook + 5 probe scripts discovered/built during the live L3 cycle that produced **7/7 PASS in 1.0m** (no orphans, canonical verifier clean post-run).

## Why this matters

The L3 run made several improvements to the test infrastructure that needed to be committed back to the repo for future regression testing. Without this PR, future agents would have to re-discover:
- The missing log-dir path that breaks SSM (post-#723 deploy regression)
- The missing Frappe Role DocTypes that block test user creation
- The diagnostic probe scripts for common L3 setup issues

## Files

### Modified scripts
- `scripts/s233_l3_seed_preconditions.py` — added `/home/frappe/frappe-bench/hq.bebang.ph/logs` to preamble (Frappe needs it before `frappe.connect()`)
- `scripts/s233_l3_teardown_test_store.py` — same preamble fix

### New scripts
- `scripts/s233_l3_seed_roles.py` — idempotent: creates BD Manager, Business Development, Crew Frappe Role DocTypes if missing (fixes a long-standing fixture-migration gap)
- `scripts/s233_l3_probe_roles.py` — read-only role probe
- `scripts/s233_l3_probe_territories.py` — read-only territory + customer group probe
- `scripts/s233_l3_probe_test_records.py` — read-only canonical 4-record state probe
- `scripts/s233_l3_probe_bfc_bki.py` — read-only BFC + BKI is_group + entity_category probe

### New runbook
- `docs/testing/S233_L3_RUNBOOK.md` — 5-step pipeline, file inventory, CEO directive (real-life browser-only), 4 collateral defects discovered, hotfix sequence (#720 → #721 → #723) that landed S233

## Test plan

- [x] All scripts confirmed working in latest L3 cycle (2026-05-04)
- [x] Result: 7/7 scenarios pass + clean teardown + 49/49 canonical
- [ ] Sam reviews + merges → no deploy needed (scripts only)

## Companion bei-tasks PR

bei-tasks branch `chore/s233-test-library` ships the canonicalStoreShape.ts assertion rewrite + s233-create-store-ui.spec.ts scenario fixes (S4 reframe, S8 race optimization, retries disabled on serial spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)