### PR TITLE
docs(l3): BKI->Store billing sweep findings — 3 critical defects, no fix yet

### DIFF
--- a/output/l3/billing-sweep-2026-05-11/DEFECTS.md
+++ b/output/l3/billing-sweep-2026-05-11/DEFECTS.md
@@ -1,0 +1,142 @@
+# Billing Sweep Defects — BKI→Store PI Generator
+
+**Sweep date:** 2026-05-11
+**Scope:** 49 candidate buyer Companies (45 canonical stores + 4 BEI-parent skeleton stores from S243)
+**Evidence:** `tmp/billing-sweep/sweep_result.json`, `tmp/billing-sweep/one_failure_result.json`, `tmp/billing-sweep/perp_result.json`
+
+## Verdict counts
+
+| Verdict | Count | Meaning |
+|---|---|---|
+| PASS (with caveats) | 13 | PI created — BUT see DEFECT C below |
+| FAIL (PI never created) | 30 | DEFECT B |
+| FAIL (PI created, wrong expense acct) | 2 | DEFECT B + C |
+| DEFECT_CONFIRMED (4 BEI-parent stores) | 4 | DEFECT A |
+
+**No leftover test SIs or PIs.** Cleanup verified: `aftermath_result.json` → leftover_si=0, leftover_pi=0, orphan_pi=0.
+
+---
+
+## DEFECT A — 4 stores miss `Company.cost_center` (CRITICAL)
+
+**Stores:** ROBINSONS ANTIPOLO, SM MANILA, SM MEGAMALL, SM SOUTHMALL (all under BEBANG ENTERPRISE INC. parent)
+
+**Symptom:** PI generation fails silently via savepoint rollback.
+
+**Cause:** S243 seeded canonical CoA accounts on these 4 stores but did NOT set `Company.cost_center`. The generator's `_resolve_per_store_cost_center` falls back to `Company.cost_center` → NULL → `frappe.throw` → savepoint rollback → no PI created.
+
+**Fix:** Set `Company.cost_center = 'Main - <ABBR>'` per store. Verify `Main - <ABBR>` Cost Center exists first.
+
+**Severity:** CRITICAL — silent revenue posting miss on 4 active stores.
+
+---
+
+## DEFECT B — 32 stores miss `Company.stock_received_but_not_billed` (CRITICAL, NEW)
+
+**Stores:** All 32 of the FAIL stores have `Company.enable_perpetual_inventory=1` AND `stock_received_but_not_billed=NULL`. 
+
+The 13 PASS stores have `enable_perpetual_inventory=0` — they passed only because ERPNext's auto-stock-accounting logic was bypassed entirely.
+
+**Symptom:** PI generation fails silently via savepoint rollback.
+
+**Cause:** ERPNext's `purchase_invoice.set_expense_account()` calls `get_company_default("stock_received_but_not_billed")` when `update_stock=1` AND `is_perpetual_inventory_enabled(company)` is True. If the company default isn't set → `frappe.throw("Please set default Stock Received But Not Billed in Company ...")` → savepoint rollback → no PI created.
+
+**Proof (full traceback captured in `one_failure_result.json` for AYALA FAIRVIEW TERRACES):**
+```
+frappe.exceptions.ValidationError: Please set default Stock Received But Not Billed 
+in Company AYALA FAIRVIEW TERRACES - BEBANG FT INC.
+  at erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py:455
+  → self.get_company_default("stock_received_but_not_billed")
+```
+
+**Per-Company evidence:**
+
+| `enable_perpetual_inventory` | `stock_received_but_not_billed` | Verdict | Count |
+|---|---|---|---|
+| 0 (disabled) | NULL | PASS | 13 |
+| 1 (enabled) | NULL | FAIL (no PI) | 30 |
+| 1 (enabled) | SET | FAIL (wrong expense_account) | 2 (GHO, SMK) |
+| 0 (disabled) | NULL | DEFECT A | 4 |
+
+**Fix options** (architectural decision needed):
+
+1. **Set `Company.stock_received_but_not_billed` on the 32 stores** — point to a per-store SRBNB account. ERPNext's standard template uses `Stock Received But Not Billed - <ABBR>` (a Liability account). Most stores already have such an account but it's not set as the Company default.
+
+2. **Disable `enable_perpetual_inventory=0` on the 32 stores** — match the 13 PASS stores. Side effect: no auto-stock-accounting JEs on PI submit. Inventory still moves via SLE but no GL impact from PI directly.
+
+3. **Stop using `update_stock=1` in the generator** — change ICT-003 design. Separate stock receipt (via Stock Entry) from billing (PI with `update_stock=0`). Two-document flow.
+
+**Severity:** CRITICAL — most stores (32/45 active) can't generate a store-side PI today. The "silent" nature means BKI's SI submits cleanly while the store's books gain nothing — no payable, no inventory cost, no expense.
+
+---
+
+## DEFECT C — `update_stock=1` causes expense_account to be overridden (CRITICAL)
+
+**Stores affected:** All stores where `enable_perpetual_inventory=1`. Visible on 2 stores (GHO, SMK) where SRBNB happens to be set so PI insertion succeeds.
+
+**Symptom:** Generator computes `expense_account = "1104210 - Inventory-from-Commissary"` correctly, then ERPNext's `set_expense_account(for_validate=True)` OVERWRITES it with the warehouse's account (e.g., `"Stock In Hand - GHO"`).
+
+**Cause:** ERPNext's `purchase_invoice.py:set_expense_account` runs during `validate` with `for_validate=True`. The branch `if not item.expense_account or for_validate` means it always replaces during validate.
+
+**Result:** Even when the PI inserts successfully, the journal entries on submit will hit:
+- Dr: `Stock In Hand - <ABBR>` (whatever Warehouse.account is)
+- Cr: `2103210 - AP-Trade-BKI - <ABBR>`
+
+NOT what the canonical CoA design intended (which was `Dr: 1104210 - Inventory-from-Commissary`).
+
+**Severity:** CRITICAL when PI submits go live — wrong GL accounts on every store-side PI.
+
+**Fix options:**
+
+1. **Map `Warehouse.account = "1104210 - Inventory-from-Commissary"`** per store. Then ERPNext's override picks the desired account.
+
+2. **Stop using `update_stock=1`.** Same as DEFECT B option 3.
+
+3. **Accept the override** — change ICT-003 design to use `Stock In Hand - <ABBR>` as the canonical inventory landing account, and reposition `1104210 - Inventory-from-Commissary` as a reporting roll-up.
+
+---
+
+## DEFECT D (informational) — 13 "PASS" stores have `enable_perpetual_inventory=0`
+
+These 13 stores passed only by accident — their perpetual inventory is disabled, so the PI inserts without stock accounting. On submit, no stock GL entries are created at all. The PI behaves as a non-stock invoice.
+
+**Implication:** Even the "passing" stores are not posting inventory to the store's books on PI submit. The whole "BKI→Store inventory transfer via update_stock=1 PI" mechanism is broken or skipped on 100% of active stores.
+
+This is a SOFT PASS — the test infrastructure accepted these as PASS because the asserted fields match, but the GL outcome isn't what the canonical design called for.
+
+---
+
+## Architectural summary
+
+The ICT-003 design as implemented:
+- Generator sets `pi.update_stock=1` so inventory lands on the store's books
+- Generator sets `pi.items[].expense_account = "1104210 - Inventory-from-Commissary"`
+
+Reality:
+- `update_stock=1` + perpetual inventory triggers ERPNext's SRBNB validation → blocks PI for 32 stores
+- `update_stock=1` + perpetual inventory triggers expense_account override → wrong account for 2 visible + all 32 if unblocked
+
+**The current generator is incompatible with `enable_perpetual_inventory=1` across all 45 active stores.**
+
+For the 13 stores where it "works," the design's GL intent is silently dropped because perpetual is off.
+
+---
+
+## Cleanup state
+
+- Leftover SIs: 0
+- Leftover PIs: 0
+- Orphan PIs: 0
+- Production state restored to pre-sweep.
+
+---
+
+## Suggested next steps (need CEO decision)
+
+The original Phase C plan (4-store cost_center fix) only addresses DEFECT A. The newly-discovered DEFECTS B/C/D require a real architectural decision before any fix sprint is sensible:
+
+**Question for Sam:** how do we want BKI→Store PI inventory mechanics to actually work in production?
+
+- **Option 1** (least invasive): Disable `enable_perpetual_inventory=0` on the 32 stores to match the 13. Generator works, but no automatic stock GL on store-side PIs (the inventory transfer is implicit via SLE only).
+- **Option 2** (correct ERPNext path): Enable perpetual everywhere AND set SRBNB + warehouse.account = 1104210 per store + accept ERPNext's expense_account model. Many small data fixes per store.
+- **Option 3** (redesign): Stop using `update_stock=1` on PI. Generator becomes billing-only. Inventory moves via separate Stock Entry doc. Requires generator rewrite.

