### PR TITLE
S238 hotfix: _resolve_per_store_cost_center safe when Warehouse.custom_cost_center absent

### DIFF
--- a/hrms/api/bki_store_pi_generator.py
+++ b/hrms/api/bki_store_pi_generator.py
@@ -172,19 +172,30 @@ def _resolve_per_store_cost_center(buyer_company, buyer_warehouse):
 	Frappe's `Cost Center.company == doc.company` validation, and the
 	savepoint try/except would silently swallow the error -> 0 PIs created.
 
+	v2.2-hotfix (2026-05-10): the `Warehouse.custom_cost_center` Custom Field
+	cited in the plan (pattern from store.py:5278) does NOT exist on production.
+	The existing call site `store.py:_get_store_cost_center` is dead code (would
+	throw 'Unknown column' if exercised). Guard the lookup with
+	`frappe.get_meta().has_field()` so this function falls back to
+	`Company.cost_center` cleanly when the field is absent.
+
 	Resolution order:
-	  1. `Warehouse.custom_cost_center` (pattern from store.py:5276-5281)
-	  2. `Company.cost_center` default
+	  1. `Warehouse.custom_cost_center` IF the Custom Field exists
+	  2. `Company.cost_center` default (always works — set on every Company)
 	  3. Throw if neither set — fail loud, not silent.
 	"""
-	cc = frappe.db.get_value("Warehouse", buyer_warehouse, "custom_cost_center")
+	cc = None
+	# v2.2-hotfix: only query if the Custom Field actually exists on Warehouse
+	if frappe.get_meta("Warehouse").has_field("custom_cost_center"):
+		cc = frappe.db.get_value("Warehouse", buyer_warehouse, "custom_cost_center")
 	if not cc:
 		cc = frappe.db.get_value("Company", buyer_company, "cost_center")
 	if not cc:
 		frappe.throw(_(
 			f"S238: per-store Cost Center not found for {buyer_company}. "
-			f"Set either Warehouse({buyer_warehouse}).custom_cost_center OR "
-			f"Company({buyer_company}).cost_center."
+			f"Set Company({buyer_company}).cost_center "
+			f"(or install Warehouse.custom_cost_center Custom Field if per-warehouse "
+			f"granularity is needed)."
 		))
 	return cc
 


### PR DESCRIPTION
## ⚠️ Hotfix — discovered during PR #739 post-deploy smoke-test prep

The plan's v2.1-CRIT-2 fix referenced `Warehouse.custom_cost_center` as the primary cost-center source (pattern from `store.py:5278`). **That Custom Field does NOT exist on production tabWarehouse.** The existing call site in `store.py` is itself broken (would throw 'Unknown column' if exercised — currently dead code).

S238's `_resolve_per_store_cost_center` inherited the same broken assumption. Without this hotfix, the very first BKI SI submission on production would:

1. `on_submit` hook fires
2. `build_store_pi` → `_resolve_per_store_cost_center`
3. `frappe.db.get_value('Warehouse', ..., 'custom_cost_center')` throws
4. Savepoint rollback (try/except is fail-soft)
5. Error logged (`S238 Store PI Generator Error`)
6. SI submit completes; **NO Draft PI created**
→ **100% silent miss rate** on PI generation

## Diagnosis

Production probe (2026-05-10) shows:

| Check | Result |
|---|---|
| `tabCustom Field` rows on Warehouse | 3: `custom_area_supervisor`, `custom_pcf_enabled`, `custom_territory_cluster` |
| `tabWarehouse` has `custom_cost_center` column | ❌ NO |
| `frappe.get_meta('Warehouse').has_field('custom_cost_center')` | ❌ False |
| `Company.cost_center` for ARANETA | ✅ `'Main - ARGW'` |
| BKI SIs to ARANETA all use cost_center | `'Stores - BKI'` (BKI's; not store's — exactly what v2.1-CRIT-2 needed to avoid) |

## Fix

Guard the Warehouse lookup with `frappe.get_meta().has_field()` so the function falls back to `Company.cost_center` cleanly when the field is absent. 5-line change.

```python
# v2.2-hotfix: only query if the Custom Field actually exists on Warehouse
if frappe.get_meta("Warehouse").has_field("custom_cost_center"):
    cc = frappe.db.get_value("Warehouse", buyer_warehouse, "custom_cost_center")
if not cc:
    cc = frappe.db.get_value("Company", buyer_company, "cost_center")
```

All other v2.1-CRIT-2 semantics preserved: still uses per-store CC (not BKI's), still throws if neither source provides one, comment updated to reflect production reality.

## No regression risk

- 0 BKI SIs have been submitted since #738 deploy (2026-05-09T11:28Z) — the hook has never run with the buggy version, so no incorrect PIs to clean up.
- Hotfix is non-functional change to current behavior — purely makes the dead code path safe.
- No other code reads `Warehouse.custom_cost_center` correctly anyway (`store.py:_get_store_cost_center` is unreached).

## After this merges

PR #739's smoke test (which Sam asked me to run) can proceed: create test BKI→store SI → verify Draft PI generated correctly with `Company.cost_center` → cancel → verify cascade → delete test data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)