### PR TITLE
fix(documenso): stale-closure cookie Expires bug + signin health probe

### DIFF
--- a/scripts/documenso/patch_session_cookie_stale_closure.py
+++ b/scripts/documenso/patch_session_cookie_stale_closure.py
@@ -1,0 +1,264 @@
+"""Patch Documenso's session-cookies.js to fix a stale-closure cookie Expires bug.
+
+PROBLEM
+-------
+In `packages/auth/server/lib/session/session-cookies.ts`, the module exports a
+`sessionCookieOptions` object whose `expires` field is computed at module load:
+
+    const sessionCookieOptions = {
+      ...,
+      expires: new Date(Date.now() + AUTH_SESSION_LIFETIME)
+    };
+
+Node imports the module ONCE when the container boots. The `expires` is frozen
+to (boot_time + 30 days) and never recomputed. After 30 days of uptime, every
+cookie issued has `Expires=<past>` in the response header.
+
+Per RFC 6265, `Max-Age` should override `Expires` when both are present, but
+in practice:
+  - curl drops cookies with past Expires outright
+  - Safari is strict and may drop them
+  - Some corporate proxies strip them
+  - Some Chromium edge cases reject them
+
+The result: users complete the Google OAuth flow, return to /api/auth/callback/google,
+but the server can't find the state/code_verifier cookies (browser dropped them)
+→ 500 INVALID_REQUEST or OAuth2RequestError: invalid_grant.
+
+INCIDENT
+--------
+Discovered 2026-05-18 when all users were unable to sign in via Google to
+sign.bebang.ph. Container had been up since 2026-04-17 (30 days, 5 hours), so the
+frozen Expires date was already in the past (2026-05-17 01:55 UTC).
+
+FIX
+---
+Replace the static `expires` field with `maxAge`, which the browser computes on
+receipt instead of trusting a server-baked timestamp.
+
+    expires: new Date(Date.now() + AUTH_SESSION_LIFETIME)   # WRONG
+    maxAge: Math.floor(AUTH_SESSION_LIFETIME / 1000)         # RIGHT
+
+Hono cookie helper accepts `maxAge` in seconds. AUTH_SESSION_LIFETIME is in ms.
+
+USAGE
+-----
+    python scripts/documenso/patch_session_cookie_stale_closure.py
+    python scripts/documenso/patch_session_cookie_stale_closure.py --verify-only
+    python scripts/documenso/patch_session_cookie_stale_closure.py --no-restart
+    python scripts/documenso/patch_session_cookie_stale_closure.py --no-commit
+
+After a successful patch, restarts the container so Node re-imports the module,
+then commits the patched container to documenso/documenso:v2.8.1-bei-patched
+(deleting the old tag first per the documenso-fields-size skill hygiene rule).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from typing import Any
+
+AWS_REGION = "ap-southeast-1"
+INSTANCE_ID = "i-026b7477d27bd46d6"
+CONTAINER = "documenso"
+PATCH_TARGET = (
+    "/app/apps/remix/build/server/hono/packages/auth/server/lib/session/session-cookies.js"
+)
+OLD_LINE = "expires: new Date(Date.now() + AUTH_SESSION_LIFETIME)"
+NEW_LINE = "maxAge: Math.floor(AUTH_SESSION_LIFETIME / 1000)"
+PATCHED_IMAGE = "documenso/documenso:v2.8.1-bei-patched"
+COMMIT_MSG = (
+    "BEI: fix stale-closure expires bug in session-cookies.js + prior CC/Resend/field-size patches"
+)
+
+
+def ssm_run(commands: list[str], timeout: int = 240) -> dict[str, Any]:
+    """Execute a list of shell commands on the EC2 host via SSM."""
+    params = json.dumps({"commands": commands, "executionTimeout": [str(timeout)]})
+    send = subprocess.run(
+        [
+            "aws", "ssm", "send-command",
+            "--instance-ids", INSTANCE_ID,
+            "--document-name", "AWS-RunShellScript",
+            "--parameters", params,
+            "--region", AWS_REGION,
+            "--output", "json",
+        ],
+        capture_output=True, text=True,
+        creationflags=0x08000000 if sys.platform == "win32" else 0,
+    )
+    if send.returncode != 0:
+        raise RuntimeError(f"ssm send-command failed: {send.stderr}")
+    cid = json.loads(send.stdout)["Command"]["CommandId"]
+    deadline = time.time() + timeout + 60
+    while time.time() < deadline:
+        time.sleep(4)
+        inv = subprocess.run(
+            [
+                "aws", "ssm", "get-command-invocation",
+                "--command-id", cid,
+                "--instance-id", INSTANCE_ID,
+                "--region", AWS_REGION,
+                "--output", "json",
+            ],
+            capture_output=True, text=True,
+            creationflags=0x08000000 if sys.platform == "win32" else 0,
+        )
+        if inv.returncode != 0:
+            continue
+        data = json.loads(inv.stdout)
+        if data["Status"] in ("Success", "Failed", "TimedOut", "Cancelled"):
+            return {
+                "status": data["Status"],
+                "stdout": data.get("StandardOutputContent", ""),
+                "stderr": data.get("StandardErrorContent", ""),
+                "command_id": cid,
+            }
+    raise TimeoutError(f"SSM command {cid} did not finish within {timeout + 60}s")
+
+
+def check_patch_state() -> str:
+    """Return 'patched', 'unpatched', or 'unknown'."""
+    cmds = [
+        f"docker exec {CONTAINER} grep -F '{NEW_LINE}' {PATCH_TARGET} >/dev/null 2>&1 "
+        f"&& echo STATE=patched "
+        f"|| (docker exec {CONTAINER} grep -F '{OLD_LINE}' {PATCH_TARGET} >/dev/null 2>&1 "
+        f"&& echo STATE=unpatched || echo STATE=unknown)"
+    ]
+    r = ssm_run(cmds, timeout=60)
+    for line in r["stdout"].splitlines():
+        if line.startswith("STATE="):
+            return line.split("=", 1)[1].strip()
+    return "unknown"
+
+
+def apply_patch() -> dict[str, Any]:
+    """Apply the sed patch to the running container."""
+    cmds = [
+        f"docker exec {CONTAINER} cp {PATCH_TARGET} {PATCH_TARGET}.bak",
+        # `|` delimiter since OLD/NEW contain `/`
+        f"docker exec {CONTAINER} sed -i 's|{OLD_LINE}|{NEW_LINE}|' {PATCH_TARGET}",
+        # Verify
+        f"docker exec {CONTAINER} grep -F '{NEW_LINE}' {PATCH_TARGET} "
+        f"&& echo PATCH_VERIFIED || echo PATCH_VERIFICATION_FAILED",
+    ]
+    return ssm_run(cmds, timeout=60)
+
+
+def restart_container() -> dict[str, Any]:
+    """Restart documenso container and wait for /signin to return 200."""
+    cmds = [
+        f"docker restart {CONTAINER}",
+        "for i in $(seq 1 30); do",
+        "  code=$(curl -sS -m 5 -o /dev/null -w '%{http_code}' https://sign.bebang.ph/signin 2>/dev/null)",
+        "  if [ \"$code\" = \"200\" ]; then echo HEALTHY_AFTER_${i}_ATTEMPTS; break; fi",
+        "  sleep 3",
+        "done",
+    ]
+    return ssm_run(cmds, timeout=180)
+
+
+def verify_cookies_have_no_expires() -> dict[str, Any]:
+    """Confirm the response no longer carries an `Expires=` cookie attribute."""
+    cmds = [
+        "curl -sS -m 10 -X POST -i https://sign.bebang.ph/api/auth/oauth/authorize/google "
+        "2>&1 | grep -i 'set-cookie:' | head -5",
+    ]
+    return ssm_run(cmds, timeout=30)
+
+
+def commit_patched_image() -> dict[str, Any]:
+    """Delete old patched tag, commit the running container as the new patched image."""
+    cmds = [
+        f"docker rmi {PATCHED_IMAGE} 2>&1 || echo 'rmi failed (container may still hold ref - usually ok)'",
+        f"docker commit -m '{COMMIT_MSG}' {CONTAINER} {PATCHED_IMAGE}",
+        f"docker images {PATCHED_IMAGE} --format 'id={{{{.ID}}}} created={{{{.CreatedAt}}}}'",
+    ]
+    return ssm_run(cmds, timeout=180)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Only report the current patch state; do not modify anything.",
+    )
+    parser.add_argument(
+        "--no-restart",
+        action="store_true",
+        help="Apply the patch but do not restart the container (no runtime effect until restart).",
+    )
+    parser.add_argument(
+        "--no-commit",
+        action="store_true",
+        help="Apply + restart but do not commit a new Docker image. Patch will be lost if the container is ever recreated.",
+    )
+    args = parser.parse_args()
+
+    print(f"[1/5] Checking patch state on {CONTAINER}@{INSTANCE_ID}...")
+    state = check_patch_state()
+    print(f"      state = {state}")
+
+    if args.verify_only:
+        return 0 if state == "patched" else 1
+
+    if state == "patched":
+        print("Patch already applied. Nothing to do.")
+        print("If you want to force re-commit anyway, run with --no-restart removed.")
+        return 0
+    if state == "unknown":
+        print("ERROR: Could not detect patch state. Source file may have changed shape upstream.")
+        print(f"Inspect manually: docker exec {CONTAINER} cat {PATCH_TARGET}")
+        return 2
+
+    print("[2/5] Applying patch...")
+    r = apply_patch()
+    if "PATCH_VERIFIED" not in r["stdout"]:
+        print("ERROR: patch verification failed")
+        print(r["stdout"])
+        print(r["stderr"])
+        return 3
+    print("      OK: patch applied + verified in /app/...")
+
+    if args.no_restart:
+        print("--no-restart given. Patch is on disk but not in memory until container restart.")
+        return 0
+
+    print("[3/5] Restarting container so Node re-imports the patched module...")
+    r = restart_container()
+    if "HEALTHY_AFTER_" not in r["stdout"]:
+        print("ERROR: container did not become healthy after restart")
+        print(r["stdout"])
+        return 4
+    print(f"      {next(l for l in r['stdout'].splitlines() if 'HEALTHY_AFTER_' in l)}")
+
+    print("[4/5] Smoke-testing cookies on /api/auth/oauth/authorize/google...")
+    r = verify_cookies_have_no_expires()
+    if "Expires=" in r["stdout"]:
+        print("ERROR: response still carries Expires= attribute on cookies. Patch may not have taken effect.")
+        print(r["stdout"])
+        return 5
+    if "Max-Age=" not in r["stdout"]:
+        print("ERROR: response does not carry Max-Age= attribute. Endpoint may be returning unexpected shape.")
+        print(r["stdout"])
+        return 6
+    print("      OK: cookies have Max-Age= and NO Expires= attribute.")
+
+    if args.no_commit:
+        print("--no-commit given. Patch is live in the running container but NOT in the image.")
+        print("If the container is recreated, the patch will be lost.")
+        return 0
+
+    print(f"[5/5] Committing patched container to {PATCHED_IMAGE}...")
+    r = commit_patched_image()
+    print(r["stdout"])
+    print("Done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/documenso/probe_signin_cookies.py
+++ b/scripts/documenso/probe_signin_cookies.py
@@ -1,0 +1,203 @@
+"""Daily health probe — verify sign.bebang.ph cookies are NOT born already expired.
+
+Detects regressions of the stale-closure Expires bug fixed on 2026-05-18.
+
+WHAT IT CHECKS
+--------------
+POSTs to https://sign.bebang.ph/api/auth/oauth/authorize/google and validates
+the Set-Cookie headers on the response:
+
+  HEALTHY (any of these):
+    - cookie has Max-Age=NNN and NO Expires= attribute (the patched state)
+    - cookie has Max-Age=NNN and Expires=<future date>
+
+  BROKEN (must alert):
+    - cookie has Expires=<past date>      ← the stale-closure bug recurring
+    - endpoint returns non-200             ← deeper service failure
+    - response has no JSON redirectUrl     ← provider config drift
+    - cookie is missing entirely           ← auth module unloaded
+
+WHAT IT DOES ON BROKEN
+----------------------
+- exit code 1 (suitable for cron / monitoring)
+- if --chat-webhook URL is given (or BEI_DOCUMENSO_PROBE_WEBHOOK env var),
+  POSTs an alert payload to a Google Chat incoming webhook
+- prints a one-line diagnosis to stdout
+
+USAGE
+-----
+    # Manual run
+    python scripts/documenso/probe_signin_cookies.py
+
+    # With chat alert
+    python scripts/documenso/probe_signin_cookies.py --chat-webhook 'https://chat.googleapis.com/...'
+
+    # As cron on EC2 host (suggested):
+    #   */60 * * * * /usr/bin/python3 /opt/bei/probe_signin_cookies.py --chat-webhook "$WEBHOOK" >> /var/log/documenso_signin_probe.log 2>&1
+
+EXIT CODES
+----------
+    0  cookie state is healthy
+    1  cookie state is broken — alert worth sending
+    2  could not probe (network/dns/timeout) — does not mean broken, but worth knowing
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+
+ENDPOINT = "https://sign.bebang.ph/api/auth/oauth/authorize/google"
+TIMEOUT_S = 15
+EXPECTED_COOKIES = ("google_oauth_state", "google_code_verifier")
+
+
+def probe() -> tuple[int, str, dict]:
+    """Returns (exit_code, message, evidence)."""
+    req = urllib.request.Request(
+        ENDPOINT,
+        data=b"{}",
+        method="POST",
+        headers={"Content-Type": "application/json", "User-Agent": "bei-signin-probe/1"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            headers = list(resp.getheaders())
+            status = resp.status
+    except urllib.error.HTTPError as e:
+        return 2, f"HTTP {e.code} from authorize endpoint", {"http_code": e.code}
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        return 2, f"could not reach authorize endpoint: {e}", {"error": str(e)}
+
+    evidence: dict = {
+        "http_code": status,
+        "endpoint": ENDPOINT,
+        "probed_at_utc": datetime.now(timezone.utc).isoformat(),
+        "set_cookie_headers": [v for k, v in headers if k.lower() == "set-cookie"],
+        "body_snippet": body[:200],
+    }
+
+    if status != 200:
+        return 1, f"endpoint returned HTTP {status} (expected 200)", evidence
+
+    try:
+        parsed = json.loads(body)
+        redirect_url = parsed.get("redirectUrl", "")
+    except ValueError:
+        return 1, "response is not valid JSON", evidence
+    if "accounts.google.com" not in redirect_url:
+        return 1, "response JSON does not contain a Google redirect URL", evidence
+
+    set_cookies = [v for k, v in headers if k.lower() == "set-cookie"]
+    if not set_cookies:
+        return 1, "no Set-Cookie headers in response — auth module not setting cookies", evidence
+
+    findings = []
+    cookies_seen: set[str] = set()
+    for sc in set_cookies:
+        name = sc.split("=", 1)[0].strip()
+        cookies_seen.add(name)
+        attrs = {}
+        for part in sc.split(";")[1:]:
+            part = part.strip()
+            if "=" in part:
+                k, _, v = part.partition("=")
+                attrs[k.strip().lower()] = v.strip()
+            else:
+                attrs[part.lower()] = True
+        has_max_age = "max-age" in attrs
+        expires_value = attrs.get("expires")
+        finding: dict = {"name": name, "has_max_age": has_max_age, "expires": expires_value}
+        if expires_value:
+            # Parse RFC 7231 IMF-fixdate, e.g. "Sun, 17 May 2026 01:55:00 GMT"
+            try:
+                exp_dt = datetime.strptime(expires_value, "%a, %d %b %Y %H:%M:%S GMT").replace(
+                    tzinfo=timezone.utc
+                )
+                finding["expires_dt"] = exp_dt.isoformat()
+                if exp_dt < datetime.now(timezone.utc):
+                    finding["fault"] = "EXPIRES_IN_PAST"
+            except ValueError:
+                finding["fault"] = "EXPIRES_UNPARSEABLE"
+        findings.append(finding)
+
+    evidence["cookie_findings"] = findings
+
+    missing = [c for c in EXPECTED_COOKIES if c not in cookies_seen]
+    if missing:
+        return 1, f"missing expected cookies: {missing}", evidence
+
+    bad = [f for f in findings if f.get("fault")]
+    if bad:
+        names = ", ".join(f["name"] for f in bad)
+        return 1, f"cookies with past/unparseable Expires: {names}", evidence
+
+    healthy_state = (
+        "patched (Max-Age only)"
+        if not any(f.get("expires") for f in findings)
+        else "unpatched-but-functional (Max-Age + future Expires)"
+    )
+    return 0, f"OK - {healthy_state}", evidence
+
+
+def send_chat_alert(webhook: str, message: str, evidence: dict) -> None:
+    """POST a Google Chat incoming-webhook message about a broken probe."""
+    text = (
+        "*sign.bebang.ph sign-in probe FAILED*\n"
+        f"`{message}`\n"
+        f"Probed at: {evidence.get('probed_at_utc')}\n"
+        f"HTTP: {evidence.get('http_code')}\n"
+        "Suggested first steps:\n"
+        "1. `docker restart documenso` on EC2 i-026b7477d27bd46d6 (30-day temp fix)\n"
+        "2. `python scripts/documenso/patch_session_cookie_stale_closure.py` (permanent fix)\n"
+        "3. Check that the running image is `documenso/documenso:v2.8.1-bei-patched`"
+    )
+    payload = json.dumps({"text": text}).encode()
+    req = urllib.request.Request(
+        webhook,
+        data=payload,
+        method="POST",
+        headers={"Content-Type": "application/json; charset=UTF-8"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+    except Exception as e:
+        print(f"alert delivery failed: {e}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--chat-webhook",
+        default=os.environ.get("BEI_DOCUMENSO_PROBE_WEBHOOK"),
+        help="Google Chat incoming webhook URL. Defaults to $BEI_DOCUMENSO_PROBE_WEBHOOK env var.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full evidence dict as JSON to stdout (in addition to the one-liner).",
+    )
+    args = parser.parse_args()
+
+    code, message, evidence = probe()
+    print(f"[{('OK' if code == 0 else 'FAIL' if code == 1 else 'WARN')}] {message}")
+    if args.json:
+        print(json.dumps(evidence, indent=2, default=str))
+
+    if code == 1 and args.chat_webhook:
+        send_chat_alert(args.chat_webhook, message, evidence)
+
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Adds an idempotent patch script for the Documenso `session-cookies.js` stale-closure bug that broke Google sign-in to sign.bebang.ph today.
- Adds a daily health probe that hits the authorize endpoint and exits non-zero if Set-Cookie ever ships a past `Expires` again.
- The actual patch is already live in production: `documenso/documenso:v2.8.1-bei-patched` `sha256:bcf51a959e96`. This PR is the source-of-truth + automation tooling so it never recurs silently.

## Root cause (today's incident)
`session-cookies.js` defined `sessionCookieOptions.expires = new Date(Date.now() + AUTH_SESSION_LIFETIME)` at module load. Node imports the module once when the container boots, so `Date.now()` is evaluated ONE time. After ~30 days uptime the frozen value is in the past. curl/Safari/some Chromium drop cookies with past `Expires` outright, breaking OAuth state + PKCE.

Reproduced today: container had been up since 2026-04-17T01:54:52, frozen `Expires` was exactly +30d = 2026-05-17 (yesterday).

## Files
- ``scripts/documenso/patch_session_cookie_stale_closure.py`` — idempotent. ``--verify-only`` checks state without modifying. Applies, restarts, smoke-tests, ``docker commit``s to the patched image (with ``rmi`` of old tag per the documenso-fields-size skill hygiene rule).
- ``scripts/documenso/probe_signin_cookies.py`` — pure stdlib, parses Set-Cookie headers, alerts via Google Chat webhook if configured. Designed for cron.

## What still needs doing (outside this PR)
1. Schedule ``probe_signin_cookies.py`` somewhere. Suggestion: host cron on EC2 ``i-026b7477d27bd46d6`` (same box as Documenso) since AWS SSM + curl is already proven there. Alternative: Blip Sentinel.
2. File the upstream issue. Draft text is in ``tmp/documenso_upstream_issue_draft.md`` locally (not committed — it's a one-shot artifact).

## Test plan
- [x] ``python scripts/documenso/patch_session_cookie_stale_closure.py --verify-only`` against live prod returns ``state = patched`` (already deployed)
- [x] ``python scripts/documenso/probe_signin_cookies.py`` against live prod returns ``[OK] OK - patched (Max-Age only)``
- [x] Container is on patched image (``docker inspect documenso`` shows ``Image=documenso/documenso:v2.8.1-bei-patched``)
- [x] Smoke test ``curl -i POST /api/auth/oauth/authorize/google`` — cookies have ``Max-Age=600`` and NO ``Expires=`` attribute

## Notes
- Branch was rebased onto current ``origin/production`` (commit ``35e050990`` ``registry(s242): update row to PLANNED_AUDITED_v1.1``).
- No code in ``hrms/`` is touched. This is operator-side automation for the self-hosted Documenso on EC2.