### PR TITLE
S238 hotfix #3: remove inter_company_invoice_reference (incompatible with external Trade Supplier)

### DIFF
--- a/hrms/api/bki_store_pi_generator.py
+++ b/hrms/api/bki_store_pi_generator.py
@@ -160,8 +160,18 @@ def build_store_pi(si, buyer_company):
 	pi.bill_no = si.name
 	pi.bill_date = si.posting_date
 	pi.bki_si_reference = si.name
-	# v2-W (G-046 dashboard): also set the standard ERPNext IC ref
-	pi.inter_company_invoice_reference = si.name
+	# v2.2-icref-hotfix (2026-05-10): the original v2-W intent was to set the
+	# standard ERPNext `inter_company_invoice_reference` field for G-046
+	# dashboard support. But ERPNext's `validate_inter_company_party` in
+	# sales_invoice.py:2095 throws "Invalid Supplier for Inter Company
+	# Transaction" when this field is set AND `pi.supplier.is_internal_supplier=0`.
+	# Per ICT-001..006 (CFO Butch's separate-legal-entity stance), the BKI Trade
+	# Supplier MUST be `is_internal_supplier=0` — which is incompatible with
+	# `inter_company_invoice_reference`. The two are mutually exclusive in
+	# ERPNext's model. We use the new `bki_si_reference` Custom Field (set above)
+	# as the authoritative cross-doc link instead. G-046 dashboard updates to
+	# query `bki_si_reference` instead of `inter_company_invoice_reference` are
+	# a separate follow-up sprint candidate.
 	pi.update_stock = 1
 	pi.set_warehouse = buyer_warehouse                    # v2-B2
 	pi.credit_to = ap_account


### PR DESCRIPTION
## ⚠️ Hotfix #3 — third defect surfaced by smoke test

After PR #741 (currency hotfix) deployed, smoke test revealed:

```
ValidationError: Invalid Supplier for Inter Company Transaction.
```

## Root cause

ERPNext's `validate_inter_company_party` (sales_invoice.py:2095) requires:
- IF `pi.inter_company_invoice_reference` is set
- THEN `pi.supplier` must be an Internal Supplier representing the SI's company

But per **ICT-001..006 (CFO Butch's separate-legal-entity stance)**, the BKI Trade Supplier is `is_internal_supplier=0` (NOT internal). The two conditions are mutually exclusive in ERPNext's model.

## Why was this set?

Original v2-W comment said: *"set the standard ERPNext IC ref so existing procurement dashboards at procurement.py:4707/4731/4765 continue to report"* — i.e., G-046 dashboard support.

But ERPNext's runtime validation forbids the combination. The audit chain didn't catch this because adversarial fact-check focused on plan-level claims, not ERPNext runtime validation behavior.

## Fix

Don't set `inter_company_invoice_reference`. Use the new `bki_si_reference` Custom Field (already set on the line above) as the authoritative cross-doc link.

```python
pi.bill_no = si.name
pi.bill_date = si.posting_date
pi.bki_si_reference = si.name
# REMOVED: pi.inter_company_invoice_reference = si.name (ERPNext rejects external supplier with IC ref)
pi.update_stock = 1
```

G-046 dashboard updates to query `bki_si_reference` instead of `inter_company_invoice_reference` are a **follow-up sprint candidate** (along with the test-data cleanup, canonical CoA harmonization, etc).

## Smoke test after this lands (expected — full path)

| Stage | Expected |
|---|---|
| Autoname | `BKI-SI-2026-00981-2` ✅ (validated in earlier smoke runs) |
| `_resolve_per_store_cost_center` | `Main - ARGW` ✅ (PR #740 hotfix) |
| `pi.currency` | `PHP` ✅ (PR #741 hotfix) |
| **`pi.insert()`** | ✅ Draft PI created on ARGW books |
| Cancel cascade | ✅ deletes the Draft PI |
| Force-delete test SI | ✅ clean state |

🤖 Generated with [Claude Code](https://claude.com/claude-code)