### PR TITLE
S238 hotfix #2: explicit pi.currency=PHP (smoke test surfaced INR/PHP mismatch)

### DIFF
--- a/hrms/api/bki_store_pi_generator.py
+++ b/hrms/api/bki_store_pi_generator.py
@@ -135,9 +135,24 @@ def build_store_pi(si, buyer_company):
 	# v2.1-CRIT-2: resolve per-store cost_center BEFORE building items.
 	buyer_cost_center = _resolve_per_store_cost_center(buyer_company, buyer_warehouse)
 
+	# v2.2-currency-hotfix (2026-05-10): explicitly resolve currency from buyer Company.
+	# `frappe.new_doc("Purchase Invoice")` initializes currency to the system default
+	# (INR for fresh ERPNext) regardless of Supplier.default_currency. Without this
+	# line, ERPNext's `validate_party_account_currency` throws:
+	#   "Party Account ... currency (PHP) and document currency (INR) should be same"
+	# because the AP-Trade-BKI account is PHP but the doc currency is still INR.
+	# Discovered during PR #740 post-deploy smoke test (2026-05-10).
+	buyer_currency = (
+		frappe.db.get_value("Company", buyer_company, "default_currency") or "PHP"
+	)
+
 	pi = frappe.new_doc("Purchase Invoice")
 	pi.company = buyer_company
 	pi.supplier = BKI_TRADE_SUPPLIER
+	pi.currency = buyer_currency                          # v2.2-currency-hotfix
+	pi.conversion_rate = 1.0                              # PHP-to-PHP, no conversion
+	pi.price_list_currency = buyer_currency               # v2.2-currency-hotfix
+	pi.plc_conversion_rate = 1.0                          # PHP-to-PHP
 	pi.posting_date = si.posting_date
 	# v2-B8: mirror posting_time so SLE lands at SI's exact timestamp
 	pi.set_posting_time = 1


### PR DESCRIPTION
## ⚠️ Hotfix #2 — discovered during smoke test on production

After PR #740 (cost-center hotfix) deployed, smoke test revealed a second defect:

```
ValidationError: Party Account 2103210 - 2103210 - AP-Trade-BKI - ARGW
                  currency (PHP) and document currency (INR) should be same
```

## Root cause

`frappe.new_doc('Purchase Invoice')` initializes the doc with the **system-default currency (INR)** in ERPNext's base install. The Trade Supplier's `default_currency` was NULL so set_missing_values didn't override. ERPNext's `validate_party_account_currency` then rejected because `credit_to` (PHP) didn't match `doc.currency` (INR).

## Smoke test trace (captured 2026-05-10 07:39 UTC)

| Stage | Result |
|---|---|
| Hotfix #1 deployed (`Warehouse.custom_cost_center` guard) | ✅ |
| **Autoname hook fired** — SI got name `BKI-SI-2026-00981-2` (matching expected `BKI-SI-{YYYY}-{tail}-{n+1}`) | ✅ |
| SI submitted, docstatus=1, grand_total=₱1.12 | ✅ |
| `_resolve_per_store_cost_center` correctly resolved `Main - ARGW` from Company.cost_center | ✅ |
| `resolve_account_by_number` correctly resolved all 3 leaf accounts on ARGW | ✅ |
| `_mirror_items` constructed correct PI item line w/ `expense_account=Inventory-from-Commissary - ARGW`, `cost_center=Main - ARGW` | ✅ |
| `_mirror_taxes` constructed correct PI tax row w/ `account_head=Input VAT - BKI Inter-Co - ARGW` | ✅ |
| `pi.bei_legal_entity = ARANETA GATEWAY...` (NOT seller's, v2.1-CRIT-1 holds) | ✅ |
| **`pi.insert()` failed** at `validate_party_account_currency` with INR/PHP mismatch | ❌ |
| Cancel cascade: cleanly handled the missing PI (no error, `pi_still_exists: false`) | ✅ |
| Force-delete of test SI: clean | ✅ |

So the autoname + cancel cascade + items/taxes mirroring + cost_center hotfix + bei_legal_entity all work. Only the currency was wrong on the in-memory PI doc.

## Fix

Resolve `buyer_currency` from `Company.default_currency` (falls back to PHP) and explicitly set on the PI doc immediately after `new_doc`. Also set `conversion_rate`, `price_list_currency`, `plc_conversion_rate` to keep ERPNext happy.

```python
buyer_currency = (
    frappe.db.get_value("Company", buyer_company, "default_currency") or "PHP"
)

pi = frappe.new_doc("Purchase Invoice")
pi.company = buyer_company
pi.supplier = BKI_TRADE_SUPPLIER
pi.currency = buyer_currency                          # v2.2-currency-hotfix
pi.conversion_rate = 1.0
pi.price_list_currency = buyer_currency               # v2.2-currency-hotfix
pi.plc_conversion_rate = 1.0
...
```

15-line diff. Single function (`build_store_pi`). ARANETA `Company.default_currency = 'PHP'` verified; same for all 49 per-store Companies.

## After this merges

I re-run the smoke test on production:
- Create test BKI→ARANETA SI with `custom_bei_store_order=BEI-ORD-2026-00981`
- Verify autoname + Draft PI created correctly
- Cancel SI → verify cascade deletes Draft PI
- Force-delete test SI
- Update SUMMARY.md with smoke results

🤖 Generated with [Claude Code](https://claude.com/claude-code)