--- a/output/l3/billing-sweep-2026-05-11/GAP_ANALYSIS.md
+++ b/output/l3/billing-sweep-2026-05-11/GAP_ANALYSIS.md
@@ -1,0 +1,115 @@
+# Billing Sweep — Per-Store Gap Analysis
+
+**Generated:** 2026-05-11
+**Probe source:** `tmp/billing-sweep/probe_result.json` (S244_PROBE)
+**Scope:** All candidate buyer Companies that the BKI→Store PI generator (S238) would fire for.
+
+## Headline
+
+- **Candidate buyer Companies queried:** 51
+- **🟢 READY for live-fire smoke test (45):** All canonical store Companies with full preconditions
+- **🟥 BLOCKED — defects discovered (4):** Stores missing `Company.cost_center`
+- **⚪ NOT-IN-SCOPE (2):** Companies that aren't store buyers
+
+## Global state — ✅ all good
+
+| Check | Value |
+|---|---|
+| `BEI Settings.enable_bki_store_pi_generator` | True ✓ |
+| `BEI Settings.bki_sales_naming_series` | `BKI-SI-.YYYY.-.#####` ✓ |
+| BKI Company exists | True ✓ |
+| BKI TRADE Supplier exists | True ✓ (disabled=0, is_internal_supplier=0, PHP) |
+| Custom Field SI.custom_bei_store_order | ✓ present |
+| Custom Field PI.bki_si_reference | ✓ present |
+| SI autoname hook | `hrms.api.bki_si_naming.set_bki_si_name` ✓ |
+| SI on_submit hook | `hrms.api.bki_store_pi_generator.maybe_generate_store_pi` ✓ |
+| SI on_cancel hook | `hrms.api.bki_store_pi_generator.cascade_cancel_store_pi` ✓ |
+| PI validate hook | `hrms.api.bki_store_pi_generator.lock_posting_date_on_bki_paired_pi` ✓ |
+
+Two extra Purchase Invoice fields the probe expected (`custom_bei_store_order`, `custom_bki_paired_si`) are absent. **Verified non-issue:** the generator only reads/writes `bki_si_reference` on PI. Those two fields were either de-scoped from v2 or never added — generator works fine without them. Removed from defects list.
+
+## Historical state (Sam already flagged for cleanup)
+
+| Metric | Count |
+|---|---|
+| BKI SIs total | 839 |
+| BKI SIs submitted | 560 |
+| BKI SIs cancelled | 230 |
+| BKI SIs draft | 49 |
+
+All test data per Sam's directive. Cleanup is the #1 follow-up.
+
+## 🟥 DEFECT — 4 stores will fail PI generation silently
+
+These 4 stores are the **same ones S243 just seeded canonical CoA for**. S243 added the accounts but did NOT set `Company.cost_center`. The PI generator's `_resolve_per_store_cost_center` will throw, the savepoint will rollback, and the SI submit proceeds without an error — **silent miss**.
+
+| Store | Abbr | Accounts (S243) | cost_center | Customer | Warehouse |
+|---|---|---|---|---|---|
+| ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC. | ROA | ✓ 3/3 | ❌ NULL | ✓ | ✓ |
+| SM MANILA - BEBANG ENTERPRISE INC. | SMM | ✓ 3/3 | ❌ NULL | ✓ | ✓ |
+| SM MEGAMALL - BEBANG ENTERPRISE INC. | SMMM | ✓ 3/3 | ❌ NULL | ✓ | ✓ |
+| SM SOUTHMALL - BEBANG ENTERPRISE INC. | SMS | ✓ 3/3 | ❌ NULL | ✓ | ✓ |
+
+**Severity:** CRITICAL — silent revenue posting miss for 4 active stores.
+
+**Suggested fix (S245 candidate):** small UPDATE per store, using each store's canonical `Main - <ABBR>` cost center (the convention used by every other ready store). Example:
+
+```sql
+UPDATE `tabCompany` SET cost_center = 'Main - ROA'  WHERE name = 'ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.';
+UPDATE `tabCompany` SET cost_center = 'Main - SMM'  WHERE name = 'SM MANILA - BEBANG ENTERPRISE INC.';
+UPDATE `tabCompany` SET cost_center = 'Main - SMMM' WHERE name = 'SM MEGAMALL - BEBANG ENTERPRISE INC.';
+UPDATE `tabCompany` SET cost_center = 'Main - SMS'  WHERE name = 'SM SOUTHMALL - BEBANG ENTERPRISE INC.';
+```
+
+**Pre-fix verification needed:** confirm `Main - <ABBR>` Cost Center exists for each of the 4 stores. If absent, the cost center itself must be created first (standard `Main - <ABBR>` is auto-created by `frappe.get_doc("Company", name).save()` but may not have run for these recently-seeded Companies).
+
+## ⚪ Not-in-scope buyer Companies (2)
+
+These Companies appear in the candidate query but are not actual store buyers:
+
+| Company | Abbr | Why excluded |
+|---|---|---|
+| BEBANG FRANCHISE CORP. | BFC | No matching Customer record; no Warehouse; no S238 accounts — separate franchise legal entity, not a store buyer |
+| LEGACY77 FOOD CORP. | L77 | Has Customer but no Warehouse, no S238 accounts — separate entity, not a store buyer |
+
+These would never receive a store order from BKI, so PI generation isn't applicable.
+
+## 🟡 Minor info — BKI TRADE Supplier missing per-Company Party Account entries
+
+All 51 candidate Companies lack `Supplier.accounts[company]` rows for `BEBANG KITCHEN INC. - Trade`. **Not a runtime blocker** — the generator computes `pi.credit_to` directly from `resolve_account_by_number(buyer_company, "2103210")`, bypassing the Supplier.accounts table.
+
+**Future Finance UX impact:** When a Finance user opens the PI manually, the AP account won't auto-populate from Supplier. Worth a one-time backfill but not blocking this sweep.
+
+## Proposed sweep plan
+
+**Phase A — Smoke-test the 45 READY stores (live-fire):**
+- Reuse `tmp/s238/smoke_test.py` pattern (create+submit+verify+cancel+force-delete per store)
+- Track every artifact in teardown ledger
+- Sequential execution (≈10s/store + cleanup → ~10 min total)
+- Expected: 45/45 PASS
+
+**Phase B — Smoke-test the 4 BROKEN stores AS-IS (defect proof):**
+- Run same pattern against ROA, SMM, SMMM, SMS
+- Expected: 4/4 SI submits succeed BUT PI not created (silent failure)
+- This confirms the defect is real and the test catches it
+
+**Phase C — Fix the 4 stores' `Company.cost_center` (S245 candidate, separate PR):**
+- UPDATE 4 Companies' `cost_center` field
+- Verify `Main - <ABBR>` cost center exists per store (create if absent)
+- Spawn worktree, commit script, open PR
+
+**Phase D — Re-smoke the 4 stores post-fix:**
+- Should now 4/4 PASS
+
+**Phase E — Cleanup all test artifacts:**
+- Force-delete any leftover test SIs from the sweep
+- Document final state in `output/l3/billing-sweep-2026-05-11/SUMMARY.md`
+- Open DEFECTS.md with the cost_center defect
+
+## Decision needed from Sam
+
+| Option | What I'd run | Risk | Time |
+|---|---|---|---|
+| **A. Full sweep (49 stores)** — phases A+B+C+D+E | Sweep 45 ready + 4 broken + fix + re-test | Moderate (creates+deletes ~53 test SIs; touches 4 Companies' master data) | ~25 min |
+| **B. Ready-only sweep (45 stores)** — phase A+E only | Just smoke 45 ready stores, defer 4-store fix to S245 | Low (no master-data changes) | ~10 min |
+| **C. Defect proof only** — phase B only | Just show the 4 broken stores fail | Very low (4 test SIs only) | ~3 min |

--- a/output/l3/billing-sweep-2026-05-11/SUMMARY.md
+++ b/output/l3/billing-sweep-2026-05-11/SUMMARY.md
@@ -1,0 +1,79 @@
+# BKI→Store Billing Sweep — Summary
+
+**Date:** 2026-05-11
+**Trigger:** Post-S243/S238 (PR #735, #738, #740, #741, #742) Company/Warehouse changes
+**Scope:** 49 buyer Company candidates exercised end-to-end via the saved S238 smoke-test pattern (create + submit BKI SI → assert paired Draft PI on store books → cancel + cascade verify → force-delete SI)
+**Cleanup status:** Production restored to pre-sweep — leftover SI=0, leftover PI=0, orphan PI=0 (verified via `aftermath_result.json`)
+
+## Headline
+
+- **0/49 stores work end-to-end as the canonical PI design intended.** The 13 stores marked PASS pass only because their `Company.enable_perpetual_inventory=0` makes ERPNext skip the auto-stock-accounting logic that the design relies on.
+- **3 distinct defect classes discovered**, none fixable by the originally-planned 4-store cost_center patch (S245). See `DEFECTS.md` for full detail.
+- **CEO chose "park as documented findings"** — no fix PR opened. Next step is a finance/Denise-led review of canonical PI design before committing to one of the 3 architectural options.
+
+## Verdict counts
+
+| Verdict | Count |
+|---|---|
+| PASS (caveats — see DEFECT D) | 13 |
+| FAIL — no PI created | 30 |
+| FAIL — PI created with wrong expense_account | 2 |
+| DEFECT_CONFIRMED — S243-fixed stores miss cost_center | 4 |
+
+## Discovered defects (full detail in `DEFECTS.md`)
+
+| ID | Affected stores | Root cause | Severity |
+|---|---|---|---|
+| A | 4 (ROA, SMM, SMMM, SMS) | Missing `Company.cost_center` after S243 | CRITICAL |
+| B | 32 | Missing `Company.stock_received_but_not_billed` when `enable_perpetual_inventory=1` | CRITICAL |
+| C | 2 visible (potentially all 32 once B unblocked) | ERPNext `set_expense_account(for_validate=True)` overrides `1104210 - Inventory-from-Commissary` with `Warehouse.account` | CRITICAL |
+| D | 13 "PASS" stores | `enable_perpetual_inventory=0` silently drops design intent — PIs create but post zero stock GL | INFORMATIONAL |
+
+## Architectural decision needed
+
+Three viable paths (see DEFECTS.md):
+
+1. **Disable perpetual everywhere** — fast, but design intent lost on all stores.
+2. **Set SRBNB + Warehouse.account=1104210 per store** — ERPNext-canonical, more data fixes.
+3. **Redesign generator** to `update_stock=0` + separate Stock Entry — clean separation, larger sprint.
+
+**Pending decision from Sam + Denise (head of finance).**
+
+## Methodology
+
+1. **Per-store readiness probe** (`probe_result.json`) — read-only. Confirmed all 45 canonical stores have Customer/Warehouse/accounts/PHP currency/cost_center (4 stores excepted for DEFECT A).
+2. **BEI Store Order resolution** (`order_probe_result.json`) — found real existing orders per store to populate SI's `custom_bei_store_order` link.
+3. **Live-fire sweep** (`sweep_result.json`) — created+submitted+verified+cancelled+force-deleted 49 test SIs. Each iteration tracked via in-memory ledger; finally block force-cleans any artifact left behind.
+4. **Aftermath probe** (`aftermath_result.json`) — confirmed 0 leftover SIs, 0 leftover PIs, 0 orphan PIs.
+5. **Single-failure deep dive** (`one_failure_result.json`) — ran one failing store (AFT) with full-traceback capture, bypassing the generator's savepoint catch to see ERPNext's raw error.
+6. **Per-Company config audit** (`perp_result.json`) — read `enable_perpetual_inventory`, `stock_received_but_not_billed`, `stock_adjustment_account` per Company. Pattern PASS=0, FAIL=1 was clean and total — perpetual inventory flag is the sole differentiator.
+
+## What was NOT done (per Sam's decision)
+
+- ❌ No fix PR opened
+- ❌ No master-data UPDATE to Company.cost_center / SRBNB / Warehouse.account
+- ❌ S245 sprint (4-store cost_center fix) NOT executed
+- ❌ Cleanup of historical 839 test BKI SIs NOT performed (still a separate follow-up)
+
+## Test artifacts (in this PR)
+
+- `output/l3/billing-sweep-2026-05-11/SUMMARY.md` (this file)
+- `output/l3/billing-sweep-2026-05-11/DEFECTS.md`
+- `output/l3/billing-sweep-2026-05-11/GAP_ANALYSIS.md`
+- `output/l3/billing-sweep-2026-05-11/evidence/probe_result.json` (per-store readiness)
+- `output/l3/billing-sweep-2026-05-11/evidence/order_probe_result.json`
+- `output/l3/billing-sweep-2026-05-11/evidence/sweep_result.json`
+- `output/l3/billing-sweep-2026-05-11/evidence/aftermath_result.json`
+- `output/l3/billing-sweep-2026-05-11/evidence/one_failure_result.json`
+- `output/l3/billing-sweep-2026-05-11/evidence/perp_result.json`
+- `scripts/billing_sweep/multi_store_smoke.py` (reusable runner)
+- `scripts/billing_sweep/probe_per_store_readiness.py`
+- `scripts/billing_sweep/probe_perpetual_inventory.py`
+- `scripts/billing_sweep/run_*.py` (SSM wrappers — all use the same gzip+base64 file exfil pattern)
+
+## Follow-up sprint candidates (in order of urgency)
+
+1. **S245-A** (post-decision) — implement Option 1, 2, or 3 from the architectural choice
+2. **S246** — cleanup of 839 historical test BKI SIs (sliced from the S238 build phase)
+3. **S247** — extend `verify_canonical_structure.py` to assert `enable_perpetual_inventory + SRBNB + cost_center + Warehouse.account` triad per store
+4. **S248** — finance review checkpoint with Denise on the ICT-003 GL model before deploying any of the above

--- a/output/l3/billing-sweep-2026-05-11/evidence/aftermath_result.json
+++ b/output/l3/billing-sweep-2026-05-11/evidence/aftermath_result.json
@@ -1,0 +1,53 @@
+{
+  "timestamp_utc": "2026-05-11T05:31:00.766616Z",
+  "error_log_count": 34,
+  "unique_error_samples": [
+    {
+      "name": "70424dnb6c",
+      "creation": "2026-05-11 13:29:23.667944",
+      "full_error": "S238: PI generation failed for SI BKI-SI-2026-01023-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+    },
+    {
+      "name": "6vu08nj2bb",
+      "creation": "2026-05-11 13:29:23.084962",
+      "full_error": "S238: PI generation failed for SI BKI-SI-2026-01018-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+    },
+    {
+      "name": "6vppa5tmig",
+      "creation": "2026-05-11 13:29:22.501137",
+      "full_error": "S238: PI generation failed for SI BKI-SI-2026-01015-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+    },
+    {
+      "name": "6vj9vnm4pj",
+      "creation": "2026-05-11 13:29:21.907756",
+      "full_error": "S238: PI generation failed for SI BKI-SI-2026-01002-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+    },
+    {
+      "name": "6v5piucp87",
+      "creation": "2026-05-11 13:29:20.543811",
+      "full_error": "S238: PI generation failed for SI BKI-SI-2026-01032-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+    },
+    {
+      "name": "6uuftk768c",
+      "creation": "2026-05-11 13:29:19.871842",
+      "full_error": "S238: PI generation failed for SI BKI-SI-2026-01031-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+    },
+    {
+      "name": "6un9qjt4hf",
+      "creation": "2026-05-11 13:29:19.197336",
+      "full_error": "S238: PI generation failed for SI BKI-SI-2026-01030-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+    },
+    {
+      "name": "6uhagsvnqv",
+      "creation": "2026-05-11 13:29:18.537854",
+      "full_error": "S238: PI generation failed for SI BKI-SI-2026-01029-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+    }
+  ],
+  "leftover_si_count": 0,
+  "leftover_si": [],
+  "leftover_pi_count": 0,
+  "leftover_pi": [],
+  "orphan_pi_count": 0,
+  "orphan_pi_sample": [],
+  "status": "OK"
+}

--- a/output/l3/billing-sweep-2026-05-11/evidence/one_failure_result.json
+++ b/output/l3/billing-sweep-2026-05-11/evidence/one_failure_result.json
@@ -1,0 +1,58 @@
+{
+  "timestamp_utc": "2026-05-11T05:33:45.754850Z",
+  "si_inserted": "BKI-SI-2026-00983-2",
+  "build_phase": {
+    "started_at": "2026-05-11T05:33:47.178456Z",
+    "build_ok": true,
+    "pi_dict": {
+      "company": "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+      "supplier": "BEBANG KITCHEN INC. - Trade",
+      "currency": "PHP",
+      "conversion_rate": 1.0,
+      "set_warehouse": "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+      "credit_to": "2103210 - 2103210 - AP-Trade-BKI - AFT",
+      "update_stock": 1,
+      "items_count": 1,
+      "taxes_count": 1,
+      "first_item_expense": "1104210 - 1104210 - Inventory-from-Commissary - AFT",
+      "first_item_warehouse": "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+      "first_item_cost_center": "Main - AFT"
+    }
+  },
+  "insert_phase": {
+    "insert_ok": false,
+    "error": "Please set default Stock Received But Not Billed in Company AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+    "full_traceback": "Traceback (most recent call last):\n  File \"/tmp/s244_one.py\", line 96, in main\n    pi.insert(ignore_permissions=True)\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 309, in insert\n    self.run_before_save_methods()\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 1140, in run_before_save_methods\n    self.run_method(\"validate\")\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 1011, in run_method\n    out = Document.hook(fn)(self, *args, **kwargs)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 1371, in composer\n    return composed(self, method, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 1353, in runner\n    add_to_return_value(self, fn(self, *args, **kwargs))\n                              ^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 1008, in fn\n    return method_object(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py\", line 264, in validate\n    super().validate()\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/buying_controller.py\", line 34, in validate\n    super().validate()\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/subcontracting_controller.py\", line 60, in validate\n    super().validate()\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/stock_controller.py\", line 52, in validate\n    super().validate()\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/accounts_controller.py\", line 226, in validate\n    self.set_missing_values(for_validate=True)\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py\", line 357, in set_missing_values\n    super().set_missing_values(for_validate)\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/buying_controller.py\", line 182, in set_missing_values\n    self.set_missing_item_details(for_validate)\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/accounts_controller.py\", line 1119, in set_missing_item_details\n    self.set_expense_account(for_validate)\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py\", line 455, in set_expense_account\n    stock_not_billed_account = self.get_company_default(\"stock_received_but_not_billed\")\n                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/accounts_controller.py\", line 2288, in get_company_default\n    return get_company_default(self.company, fieldname, ignore_validation=ignore_validation)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/utils/typing_validations.py\", line 32, in wrapper\n    return func(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/utils.py\", line 1103, in get_company_default\n    throw(\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py\", line 619, in throw\n    msgprint(\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py\", line 584, in msgprint\n    _raise_exception()\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py\", line 535, in _raise_exception\n    raise exc\nfrappe.exceptions.ValidationError: Please set default Stock Received But Not Billed in Company AYALA FAIRVIEW TERRACES - BEBANG FT INC.\n"
+  },
+  "warehouse_default_account": null,
+  "s238_accounts": [
+    {
+      "name": "1104210 - 1104210 - Inventory-from-Commissary - AFT",
+      "account_number": "1104210",
+      "account_type": "Stock",
+      "root_type": "Asset",
+      "is_group": 0,
+      "disabled": 0
+    },
+    {
+      "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - AFT",
+      "account_number": "1106210",
+      "account_type": "Tax",
+      "root_type": "Asset",
+      "is_group": 0,
+      "disabled": 0
+    },
+    {
+      "name": "2103210 - 2103210 - AP-Trade-BKI - AFT",
+      "account_number": "2103210",
+      "account_type": "Payable",
+      "root_type": "Liability",
+      "is_group": 0,
+      "disabled": 0
+    }
+  ],
+  "status": "OK",
+  "cleanup_log": [
+    "Deleted SI BKI-SI-2026-00983-2"
+  ]
+}

--- a/output/l3/billing-sweep-2026-05-11/evidence/order_probe_result.json
+++ b/output/l3/billing-sweep-2026-05-11/evidence/order_probe_result.json
@@ -1,0 +1,256 @@
+{
+  "timestamp_utc": "2026-05-11T05:27:33.777226Z",
+  "doctype_meta": {
+    "fields": [
+      {
+        "fieldname": "store",
+        "fieldtype": "Link",
+        "options": "Warehouse"
+      },
+      {
+        "fieldname": "company",
+        "fieldtype": "Link",
+        "options": "Company"
+      }
+    ],
+    "total_rows": 713,
+    "sample_keys": [
+      "name",
+      "creation",
+      "modified",
+      "modified_by",
+      "owner",
+      "docstatus",
+      "idx",
+      "naming_series",
+      "store",
+      "order_date",
+      "delivery_date",
+      "status",
+      "submitted_by",
+      "approved_by",
+      "approved_at",
+      "_user_tags",
+      "_comments",
+      "_assign",
+      "_liked_by",
+      "is_bulk_order",
+      "is_emergency",
+      "cargo_category",
+      "delivery_schedule_day",
+      "notes",
+      "trip",
+      "requires_dual_approval",
+      "approval_stage",
+      "second_approver",
+      "second_approval_date",
+      "dr_number",
+      "trip_stop",
+      "company"
+    ],
+    "sample_subset": {
+      "name": "BEI-ORD-2026-01033",
+      "store": "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+      "company": "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP."
+    }
+  },
+  "per_store_orders": {
+    "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC": {
+      "order_no": "BEI-ORD-2026-00981",
+      "matched_field": "company"
+    },
+    "AYALA EVO CITY - BEBANG MEGA INC.": {
+      "order_no": "BEI-ORD-2026-00982",
+      "matched_field": "company"
+    },
+    "AYALA FAIRVIEW TERRACES - BEBANG FT INC.": {
+      "order_no": "BEI-ORD-2026-00983",
+      "matched_field": "company"
+    },
+    "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.": {
+      "order_no": "BEI-ORD-2026-00984",
+      "matched_field": "company"
+    },
+    "AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.": {
+      "order_no": "BEI-ORD-2026-00985",
+      "matched_field": "company"
+    },
+    "AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.": {
+      "order_no": "BEI-ORD-2026-00986",
+      "matched_field": "company"
+    },
+    "AYALA VERMOSA - BEBANG MEGA INC.": {
+      "order_no": "BEI-ORD-2026-00988",
+      "matched_field": "company"
+    },
+    "BF HOMES - BEBANG BF HOMES INC.": {
+      "order_no": "BEI-ORD-2026-00989",
+      "matched_field": "company"
+    },
+    "CTTM TOMAS MORATO - B CUBED VENTURES CORP.": {
+      "order_no": "BEI-ORD-2026-00990",
+      "matched_field": "company"
+    },
+    "D'VERDE CALAMBA - TAJ FOOD CORP.": {
+      "order_no": "BEI-ORD-2026-00991",
+      "matched_field": "company"
+    },
+    "EVER COMMONWEALTH - DLS DESSERT CRAFT INC.": {
+      "order_no": "BEI-ORD-2026-00992",
+      "matched_field": "company"
+    },
+    "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.": {
+      "order_no": "BEI-ORD-2026-00993",
+      "matched_field": "company"
+    },
+    "LUCKY CHINATOWN - BEBANG LCT INC.": {
+      "order_no": "BEI-ORD-2026-00994",
+      "matched_field": "company"
+    },
+    "MEGAWIDE PITX - BEBANG PITX INC.": {
+      "order_no": "BEI-ORD-2026-00995",
+      "matched_field": "company"
+    },
+    "MEGAWORLD PASEO CENTER - BEBANG PASEO INC.": {
+      "order_no": "BEI-ORD-2026-00997",
+      "matched_field": "company"
+    },
+    "MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.": {
+      "order_no": "BEI-ORD-2026-00998",
+      "matched_field": "company"
+    },
+    "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.": {
+      "order_no": "BEI-ORD-2026-00999",
+      "matched_field": "company"
+    },
+    "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.": {
+      "order_no": "BEI-ORD-2026-01000",
+      "matched_field": "company"
+    },
+    "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC": {
+      "order_no": "BEI-ORD-2026-01001",
+      "matched_field": "company"
+    },
+    "ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC": {
+      "order_no": "BEI-ORD-2026-01003",
+      "matched_field": "company"
+    },
+    "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.": {
+      "order_no": "BEI-ORD-2026-01005",
+      "matched_field": "company"
+    },
+    "ROBINSONS IMUS - BEBANG MEGA INC.": {
+      "order_no": "BEI-ORD-2026-01007",
+      "matched_field": "company"
+    },
+    "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.": {
+      "order_no": "BEI-ORD-2026-01008",
+      "matched_field": "company"
+    },
+    "SM BICUTAN - BEBANG SM BICUTAN INC.": {
+      "order_no": "BEI-ORD-2026-01009",
+      "matched_field": "company"
+    },
+    "SM CALOOCAN - TAJ FOOD CORP.": {
+      "order_no": "BEI-ORD-2026-01010",
+      "matched_field": "company"
+    },
+    "SM CLARK - RED TALDAWA FOODS OPC": {
+      "order_no": "BEI-ORD-2026-01011",
+      "matched_field": "company"
+    },
+    "SM EAST ORTIGAS - BEBANG SMEO INC.": {
+      "order_no": "BEI-ORD-2026-01012",
+      "matched_field": "company"
+    },
+    "SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.": {
+      "order_no": "BEI-ORD-2026-01013",
+      "matched_field": "company"
+    },
+    "SM MALL OF ASIA - BEBANG SMOA INC.": {
+      "order_no": "BEI-ORD-2026-01014",
+      "matched_field": "company"
+    },
+    "SM MARIKINA - BEBANG SM MARIKINA INC.": {
+      "order_no": "BEI-ORD-2026-01016",
+      "matched_field": "company"
+    },
+    "SM MARILAO - BEBANG MARILAO INC.": {
+      "order_no": "BEI-ORD-2026-01017",
+      "matched_field": "company"
+    },
+    "SM NORTH EDSA - BEBANG NORTH EDSA INC.": {
+      "order_no": "BEI-ORD-2026-01019",
+      "matched_field": "company"
+    },
+    "SM PULILAN - BEBANG SMM INC.": {
+      "order_no": "BEI-ORD-2026-01020",
+      "matched_field": "company"
+    },
+    "SM SAN JOSE DEL MONTE - JL TRADE OPC": {
+      "order_no": "BEI-ORD-2026-01021",
+      "matched_field": "company"
+    },
+    "SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC": {
+      "order_no": "BEI-ORD-2026-01022",
+      "matched_field": "company"
+    },
+    "SM STA. ROSA - SWEET HARMONY FOOD CORP.": {
+      "order_no": "BEI-ORD-2026-01024",
+      "matched_field": "company"
+    },
+    "SM TANZA - BEBANG MEGA INC.": {
+      "order_no": "BEI-ORD-2026-01025",
+      "matched_field": "company"
+    },
+    "SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.": {
+      "order_no": "BEI-ORD-2026-01026",
+      "matched_field": "company"
+    },
+    "SM VALENZUELA - BEBANG SMV INC.": {
+      "order_no": "BEI-ORD-2026-01027",
+      "matched_field": "company"
+    },
+    "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.": {
+      "order_no": "BEI-ORD-2026-01028",
+      "matched_field": "company"
+    },
+    "THE GRID ROCKWELL - TASTECARTEL CORP.": {
+      "order_no": "BEI-ORD-2026-01029",
+      "matched_field": "company"
+    },
+    "THE TERMINAL - BEBANG STARMALL ALABANG INC.": {
+      "order_no": "BEI-ORD-2026-01030",
+      "matched_field": "company"
+    },
+    "UP TOWN MALL BGC - DMD HOLDINGS INC.": {
+      "order_no": "BEI-ORD-2026-01031",
+      "matched_field": "company"
+    },
+    "VISTA MALL TAGUIG - TRICERN FOOD CORP.": {
+      "order_no": "BEI-ORD-2026-01032",
+      "matched_field": "company"
+    },
+    "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.": {
+      "order_no": "BEI-ORD-2026-01033",
+      "matched_field": "company"
+    },
+    "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.": {
+      "order_no": "BEI-ORD-2026-01002",
+      "matched_field": "company"
+    },
+    "SM MANILA - BEBANG ENTERPRISE INC.": {
+      "order_no": "BEI-ORD-2026-01015",
+      "matched_field": "company"
+    },
+    "SM MEGAMALL - BEBANG ENTERPRISE INC.": {
+      "order_no": "BEI-ORD-2026-01018",
+      "matched_field": "company"
+    },
+    "SM SOUTHMALL - BEBANG ENTERPRISE INC.": {
+      "order_no": "BEI-ORD-2026-01023",
+      "matched_field": "company"
+    }
+  },
+  "status": "OK"
+}

--- a/output/l3/billing-sweep-2026-05-11/evidence/perp_result.json
+++ b/output/l3/billing-sweep-2026-05-11/evidence/perp_result.json
@@ -1,0 +1,397 @@
+{
+  "timestamp_utc": "2026-05-11T05:36:32.033581Z",
+  "company_stock_fields": [
+    {
+      "fieldname": "stock_tab",
+      "fieldtype": "Tab Break",
+      "label": "Stock and Manufacturing"
+    },
+    {
+      "fieldname": "auto_accounting_for_stock_settings",
+      "fieldtype": "Section Break",
+      "label": "Stock Settings"
+    },
+    {
+      "fieldname": "enable_perpetual_inventory",
+      "fieldtype": "Check",
+      "label": "Enable Perpetual Inventory"
+    },
+    {
+      "fieldname": "enable_provisional_accounting_for_non_stock_items",
+      "fieldtype": "Check",
+      "label": "Enable Provisional Accounting For Non Stock Items"
+    },
+    {
+      "fieldname": "default_inventory_account",
+      "fieldtype": "Link",
+      "label": "Default Inventory Account"
+    },
+    {
+      "fieldname": "stock_adjustment_account",
+      "fieldtype": "Link",
+      "label": "Stock Adjustment Account"
+    },
+    {
+      "fieldname": "stock_received_but_not_billed",
+      "fieldtype": "Link",
+      "label": "Stock Received But Not Billed"
+    }
+  ],
+  "company_columns": [
+    "enable_perpetual_inventory",
+    "enable_provisional_accounting_for_non_stock_items",
+    "stock_adjustment_account",
+    "stock_received_but_not_billed"
+  ],
+  "per_company": [
+    {
+      "name": "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "AYALA EVO CITY - BEBANG MEGA INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "AYALA VERMOSA - BEBANG MEGA INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "BF HOMES - BEBANG BF HOMES INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "CTTM TOMAS MORATO - B CUBED VENTURES CORP.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "D'VERDE CALAMBA - TAJ FOOD CORP.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "EVER COMMONWEALTH - DLS DESSERT CRAFT INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "LUCKY CHINATOWN - BEBANG LCT INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "MEGAWIDE PITX - BEBANG PITX INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "MEGAWORLD PASEO CENTER - BEBANG PASEO INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": "Stock Adjustment - GHO",
+      "stock_received_but_not_billed": "Stock Received But Not Billed - GHO"
+    },
+    {
+      "name": "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "ROBINSONS IMUS - BEBANG MEGA INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM BICUTAN - BEBANG SM BICUTAN INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM CALOOCAN - TAJ FOOD CORP.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM CLARK - RED TALDAWA FOODS OPC",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM EAST ORTIGAS - BEBANG SMEO INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM MALL OF ASIA - BEBANG SMOA INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM MANILA - BEBANG ENTERPRISE INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM MARIKINA - BEBANG SM MARIKINA INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": "Stock Adjustment - SMK",
+      "stock_received_but_not_billed": "Stock Received But Not Billed - BEI"
+    },
+    {
+      "name": "SM MARILAO - BEBANG MARILAO INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM MEGAMALL - BEBANG ENTERPRISE INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM NORTH EDSA - BEBANG NORTH EDSA INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM PULILAN - BEBANG SMM INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM SAN JOSE DEL MONTE - JL TRADE OPC",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM SOUTHMALL - BEBANG ENTERPRISE INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM TANZA - BEBANG MEGA INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "SM VALENZUELA - BEBANG SMV INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "THE GRID ROCKWELL - TASTECARTEL CORP.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+      "enable_perpetual_inventory": 1,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    },
+    {
+      "name": "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+      "enable_perpetual_inventory": 0,
+      "enable_provisional_accounting_for_non_stock_items": 0,
+      "stock_adjustment_account": null,
+      "stock_received_but_not_billed": null
+    }
+  ],
+  "erpnext_perpetual_helper": {
+    "ARANETA_PASS": false,
+    "AFT_FAIL": true,
+    "GHO_FAIL": true
+  },
+  "status": "OK"
+}

--- a/output/l3/billing-sweep-2026-05-11/evidence/probe_result.json
+++ b/output/l3/billing-sweep-2026-05-11/evidence/probe_result.json
@@ -1,0 +1,2061 @@
+{
+  "sprint": "billing-sweep-2026-05-11",
+  "purpose": "BKI->Store PI generator per-store readiness",
+  "timestamp_utc": "2026-05-11T05:03:40.877244Z",
+  "global": {
+    "enable_bki_store_pi_generator": true,
+    "bki_sales_naming_series": "BKI-SI-.YYYY.-.#####",
+    "bki_company_exists": true,
+    "bki_trade_supplier_exists": true,
+    "bki_trade_supplier_attrs": {
+      "disabled": 0,
+      "is_internal_supplier": 0,
+      "supplier_group": "Services",
+      "default_currency": "PHP"
+    },
+    "custom_fields": [
+      {
+        "doctype": "Sales Invoice",
+        "field": "custom_bei_store_order",
+        "present": true
+      },
+      {
+        "doctype": "Purchase Invoice",
+        "field": "custom_bei_store_order",
+        "present": false
+      },
+      {
+        "doctype": "Purchase Invoice",
+        "field": "custom_bki_paired_si",
+        "present": false
+      },
+      {
+        "doctype": "Purchase Invoice",
+        "field": "bki_si_reference",
+        "present": true
+      }
+    ],
+    "si_autoname_hooks": [
+      "hrms.api.bki_si_naming.set_bki_si_name"
+    ],
+    "si_on_submit_hooks": [
+      "erpnext.regional.create_transaction_log",
+      "erpnext.regional.italy.utils.sales_invoice_on_submit",
+      "hrms.api.bki_store_pi_generator.maybe_generate_store_pi"
+    ],
+    "si_on_cancel_hooks": [
+      "erpnext.regional.italy.utils.sales_invoice_on_cancel",
+      "hrms.api.bki_store_pi_generator.cascade_cancel_store_pi"
+    ],
+    "pi_validate_hooks": [
+      "erpnext.regional.united_arab_emirates.utils.update_grand_total_for_rcm",
+      "erpnext.regional.united_arab_emirates.utils.validate_returns",
+      "hrms.api.bki_store_pi_generator.lock_posting_date_on_bki_paired_pi"
+    ]
+  },
+  "stores": [
+    {
+      "company": "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "abbr": "ARGW",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - ARGW",
+      "cost_center_set": true,
+      "parent_company": "TUNGSTEN CAPITAL HOLDINGS OPC",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - ARGW",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ARGW",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - ARGW",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "AYALA EVO CITY - BEBANG MEGA INC.",
+      "abbr": "AYEVO",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - AYEVO",
+      "cost_center_set": true,
+      "parent_company": "BEBANG MEGA INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - AYEVO",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - AYEVO",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - AYEVO",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+      "abbr": "AFT",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - AFT",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - AFT",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - AFT",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - AFT",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.",
+      "abbr": "AMM",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - AMM",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - AMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - AMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - AMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.",
+      "abbr": "AYSOL",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - AYSOL",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - AYSOL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - AYSOL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - AYSOL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.",
+      "abbr": "UPTC",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - UPTC",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - UPTC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - UPTC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - UPTC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "AYALA VERMOSA - BEBANG MEGA INC.",
+      "abbr": "AYVER",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - AYVER",
+      "cost_center_set": true,
+      "parent_company": "BEBANG MEGA INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - AYVER",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - AYVER",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - AYVER",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "BEBANG FRANCHISE CORP.",
+      "abbr": "BFC",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - BFC",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": false,
+      "warehouse_exists_with_same_name": false,
+      "accounts": {
+        "1104210": {
+          "missing": true
+        },
+        "1106210": {
+          "missing": true
+        },
+        "2103210": {
+          "missing": true
+        }
+      },
+      "all_accounts_present": false,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": false
+    },
+    {
+      "company": "BF HOMES - BEBANG BF HOMES INC.",
+      "abbr": "BFH",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - BFH",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - BFH",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - BFH",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - BFH",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "CTTM TOMAS MORATO - B CUBED VENTURES CORP.",
+      "abbr": "CTTM",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - CTTM",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - CTTM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - CTTM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - CTTM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "D'VERDE CALAMBA - TAJ FOOD CORP.",
+      "abbr": "DVCAL",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - DVCAL",
+      "cost_center_set": true,
+      "parent_company": "TAJ FOOD CORP.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - DVCAL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - DVCAL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - DVCAL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "EVER COMMONWEALTH - DLS DESSERT CRAFT INC.",
+      "abbr": "EGC",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - EGC",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - EGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - EGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - EGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.",
+      "abbr": "FMA",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - FMA",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - FMA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - FMA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - FMA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "LEGACY77 FOOD CORP.",
+      "abbr": "L77",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - L77",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": false,
+      "accounts": {
+        "1104210": {
+          "missing": true
+        },
+        "1106210": {
+          "missing": true
+        },
+        "2103210": {
+          "missing": true
+        }
+      },
+      "all_accounts_present": false,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": false
+    },
+    {
+      "company": "LUCKY CHINATOWN - BEBANG LCT INC.",
+      "abbr": "LCT",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - LCT",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - LCT",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - LCT",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - LCT",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "MEGAWIDE PITX - BEBANG PITX INC.",
+      "abbr": "PTX",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - PTX",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - PTX",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - PTX",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - PTX",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "MEGAWORLD PASEO CENTER - BEBANG PASEO INC.",
+      "abbr": "MPD",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - MPD",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - MPD",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - MPD",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - MPD",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.",
+      "abbr": "VGC",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - VGC",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - VGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - VGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - VGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+      "abbr": "NAIA",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - NAIA",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - NAIA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - NAIA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - NAIA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+      "abbr": "ESM",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - ESM",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - ESM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ESM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - ESM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+      "abbr": "GHO",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - GHO",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - GHO",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - GHO",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - GHO",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.",
+      "abbr": "ROA",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": null,
+      "cost_center_set": false,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - ROA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ROA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - ROA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": false
+    },
+    {
+      "company": "ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "abbr": "ROBGS",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - ROBGS",
+      "cost_center_set": true,
+      "parent_company": "TUNGSTEN CAPITAL HOLDINGS OPC",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - ROBGS",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ROBGS",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - ROBGS",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+      "abbr": "ROBGT",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - ROBGT",
+      "cost_center_set": true,
+      "parent_company": "BEBANG MEGA INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - ROBGT",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ROBGT",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - ROBGT",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "ROBINSONS IMUS - BEBANG MEGA INC.",
+      "abbr": "ROBIM",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - ROBIM",
+      "cost_center_set": true,
+      "parent_company": "BEBANG MEGA INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - ROBIM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ROBIM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - ROBIM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+      "abbr": "ROBDA",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - ROBDA",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - ROBDA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ROBDA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - ROBDA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM BICUTAN - BEBANG SM BICUTAN INC.",
+      "abbr": "SMBIC",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMBIC",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMBIC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMBIC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMBIC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM CALOOCAN - TAJ FOOD CORP.",
+      "abbr": "SMCAL",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMCAL",
+      "cost_center_set": true,
+      "parent_company": "TAJ FOOD CORP.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMCAL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMCAL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMCAL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM CLARK - RED TALDAWA FOODS OPC",
+      "abbr": "SMCLK",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMCLK",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMCLK",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMCLK",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMCLK",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM EAST ORTIGAS - BEBANG SMEO INC.",
+      "abbr": "SMEO",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMEO",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMEO",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMEO",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMEO",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.",
+      "abbr": "SMGC",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMGC",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM MALL OF ASIA - BEBANG SMOA INC.",
+      "abbr": "SMMOA",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMMOA",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMMOA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMMOA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMMOA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM MANILA - BEBANG ENTERPRISE INC.",
+      "abbr": "SMM",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": null,
+      "cost_center_set": false,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": false
+    },
+    {
+      "company": "SM MARIKINA - BEBANG SM MARIKINA INC.",
+      "abbr": "SMK",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMK",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMK",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMK",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMK",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM MARILAO - BEBANG MARILAO INC.",
+      "abbr": "SMMAR",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMMAR",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMMAR",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMMAR",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMMAR",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM MEGAMALL - BEBANG ENTERPRISE INC.",
+      "abbr": "SMMM",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": null,
+      "cost_center_set": false,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": false
+    },
+    {
+      "company": "SM NORTH EDSA - BEBANG NORTH EDSA INC.",
+      "abbr": "SMNE",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMNE",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMNE",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMNE",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMNE",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM PULILAN - BEBANG SMM INC.",
+      "abbr": "SMPUL",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMPUL",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMPUL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMPUL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMPUL",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM SAN JOSE DEL MONTE - JL TRADE OPC",
+      "abbr": "SJDM",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SJDM",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SJDM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SJDM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SJDM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "abbr": "SMSDN",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMSDN",
+      "cost_center_set": true,
+      "parent_company": "TUNGSTEN CAPITAL HOLDINGS OPC",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMSDN",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMSDN",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMSDN",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM SOUTHMALL - BEBANG ENTERPRISE INC.",
+      "abbr": "SMS",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": null,
+      "cost_center_set": false,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMS",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMS",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMS",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": false
+    },
+    {
+      "company": "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+      "abbr": "SMSTR",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMSTR",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMSTR",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMSTR",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMSTR",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM TANZA - BEBANG MEGA INC.",
+      "abbr": "SMTZ",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMTZ",
+      "cost_center_set": true,
+      "parent_company": "BEBANG MEGA INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMTZ",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMTZ",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMTZ",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.",
+      "abbr": "SMTAY",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMTAY",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMTAY",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMTAY",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMTAY",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "SM VALENZUELA - BEBANG SMV INC.",
+      "abbr": "SMV",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SMV",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SMV",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMV",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SMV",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+      "abbr": "SLGM",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - SLGM",
+      "cost_center_set": true,
+      "parent_company": "SM MARIKINA - BEBANG SM MARIKINA INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - SLGM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SLGM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - SLGM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "THE GRID ROCKWELL - TASTECARTEL CORP.",
+      "abbr": "TGR",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - TGR",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - TGR",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - TGR",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - TGR",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+      "abbr": "TTA",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - TTA",
+      "cost_center_set": true,
+      "parent_company": "BEBANG ENTERPRISE INC.",
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - TTA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - TTA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - TTA",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+      "abbr": "UMBGC",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - UMBGC",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - UMBGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - UMBGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - UMBGC",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+      "abbr": "VMTAG",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - VMTAG",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - VMTAG",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - VMTAG",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - VMTAG",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    },
+    {
+      "company": "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+      "abbr": "XMM",
+      "default_currency": "PHP",
+      "default_currency_is_php": true,
+      "cost_center": "Main - XMM",
+      "cost_center_set": true,
+      "parent_company": null,
+      "customer_exists_with_same_name": true,
+      "warehouse_exists_with_same_name": true,
+      "accounts": {
+        "1104210": {
+          "name": "1104210 - 1104210 - Inventory-from-Commissary - XMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "1106210": {
+          "name": "1106210 - 1106210 - Input VAT - BKI Inter-Co - XMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Asset",
+          "account_currency": "PHP"
+        },
+        "2103210": {
+          "name": "2103210 - 2103210 - AP-Trade-BKI - XMM",
+          "disabled": 0,
+          "is_group": 0,
+          "root_type": "Liability",
+          "account_currency": "PHP"
+        }
+      },
+      "all_accounts_present": true,
+      "bki_supplier_account_set": false,
+      "bki_supplier_account_value": null,
+      "ready_for_pi_generation": true
+    }
+  ],
+  "history": {
+    "bki_si_total": 839,
+    "bki_si_draft": 49,
+    "bki_si_submitted": 560,
+    "bki_si_cancelled": 230
+  },
+  "seed_data": {
+    "pm003": {
+      "item_code": "PM003",
+      "item_name": "LONG SPOON GREEN W/ POUCH",
+      "is_stock_item": 1
+    }
+  },
+  "summary": {
+    "total_candidate_buyer_companies": 51,
+    "ready_for_pi_generation": 45,
+    "missing_customer": [
+      "BEBANG FRANCHISE CORP."
+    ],
+    "missing_warehouse": [
+      "BEBANG FRANCHISE CORP.",
+      "LEGACY77 FOOD CORP."
+    ],
+    "non_php_currency": [],
+    "missing_cost_center": [
+      "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.",
+      "SM MANILA - BEBANG ENTERPRISE INC.",
+      "SM MEGAMALL - BEBANG ENTERPRISE INC.",
+      "SM SOUTHMALL - BEBANG ENTERPRISE INC."
+    ],
+    "missing_any_acct": [
+      "BEBANG FRANCHISE CORP.",
+      "LEGACY77 FOOD CORP."
+    ],
+    "missing_bki_supplier_acct": [
+      "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "AYALA EVO CITY - BEBANG MEGA INC.",
+      "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+      "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.",
+      "AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.",
+      "AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.",
+      "AYALA VERMOSA - BEBANG MEGA INC.",
+      "BEBANG FRANCHISE CORP.",
+      "BF HOMES - BEBANG BF HOMES INC.",
+      "CTTM TOMAS MORATO - B CUBED VENTURES CORP.",
+      "D'VERDE CALAMBA - TAJ FOOD CORP.",
+      "EVER COMMONWEALTH - DLS DESSERT CRAFT INC.",
+      "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.",
+      "LEGACY77 FOOD CORP.",
+      "LUCKY CHINATOWN - BEBANG LCT INC.",
+      "MEGAWIDE PITX - BEBANG PITX INC.",
+      "MEGAWORLD PASEO CENTER - BEBANG PASEO INC.",
+      "MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.",
+      "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+      "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+      "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+      "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.",
+      "ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+      "ROBINSONS IMUS - BEBANG MEGA INC.",
+      "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+      "SM BICUTAN - BEBANG SM BICUTAN INC.",
+      "SM CALOOCAN - TAJ FOOD CORP.",
+      "SM CLARK - RED TALDAWA FOODS OPC",
+      "SM EAST ORTIGAS - BEBANG SMEO INC.",
+      "SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.",
+      "SM MALL OF ASIA - BEBANG SMOA INC.",
+      "SM MANILA - BEBANG ENTERPRISE INC.",
+      "SM MARIKINA - BEBANG SM MARIKINA INC.",
+      "SM MARILAO - BEBANG MARILAO INC.",
+      "SM MEGAMALL - BEBANG ENTERPRISE INC.",
+      "SM NORTH EDSA - BEBANG NORTH EDSA INC.",
+      "SM PULILAN - BEBANG SMM INC.",
+      "SM SAN JOSE DEL MONTE - JL TRADE OPC",
+      "SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "SM SOUTHMALL - BEBANG ENTERPRISE INC.",
+      "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+      "SM TANZA - BEBANG MEGA INC.",
+      "SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.",
+      "SM VALENZUELA - BEBANG SMV INC.",
+      "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+      "THE GRID ROCKWELL - TASTECARTEL CORP.",
+      "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+      "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+      "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+      "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP."
+    ]
+  },
+  "status": "OK"
+}

--- a/output/l3/billing-sweep-2026-05-11/evidence/sweep_result.json
+++ b/output/l3/billing-sweep-2026-05-11/evidence/sweep_result.json
@@ -1,0 +1,2524 @@
+{
+  "sweep": "billing-sweep-2026-05-11",
+  "timestamp_utc": "2026-05-11T05:28:43.268882Z",
+  "stores_ready_count": 45,
+  "stores_broken_count": 4,
+  "results": [
+    {
+      "idx": 1,
+      "company": "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "phase": "READY",
+      "store_label": "ARANETA GATEWAY",
+      "order_no": "BEI-ORD-2026-00981",
+      "abbr": "ARGW",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00981-2",
+          "si_name_post_autoname": "BKI-SI-2026-00981-2",
+          "expected_autoname": "BKI-SI-2026-00981-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00981-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-00981-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-00981-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - ARGW",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "ARANETA GATEWAY",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - ARGW",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - ARGW",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ARGW",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - ARGW"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 2,
+      "company": "AYALA EVO CITY - BEBANG MEGA INC.",
+      "phase": "READY",
+      "store_label": "AYALA EVO CITY",
+      "order_no": "BEI-ORD-2026-00982",
+      "abbr": "AYEVO",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00982-2",
+          "si_name_post_autoname": "BKI-SI-2026-00982-2",
+          "expected_autoname": "BKI-SI-2026-00982-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00982-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "AYALA EVO CITY - BEBANG MEGA INC.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-00982-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-00982-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "AYALA EVO CITY - BEBANG MEGA INC.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - AYEVO",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "AYALA EVO CITY - BEBANG MEGA INC.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "AYALA EVO CITY",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - AYEVO",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "AYALA EVO CITY - BEBANG MEGA INC.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - AYEVO",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - AYEVO",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - AYEVO"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 3,
+      "company": "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+      "phase": "READY",
+      "store_label": "AYALA FAIRVIEW TERRACES",
+      "order_no": "BEI-ORD-2026-00983",
+      "abbr": "AFT",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00983-2",
+          "si_name_post_autoname": "BKI-SI-2026-00983-2",
+          "expected_autoname": "BKI-SI-2026-00983-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00983-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6m6srpid58",
+              "creation": "2026-05-11 13:28:51.881206",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00983-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 4,
+      "company": "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.",
+      "phase": "READY",
+      "store_label": "AYALA MARKET MARKET",
+      "order_no": "BEI-ORD-2026-00984",
+      "abbr": "AMM",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00984-2",
+          "si_name_post_autoname": "BKI-SI-2026-00984-2",
+          "expected_autoname": "BKI-SI-2026-00984-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00984-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6mdon22u06",
+              "creation": "2026-05-11 13:28:52.528417",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00984-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 5,
+      "company": "AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.",
+      "phase": "READY",
+      "store_label": "AYALA SOLENAD",
+      "order_no": "BEI-ORD-2026-00985",
+      "abbr": "AYSOL",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00985-2",
+          "si_name_post_autoname": "BKI-SI-2026-00985-2",
+          "expected_autoname": "BKI-SI-2026-00985-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00985-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6mjakest9a",
+              "creation": "2026-05-11 13:28:53.198396",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00985-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 6,
+      "company": "AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.",
+      "phase": "READY",
+      "store_label": "AYALA UP TOWN CENTER",
+      "order_no": "BEI-ORD-2026-00986",
+      "abbr": "UPTC",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00986-2",
+          "si_name_post_autoname": "BKI-SI-2026-00986-2",
+          "expected_autoname": "BKI-SI-2026-00986-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00986-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6mq1re60s0",
+              "creation": "2026-05-11 13:28:53.859030",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00986-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 7,
+      "company": "AYALA VERMOSA - BEBANG MEGA INC.",
+      "phase": "READY",
+      "store_label": "AYALA VERMOSA",
+      "order_no": "BEI-ORD-2026-00988",
+      "abbr": "AYVER",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00988-1",
+          "si_name_post_autoname": "BKI-SI-2026-00988-1",
+          "expected_autoname": "BKI-SI-2026-00988-1",
+          "expected_autoname_prefix": "BKI-SI-2026-00988-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "AYALA VERMOSA - BEBANG MEGA INC.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-00988-1",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-00988-1",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "AYALA VERMOSA - BEBANG MEGA INC.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - AYVER",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "AYALA VERMOSA - BEBANG MEGA INC.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "AYALA VERMOSA",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - AYVER",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "AYALA VERMOSA - BEBANG MEGA INC.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - AYVER",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - AYVER",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - AYVER"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 8,
+      "company": "BF HOMES - BEBANG BF HOMES INC.",
+      "phase": "READY",
+      "store_label": "BF HOMES",
+      "order_no": "BEI-ORD-2026-00989",
+      "abbr": "BFH",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00989-2",
+          "si_name_post_autoname": "BKI-SI-2026-00989-2",
+          "expected_autoname": "BKI-SI-2026-00989-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00989-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6n9of2nsfg",
+              "creation": "2026-05-11 13:28:55.331806",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00989-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 9,
+      "company": "CTTM TOMAS MORATO - B CUBED VENTURES CORP.",
+      "phase": "READY",
+      "store_label": "CTTM TOMAS MORATO",
+      "order_no": "BEI-ORD-2026-00990",
+      "abbr": "CTTM",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00990-2",
+          "si_name_post_autoname": "BKI-SI-2026-00990-2",
+          "expected_autoname": "BKI-SI-2026-00990-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00990-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6nflmfvees",
+              "creation": "2026-05-11 13:28:55.988085",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00990-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 10,
+      "company": "D'VERDE CALAMBA - TAJ FOOD CORP.",
+      "phase": "READY",
+      "store_label": "D'VERDE CALAMBA",
+      "order_no": "BEI-ORD-2026-00991",
+      "abbr": "DVCAL",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00991-2",
+          "si_name_post_autoname": "BKI-SI-2026-00991-2",
+          "expected_autoname": "BKI-SI-2026-00991-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00991-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "D'VERDE CALAMBA - TAJ FOOD CORP.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-00991-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-00991-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "D'VERDE CALAMBA - TAJ FOOD CORP.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - DVCAL",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "D'VERDE CALAMBA - TAJ FOOD CORP.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "D'VERDE CALAMBA",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - DVCAL",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "D'VERDE CALAMBA - TAJ FOOD CORP.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - DVCAL",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - DVCAL",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - DVCAL"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 11,
+      "company": "EVER COMMONWEALTH - DLS DESSERT CRAFT INC.",
+      "phase": "READY",
+      "store_label": "EVER COMMONWEALTH",
+      "order_no": "BEI-ORD-2026-00992",
+      "abbr": "EGC",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00992-2",
+          "si_name_post_autoname": "BKI-SI-2026-00992-2",
+          "expected_autoname": "BKI-SI-2026-00992-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00992-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6ntktpc0do",
+              "creation": "2026-05-11 13:28:57.383046",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00992-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 12,
+      "company": "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.",
+      "phase": "READY",
+      "store_label": "FESTIVAL MALL ALABANG",
+      "order_no": "BEI-ORD-2026-00993",
+      "abbr": "FMA",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00993-2",
+          "si_name_post_autoname": "BKI-SI-2026-00993-2",
+          "expected_autoname": "BKI-SI-2026-00993-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00993-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6o4jfp6l3c",
+              "creation": "2026-05-11 13:28:58.072569",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00993-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 13,
+      "company": "LUCKY CHINATOWN - BEBANG LCT INC.",
+      "phase": "READY",
+      "store_label": "LUCKY CHINATOWN",
+      "order_no": "BEI-ORD-2026-00994",
+      "abbr": "LCT",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00994-2",
+          "si_name_post_autoname": "BKI-SI-2026-00994-2",
+          "expected_autoname": "BKI-SI-2026-00994-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00994-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6ob3fvj2e9",
+              "creation": "2026-05-11 13:28:58.728022",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00994-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 14,
+      "company": "MEGAWIDE PITX - BEBANG PITX INC.",
+      "phase": "READY",
+      "store_label": "MEGAWIDE PITX",
+      "order_no": "BEI-ORD-2026-00995",
+      "abbr": "PTX",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00995-2",
+          "si_name_post_autoname": "BKI-SI-2026-00995-2",
+          "expected_autoname": "BKI-SI-2026-00995-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00995-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6ohv9mgd2g",
+              "creation": "2026-05-11 13:28:59.387695",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00995-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 15,
+      "company": "MEGAWORLD PASEO CENTER - BEBANG PASEO INC.",
+      "phase": "READY",
+      "store_label": "MEGAWORLD PASEO CENTER",
+      "order_no": "BEI-ORD-2026-00997",
+      "abbr": "MPD",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00997-1",
+          "si_name_post_autoname": "BKI-SI-2026-00997-1",
+          "expected_autoname": "BKI-SI-2026-00997-1",
+          "expected_autoname_prefix": "BKI-SI-2026-00997-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6ooqrp44mp",
+              "creation": "2026-05-11 13:29:00.078942",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00997-1: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 16,
+      "company": "MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.",
+      "phase": "READY",
+      "store_label": "MEGAWORLD VENICE GRAND CANAL",
+      "order_no": "BEI-ORD-2026-00998",
+      "abbr": "VGC",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00998-2",
+          "si_name_post_autoname": "BKI-SI-2026-00998-2",
+          "expected_autoname": "BKI-SI-2026-00998-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00998-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6ov8h7lpl4",
+              "creation": "2026-05-11 13:29:00.746038",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-00998-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 17,
+      "company": "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+      "phase": "READY",
+      "store_label": "NAIA T3",
+      "order_no": "BEI-ORD-2026-00999",
+      "abbr": "NAIA",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-00999-2",
+          "si_name_post_autoname": "BKI-SI-2026-00999-2",
+          "expected_autoname": "BKI-SI-2026-00999-2",
+          "expected_autoname_prefix": "BKI-SI-2026-00999-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-00999-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-00999-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - NAIA",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "NAIA T3",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - NAIA",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - NAIA",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - NAIA",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - NAIA"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 18,
+      "company": "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+      "phase": "READY",
+      "store_label": "ORTIGAS ESTANCIA",
+      "order_no": "BEI-ORD-2026-01000",
+      "abbr": "ESM",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01000-2",
+          "si_name_post_autoname": "BKI-SI-2026-01000-2",
+          "expected_autoname": "BKI-SI-2026-01000-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01000-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01000-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01000-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - ESM",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "ORTIGAS ESTANCIA",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - ESM",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - ESM",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ESM",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - ESM"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 19,
+      "company": "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+      "phase": "READY",
+      "store_label": "ORTIGAS GREENHILLS",
+      "order_no": "BEI-ORD-2026-01001",
+      "abbr": "GHO",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01001-2",
+          "si_name_post_autoname": "BKI-SI-2026-01001-2",
+          "expected_autoname": "BKI-SI-2026-01001-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01001-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01001-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01001-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - GHO",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "ORTIGAS GREENHILLS",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "Stock In Hand - GHO",
+          "pi_item0_expense_is_1104210": false,
+          "pi_item0_warehouse": "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - GHO",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - GHO",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - GHO"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 20,
+      "company": "ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "phase": "READY",
+      "store_label": "ROBINSONS GALLERIA SOUTH",
+      "order_no": "BEI-ORD-2026-01003",
+      "abbr": "ROBGS",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01003-2",
+          "si_name_post_autoname": "BKI-SI-2026-01003-2",
+          "expected_autoname": "BKI-SI-2026-01003-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01003-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6puqufduop",
+              "creation": "2026-05-11 13:29:03.833485",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01003-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 21,
+      "company": "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+      "phase": "READY",
+      "store_label": "ROBINSONS GENERAL TRIAS",
+      "order_no": "BEI-ORD-2026-01005",
+      "abbr": "ROBGT",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01005-1",
+          "si_name_post_autoname": "BKI-SI-2026-01005-1",
+          "expected_autoname": "BKI-SI-2026-01005-1",
+          "expected_autoname_prefix": "BKI-SI-2026-01005-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01005-1",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01005-1",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - ROBGT",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "ROBINSONS GENERAL TRIAS",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - ROBGT",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - ROBGT",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ROBGT",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - ROBGT"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 22,
+      "company": "ROBINSONS IMUS - BEBANG MEGA INC.",
+      "phase": "READY",
+      "store_label": "ROBINSONS IMUS",
+      "order_no": "BEI-ORD-2026-01007",
+      "abbr": "ROBIM",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01007-1",
+          "si_name_post_autoname": "BKI-SI-2026-01007-1",
+          "expected_autoname": "BKI-SI-2026-01007-1",
+          "expected_autoname_prefix": "BKI-SI-2026-01007-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "ROBINSONS IMUS - BEBANG MEGA INC.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01007-1",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01007-1",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "ROBINSONS IMUS - BEBANG MEGA INC.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - ROBIM",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "ROBINSONS IMUS - BEBANG MEGA INC.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "ROBINSONS IMUS",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - ROBIM",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "ROBINSONS IMUS - BEBANG MEGA INC.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - ROBIM",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ROBIM",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - ROBIM"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 23,
+      "company": "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+      "phase": "READY",
+      "store_label": "ROBINSONS PLACE DASMARINAS",
+      "order_no": "BEI-ORD-2026-01008",
+      "abbr": "ROBDA",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01008-2",
+          "si_name_post_autoname": "BKI-SI-2026-01008-2",
+          "expected_autoname": "BKI-SI-2026-01008-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01008-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01008-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01008-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - ROBDA",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "ROBINSONS PLACE DASMARINAS",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - ROBDA",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - ROBDA",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - ROBDA",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - ROBDA"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 24,
+      "company": "SM BICUTAN - BEBANG SM BICUTAN INC.",
+      "phase": "READY",
+      "store_label": "SM BICUTAN",
+      "order_no": "BEI-ORD-2026-01009",
+      "abbr": "SMBIC",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01009-2",
+          "si_name_post_autoname": "BKI-SI-2026-01009-2",
+          "expected_autoname": "BKI-SI-2026-01009-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01009-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6qs3hg07v8",
+              "creation": "2026-05-11 13:29:06.860333",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01009-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 25,
+      "company": "SM CALOOCAN - TAJ FOOD CORP.",
+      "phase": "READY",
+      "store_label": "SM CALOOCAN",
+      "order_no": "BEI-ORD-2026-01010",
+      "abbr": "SMCAL",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01010-2",
+          "si_name_post_autoname": "BKI-SI-2026-01010-2",
+          "expected_autoname": "BKI-SI-2026-01010-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01010-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6r3ai3hcvv",
+              "creation": "2026-05-11 13:29:07.522976",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01010-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 26,
+      "company": "SM CLARK - RED TALDAWA FOODS OPC",
+      "phase": "READY",
+      "store_label": "SM CLARK",
+      "order_no": "BEI-ORD-2026-01011",
+      "abbr": "SMCLK",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01011-2",
+          "si_name_post_autoname": "BKI-SI-2026-01011-2",
+          "expected_autoname": "BKI-SI-2026-01011-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01011-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6r9mho7a1t",
+              "creation": "2026-05-11 13:29:08.160860",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01011-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 27,
+      "company": "SM EAST ORTIGAS - BEBANG SMEO INC.",
+      "phase": "READY",
+      "store_label": "SM EAST ORTIGAS",
+      "order_no": "BEI-ORD-2026-01012",
+      "abbr": "SMEO",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01012-2",
+          "si_name_post_autoname": "BKI-SI-2026-01012-2",
+          "expected_autoname": "BKI-SI-2026-01012-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01012-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6rgrrrd30t",
+              "creation": "2026-05-11 13:29:08.820589",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01012-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 28,
+      "company": "SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.",
+      "phase": "READY",
+      "store_label": "SM GRAND CENTRAL",
+      "order_no": "BEI-ORD-2026-01013",
+      "abbr": "SMGC",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01013-2",
+          "si_name_post_autoname": "BKI-SI-2026-01013-2",
+          "expected_autoname": "BKI-SI-2026-01013-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01013-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6rm5oafsbp",
+              "creation": "2026-05-11 13:29:09.490543",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01013-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 29,
+      "company": "SM MALL OF ASIA - BEBANG SMOA INC.",
+      "phase": "READY",
+      "store_label": "SM MALL OF ASIA",
+      "order_no": "BEI-ORD-2026-01014",
+      "abbr": "SMMOA",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01014-2",
+          "si_name_post_autoname": "BKI-SI-2026-01014-2",
+          "expected_autoname": "BKI-SI-2026-01014-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01014-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6rtq0no58f",
+              "creation": "2026-05-11 13:29:10.156768",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01014-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 30,
+      "company": "SM MARIKINA - BEBANG SM MARIKINA INC.",
+      "phase": "READY",
+      "store_label": "SM MARIKINA",
+      "order_no": "BEI-ORD-2026-01016",
+      "abbr": "SMK",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01016-2",
+          "si_name_post_autoname": "BKI-SI-2026-01016-2",
+          "expected_autoname": "BKI-SI-2026-01016-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01016-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "SM MARIKINA - BEBANG SM MARIKINA INC.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01016-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01016-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "SM MARIKINA - BEBANG SM MARIKINA INC.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - SMK",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "SM MARIKINA - BEBANG SM MARIKINA INC.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "SM MARIKINA",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "Stock In Hand - SMK",
+          "pi_item0_expense_is_1104210": false,
+          "pi_item0_warehouse": "SM MARIKINA - BEBANG SM MARIKINA INC.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - SMK",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMK",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - SMK"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 31,
+      "company": "SM MARILAO - BEBANG MARILAO INC.",
+      "phase": "READY",
+      "store_label": "SM MARILAO",
+      "order_no": "BEI-ORD-2026-01017",
+      "abbr": "SMMAR",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01017-2",
+          "si_name_post_autoname": "BKI-SI-2026-01017-2",
+          "expected_autoname": "BKI-SI-2026-01017-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01017-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6sbsa59i9t",
+              "creation": "2026-05-11 13:29:11.578091",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01017-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 32,
+      "company": "SM NORTH EDSA - BEBANG NORTH EDSA INC.",
+      "phase": "READY",
+      "store_label": "SM NORTH EDSA",
+      "order_no": "BEI-ORD-2026-01019",
+      "abbr": "SMNE",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01019-2",
+          "si_name_post_autoname": "BKI-SI-2026-01019-2",
+          "expected_autoname": "BKI-SI-2026-01019-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01019-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6sitncg5mf",
+              "creation": "2026-05-11 13:29:12.271082",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01019-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 33,
+      "company": "SM PULILAN - BEBANG SMM INC.",
+      "phase": "READY",
+      "store_label": "SM PULILAN",
+      "order_no": "BEI-ORD-2026-01020",
+      "abbr": "SMPUL",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01020-2",
+          "si_name_post_autoname": "BKI-SI-2026-01020-2",
+          "expected_autoname": "BKI-SI-2026-01020-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01020-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6spgua4lca",
+              "creation": "2026-05-11 13:29:12.906284",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01020-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 34,
+      "company": "SM SAN JOSE DEL MONTE - JL TRADE OPC",
+      "phase": "READY",
+      "store_label": "SM SAN JOSE DEL MONTE",
+      "order_no": "BEI-ORD-2026-01021",
+      "abbr": "SJDM",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01021-2",
+          "si_name_post_autoname": "BKI-SI-2026-01021-2",
+          "expected_autoname": "BKI-SI-2026-01021-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01021-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6svermilvc",
+              "creation": "2026-05-11 13:29:13.559889",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01021-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 35,
+      "company": "SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC",
+      "phase": "READY",
+      "store_label": "SM SANGANDAAN",
+      "order_no": "BEI-ORD-2026-01022",
+      "abbr": "SMSDN",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01022-2",
+          "si_name_post_autoname": "BKI-SI-2026-01022-2",
+          "expected_autoname": "BKI-SI-2026-01022-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01022-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6t6saeuss9",
+              "creation": "2026-05-11 13:29:14.214298",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01022-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 36,
+      "company": "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+      "phase": "READY",
+      "store_label": "SM STA. ROSA",
+      "order_no": "BEI-ORD-2026-01024",
+      "abbr": "SMSTR",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01024-2",
+          "si_name_post_autoname": "BKI-SI-2026-01024-2",
+          "expected_autoname": "BKI-SI-2026-01024-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01024-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01024-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01024-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - SMSTR",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "SM STA. ROSA",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - SMSTR",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - SMSTR",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMSTR",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - SMSTR"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 37,
+      "company": "SM TANZA - BEBANG MEGA INC.",
+      "phase": "READY",
+      "store_label": "SM TANZA",
+      "order_no": "BEI-ORD-2026-01025",
+      "abbr": "SMTZ",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01025-2",
+          "si_name_post_autoname": "BKI-SI-2026-01025-2",
+          "expected_autoname": "BKI-SI-2026-01025-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01025-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "SM TANZA - BEBANG MEGA INC.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01025-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01025-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "SM TANZA - BEBANG MEGA INC.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - SMTZ",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "SM TANZA - BEBANG MEGA INC.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "SM TANZA",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - SMTZ",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "SM TANZA - BEBANG MEGA INC.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - SMTZ",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SMTZ",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - SMTZ"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 38,
+      "company": "SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.",
+      "phase": "READY",
+      "store_label": "SM TAYTAY",
+      "order_no": "BEI-ORD-2026-01026",
+      "abbr": "SMTAY",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01026-2",
+          "si_name_post_autoname": "BKI-SI-2026-01026-2",
+          "expected_autoname": "BKI-SI-2026-01026-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01026-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6ts5jbfl0j",
+              "creation": "2026-05-11 13:29:16.418420",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01026-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 39,
+      "company": "SM VALENZUELA - BEBANG SMV INC.",
+      "phase": "READY",
+      "store_label": "SM VALENZUELA",
+      "order_no": "BEI-ORD-2026-01027",
+      "abbr": "SMV",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01027-2",
+          "si_name_post_autoname": "BKI-SI-2026-01027-2",
+          "expected_autoname": "BKI-SI-2026-01027-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01027-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6u2rptt4qm",
+              "creation": "2026-05-11 13:29:17.096889",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01027-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 40,
+      "company": "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+      "phase": "READY",
+      "store_label": "STA. LUCIA EAST GRAND MALL",
+      "order_no": "BEI-ORD-2026-01028",
+      "abbr": "SLGM",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01028-2",
+          "si_name_post_autoname": "BKI-SI-2026-01028-2",
+          "expected_autoname": "BKI-SI-2026-01028-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01028-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01028-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01028-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - SLGM",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "STA. LUCIA EAST GRAND MALL",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - SLGM",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - SLGM",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - SLGM",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - SLGM"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 41,
+      "company": "THE GRID ROCKWELL - TASTECARTEL CORP.",
+      "phase": "READY",
+      "store_label": "THE GRID ROCKWELL",
+      "order_no": "BEI-ORD-2026-01029",
+      "abbr": "TGR",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01029-2",
+          "si_name_post_autoname": "BKI-SI-2026-01029-2",
+          "expected_autoname": "BKI-SI-2026-01029-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01029-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6uhagsvnqv",
+              "creation": "2026-05-11 13:29:18.537854",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01029-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 42,
+      "company": "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+      "phase": "READY",
+      "store_label": "THE TERMINAL",
+      "order_no": "BEI-ORD-2026-01030",
+      "abbr": "TTA",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01030-2",
+          "si_name_post_autoname": "BKI-SI-2026-01030-2",
+          "expected_autoname": "BKI-SI-2026-01030-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01030-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6un9qjt4hf",
+              "creation": "2026-05-11 13:29:19.197336",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01030-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 43,
+      "company": "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+      "phase": "READY",
+      "store_label": "UP TOWN MALL BGC",
+      "order_no": "BEI-ORD-2026-01031",
+      "abbr": "UMBGC",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01031-2",
+          "si_name_post_autoname": "BKI-SI-2026-01031-2",
+          "expected_autoname": "BKI-SI-2026-01031-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01031-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6uuftk768c",
+              "creation": "2026-05-11 13:29:19.871842",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01031-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 44,
+      "company": "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+      "phase": "READY",
+      "store_label": "VISTA MALL TAGUIG",
+      "order_no": "BEI-ORD-2026-01032",
+      "abbr": "VMTAG",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01032-2",
+          "si_name_post_autoname": "BKI-SI-2026-01032-2",
+          "expected_autoname": "BKI-SI-2026-01032-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01032-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6v5piucp87",
+              "creation": "2026-05-11 13:29:20.543811",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01032-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "FAIL"
+    },
+    {
+      "idx": 45,
+      "company": "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+      "phase": "READY",
+      "store_label": "XENTROMALL MONTALBAN",
+      "order_no": "BEI-ORD-2026-01033",
+      "abbr": "XMM",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01033-2",
+          "si_name_post_autoname": "BKI-SI-2026-01033-2",
+          "expected_autoname": "BKI-SI-2026-01033-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01033-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": "ACC-PINV-2026-00700",
+          "pi_exists": true,
+          "pi_company": "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+          "pi_company_matches_buyer": true,
+          "pi_supplier": "BEBANG KITCHEN INC. - Trade",
+          "pi_supplier_is_bki_trade": true,
+          "pi_docstatus": 0,
+          "pi_is_draft": true,
+          "pi_currency": "PHP",
+          "pi_currency_is_php": true,
+          "pi_conversion_rate": 1.0,
+          "pi_bill_no": "BKI-SI-2026-01033-2",
+          "pi_bill_no_matches_si": true,
+          "pi_bki_si_reference": "BKI-SI-2026-01033-2",
+          "pi_bki_si_reference_matches": true,
+          "pi_inter_company_invoice_reference": null,
+          "pi_update_stock": 1,
+          "pi_set_warehouse": "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+          "pi_set_warehouse_matches_buyer": true,
+          "pi_credit_to": "2103210 - 2103210 - AP-Trade-BKI - XMM",
+          "pi_credit_to_is_2103210": true,
+          "pi_bei_legal_entity": "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+          "pi_bei_legal_entity_is_buyer": true,
+          "pi_bei_store_label": "XENTROMALL MONTALBAN",
+          "pi_grand_total": 1.12,
+          "pi_items_count": 1,
+          "pi_taxes_count": 1,
+          "pi_item0_code": "PM003",
+          "pi_item0_qty": 1.0,
+          "pi_item0_rate": 1.0,
+          "pi_item0_expense_account": "1104210 - 1104210 - Inventory-from-Commissary - XMM",
+          "pi_item0_expense_is_1104210": true,
+          "pi_item0_warehouse": "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+          "pi_item0_warehouse_matches_buyer": true,
+          "pi_item0_cost_center": "Main - XMM",
+          "pi_tax0_account": "1106210 - 1106210 - Input VAT - BKI Inter-Co - XMM",
+          "pi_tax0_account_is_1106210": true,
+          "pi_tax0_charge_type": "Actual",
+          "pi_tax0_cost_center": "Main - XMM"
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "PASS"
+    },
+    {
+      "idx": 46,
+      "company": "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.",
+      "phase": "BROKEN",
+      "store_label": "ROBINSONS ANTIPOLO",
+      "order_no": "BEI-ORD-2026-01002",
+      "abbr": "ROA",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01002-2",
+          "si_name_post_autoname": "BKI-SI-2026-01002-2",
+          "expected_autoname": "BKI-SI-2026-01002-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01002-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6vj9vnm4pj",
+              "creation": "2026-05-11 13:29:21.907756",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01002-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "DEFECT_CONFIRMED"
+    },
+    {
+      "idx": 47,
+      "company": "SM MANILA - BEBANG ENTERPRISE INC.",
+      "phase": "BROKEN",
+      "store_label": "SM MANILA",
+      "order_no": "BEI-ORD-2026-01015",
+      "abbr": "SMM",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01015-2",
+          "si_name_post_autoname": "BKI-SI-2026-01015-2",
+          "expected_autoname": "BKI-SI-2026-01015-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01015-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6vppa5tmig",
+              "creation": "2026-05-11 13:29:22.501137",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01015-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "DEFECT_CONFIRMED"
+    },
+    {
+      "idx": 48,
+      "company": "SM MEGAMALL - BEBANG ENTERPRISE INC.",
+      "phase": "BROKEN",
+      "store_label": "SM MEGAMALL",
+      "order_no": "BEI-ORD-2026-01018",
+      "abbr": "SMMM",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01018-2",
+          "si_name_post_autoname": "BKI-SI-2026-01018-2",
+          "expected_autoname": "BKI-SI-2026-01018-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01018-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "6vu08nj2bb",
+              "creation": "2026-05-11 13:29:23.084962",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01018-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "DEFECT_CONFIRMED"
+    },
+    {
+      "idx": 49,
+      "company": "SM SOUTHMALL - BEBANG ENTERPRISE INC.",
+      "phase": "BROKEN",
+      "store_label": "SM SOUTHMALL",
+      "order_no": "BEI-ORD-2026-01023",
+      "abbr": "SMS",
+      "stages": {
+        "create_submit": {
+          "ok": true,
+          "si_name_pre_autoname": "BKI-SI-2026-01023-2",
+          "si_name_post_autoname": "BKI-SI-2026-01023-2",
+          "expected_autoname": "BKI-SI-2026-01023-2",
+          "expected_autoname_prefix": "BKI-SI-2026-01023-",
+          "autoname_matches_pattern": true,
+          "autoname_exact_match": true,
+          "grand_total": 1.12
+        },
+        "assert_pi": {
+          "pi_name": null,
+          "pi_exists": false,
+          "recent_error_logs": [
+            {
+              "name": "70424dnb6c",
+              "creation": "2026-05-11 13:29:23.667944",
+              "preview": "S238: PI generation failed for SI BKI-SI-2026-01023-2: Traceback (most recent call last):\n  File \"apps/hrms/hrms/api/bki_store_pi_ge..."
+            }
+          ]
+        },
+        "cancel": {
+          "ok": true,
+          "si_docstatus": 2,
+          "pi_still_exists_after_cancel": false,
+          "cascade_worked": true
+        },
+        "delete": {
+          "ok": true,
+          "si_still_exists": false
+        }
+      },
+      "verdict": "DEFECT_CONFIRMED"
+    }
+  ],
+  "cleanup_log": [],
+  "status": "OK",
+  "remaining_in_tracker": [],
+  "verdict_counts": {
+    "PASS": 13,
+    "FAIL": 32,
+    "DEFECT_CONFIRMED": 4
+  }
+}

--- a/scripts/billing_sweep/README.md
+++ b/scripts/billing_sweep/README.md
@@ -1,0 +1,58 @@
+# Billing Sweep Toolkit
+
+Read-only probes + live-fire smoke runner for the BKI→Store PI generator (S238 ICT-003).
+
+## What it does
+
+Validates that every BEI store's Company books accept a Draft PI generated when BKI submits a paired Sales Invoice. Walks all 49 candidate buyer Companies, creates a test SI per store, asserts the cascaded PI fields, then cancels and force-deletes the SI (cascade kills the PI).
+
+All scripts run inside the Frappe backend Docker container via SSM (`i-026b7477d27bd46d6`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `multi_store_smoke.py` | Full 49-store sweep. Create→submit→assert→cancel→delete per store. |
+| `probe_per_store_readiness.py` | Per-store readiness check: Customer/Warehouse/cost_center/CoA accounts/PHP currency/required custom fields. |
+| `probe_perpetual_inventory.py` | Per-Company `enable_perpetual_inventory` + `stock_received_but_not_billed` audit. |
+| `probe_stock_defaults.py` | Wider Company stock default audit. |
+| `probe_order_per_store.py` | Finds one real existing BEI Store Order per store to populate `custom_bei_store_order` link. |
+| `probe_one_failure_full_trace.py` | Triggers a single failing store with full traceback capture (bypasses `frappe.log_error` truncation). |
+| `probe_sweep_aftermath.py` | Post-sweep cleanup verification — checks no leftover SI/PI/orphan rows. |
+| `run_*.py` | SSM wrappers for each probe. Use gzip+base64 file exfil to avoid SSM stdout truncation. |
+
+## Pattern (SSM file exfil)
+
+The SSM `get_command_invocation` response truncates `StandardOutputContent` at roughly 24KB. To return large JSON, the probes write to `/tmp/sNNN_*.json` inside the container and the wrapper does:
+
+```bash
+docker cp $BACKEND:/tmp/sNNN_result.json /tmp/sNNN_result.json
+gzip -c /tmp/sNNN_result.json > /tmp/sNNN_result.json.gz
+echo S244_FILE_BEGIN
+base64 -w0 /tmp/sNNN_result.json.gz; echo
+echo S244_FILE_END
+```
+
+The wrapper extracts between the markers, base64-decodes, gunzips, and writes to disk. Reuse this pattern for any probe that produces >24KB of output.
+
+## How to re-run the full sweep
+
+```bash
+cd F:/Dropbox/Projects/BEI-ERP
+python scripts/billing_sweep/run_perp.py        # confirm Company config state
+python scripts/billing_sweep/run_probe.py       # confirm per-store readiness
+python scripts/billing_sweep/run_order_probe.py # refresh STORE_ORDER_MAP
+# edit multi_store_smoke.py with refreshed map if needed
+python scripts/billing_sweep/run_sweep.py       # live-fire — creates+cleans up test SIs
+python scripts/billing_sweep/run_aftermath.py   # verify cleanup
+```
+
+Each probe writes its result alongside the wrapper (e.g., `run_probe.py` → `probe_result.json`).
+
+## Cleanup guarantee
+
+`multi_store_smoke.py` maintains a `CREATED` list of all artifacts and runs `_final_cleanup()` in a top-level finally block. The aftermath probe verifies leftover_si=0, leftover_pi=0, orphan_pi=0 before declaring a successful sweep.
+
+## Output committed to repo
+
+`output/l3/billing-sweep-2026-05-11/` (SUMMARY, DEFECTS, GAP_ANALYSIS, evidence/*.json).

--- a/scripts/billing_sweep/multi_store_smoke.py
+++ b/scripts/billing_sweep/multi_store_smoke.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Billing-sweep multi-store smoke runner — BKI->Store PI generator validation.
+
+For each store in STORES_READY (45) + STORES_BROKEN (4):
+  1. Create + submit a test BKI SI with customer=store Company, item=PM003 @ 1.00 PHP
+  2. Capture autoname result (BKI-SI-YYYY-tail-n)
+  3. Probe for the paired Draft PI on the store's Company books
+  4. Cancel the SI -> cascade should delete the Draft PI
+  5. Force-delete the cancelled SI
+
+Expected:
+  STORES_READY (45)  -> PI created with all 12 mirror fields correct
+  STORES_BROKEN (4)  -> SI submits but NO PI exists (silent _resolve_per_store_cost_center failure)
+
+Output: /tmp/s244_sweep_result.json  with per-store breakdown + summary.
+ALL artifacts cleaned up in finally block.
+"""
+from __future__ import annotations
+
+import os
+for d in [
+    "/home/frappe/logs",
+    "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+    "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+]:
+    os.makedirs(d, exist_ok=True)
+
+import json
+import sys
+import traceback
+from datetime import datetime
+
+import frappe  # type: ignore
+
+BKI_COMPANY = "BEBANG KITCHEN INC."
+BKI_TRADE_SUPPLIER = "BEBANG KITCHEN INC. - Trade"
+ITEM_CODE = "PM003"
+RATE = 1.00
+QTY = 1
+TODAY = "2026-05-11"
+TAX_TEMPLATE = "BKI Output VAT 12% Sales - BKI"
+DEBIT_TO = "Debtors - BKI"
+
+# 45 stores ready for PI generation (from probe_result.json summary)
+STORES_READY = [
+    "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+    "AYALA EVO CITY - BEBANG MEGA INC.",
+    "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+    "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.",
+    "AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.",
+    "AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.",
+    "AYALA VERMOSA - BEBANG MEGA INC.",
+    "BF HOMES - BEBANG BF HOMES INC.",
+    "CTTM TOMAS MORATO - B CUBED VENTURES CORP.",
+    "D'VERDE CALAMBA - TAJ FOOD CORP.",
+    "EVER COMMONWEALTH - DLS DESSERT CRAFT INC.",
+    "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.",
+    "LUCKY CHINATOWN - BEBANG LCT INC.",
+    "MEGAWIDE PITX - BEBANG PITX INC.",
+    "MEGAWORLD PASEO CENTER - BEBANG PASEO INC.",
+    "MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.",
+    "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+    "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+    "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+    "ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC",
+    "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+    "ROBINSONS IMUS - BEBANG MEGA INC.",
+    "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+    "SM BICUTAN - BEBANG SM BICUTAN INC.",
+    "SM CALOOCAN - TAJ FOOD CORP.",
+    "SM CLARK - RED TALDAWA FOODS OPC",
+    "SM EAST ORTIGAS - BEBANG SMEO INC.",
+    "SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.",
+    "SM MALL OF ASIA - BEBANG SMOA INC.",
+    "SM MARIKINA - BEBANG SM MARIKINA INC.",
+    "SM MARILAO - BEBANG MARILAO INC.",
+    "SM NORTH EDSA - BEBANG NORTH EDSA INC.",
+    "SM PULILAN - BEBANG SMM INC.",
+    "SM SAN JOSE DEL MONTE - JL TRADE OPC",
+    "SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC",
+    "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+    "SM TANZA - BEBANG MEGA INC.",
+    "SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.",
+    "SM VALENZUELA - BEBANG SMV INC.",
+    "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+    "THE GRID ROCKWELL - TASTECARTEL CORP.",
+    "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+    "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+    "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+    "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+]
+
+# 4 stores expected to FAIL PI generation (missing Company.cost_center)
+STORES_BROKEN = [
+    "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.",
+    "SM MANILA - BEBANG ENTERPRISE INC.",
+    "SM MEGAMALL - BEBANG ENTERPRISE INC.",
+    "SM SOUTHMALL - BEBANG ENTERPRISE INC.",
+]
+
+# Real BEI Store Order # per store (queried via probe_order_per_store.py 2026-05-11)
+STORE_ORDER_MAP = {
+    'ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC': 'BEI-ORD-2026-00981',
+    'AYALA EVO CITY - BEBANG MEGA INC.': 'BEI-ORD-2026-00982',
+    'AYALA FAIRVIEW TERRACES - BEBANG FT INC.': 'BEI-ORD-2026-00983',
+    'AYALA MARKET MARKET - BEBANG MARKET MARKET INC.': 'BEI-ORD-2026-00984',
+    'AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.': 'BEI-ORD-2026-00985',
+    'AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.': 'BEI-ORD-2026-00986',
+    'AYALA VERMOSA - BEBANG MEGA INC.': 'BEI-ORD-2026-00988',
+    'BF HOMES - BEBANG BF HOMES INC.': 'BEI-ORD-2026-00989',
+    'CTTM TOMAS MORATO - B CUBED VENTURES CORP.': 'BEI-ORD-2026-00990',
+    "D'VERDE CALAMBA - TAJ FOOD CORP.": 'BEI-ORD-2026-00991',
+    'EVER COMMONWEALTH - DLS DESSERT CRAFT INC.': 'BEI-ORD-2026-00992',
+    'FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.': 'BEI-ORD-2026-00993',
+    'LUCKY CHINATOWN - BEBANG LCT INC.': 'BEI-ORD-2026-00994',
+    'MEGAWIDE PITX - BEBANG PITX INC.': 'BEI-ORD-2026-00995',
+    'MEGAWORLD PASEO CENTER - BEBANG PASEO INC.': 'BEI-ORD-2026-00997',
+    'MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.': 'BEI-ORD-2026-00998',
+    'NAIA T3 - HALO-HALO TERMINAL FOOD CORP.': 'BEI-ORD-2026-00999',
+    'ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.': 'BEI-ORD-2026-01000',
+    'ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC': 'BEI-ORD-2026-01001',
+    'ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC': 'BEI-ORD-2026-01003',
+    'ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.': 'BEI-ORD-2026-01005',
+    'ROBINSONS IMUS - BEBANG MEGA INC.': 'BEI-ORD-2026-01007',
+    'ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.': 'BEI-ORD-2026-01008',
+    'SM BICUTAN - BEBANG SM BICUTAN INC.': 'BEI-ORD-2026-01009',
+    'SM CALOOCAN - TAJ FOOD CORP.': 'BEI-ORD-2026-01010',
+    'SM CLARK - RED TALDAWA FOODS OPC': 'BEI-ORD-2026-01011',
+    'SM EAST ORTIGAS - BEBANG SMEO INC.': 'BEI-ORD-2026-01012',
+    'SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.': 'BEI-ORD-2026-01013',
+    'SM MALL OF ASIA - BEBANG SMOA INC.': 'BEI-ORD-2026-01014',
+    'SM MARIKINA - BEBANG SM MARIKINA INC.': 'BEI-ORD-2026-01016',
+    'SM MARILAO - BEBANG MARILAO INC.': 'BEI-ORD-2026-01017',
+    'SM NORTH EDSA - BEBANG NORTH EDSA INC.': 'BEI-ORD-2026-01019',
+    'SM PULILAN - BEBANG SMM INC.': 'BEI-ORD-2026-01020',
+    'SM SAN JOSE DEL MONTE - JL TRADE OPC': 'BEI-ORD-2026-01021',
+    'SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC': 'BEI-ORD-2026-01022',
+    'SM STA. ROSA - SWEET HARMONY FOOD CORP.': 'BEI-ORD-2026-01024',
+    'SM TANZA - BEBANG MEGA INC.': 'BEI-ORD-2026-01025',
+    'SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.': 'BEI-ORD-2026-01026',
+    'SM VALENZUELA - BEBANG SMV INC.': 'BEI-ORD-2026-01027',
+    'STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.': 'BEI-ORD-2026-01028',
+    'THE GRID ROCKWELL - TASTECARTEL CORP.': 'BEI-ORD-2026-01029',
+    'THE TERMINAL - BEBANG STARMALL ALABANG INC.': 'BEI-ORD-2026-01030',
+    'UP TOWN MALL BGC - DMD HOLDINGS INC.': 'BEI-ORD-2026-01031',
+    'VISTA MALL TAGUIG - TRICERN FOOD CORP.': 'BEI-ORD-2026-01032',
+    'XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.': 'BEI-ORD-2026-01033',
+    'ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.': 'BEI-ORD-2026-01002',
+    'SM MANILA - BEBANG ENTERPRISE INC.': 'BEI-ORD-2026-01015',
+    'SM MEGAMALL - BEBANG ENTERPRISE INC.': 'BEI-ORD-2026-01018',
+    'SM SOUTHMALL - BEBANG ENTERPRISE INC.': 'BEI-ORD-2026-01023',
+}
+
+# Master tracker — populated as docs are created; finally force-deletes all
+CREATED: list[dict] = []
+
+
+def _store_label(company_name: str) -> str:
+    """The part before ' - ' is the storefront label (e.g., 'ARANETA GATEWAY')."""
+    return company_name.split(" - ")[0].strip() or company_name
+
+
+def _smoke_one_store(idx: int, company: str, phase: str) -> dict:
+    """Run create+submit+assert+cancel+delete on one store. Returns full result dict."""
+    order_no = STORE_ORDER_MAP.get(company)
+    result = {
+        "idx": idx,
+        "company": company,
+        "phase": phase,  # 'READY' or 'BROKEN'
+        "store_label": _store_label(company),
+        "order_no": order_no,
+        "abbr": frappe.db.get_value("Company", company, "abbr"),
+        "stages": {},
+    }
+    if not order_no:
+        result["stages"]["create_submit"] = {
+            "ok": False,
+            "error": f"No BEI Store Order in STORE_ORDER_MAP for {company}",
+        }
+        return result
+    si_name_pre = None
+    si_name_post = None
+    pi_name = None
+
+    # --- stage create+submit ---
+    try:
+        si = frappe.new_doc("Sales Invoice")
+        si.company = BKI_COMPANY
+        si.customer = company
+        si.posting_date = TODAY
+        si.set_posting_time = 1
+        si.posting_time = "10:00:00"
+        si.naming_series = "BKI-SI-.YYYY.-.#####"
+        si.debit_to = DEBIT_TO
+        si.taxes_and_charges = TAX_TEMPLATE
+        si.currency = "PHP"
+        si.custom_bei_store_order = order_no
+        # S192 + S203 mandatory fields
+        si.bei_legal_entity = BKI_COMPANY
+        si.bei_store_label = result["store_label"]
+        si.append("items", {
+            "item_code": ITEM_CODE,
+            "qty": QTY,
+            "rate": RATE,
+        })
+        template_taxes = frappe.db.sql(
+            """SELECT charge_type, account_head, description, rate, included_in_print_rate, cost_center
+               FROM `tabSales Taxes and Charges`
+               WHERE parent=%s ORDER BY idx""",
+            TAX_TEMPLATE,
+            as_dict=True,
+        )
+        for t in (template_taxes or []):
+            si.append("taxes", t)
+
+        si.insert(ignore_permissions=True)
+        si_name_pre = si.name
+        CREATED.append({"doctype": "Sales Invoice", "name": si.name, "stage": "draft"})
+
+        # Compute expected autoname BEFORE submit (post-submit it's renamed)
+        # autoname formula: BKI-SI-{year}-{tail}-{existing_count + 1}
+        import re as _re
+        m = _re.match(r"^BEI-ORD-(\d{4})-(\d+)$", order_no)
+        if m:
+            year, tail = m.group(1), m.group(2)
+            existing_count = frappe.db.count(
+                "Sales Invoice",
+                {
+                    "custom_bei_store_order": order_no,
+                    "company": BKI_COMPANY,
+                    "name": ["!=", si.name or ""],
+                },
+            )
+            expected_prefix = f"BKI-SI-{year}-{tail}-"
+            expected_autoname = f"BKI-SI-{year}-{tail}-{existing_count + 1}"
+        else:
+            expected_prefix = "BKI-SI-MISC-"
+            expected_autoname = None
+
+        si.submit()
+        si_name_post = si.name
+        # Update tracker with post-autoname name
+        CREATED[-1]["name"] = si.name
+        CREATED[-1]["stage"] = "submitted"
+
+        result["stages"]["create_submit"] = {
+            "ok": True,
+            "si_name_pre_autoname": si_name_pre,
+            "si_name_post_autoname": si_name_post,
+            "expected_autoname": expected_autoname,
+            "expected_autoname_prefix": expected_prefix,
+            "autoname_matches_pattern": si_name_post.startswith(expected_prefix),
+            "autoname_exact_match": (si_name_post == expected_autoname) if expected_autoname else None,
+            "grand_total": si.grand_total,
+        }
+    except Exception as e:
+        result["stages"]["create_submit"] = {
+            "ok": False,
+            "error": str(e)[:500],
+            "traceback": traceback.format_exc()[:1200],
+        }
+        return result
+
+    # --- stage assert_pi ---
+    try:
+        pi_name = frappe.db.get_value(
+            "Purchase Invoice", {"bki_si_reference": si_name_post}, "name"
+        )
+        result["stages"]["assert_pi"] = {"pi_name": pi_name, "pi_exists": bool(pi_name)}
+
+        if pi_name:
+            CREATED.append({"doctype": "Purchase Invoice", "name": pi_name, "stage": "draft"})
+            pi = frappe.get_doc("Purchase Invoice", pi_name)
+            # Capture all 20 fields like the S238 smoke test
+            result["stages"]["assert_pi"].update({
+                "pi_company": pi.company,
+                "pi_company_matches_buyer": pi.company == company,
+                "pi_supplier": pi.supplier,
+                "pi_supplier_is_bki_trade": pi.supplier == BKI_TRADE_SUPPLIER,
+                "pi_docstatus": pi.docstatus,
+                "pi_is_draft": pi.docstatus == 0,
+                "pi_currency": pi.currency,
+                "pi_currency_is_php": pi.currency == "PHP",
+                "pi_conversion_rate": float(pi.conversion_rate or 0),
+                "pi_bill_no": pi.bill_no,
+                "pi_bill_no_matches_si": pi.bill_no == si_name_post,
+                "pi_bki_si_reference": pi.bki_si_reference,
+                "pi_bki_si_reference_matches": pi.bki_si_reference == si_name_post,
+                "pi_inter_company_invoice_reference": pi.inter_company_invoice_reference,
+                "pi_update_stock": pi.update_stock,
+                "pi_set_warehouse": pi.set_warehouse,
+                "pi_set_warehouse_matches_buyer": pi.set_warehouse == company,
+                "pi_credit_to": pi.credit_to,
+                "pi_credit_to_is_2103210": "2103210" in (pi.credit_to or ""),
+                "pi_bei_legal_entity": getattr(pi, "bei_legal_entity", None),
+                "pi_bei_legal_entity_is_buyer": getattr(pi, "bei_legal_entity", None) == company,
+                "pi_bei_store_label": getattr(pi, "bei_store_label", None),
+                "pi_grand_total": float(pi.grand_total or 0),
+                "pi_items_count": len(pi.items),
+                "pi_taxes_count": len(pi.taxes),
+            })
+            if pi.items:
+                first = pi.items[0]
+                result["stages"]["assert_pi"].update({
+                    "pi_item0_code": first.item_code,
+                    "pi_item0_qty": float(first.qty or 0),
+                    "pi_item0_rate": float(first.rate or 0),
+                    "pi_item0_expense_account": first.expense_account,
+                    "pi_item0_expense_is_1104210": "1104210" in (first.expense_account or ""),
+                    "pi_item0_warehouse": first.warehouse,
+                    "pi_item0_warehouse_matches_buyer": first.warehouse == company,
+                    "pi_item0_cost_center": first.cost_center,
+                })
+            if pi.taxes:
+                first_tax = pi.taxes[0]
+                result["stages"]["assert_pi"].update({
+                    "pi_tax0_account": first_tax.account_head,
+                    "pi_tax0_account_is_1106210": "1106210" in (first_tax.account_head or ""),
+                    "pi_tax0_charge_type": first_tax.charge_type,
+                    "pi_tax0_cost_center": first_tax.cost_center,
+                })
+        else:
+            # Look for recent error logs referencing this SI
+            errs = frappe.db.sql(
+                """SELECT name, error, creation FROM `tabError Log`
+                   WHERE error LIKE %s AND creation >= NOW() - INTERVAL 5 MINUTE
+                   ORDER BY creation DESC LIMIT 2""",
+                f"%{si_name_post}%",
+                as_dict=True,
+            )
+            result["stages"]["assert_pi"]["recent_error_logs"] = [
+                {
+                    "name": r["name"],
+                    "creation": str(r["creation"]),
+                    "preview": r["error"][:400],
+                }
+                for r in errs
+            ]
+    except Exception as e:
+        result["stages"]["assert_pi"] = {
+            "ok": False,
+            "error": str(e)[:500],
+        }
+
+    # --- stage cancel ---
+    try:
+        si = frappe.get_doc("Sales Invoice", si_name_post)
+        si.cancel()
+        result["stages"]["cancel"] = {"ok": True, "si_docstatus": si.docstatus}
+
+        pi_still_exists = bool(
+            frappe.db.exists("Purchase Invoice", {"bki_si_reference": si_name_post})
+        )
+        result["stages"]["cancel"]["pi_still_exists_after_cancel"] = pi_still_exists
+        result["stages"]["cancel"]["cascade_worked"] = (not pi_still_exists) if pi_name else True
+    except Exception as e:
+        result["stages"]["cancel"] = {"ok": False, "error": str(e)[:500]}
+
+    # --- stage force-delete SI ---
+    try:
+        frappe.delete_doc("Sales Invoice", si_name_post, force=True, ignore_permissions=True)
+        result["stages"]["delete"] = {
+            "ok": True,
+            "si_still_exists": bool(frappe.db.exists("Sales Invoice", si_name_post)),
+        }
+        # Drop from tracker since we successfully cleaned it up
+        CREATED[:] = [c for c in CREATED if not (c["doctype"] == "Sales Invoice" and c["name"] == si_name_post)]
+        # Drop PI tracker if cascade already deleted it
+        if pi_name and not frappe.db.exists("Purchase Invoice", pi_name):
+            CREATED[:] = [c for c in CREATED if not (c["doctype"] == "Purchase Invoice" and c["name"] == pi_name)]
+    except Exception as e:
+        result["stages"]["delete"] = {"ok": False, "error": str(e)[:500]}
+
+    # --- per-store verdict ---
+    if phase == "READY":
+        # PI must have been created with all key fields correct
+        ap = result["stages"].get("assert_pi", {})
+        delete_ok = result["stages"].get("delete", {}).get("ok", False)
+        cancel_ok = result["stages"].get("cancel", {}).get("ok", False)
+        cascade_ok = result["stages"].get("cancel", {}).get("cascade_worked", False)
+        all_good = (
+            result["stages"].get("create_submit", {}).get("ok", False)
+            and ap.get("pi_exists", False)
+            and ap.get("pi_company_matches_buyer", False)
+            and ap.get("pi_supplier_is_bki_trade", False)
+            and ap.get("pi_currency_is_php", False)
+            and ap.get("pi_set_warehouse_matches_buyer", False)
+            and ap.get("pi_credit_to_is_2103210", False)
+            and ap.get("pi_item0_expense_is_1104210", False)
+            and ap.get("pi_tax0_account_is_1106210", False)
+            and ap.get("pi_bki_si_reference_matches", False)
+            and cancel_ok
+            and cascade_ok
+            and delete_ok
+        )
+        result["verdict"] = "PASS" if all_good else "FAIL"
+    else:
+        # BROKEN — expect SI submit OK, PI NOT created (defect proof)
+        cs_ok = result["stages"].get("create_submit", {}).get("ok", False)
+        pi_exists = result["stages"].get("assert_pi", {}).get("pi_exists", True)
+        delete_ok = result["stages"].get("delete", {}).get("ok", False)
+        defect_confirmed = (cs_ok and not pi_exists)
+        result["verdict"] = "DEFECT_CONFIRMED" if (defect_confirmed and delete_ok) else "DEFECT_UNEXPECTED_STATE"
+
+    return result
+
+
+def _final_cleanup() -> list[str]:
+    """Force-delete any artifact still in CREATED tracker."""
+    log = []
+    for entry in list(CREATED):
+        dt = entry["doctype"]
+        nm = entry["name"]
+        try:
+            if frappe.db.exists(dt, nm):
+                doc = frappe.get_doc(dt, nm)
+                if doc.docstatus == 1:
+                    try:
+                        doc.cancel()
+                        log.append(f"Cancelled {dt} {nm}")
+                    except Exception as e:
+                        log.append(f"Cancel failed for {dt} {nm}: {str(e)[:200]}")
+                try:
+                    frappe.delete_doc(dt, nm, force=True, ignore_permissions=True)
+                    log.append(f"Force-deleted {dt} {nm}")
+                except Exception as e:
+                    log.append(f"Delete failed for {dt} {nm}: {str(e)[:200]}")
+            else:
+                log.append(f"Already gone: {dt} {nm}")
+        except Exception as e:
+            log.append(f"Cleanup exception {dt} {nm}: {str(e)[:200]}")
+    try:
+        frappe.db.commit()
+    except Exception:
+        pass
+    return log
+
+
+def main() -> None:
+    payload = {
+        "sweep": "billing-sweep-2026-05-11",
+        "timestamp_utc": datetime.utcnow().isoformat() + "Z",
+        "stores_ready_count": len(STORES_READY),
+        "stores_broken_count": len(STORES_BROKEN),
+        "results": [],
+        "cleanup_log": [],
+    }
+
+    try:
+        frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+        frappe.connect()
+        frappe.set_user("Administrator")
+
+        # Phase A — READY stores (45)
+        for idx, company in enumerate(STORES_READY, start=1):
+            try:
+                r = _smoke_one_store(idx, company, "READY")
+            except Exception as e:
+                r = {"company": company, "phase": "READY", "verdict": "RUNNER_ERROR",
+                     "error": str(e)[:500], "traceback": traceback.format_exc()[:1200]}
+            payload["results"].append(r)
+            try:
+                frappe.db.commit()
+            except Exception:
+                pass
+
+        # Phase B — BROKEN stores (4)
+        for idx, company in enumerate(STORES_BROKEN, start=46):
+            try:
+                r = _smoke_one_store(idx, company, "BROKEN")
+            except Exception as e:
+                r = {"company": company, "phase": "BROKEN", "verdict": "RUNNER_ERROR",
+                     "error": str(e)[:500], "traceback": traceback.format_exc()[:1200]}
+            payload["results"].append(r)
+            try:
+                frappe.db.commit()
+            except Exception:
+                pass
+
+        payload["status"] = "OK"
+
+    except Exception as e:
+        payload["status"] = "ERROR"
+        payload["fatal_error"] = str(e)
+        payload["traceback"] = traceback.format_exc()
+
+    # Always run cleanup
+    payload["cleanup_log"] = _final_cleanup()
+    payload["remaining_in_tracker"] = list(CREATED)
+
+    # Summary tallies
+    verdicts = {}
+    for r in payload["results"]:
+        v = r.get("verdict", "UNKNOWN")
+        verdicts[v] = verdicts.get(v, 0) + 1
+    payload["verdict_counts"] = verdicts
+
+    out_path = "/tmp/s244_sweep_result.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    sys.stdout.write(f"S244_SWEEP_OK status={payload.get('status')} "
+                     f"results={len(payload['results'])} verdicts={verdicts}\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/billing_sweep/probe_one_failure_full_trace.py
+++ b/scripts/billing_sweep/probe_one_failure_full_trace.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Trigger a single PI generation for one failing store; capture FULL traceback.
+
+Bypasses frappe.log_error truncation by intercepting the exception directly
+via try/except in this script BEFORE the generator's savepoint catches it.
+"""
+from __future__ import annotations
+
+import os
+for d in ["/home/frappe/logs", "/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+
+import json
+import sys
+import traceback
+from datetime import datetime
+
+import frappe  # type: ignore
+
+# A store that FAILED at PI generation in the sweep
+TARGET_COMPANY = "AYALA FAIRVIEW TERRACES - BEBANG FT INC."
+TARGET_ORDER = "BEI-ORD-2026-00983"
+
+BKI_COMPANY = "BEBANG KITCHEN INC."
+
+
+def main() -> None:
+    payload = {"timestamp_utc": datetime.utcnow().isoformat() + "Z"}
+    si_name = None
+    pi_name = None
+    try:
+        frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+        frappe.connect()
+        frappe.set_user("Administrator")
+
+        from hrms.api.bki_store_pi_generator import build_store_pi
+
+        # Create the SI exactly as the sweep did
+        si = frappe.new_doc("Sales Invoice")
+        si.company = BKI_COMPANY
+        si.customer = TARGET_COMPANY
+        si.posting_date = "2026-05-11"
+        si.set_posting_time = 1
+        si.posting_time = "11:30:00"
+        si.naming_series = "BKI-SI-.YYYY.-.#####"
+        si.debit_to = "Debtors - BKI"
+        si.taxes_and_charges = "BKI Output VAT 12% Sales - BKI"
+        si.currency = "PHP"
+        si.custom_bei_store_order = TARGET_ORDER
+        si.bei_legal_entity = BKI_COMPANY
+        si.bei_store_label = "AYALA FAIRVIEW TERRACES"
+        si.append("items", {"item_code": "PM003", "qty": 1, "rate": 1.00})
+        template_taxes = frappe.db.sql(
+            """SELECT charge_type, account_head, description, rate,
+                      included_in_print_rate, cost_center
+               FROM `tabSales Taxes and Charges`
+               WHERE parent='BKI Output VAT 12% Sales - BKI' ORDER BY idx""",
+            as_dict=True,
+        )
+        for t in (template_taxes or []):
+            si.append("taxes", t)
+
+        si.insert(ignore_permissions=True)
+        si_name = si.name
+        payload["si_inserted"] = si_name
+
+        # Submit (this fires the generator hook). BUT — we want full traceback.
+        # Instead of submit() let's manually walk build_store_pi to capture the
+        # exception location and full stack.
+        si.docstatus = 1  # mark as submitted for the generator's logic
+        # We won't actually call frappe submit which fires all hooks; just call
+        # the build directly so we see WHY it fails.
+
+        payload["build_phase"] = {"started_at": datetime.utcnow().isoformat() + "Z"}
+        try:
+            pi = build_store_pi(si, TARGET_COMPANY)
+            payload["build_phase"]["build_ok"] = True
+            payload["build_phase"]["pi_dict"] = {
+                "company": pi.company,
+                "supplier": pi.supplier,
+                "currency": pi.currency,
+                "conversion_rate": float(pi.conversion_rate or 0),
+                "set_warehouse": pi.set_warehouse,
+                "credit_to": pi.credit_to,
+                "update_stock": pi.update_stock,
+                "items_count": len(pi.items),
+                "taxes_count": len(pi.taxes),
+                "first_item_expense": pi.items[0].expense_account if pi.items else None,
+                "first_item_warehouse": pi.items[0].warehouse if pi.items else None,
+                "first_item_cost_center": pi.items[0].cost_center if pi.items else None,
+            }
+            # Now try to insert the PI to capture validation errors
+            try:
+                pi.insert(ignore_permissions=True)
+                pi_name = pi.name
+                payload["insert_phase"] = {"insert_ok": True, "pi_name": pi.name}
+                # Re-fetch the inserted doc to see what ERPNext actually persisted
+                pi_db = frappe.get_doc("Purchase Invoice", pi.name)
+                payload["insert_phase"]["after_insert"] = {
+                    "expense_account_first_item": pi_db.items[0].expense_account if pi_db.items else None,
+                    "warehouse_first_item": pi_db.items[0].warehouse if pi_db.items else None,
+                    "cost_center_first_item": pi_db.items[0].cost_center if pi_db.items else None,
+                    "credit_to": pi_db.credit_to,
+                    "currency": pi_db.currency,
+                    "supplier": pi_db.supplier,
+                    "company": pi_db.company,
+                }
+            except Exception as ie:
+                payload["insert_phase"] = {
+                    "insert_ok": False,
+                    "error": str(ie)[:1500],
+                    "full_traceback": traceback.format_exc(),
+                }
+        except Exception as be:
+            payload["build_phase"]["build_ok"] = False
+            payload["build_phase"]["error"] = str(be)[:1500]
+            payload["build_phase"]["full_traceback"] = traceback.format_exc()
+
+        # Also probe warehouse defaults that ERPNext uses to override expense_account
+        wh_account = frappe.db.get_value("Warehouse", TARGET_COMPANY, "account")
+        payload["warehouse_default_account"] = wh_account
+
+        # Probe Account "1104210 - Inventory-from-Commissary - FT"
+        cands = frappe.db.sql(
+            """SELECT name, account_number, account_type, root_type, is_group, disabled
+               FROM `tabAccount`
+               WHERE company=%s AND account_number IN ('1104210','1106210','2103210')""",
+            TARGET_COMPANY,
+            as_dict=True,
+        )
+        payload["s238_accounts"] = cands
+
+        payload["status"] = "OK"
+
+    except Exception as e:
+        payload["status"] = "ERROR"
+        payload["fatal_error"] = str(e)
+        payload["traceback"] = traceback.format_exc()
+
+    # Cleanup any created docs
+    cleanup_log = []
+    try:
+        if pi_name and frappe.db.exists("Purchase Invoice", pi_name):
+            try:
+                frappe.delete_doc("Purchase Invoice", pi_name, force=True, ignore_permissions=True)
+                cleanup_log.append(f"Deleted PI {pi_name}")
+            except Exception as e:
+                cleanup_log.append(f"Delete PI {pi_name} failed: {str(e)[:200]}")
+        if si_name and frappe.db.exists("Sales Invoice", si_name):
+            try:
+                doc = frappe.get_doc("Sales Invoice", si_name)
+                if doc.docstatus == 1:
+                    try:
+                        doc.cancel()
+                        cleanup_log.append(f"Cancelled SI {si_name}")
+                    except Exception:
+                        pass
+                frappe.delete_doc("Sales Invoice", si_name, force=True, ignore_permissions=True)
+                cleanup_log.append(f"Deleted SI {si_name}")
+            except Exception as e:
+                cleanup_log.append(f"Delete SI {si_name} failed: {str(e)[:200]}")
+        frappe.db.commit()
+    except Exception as e:
+        cleanup_log.append(f"Cleanup wrapper failed: {str(e)[:200]}")
+    payload["cleanup_log"] = cleanup_log
+
+    out_path = "/tmp/s244_one_failure.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    sys.stdout.write(f"S244_ONE_FAILURE_OK status={payload.get('status')}\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/billing_sweep/probe_order_per_store.py
+++ b/scripts/billing_sweep/probe_order_per_store.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Probe — for each store, find a real existing BEI Store Order # we can link to.
+
+Read-only. Looks up the latest existing BEI Store Order per store. Falls back
+to the doctype's natural-keyed list if necessary.
+"""
+from __future__ import annotations
+
+import os
+for d in [
+    "/home/frappe/logs",
+    "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+    "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+]:
+    os.makedirs(d, exist_ok=True)
+
+import json
+import sys
+from datetime import datetime
+
+import frappe  # type: ignore
+
+ALL_STORES = [
+    "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+    "AYALA EVO CITY - BEBANG MEGA INC.",
+    "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+    "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.",
+    "AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.",
+    "AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.",
+    "AYALA VERMOSA - BEBANG MEGA INC.",
+    "BF HOMES - BEBANG BF HOMES INC.",
+    "CTTM TOMAS MORATO - B CUBED VENTURES CORP.",
+    "D'VERDE CALAMBA - TAJ FOOD CORP.",
+    "EVER COMMONWEALTH - DLS DESSERT CRAFT INC.",
+    "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.",
+    "LUCKY CHINATOWN - BEBANG LCT INC.",
+    "MEGAWIDE PITX - BEBANG PITX INC.",
+    "MEGAWORLD PASEO CENTER - BEBANG PASEO INC.",
+    "MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.",
+    "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+    "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+    "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+    "ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC",
+    "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+    "ROBINSONS IMUS - BEBANG MEGA INC.",
+    "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+    "SM BICUTAN - BEBANG SM BICUTAN INC.",
+    "SM CALOOCAN - TAJ FOOD CORP.",
+    "SM CLARK - RED TALDAWA FOODS OPC",
+    "SM EAST ORTIGAS - BEBANG SMEO INC.",
+    "SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.",
+    "SM MALL OF ASIA - BEBANG SMOA INC.",
+    "SM MARIKINA - BEBANG SM MARIKINA INC.",
+    "SM MARILAO - BEBANG MARILAO INC.",
+    "SM NORTH EDSA - BEBANG NORTH EDSA INC.",
+    "SM PULILAN - BEBANG SMM INC.",
+    "SM SAN JOSE DEL MONTE - JL TRADE OPC",
+    "SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC",
+    "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+    "SM TANZA - BEBANG MEGA INC.",
+    "SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.",
+    "SM VALENZUELA - BEBANG SMV INC.",
+    "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+    "THE GRID ROCKWELL - TASTECARTEL CORP.",
+    "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+    "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+    "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+    "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+    "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.",
+    "SM MANILA - BEBANG ENTERPRISE INC.",
+    "SM MEGAMALL - BEBANG ENTERPRISE INC.",
+    "SM SOUTHMALL - BEBANG ENTERPRISE INC.",
+]
+
+
+def main() -> None:
+    payload = {
+        "timestamp_utc": datetime.utcnow().isoformat() + "Z",
+        "doctype_meta": {},
+        "per_store_orders": {},
+    }
+    try:
+        frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+        frappe.connect()
+        frappe.set_user("Administrator")
+
+        # First: discover the BEI Store Order doctype shape (what's the company link field?)
+        if frappe.db.exists("DocType", "BEI Store Order"):
+            meta = frappe.get_meta("BEI Store Order")
+            payload["doctype_meta"]["fields"] = [
+                {"fieldname": f.fieldname, "fieldtype": f.fieldtype, "options": f.options}
+                for f in meta.fields
+                if f.fieldtype in ("Link", "Data", "Select") and f.fieldname in
+                ("company", "buyer_company", "store_company", "store", "buyer", "store_warehouse",
+                 "buyer_warehouse", "customer", "to_company", "source_warehouse")
+            ]
+            payload["doctype_meta"]["total_rows"] = frappe.db.count("BEI Store Order")
+
+            # Get a sample row to see what fields are populated
+            sample = frappe.db.sql(
+                """SELECT * FROM `tabBEI Store Order` ORDER BY creation DESC LIMIT 1""",
+                as_dict=True,
+            )
+            if sample:
+                # Reduce to only fields that contain a store-like name
+                row = sample[0]
+                payload["doctype_meta"]["sample_keys"] = list(row.keys())[:50]
+                payload["doctype_meta"]["sample_subset"] = {
+                    k: row[k] for k in row.keys()
+                    if k in ("name", "company", "buyer_company", "store", "store_company",
+                             "warehouse", "source_warehouse", "buyer_warehouse",
+                             "to_company", "from_company")
+                }
+
+        # For each store, try several candidate field names to find an order
+        for store in ALL_STORES:
+            found = None
+            # Try multiple candidate fields
+            for field_name in ("buyer_company", "store_company", "company", "buyer", "to_company"):
+                try:
+                    n = frappe.db.get_value(
+                        "BEI Store Order",
+                        {field_name: store},
+                        "name",
+                        order_by="creation desc",
+                    )
+                    if n:
+                        found = {"order_no": n, "matched_field": field_name}
+                        break
+                except Exception:
+                    continue
+            # Last resort: search by store name in any text-like field
+            if not found:
+                try:
+                    rows = frappe.db.sql(
+                        """SELECT name FROM `tabBEI Store Order`
+                           WHERE store_warehouse LIKE %s OR buyer_warehouse LIKE %s
+                           ORDER BY creation DESC LIMIT 1""",
+                        (f"%{store}%", f"%{store}%"),
+                        as_dict=True,
+                    )
+                    if rows:
+                        found = {"order_no": rows[0]["name"], "matched_field": "warehouse_like"}
+                except Exception as e:
+                    payload.setdefault("query_errors", []).append(
+                        f"{store}: {str(e)[:200]}"
+                    )
+            payload["per_store_orders"][store] = found
+
+        payload["status"] = "OK"
+
+    except Exception as e:
+        import traceback
+        payload["status"] = "ERROR"
+        payload["fatal_error"] = str(e)
+        payload["traceback"] = traceback.format_exc()
+
+    out_path = "/tmp/s244_order_probe.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    sys.stdout.write(f"S244_ORDER_PROBE_OK status={payload.get('status')}\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/billing_sweep/probe_per_store_readiness.py
+++ b/scripts/billing_sweep/probe_per_store_readiness.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Billing sweep probe — verify BKI→Store PI generator preconditions per store.
+
+Read-only. No data created. Reports per-Company readiness across all stores
+that could potentially be a buyer (Customer.name == Company.name canonical match).
+
+Output is bracketed with S244_PROBE_BEGIN / S244_PROBE_END markers so the
+SSM wrapper can extract the JSON cleanly.
+"""
+from __future__ import annotations
+
+import os
+for d in [
+    "/home/frappe/logs",
+    "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+    "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+]:
+    os.makedirs(d, exist_ok=True)
+
+import json
+import sys
+from datetime import datetime
+
+import frappe  # type: ignore
+
+BKI_COMPANY = "BEBANG KITCHEN INC."
+BKI_TRADE_SUPPLIER = "BEBANG KITCHEN INC. - Trade"
+
+# Account numbers seeded by S238 PI generator
+ACCT_NUMBERS = ("1104210", "1106210", "2103210")
+
+# Custom Fields required (global)
+REQUIRED_CUSTOM_FIELDS = [
+    ("Sales Invoice", "custom_bei_store_order"),
+    ("Purchase Invoice", "custom_bei_store_order"),
+    ("Purchase Invoice", "custom_bki_paired_si"),
+    ("Purchase Invoice", "bki_si_reference"),
+]
+
+
+def _global_state():
+    out = {}
+
+    # BEI Settings flags
+    settings = frappe.get_single("BEI Settings")
+    out["enable_bki_store_pi_generator"] = bool(
+        getattr(settings, "enable_bki_store_pi_generator", 0)
+    )
+    out["bki_sales_naming_series"] = (
+        getattr(settings, "bki_sales_naming_series", "") or ""
+    )
+
+    # BKI master
+    out["bki_company_exists"] = bool(frappe.db.exists("Company", BKI_COMPANY))
+    out["bki_trade_supplier_exists"] = bool(
+        frappe.db.exists("Supplier", BKI_TRADE_SUPPLIER)
+    )
+    if out["bki_trade_supplier_exists"]:
+        supp = frappe.db.get_value(
+            "Supplier",
+            BKI_TRADE_SUPPLIER,
+            ["disabled", "is_internal_supplier", "supplier_group", "default_currency"],
+            as_dict=True,
+        )
+        out["bki_trade_supplier_attrs"] = supp
+
+    # Custom Fields
+    cf_status = []
+    for doctype, fieldname in REQUIRED_CUSTOM_FIELDS:
+        present = frappe.get_meta(doctype).has_field(fieldname)
+        cf_status.append({"doctype": doctype, "field": fieldname, "present": present})
+    out["custom_fields"] = cf_status
+
+    # SI naming hook autoname function registered?
+    hooks = frappe.get_hooks("doc_events") or {}
+    si_hooks = (hooks.get("Sales Invoice", {}) or {}).get("autoname", []) or []
+    pi_hooks = (hooks.get("Purchase Invoice", {}) or {}).get("validate", []) or []
+    si_submit_hooks = (hooks.get("Sales Invoice", {}) or {}).get("on_submit", []) or []
+    si_cancel_hooks = (hooks.get("Sales Invoice", {}) or {}).get("on_cancel", []) or []
+    out["si_autoname_hooks"] = list(si_hooks)
+    out["si_on_submit_hooks"] = list(si_submit_hooks)
+    out["si_on_cancel_hooks"] = list(si_cancel_hooks)
+    out["pi_validate_hooks"] = list(pi_hooks)
+
+    return out
+
+
+def _candidate_companies():
+    """Find all non-BKI, non-group, non-disabled Companies that have a matching Customer name.
+
+    These are the buyer candidates the PI generator will fire for.
+    """
+    rows = frappe.db.sql(
+        """SELECT c.name           AS company,
+                  c.abbr           AS abbr,
+                  c.default_currency AS currency,
+                  c.cost_center    AS cost_center,
+                  c.parent_company AS parent_company,
+                  IFNULL(c.is_group, 0) AS is_group
+           FROM `tabCompany` c
+           WHERE c.name != %s
+             AND IFNULL(c.is_group, 0) = 0
+           ORDER BY c.name""",
+        BKI_COMPANY,
+        as_dict=True,
+    )
+    return rows
+
+
+def _check_one_store(company):
+    """Per-store probe: returns dict of all preconditions."""
+    name = company["company"]
+    out = {
+        "company": name,
+        "abbr": company.get("abbr"),
+        "default_currency": company.get("currency"),
+        "default_currency_is_php": company.get("currency") == "PHP",
+        "cost_center": company.get("cost_center"),
+        "cost_center_set": bool(company.get("cost_center")),
+        "parent_company": company.get("parent_company"),
+    }
+
+    # Customer record with same name as Company?
+    out["customer_exists_with_same_name"] = bool(frappe.db.exists("Customer", name))
+
+    # Warehouse record with same name as Company?
+    out["warehouse_exists_with_same_name"] = bool(frappe.db.exists("Warehouse", name))
+
+    # Required accounts present on this Company?
+    acct_status = {}
+    for acct_num in ACCT_NUMBERS:
+        row = frappe.db.get_value(
+            "Account",
+            {"company": name, "account_number": acct_num},
+            ["name", "disabled", "is_group", "root_type", "account_currency"],
+            as_dict=True,
+        )
+        acct_status[acct_num] = row or {"missing": True}
+    out["accounts"] = acct_status
+    out["all_accounts_present"] = all(
+        not v.get("missing") for v in acct_status.values()
+    )
+
+    # Does BKI TRADE Supplier have a credit_to entry for this Company?
+    bki_supplier_acct = frappe.db.get_value(
+        "Party Account",
+        {
+            "parent": BKI_TRADE_SUPPLIER,
+            "parenttype": "Supplier",
+            "company": name,
+        },
+        ["account"],
+    )
+    out["bki_supplier_account_set"] = bool(bki_supplier_acct)
+    out["bki_supplier_account_value"] = bki_supplier_acct
+
+    # Roll-up readiness flag
+    out["ready_for_pi_generation"] = bool(
+        out["customer_exists_with_same_name"]
+        and out["warehouse_exists_with_same_name"]
+        and out["default_currency_is_php"]
+        and out["cost_center_set"]
+        and out["all_accounts_present"]
+    )
+    return out
+
+
+def _historical_si_stats():
+    """Count test SIs created during S238 build that are still on the system."""
+    out = {}
+    out["bki_si_total"] = frappe.db.count(
+        "Sales Invoice", {"company": BKI_COMPANY}
+    )
+    out["bki_si_draft"] = frappe.db.count(
+        "Sales Invoice", {"company": BKI_COMPANY, "docstatus": 0}
+    )
+    out["bki_si_submitted"] = frappe.db.count(
+        "Sales Invoice", {"company": BKI_COMPANY, "docstatus": 1}
+    )
+    out["bki_si_cancelled"] = frappe.db.count(
+        "Sales Invoice", {"company": BKI_COMPANY, "docstatus": 2}
+    )
+    return out
+
+
+def _find_seed_data():
+    """Find an item code that can be used as the test SI line item.
+
+    Prefers a non-stock item to avoid SLE issues, or any item with positive stock.
+    """
+    item = frappe.db.get_value(
+        "Item",
+        {"item_code": "PM003", "disabled": 0},
+        ["item_code", "item_name", "is_stock_item"],
+        as_dict=True,
+    )
+    return {"pm003": item}
+
+
+def main() -> None:
+    payload = {
+        "sprint": "billing-sweep-2026-05-11",
+        "purpose": "BKI->Store PI generator per-store readiness",
+        "timestamp_utc": datetime.utcnow().isoformat() + "Z",
+        "global": {},
+        "stores": [],
+        "history": {},
+        "seed_data": {},
+    }
+    try:
+        frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+        frappe.connect()
+        frappe.set_user("Administrator")
+
+        payload["global"] = _global_state()
+        payload["history"] = _historical_si_stats()
+        payload["seed_data"] = _find_seed_data()
+
+        for company in _candidate_companies():
+            payload["stores"].append(_check_one_store(company))
+
+        # Summary tallies
+        all_stores = payload["stores"]
+        ready = [s for s in all_stores if s["ready_for_pi_generation"]]
+        payload["summary"] = {
+            "total_candidate_buyer_companies": len(all_stores),
+            "ready_for_pi_generation": len(ready),
+            "missing_customer": [
+                s["company"] for s in all_stores
+                if not s["customer_exists_with_same_name"]
+            ],
+            "missing_warehouse": [
+                s["company"] for s in all_stores
+                if not s["warehouse_exists_with_same_name"]
+            ],
+            "non_php_currency": [
+                s["company"] for s in all_stores
+                if not s["default_currency_is_php"]
+            ],
+            "missing_cost_center": [
+                s["company"] for s in all_stores
+                if not s["cost_center_set"]
+            ],
+            "missing_any_acct": [
+                s["company"] for s in all_stores
+                if not s["all_accounts_present"]
+            ],
+            "missing_bki_supplier_acct": [
+                s["company"] for s in all_stores
+                if not s["bki_supplier_account_set"]
+            ],
+        }
+        payload["status"] = "OK"
+
+    except Exception as e:
+        import traceback
+        payload["status"] = "ERROR"
+        payload["fatal_error"] = str(e)
+        payload["traceback"] = traceback.format_exc()
+
+    out_path = "/tmp/s244_probe_result.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    sys.stdout.write(f"S244_PROBE_OK path={out_path} status={payload.get('status')} stores={len(payload.get('stores', []))}\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/billing_sweep/probe_perpetual_inventory.py
+++ b/scripts/billing_sweep/probe_perpetual_inventory.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Probe Company.enable_perpetual_inventory to confirm sweep-failure root cause."""
+from __future__ import annotations
+
+import os
+for d in ["/home/frappe/logs", "/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+
+import json
+import sys
+from datetime import datetime
+
+import frappe  # type: ignore
+
+
+def main() -> None:
+    payload = {"timestamp_utc": datetime.utcnow().isoformat() + "Z"}
+    try:
+        frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+        frappe.connect()
+        frappe.set_user("Administrator")
+
+        # List the Company fields related to perpetual inventory / stock
+        meta_fields = []
+        for f in frappe.get_meta("Company").fields:
+            if f.fieldname and any(k in (f.fieldname or "").lower() for k in
+                                    ("perpetual", "stock", "inventory")):
+                meta_fields.append({"fieldname": f.fieldname, "fieldtype": f.fieldtype,
+                                    "label": f.label})
+        payload["company_stock_fields"] = meta_fields
+
+        # Pull a column list from tabCompany matching the pattern
+        cols = frappe.db.sql(
+            """SELECT COLUMN_NAME FROM information_schema.COLUMNS
+               WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tabCompany'
+                 AND (COLUMN_NAME LIKE '%perpetual%' OR COLUMN_NAME LIKE '%stock%')""",
+            as_dict=True,
+        )
+        payload["company_columns"] = [c["COLUMN_NAME"] for c in cols]
+
+        # Compare per-company values for the 49 stores
+        STORES_ALL = [
+            "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+            "AYALA EVO CITY - BEBANG MEGA INC.",
+            "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+            "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.",
+            "AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.",
+            "AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.",
+            "AYALA VERMOSA - BEBANG MEGA INC.",
+            "BF HOMES - BEBANG BF HOMES INC.",
+            "CTTM TOMAS MORATO - B CUBED VENTURES CORP.",
+            "D'VERDE CALAMBA - TAJ FOOD CORP.",
+            "EVER COMMONWEALTH - DLS DESSERT CRAFT INC.",
+            "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.",
+            "LUCKY CHINATOWN - BEBANG LCT INC.",
+            "MEGAWIDE PITX - BEBANG PITX INC.",
+            "MEGAWORLD PASEO CENTER - BEBANG PASEO INC.",
+            "MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.",
+            "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+            "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+            "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+            "ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC",
+            "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+            "ROBINSONS IMUS - BEBANG MEGA INC.",
+            "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+            "SM BICUTAN - BEBANG SM BICUTAN INC.",
+            "SM CALOOCAN - TAJ FOOD CORP.",
+            "SM CLARK - RED TALDAWA FOODS OPC",
+            "SM EAST ORTIGAS - BEBANG SMEO INC.",
+            "SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.",
+            "SM MALL OF ASIA - BEBANG SMOA INC.",
+            "SM MARIKINA - BEBANG SM MARIKINA INC.",
+            "SM MARILAO - BEBANG MARILAO INC.",
+            "SM NORTH EDSA - BEBANG NORTH EDSA INC.",
+            "SM PULILAN - BEBANG SMM INC.",
+            "SM SAN JOSE DEL MONTE - JL TRADE OPC",
+            "SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC",
+            "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+            "SM TANZA - BEBANG MEGA INC.",
+            "SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.",
+            "SM VALENZUELA - BEBANG SMV INC.",
+            "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+            "THE GRID ROCKWELL - TASTECARTEL CORP.",
+            "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+            "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+            "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+            "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+            "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.",
+            "SM MANILA - BEBANG ENTERPRISE INC.",
+            "SM MEGAMALL - BEBANG ENTERPRISE INC.",
+            "SM SOUTHMALL - BEBANG ENTERPRISE INC.",
+        ]
+
+        # Build SELECT with all stock-related cols
+        all_cols = ["name"] + payload["company_columns"]
+        col_clause = ", ".join(f"`{c}`" for c in all_cols)
+        rows = frappe.db.sql(
+            f"SELECT {col_clause} FROM `tabCompany` WHERE name IN %s",
+            (tuple(STORES_ALL),),
+            as_dict=True,
+        )
+        payload["per_company"] = [dict(r) for r in rows]
+
+        # Also test the actual erpnext helper for one PASS and one FAIL store
+        try:
+            import erpnext
+            payload["erpnext_perpetual_helper"] = {
+                "ARANETA_PASS": bool(erpnext.is_perpetual_inventory_enabled(
+                    "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC")),
+                "AFT_FAIL": bool(erpnext.is_perpetual_inventory_enabled(
+                    "AYALA FAIRVIEW TERRACES - BEBANG FT INC.")),
+                "GHO_FAIL": bool(erpnext.is_perpetual_inventory_enabled(
+                    "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC")),
+            }
+        except Exception as e:
+            payload["erpnext_perpetual_helper"] = {"error": str(e)[:300]}
+
+        payload["status"] = "OK"
+    except Exception as e:
+        import traceback
+        payload["status"] = "ERROR"
+        payload["fatal_error"] = str(e)
+        payload["traceback"] = traceback.format_exc()
+
+    out_path = "/tmp/s244_perp.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    sys.stdout.write(f"S244_PERP_OK status={payload.get('status')}\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/billing_sweep/probe_stock_defaults.py
+++ b/scripts/billing_sweep/probe_stock_defaults.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Probe Company + Warehouse stock-related defaults to explain the sweep failures."""
+from __future__ import annotations
+
+import os
+for d in ["/home/frappe/logs", "/home/frappe/frappe-bench/logs",
+          "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+          "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs"]:
+    os.makedirs(d, exist_ok=True)
+
+import json
+import sys
+from datetime import datetime
+
+import frappe  # type: ignore
+
+# Buyer Companies from the sweep — 45 ready + 4 broken
+STORES_ALL = [
+    "ARANETA GATEWAY - TUNGSTEN CAPITAL HOLDINGS OPC",
+    "AYALA EVO CITY - BEBANG MEGA INC.",
+    "AYALA FAIRVIEW TERRACES - BEBANG FT INC.",
+    "AYALA MARKET MARKET - BEBANG MARKET MARKET INC.",
+    "AYALA SOLENAD - HFFM SOLENAD FOOD SERVICES INC.",
+    "AYALA UP TOWN CENTER - BEBANG UP TOWN CENTER INC.",
+    "AYALA VERMOSA - BEBANG MEGA INC.",
+    "BF HOMES - BEBANG BF HOMES INC.",
+    "CTTM TOMAS MORATO - B CUBED VENTURES CORP.",
+    "D'VERDE CALAMBA - TAJ FOOD CORP.",
+    "EVER COMMONWEALTH - DLS DESSERT CRAFT INC.",
+    "FESTIVAL MALL ALABANG - BEBANG FESTIVAL INC.",
+    "LUCKY CHINATOWN - BEBANG LCT INC.",
+    "MEGAWIDE PITX - BEBANG PITX INC.",
+    "MEGAWORLD PASEO CENTER - BEBANG PASEO INC.",
+    "MEGAWORLD VENICE GRAND CANAL - BEBANG VENICE GRAND CANAL INC.",
+    "NAIA T3 - HALO-HALO TERMINAL FOOD CORP.",
+    "ORTIGAS ESTANCIA - BB ESTANCIA FOOD CORP.",
+    "ORTIGAS GREENHILLS - BEIFRANCHISE FOOD OPC",
+    "ROBINSONS GALLERIA SOUTH - TUNGSTEN CAPITAL HOLDINGS OPC",
+    "ROBINSONS GENERAL TRIAS - BEBANG MEGA INC.",
+    "ROBINSONS IMUS - BEBANG MEGA INC.",
+    "ROBINSONS PLACE DASMARINAS - FREEZE DELIGHT INC.",
+    "SM BICUTAN - BEBANG SM BICUTAN INC.",
+    "SM CALOOCAN - TAJ FOOD CORP.",
+    "SM CLARK - RED TALDAWA FOODS OPC",
+    "SM EAST ORTIGAS - BEBANG SMEO INC.",
+    "SM GRAND CENTRAL - BEBANG GRAND CENTRAL INC.",
+    "SM MALL OF ASIA - BEBANG SMOA INC.",
+    "SM MARIKINA - BEBANG SM MARIKINA INC.",
+    "SM MARILAO - BEBANG MARILAO INC.",
+    "SM NORTH EDSA - BEBANG NORTH EDSA INC.",
+    "SM PULILAN - BEBANG SMM INC.",
+    "SM SAN JOSE DEL MONTE - JL TRADE OPC",
+    "SM SANGANDAAN - TUNGSTEN CAPITAL HOLDINGS OPC",
+    "SM STA. ROSA - SWEET HARMONY FOOD CORP.",
+    "SM TANZA - BEBANG MEGA INC.",
+    "SM TAYTAY - DAY ONES FOOD AND DRINK ESTABLISHMENTS CORP.",
+    "SM VALENZUELA - BEBANG SMV INC.",
+    "STA. LUCIA EAST GRAND MALL - BEBANG SM MARIKINA INC.",
+    "THE GRID ROCKWELL - TASTECARTEL CORP.",
+    "THE TERMINAL - BEBANG STARMALL ALABANG INC.",
+    "UP TOWN MALL BGC - DMD HOLDINGS INC.",
+    "VISTA MALL TAGUIG - TRICERN FOOD CORP.",
+    "XENTROMALL MONTALBAN - PERPETUAL FOOD CORP.",
+    "ROBINSONS ANTIPOLO - BEBANG ENTERPRISE INC.",
+    "SM MANILA - BEBANG ENTERPRISE INC.",
+    "SM MEGAMALL - BEBANG ENTERPRISE INC.",
+    "SM SOUTHMALL - BEBANG ENTERPRISE INC.",
+]
+
+
+def main() -> None:
+    payload = {"timestamp_utc": datetime.utcnow().isoformat() + "Z", "stores": []}
+    try:
+        frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+        frappe.connect()
+        frappe.set_user("Administrator")
+
+        for company in STORES_ALL:
+            row = {"company": company}
+            # Company-level stock defaults
+            c = frappe.db.get_value(
+                "Company",
+                company,
+                [
+                    "abbr",
+                    "cost_center",
+                    "default_currency",
+                    "stock_received_but_not_billed",
+                    "default_inventory_account",
+                    "default_expense_account",
+                    "default_cash_account",
+                    "default_bank_account",
+                    "default_receivable_account",
+                    "default_payable_account",
+                ],
+                as_dict=True,
+            )
+            row.update(c or {})
+
+            # Warehouse defaults
+            wh = frappe.db.get_value(
+                "Warehouse",
+                company,
+                ["account", "is_group", "disabled", "warehouse_type", "default_in_transit_warehouse"],
+                as_dict=True,
+            )
+            row["warehouse_attrs"] = wh or {}
+
+            # 1104210 account name on this Company
+            acct_1104210 = frappe.db.get_value(
+                "Account",
+                {"company": company, "account_number": "1104210"},
+                "name",
+            )
+            row["account_1104210"] = acct_1104210
+
+            # Does Warehouse.account == 1104210 account?
+            row["warehouse_account_is_1104210"] = bool(
+                acct_1104210 and (wh or {}).get("account") == acct_1104210
+            )
+
+            payload["stores"].append(row)
+
+        payload["status"] = "OK"
+    except Exception as e:
+        import traceback
+        payload["status"] = "ERROR"
+        payload["fatal_error"] = str(e)
+        payload["traceback"] = traceback.format_exc()
+
+    out_path = "/tmp/s244_stock_defaults.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    sys.stdout.write(f"S244_STOCK_DEFAULTS_OK status={payload.get('status')}\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/billing_sweep/probe_sweep_aftermath.py
+++ b/scripts/billing_sweep/probe_sweep_aftermath.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""After-sweep probe — read full S238 error logs + verify no leftover test artifacts."""
+from __future__ import annotations
+
+import os
+for d in [
+    "/home/frappe/logs",
+    "/home/frappe/frappe-bench/logs",
+    "/home/frappe/frappe-bench/hq.bebang.ph/logs",
+    "/home/frappe/frappe-bench/sites/hq.bebang.ph/logs",
+]:
+    os.makedirs(d, exist_ok=True)
+
+import json
+import sys
+from datetime import datetime
+
+import frappe  # type: ignore
+
+
+def main() -> None:
+    payload = {"timestamp_utc": datetime.utcnow().isoformat() + "Z"}
+    try:
+        frappe.init(site="hq.bebang.ph", sites_path="/home/frappe/frappe-bench/sites")
+        frappe.connect()
+        frappe.set_user("Administrator")
+
+        # Last 60 minutes of S238 errors with FULL text
+        errs = frappe.db.sql(
+            """SELECT name, error, creation FROM `tabError Log`
+               WHERE error LIKE 'S238: PI generation failed%'
+               AND creation >= NOW() - INTERVAL 60 MINUTE
+               ORDER BY creation DESC""",
+            as_dict=True,
+        )
+        payload["error_log_count"] = len(errs)
+        # Sample unique error stacktraces (dedupe by last 200 chars)
+        seen = set()
+        samples = []
+        for e in errs:
+            tail = e["error"][-300:] if len(e["error"]) > 300 else e["error"]
+            key = tail.split("\n")[-2] if "\n" in tail else tail
+            if key not in seen:
+                seen.add(key)
+                samples.append({
+                    "name": e["name"],
+                    "creation": str(e["creation"]),
+                    "full_error": e["error"][:4000],  # capped to keep payload manageable
+                })
+            if len(samples) >= 8:
+                break
+        payload["unique_error_samples"] = samples
+
+        # Check for any leftover test SIs (any BKI-SI-2026-009XX-N or 010XX-N created in last hour)
+        leftover_si = frappe.db.sql(
+            """SELECT name, custom_bei_store_order, customer, docstatus, creation
+               FROM `tabSales Invoice`
+               WHERE company = 'BEBANG KITCHEN INC.'
+                 AND creation >= NOW() - INTERVAL 60 MINUTE
+               ORDER BY creation DESC""",
+            as_dict=True,
+        )
+        payload["leftover_si_count"] = len(leftover_si)
+        payload["leftover_si"] = [
+            {"name": r["name"], "order": r["custom_bei_store_order"],
+             "customer": r["customer"], "docstatus": r["docstatus"],
+             "creation": str(r["creation"])}
+            for r in leftover_si
+        ]
+
+        # Check for any leftover test PIs (PIs with bki_si_reference set, created in last hour)
+        leftover_pi = frappe.db.sql(
+            """SELECT name, bki_si_reference, supplier, company, docstatus, creation
+               FROM `tabPurchase Invoice`
+               WHERE bki_si_reference IS NOT NULL AND bki_si_reference != ''
+                 AND creation >= NOW() - INTERVAL 60 MINUTE
+               ORDER BY creation DESC""",
+            as_dict=True,
+        )
+        payload["leftover_pi_count"] = len(leftover_pi)
+        payload["leftover_pi"] = [
+            {"name": r["name"], "si_ref": r["bki_si_reference"],
+             "supplier": r["supplier"], "company": r["company"],
+             "docstatus": r["docstatus"], "creation": str(r["creation"])}
+            for r in leftover_pi
+        ]
+
+        # Also check totals to detect any orphan PIs from previous sessions
+        any_orphans = frappe.db.sql(
+            """SELECT pi.name, pi.bki_si_reference, pi.company, pi.docstatus, pi.creation
+               FROM `tabPurchase Invoice` pi
+               LEFT JOIN `tabSales Invoice` si ON si.name = pi.bki_si_reference
+               WHERE pi.bki_si_reference IS NOT NULL AND pi.bki_si_reference != ''
+                 AND si.name IS NULL
+               LIMIT 10""",
+            as_dict=True,
+        )
+        payload["orphan_pi_count"] = len(any_orphans)
+        payload["orphan_pi_sample"] = [
+            {"name": r["name"], "si_ref": r["bki_si_reference"],
+             "company": r["company"], "docstatus": r["docstatus"],
+             "creation": str(r["creation"])}
+            for r in any_orphans
+        ]
+
+        payload["status"] = "OK"
+
+    except Exception as e:
+        import traceback
+        payload["status"] = "ERROR"
+        payload["fatal_error"] = str(e)
+        payload["traceback"] = traceback.format_exc()
+
+    out_path = "/tmp/s244_aftermath.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)
+    sys.stdout.write(f"S244_AFTERMATH_OK status={payload.get('status')} "
+                     f"errors={payload.get('error_log_count')} "
+                     f"leftover_si={payload.get('leftover_si_count')} "
+                     f"leftover_pi={payload.get('leftover_pi_count')}\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/billing_sweep/run_aftermath.py
+++ b/scripts/billing_sweep/run_aftermath.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""SSM-execute probe_sweep_aftermath.py."""
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import sys
+import time
+from pathlib import Path
+
+import boto3
+
+INSTANCE_ID = "i-026b7477d27bd46d6"
+REGION = "ap-southeast-1"
+HERE = Path(__file__).parent
+SCRIPT = HERE / "probe_sweep_aftermath.py"
+OUT = HERE / "aftermath_result.json"
+
+
+def main() -> int:
+    ssm = boto3.client("ssm", region_name=REGION)
+    encoded = base64.b64encode(SCRIPT.read_text(encoding="utf-8").encode()).decode()
+    cmds = [
+        "set -e",
+        "BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+        f"echo '{encoded}' | base64 -d > /tmp/s244_aftermath.py",
+        "docker cp /tmp/s244_aftermath.py $BACKEND:/tmp/s244_aftermath.py",
+        "docker exec $BACKEND bash -lc 'cd /home/frappe/frappe-bench && env/bin/python /tmp/s244_aftermath.py'",
+        "docker cp $BACKEND:/tmp/s244_aftermath.json /tmp/s244_aftermath.json",
+        "gzip -c /tmp/s244_aftermath.json > /tmp/s244_aftermath.json.gz",
+        "echo S244_FILE_BEGIN",
+        "base64 -w0 /tmp/s244_aftermath.json.gz; echo",
+        "echo S244_FILE_END",
+    ]
+    resp = ssm.send_command(InstanceIds=[INSTANCE_ID], DocumentName="AWS-RunShellScript",
+                             Parameters={"commands": cmds}, TimeoutSeconds=600)
+    cmd_id = resp["Command"]["CommandId"]
+    print(f"command_id={cmd_id}", flush=True)
+    while True:
+        time.sleep(5)
+        inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+        if inv["Status"] in ("Pending", "InProgress", "Delayed"):
+            continue
+        break
+    print(f"final_status={inv['Status']}")
+    out_text = inv.get("StandardOutputContent", "")
+    if "S244_FILE_BEGIN" in out_text:
+        b64 = out_text.split("S244_FILE_BEGIN")[1].split("S244_FILE_END")[0].strip()
+        decoded = gzip.decompress(base64.b64decode(b64)).decode("utf-8")
+        data = json.loads(decoded)
+        OUT.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        print(f"wrote {OUT}")
+        print(f"  error_log_count={data.get('error_log_count')}")
+        print(f"  leftover_si_count={data.get('leftover_si_count')}")
+        print(f"  leftover_pi_count={data.get('leftover_pi_count')}")
+        print(f"  orphan_pi_count={data.get('orphan_pi_count')}")
+        return 0
+    print(out_text); print(inv.get("StandardErrorContent", ""))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/billing_sweep/run_one_failure.py
+++ b/scripts/billing_sweep/run_one_failure.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import base64, gzip, json, sys, time
+from pathlib import Path
+import boto3
+
+INSTANCE_ID = "i-026b7477d27bd46d6"
+REGION = "ap-southeast-1"
+HERE = Path(__file__).parent
+SCRIPT = HERE / "probe_one_failure_full_trace.py"
+OUT = HERE / "one_failure_result.json"
+
+ssm = boto3.client("ssm", region_name=REGION)
+encoded = base64.b64encode(SCRIPT.read_text(encoding="utf-8").encode()).decode()
+cmds = [
+    "set -e",
+    "BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+    f"echo '{encoded}' | base64 -d > /tmp/s244_one.py",
+    "docker cp /tmp/s244_one.py $BACKEND:/tmp/s244_one.py",
+    "docker exec $BACKEND bash -lc 'cd /home/frappe/frappe-bench && env/bin/python /tmp/s244_one.py'",
+    "docker cp $BACKEND:/tmp/s244_one_failure.json /tmp/s244_one_failure.json",
+    "gzip -c /tmp/s244_one_failure.json > /tmp/s244_one_failure.json.gz",
+    "echo S244_FILE_BEGIN",
+    "base64 -w0 /tmp/s244_one_failure.json.gz; echo",
+    "echo S244_FILE_END",
+]
+resp = ssm.send_command(InstanceIds=[INSTANCE_ID], DocumentName="AWS-RunShellScript",
+                         Parameters={"commands": cmds}, TimeoutSeconds=300)
+cmd_id = resp["Command"]["CommandId"]
+print(f"command_id={cmd_id}")
+while True:
+    time.sleep(5)
+    inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+    if inv["Status"] in ("Pending", "InProgress", "Delayed"):
+        continue
+    break
+print(f"final_status={inv['Status']}")
+out_text = inv.get("StandardOutputContent", "")
+if "S244_FILE_BEGIN" in out_text:
+    b64 = out_text.split("S244_FILE_BEGIN")[1].split("S244_FILE_END")[0].strip()
+    decoded = gzip.decompress(base64.b64decode(b64)).decode("utf-8")
+    OUT.write_text(decoded, encoding="utf-8")
+    print(f"wrote {OUT}")
+    sys.exit(0)
+print(out_text); print(inv.get("StandardErrorContent", ""))
+sys.exit(1)

--- a/scripts/billing_sweep/run_order_probe.py
+++ b/scripts/billing_sweep/run_order_probe.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""SSM-execute probe_order_per_store.py."""
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import sys
+import time
+from pathlib import Path
+
+import boto3
+
+INSTANCE_ID = "i-026b7477d27bd46d6"
+REGION = "ap-southeast-1"
+HERE = Path(__file__).parent
+SCRIPT = HERE / "probe_order_per_store.py"
+OUT = HERE / "order_probe_result.json"
+
+
+def main() -> int:
+    ssm = boto3.client("ssm", region_name=REGION)
+    encoded = base64.b64encode(SCRIPT.read_text(encoding="utf-8").encode()).decode()
+    cmds = [
+        "set -e",
+        "BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+        f"echo '{encoded}' | base64 -d > /tmp/s244_order_probe.py",
+        "docker cp /tmp/s244_order_probe.py $BACKEND:/tmp/s244_order_probe.py",
+        "docker exec $BACKEND bash -lc 'cd /home/frappe/frappe-bench && env/bin/python /tmp/s244_order_probe.py'",
+        "docker cp $BACKEND:/tmp/s244_order_probe.json /tmp/s244_order_probe.json",
+        "gzip -c /tmp/s244_order_probe.json > /tmp/s244_order_probe.json.gz",
+        "echo S244_FILE_BEGIN",
+        "base64 -w0 /tmp/s244_order_probe.json.gz; echo",
+        "echo S244_FILE_END",
+    ]
+    resp = ssm.send_command(InstanceIds=[INSTANCE_ID], DocumentName="AWS-RunShellScript",
+                             Parameters={"commands": cmds}, TimeoutSeconds=600)
+    cmd_id = resp["Command"]["CommandId"]
+    print(f"command_id={cmd_id}", flush=True)
+    while True:
+        time.sleep(5)
+        inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+        if inv["Status"] in ("Pending", "InProgress", "Delayed"):
+            print(f"  status={inv['Status']}", flush=True)
+            continue
+        break
+    print(f"final_status={inv['Status']}")
+    out_text = inv.get("StandardOutputContent", "")
+    if "S244_FILE_BEGIN" in out_text:
+        b64 = out_text.split("S244_FILE_BEGIN")[1].split("S244_FILE_END")[0].strip()
+        decoded = gzip.decompress(base64.b64decode(b64)).decode("utf-8")
+        data = json.loads(decoded)
+        OUT.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        print(f"wrote {OUT}")
+        return 0
+    print(out_text); print(inv.get("StandardErrorContent", ""))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/billing_sweep/run_perp.py
+++ b/scripts/billing_sweep/run_perp.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import base64, gzip, json, sys, time
+from pathlib import Path
+import boto3
+
+INSTANCE_ID = "i-026b7477d27bd46d6"
+REGION = "ap-southeast-1"
+HERE = Path(__file__).parent
+SCRIPT = HERE / "probe_perpetual_inventory.py"
+OUT = HERE / "perp_result.json"
+
+ssm = boto3.client("ssm", region_name=REGION)
+encoded = base64.b64encode(SCRIPT.read_text(encoding="utf-8").encode()).decode()
+cmds = [
+    "set -e",
+    "BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+    f"echo '{encoded}' | base64 -d > /tmp/s244_perp.py",
+    "docker cp /tmp/s244_perp.py $BACKEND:/tmp/s244_perp.py",
+    "docker exec $BACKEND bash -lc 'cd /home/frappe/frappe-bench && env/bin/python /tmp/s244_perp.py'",
+    "docker cp $BACKEND:/tmp/s244_perp.json /tmp/s244_perp.json",
+    "gzip -c /tmp/s244_perp.json > /tmp/s244_perp.json.gz",
+    "echo S244_FILE_BEGIN",
+    "base64 -w0 /tmp/s244_perp.json.gz; echo",
+    "echo S244_FILE_END",
+]
+resp = ssm.send_command(InstanceIds=[INSTANCE_ID], DocumentName="AWS-RunShellScript",
+                         Parameters={"commands": cmds}, TimeoutSeconds=300)
+cmd_id = resp["Command"]["CommandId"]
+print(f"command_id={cmd_id}")
+while True:
+    time.sleep(5)
+    inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+    if inv["Status"] in ("Pending", "InProgress", "Delayed"):
+        continue
+    break
+print(f"final_status={inv['Status']}")
+out_text = inv.get("StandardOutputContent", "")
+if "S244_FILE_BEGIN" in out_text:
+    b64 = out_text.split("S244_FILE_BEGIN")[1].split("S244_FILE_END")[0].strip()
+    decoded = gzip.decompress(base64.b64decode(b64)).decode("utf-8")
+    OUT.write_text(decoded, encoding="utf-8")
+    print(f"wrote {OUT}")
+    sys.exit(0)
+print(out_text); print(inv.get("StandardErrorContent", ""))
+sys.exit(1)

--- a/scripts/billing_sweep/run_probe.py
+++ b/scripts/billing_sweep/run_probe.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""SSM-execute probe_per_store_readiness.py in production Frappe backend.
+
+Read-only. Writes result JSON next to this script.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import sys
+import time
+from pathlib import Path
+
+import boto3
+
+INSTANCE_ID = "i-026b7477d27bd46d6"
+REGION = "ap-southeast-1"
+HERE = Path(__file__).parent
+PROBE = HERE / "probe_per_store_readiness.py"
+OUT = HERE / "probe_result.json"
+
+
+def main() -> int:
+    ssm = boto3.client("ssm", region_name=REGION)
+    encoded = base64.b64encode(PROBE.read_text(encoding="utf-8").encode()).decode()
+
+    cmds = [
+        "set -e",
+        "BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+        'if [ -z "$BACKEND" ]; then echo "BACKEND_NOT_FOUND" && exit 1; fi',
+        f"echo '{encoded}' | base64 -d > /tmp/s244_probe.py",
+        "docker cp /tmp/s244_probe.py $BACKEND:/tmp/s244_probe.py",
+        "docker exec $BACKEND bash -lc 'cd /home/frappe/frappe-bench && env/bin/python /tmp/s244_probe.py'",
+        "docker cp $BACKEND:/tmp/s244_probe_result.json /tmp/s244_probe_result.json",
+        "gzip -c /tmp/s244_probe_result.json > /tmp/s244_probe_result.json.gz",
+        "echo S244_FILE_BEGIN",
+        "base64 -w0 /tmp/s244_probe_result.json.gz; echo",
+        "echo S244_FILE_END",
+    ]
+
+    resp = ssm.send_command(
+        InstanceIds=[INSTANCE_ID],
+        DocumentName="AWS-RunShellScript",
+        Parameters={"commands": cmds},
+        TimeoutSeconds=600,
+    )
+    cmd_id = resp["Command"]["CommandId"]
+    print(f"command_id={cmd_id}", flush=True)
+
+    while True:
+        time.sleep(5)
+        inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+        status = inv["Status"]
+        if status in ("Pending", "InProgress", "Delayed"):
+            print(f"  status={status}", flush=True)
+            continue
+        break
+
+    print(f"final_status={status}")
+    out_text = inv.get("StandardOutputContent", "")
+    err_text = inv.get("StandardErrorContent", "")
+
+    if "S244_FILE_BEGIN" in out_text and "S244_FILE_END" in out_text:
+        b64_body = out_text.split("S244_FILE_BEGIN")[1].split("S244_FILE_END")[0].strip()
+        try:
+            import gzip
+            decoded_gz = base64.b64decode(b64_body)
+            decoded = gzip.decompress(decoded_gz).decode("utf-8")
+            data = json.loads(decoded)
+            OUT.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+            print(f"wrote {OUT} ({len(decoded)} bytes)")
+            # Quick summary to stdout
+            s = data.get("summary", {})
+            print("\n=== SUMMARY ===")
+            print(f"  total candidate buyer companies: {s.get('total_candidate_buyer_companies')}")
+            print(f"  ready for PI generation        : {s.get('ready_for_pi_generation')}")
+            for key in ("missing_customer", "missing_warehouse", "non_php_currency",
+                        "missing_cost_center", "missing_any_acct", "missing_bki_supplier_acct"):
+                lst = s.get(key, [])
+                if lst:
+                    print(f"  {key} ({len(lst)}): {lst[:8]}{'...' if len(lst) > 8 else ''}")
+            return 0
+        except Exception as e:
+            print(f"PARSE_ERROR: {e}")
+            OUT.write_text(out_text, encoding="utf-8")
+            return 2
+
+    print("--- STDOUT ---")
+    print(out_text)
+    print("--- STDERR ---")
+    print(err_text)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/billing_sweep/run_stock_defaults.py
+++ b/scripts/billing_sweep/run_stock_defaults.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import base64, gzip, json, sys, time
+from pathlib import Path
+import boto3
+
+INSTANCE_ID = "i-026b7477d27bd46d6"
+REGION = "ap-southeast-1"
+HERE = Path(__file__).parent
+SCRIPT = HERE / "probe_stock_defaults.py"
+OUT = HERE / "stock_defaults.json"
+
+ssm = boto3.client("ssm", region_name=REGION)
+encoded = base64.b64encode(SCRIPT.read_text(encoding="utf-8").encode()).decode()
+cmds = [
+    "set -e",
+    "BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+    f"echo '{encoded}' | base64 -d > /tmp/s244_sd.py",
+    "docker cp /tmp/s244_sd.py $BACKEND:/tmp/s244_sd.py",
+    "docker exec $BACKEND bash -lc 'cd /home/frappe/frappe-bench && env/bin/python /tmp/s244_sd.py'",
+    "docker cp $BACKEND:/tmp/s244_stock_defaults.json /tmp/s244_stock_defaults.json",
+    "gzip -c /tmp/s244_stock_defaults.json > /tmp/s244_stock_defaults.json.gz",
+    "echo S244_FILE_BEGIN",
+    "base64 -w0 /tmp/s244_stock_defaults.json.gz; echo",
+    "echo S244_FILE_END",
+]
+resp = ssm.send_command(InstanceIds=[INSTANCE_ID], DocumentName="AWS-RunShellScript",
+                         Parameters={"commands": cmds}, TimeoutSeconds=300)
+cmd_id = resp["Command"]["CommandId"]
+print(f"command_id={cmd_id}")
+while True:
+    time.sleep(5)
+    inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+    if inv["Status"] in ("Pending", "InProgress", "Delayed"):
+        continue
+    break
+print(f"final_status={inv['Status']}")
+out_text = inv.get("StandardOutputContent", "")
+if "S244_FILE_BEGIN" in out_text:
+    b64 = out_text.split("S244_FILE_BEGIN")[1].split("S244_FILE_END")[0].strip()
+    decoded = gzip.decompress(base64.b64decode(b64)).decode("utf-8")
+    OUT.write_text(decoded, encoding="utf-8")
+    print(f"wrote {OUT}")
+    sys.exit(0)
+print(out_text); print(inv.get("StandardErrorContent", ""))
+sys.exit(1)

--- a/scripts/billing_sweep/run_sweep.py
+++ b/scripts/billing_sweep/run_sweep.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""SSM-execute multi_store_smoke.py inside the Frappe backend container.
+
+Live-fire — creates+cancels+deletes test SIs for 49 stores. All artifacts
+cleaned up by the in-script finally block.
+
+Timeout: 30 min (5-10s per store * 49 stores = ~5-8 min real, with safety margin).
+"""
+from __future__ import annotations
+
+import base64
+import gzip
+import json
+import sys
+import time
+from pathlib import Path
+
+import boto3
+
+INSTANCE_ID = "i-026b7477d27bd46d6"
+REGION = "ap-southeast-1"
+HERE = Path(__file__).parent
+SCRIPT = HERE / "multi_store_smoke.py"
+OUT = HERE / "sweep_result.json"
+
+
+def main() -> int:
+    ssm = boto3.client("ssm", region_name=REGION)
+    encoded = base64.b64encode(SCRIPT.read_text(encoding="utf-8").encode()).decode()
+
+    cmds = [
+        "set -e",
+        "BACKEND=$(docker ps --filter name=frappe_backend --format '{{.ID}}' | head -1)",
+        'if [ -z "$BACKEND" ]; then echo "BACKEND_NOT_FOUND" && exit 1; fi',
+        f"echo '{encoded}' | base64 -d > /tmp/s244_sweep.py",
+        "docker cp /tmp/s244_sweep.py $BACKEND:/tmp/s244_sweep.py",
+        "docker exec $BACKEND bash -lc 'cd /home/frappe/frappe-bench && env/bin/python /tmp/s244_sweep.py'",
+        "docker cp $BACKEND:/tmp/s244_sweep_result.json /tmp/s244_sweep_result.json",
+        "gzip -c /tmp/s244_sweep_result.json > /tmp/s244_sweep_result.json.gz",
+        "echo S244_FILE_BEGIN",
+        "base64 -w0 /tmp/s244_sweep_result.json.gz; echo",
+        "echo S244_FILE_END",
+    ]
+
+    resp = ssm.send_command(
+        InstanceIds=[INSTANCE_ID],
+        DocumentName="AWS-RunShellScript",
+        Parameters={"commands": cmds},
+        TimeoutSeconds=1800,
+    )
+    cmd_id = resp["Command"]["CommandId"]
+    print(f"command_id={cmd_id}", flush=True)
+
+    last_status = None
+    while True:
+        time.sleep(10)
+        inv = ssm.get_command_invocation(CommandId=cmd_id, InstanceId=INSTANCE_ID)
+        status = inv["Status"]
+        if status != last_status:
+            print(f"  status={status}", flush=True)
+            last_status = status
+        if status in ("Pending", "InProgress", "Delayed"):
+            continue
+        break
+
+    print(f"final_status={status}")
+    out_text = inv.get("StandardOutputContent", "")
+    err_text = inv.get("StandardErrorContent", "")
+
+    if "S244_FILE_BEGIN" in out_text and "S244_FILE_END" in out_text:
+        b64_body = out_text.split("S244_FILE_BEGIN")[1].split("S244_FILE_END")[0].strip()
+        try:
+            decoded_gz = base64.b64decode(b64_body)
+            decoded = gzip.decompress(decoded_gz).decode("utf-8")
+            data = json.loads(decoded)
+            OUT.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+            print(f"wrote {OUT} ({len(decoded)} bytes)")
+            print()
+            print("=== VERDICT COUNTS ===")
+            for k, v in (data.get("verdict_counts") or {}).items():
+                print(f"  {k}: {v}")
+            print()
+            print(f"remaining_in_tracker: {len(data.get('remaining_in_tracker', []))}")
+            cl = data.get("cleanup_log") or []
+            print(f"cleanup_log entries: {len(cl)}")
+            for line in cl[:10]:
+                print(f"  - {line}")
+            return 0
+        except Exception as e:
+            print(f"PARSE_ERROR: {e}")
+            return 2
+
+    print("--- STDOUT ---")
+    print(out_text)
+    print("--- STDERR ---")
+    print(err_text)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

L3 sweep of the BKI→Store PI generator across all 49 candidate buyer Companies. **Documentation-only PR.** No code or master-data changes. Production state verified clean (0 leftover SI/PI/orphans).

## Verdict counts

| Verdict | Count |
|---|---|
| 🟢 PASS (with caveats — see DEFECT D) | 13 |
| 🟥 FAIL — no PI created | 30 |
| 🟥 FAIL — PI created with wrong expense_account | 2 |
| 🟥 DEFECT_CONFIRMED — missing cost_center on S243 stores | 4 |

## Three defect classes discovered

**A — 4 stores** (ROA, SMM, SMMM, SMS): missing `Company.cost_center` after S243. PI generator `_resolve_per_store_cost_center` throws → savepoint rollback → silent miss.

**B — 32 stores** (NEW, unexpected): missing `Company.stock_received_but_not_billed` when `enable_perpetual_inventory=1`. ERPNext throws `ValidationError: Please set default Stock Received But Not Billed in Company ...` during PI validate → savepoint rollback → silent miss. Full traceback captured for AYALA FAIRVIEW TERRACES in evidence.

**C — 2 visible** (potentially all 32 once B is unblocked): ERPNext `set_expense_account(for_validate=True)` overwrites the manually-set \`1104210 - Inventory-from-Commissary\` with \`Warehouse.account\` (e.g. \`Stock In Hand - GHO\`). Generator design is incompatible with ERPNext auto-override when \`update_stock=1\`.

**D (informational)** — 13 \"PASS\" stores pass only because \`enable_perpetual_inventory=0\` — ERPNext auto-stock-accounting is skipped entirely. PIs insert but post **zero stock GL** on submit. The design intent of \`update_stock=1\` is silently dropped on 100% of active stores today.

Per-Company evidence (`evidence/perp_result.json`):

| `enable_perpetual_inventory` | `stock_received_but_not_billed` | Verdict | Count |
|---|---|---|---|
| 0 (disabled) | NULL | PASS — but no stock GL | 13 |
| 1 (enabled) | NULL | FAIL (no PI) | 30 |
| 1 (enabled) | SET | FAIL (wrong account) | 2 |
| 0 (disabled) | NULL | DEFECT_CONFIRMED (missing CC) | 4 |

## Architectural decision needed before any fix

1. **Disable perpetual everywhere** (match the 13 PASS pattern) — fast, simple; design intent lost.
2. **Set SRBNB + Warehouse.account=1104210 everywhere** — ERPNext-canonical; more data fixes per store.
3. **Redesign generator** (drop `update_stock=1`, split into separate Stock Entry) — clean separation; requires generator rewrite.

**CEO chose:** *park as documented findings, no fix PR yet* — pending Denise (head of finance) review of ICT-003 GL model.

## Files

- `output/l3/billing-sweep-2026-05-11/SUMMARY.md` — top-level summary
- `output/l3/billing-sweep-2026-05-11/DEFECTS.md` — full defect descriptions + fix options
- `output/l3/billing-sweep-2026-05-11/GAP_ANALYSIS.md` — initial per-store readiness
- `output/l3/billing-sweep-2026-05-11/evidence/*.json` — 6 raw probe outputs
- `scripts/billing_sweep/multi_store_smoke.py` + 6 probes + 7 SSM wrappers (reusable toolkit; README included)

## What was NOT done

- ❌ No fix PR opened
- ❌ No master-data UPDATE to `Company.cost_center` / `stock_received_but_not_billed` / `Warehouse.account`
- ❌ S245 (4-store cost_center fix originally planned) NOT executed
- ❌ Cleanup of historical 839 test BKI SIs deferred to a separate sprint

## Follow-up sprint candidates

1. **Architectural decision sprint** — Sam + Denise pick Option 1/2/3 from DEFECTS.md
2. **Cleanup of 839 test BKI SIs** (S246 candidate)
3. **Extend `verify_canonical_structure.py`** to assert perpetual+SRBNB+cost_center+warehouse.account triad
4. **ICT-003 GL model review checkpoint** with Denise

🤖 Generated with [Claude Code](https://claude.com/claude-code)