### PR TITLE
fix(documenso): reproducible Dockerfile + patch scripts + drift probe

### DIFF
--- a/scripts/documenso/Dockerfile
+++ b/scripts/documenso/Dockerfile
@@ -1,0 +1,66 @@
+# BEI Documenso — reproducible patched image
+#
+# Builds documenso/documenso:v2.8.1-bei-patched from upstream + the four
+# patch scripts in this directory. Replaces the previous "manually sed-patch
+# a running container then docker commit" workflow — which lost patches
+# (b) and (c)-on-signing-email at some point in 2026 without anyone noticing.
+#
+# Build:
+#   docker build -t documenso/documenso:v2.8.1-bei-patched -f Dockerfile .
+#
+# Then deploy by recreating the documenso container from the new image
+# (`docker stop documenso && docker rm documenso && docker run ...
+#  documenso/documenso:v2.8.1-bei-patched`).
+#
+# The four patches applied here:
+#   (a) Field-size multipliers in the envelope-editor bundle.
+#   (b) CC recipients receive the initial signing email.
+#   (c) Resend message-id captured into DocumentAuditLog (both send sites).
+#   (d) Session-cookie maxAge (fixes the stale-closure 30-day OAuth outage).
+#
+# Each patch script is idempotent and supports --verify-only — we apply once
+# and re-verify in the same RUN layer to guarantee the image is good.
+
+FROM documenso/documenso:v2.8.1
+
+USER root
+
+# Install Python only for the patching step. apk add + apk del happen in the
+# same RUN layer so Python is NOT present in the final image — keeps the size
+# delta vs upstream small (just the patched file diffs, ~200 KB).
+COPY patch_field_sizes.py \
+     patch_cc_notifications.py \
+     patch_resend_id_logging.py \
+     patch_session_cookie_stale_closure.py \
+     /tmp/bei-patch/
+
+RUN set -eux; \
+    apk add --no-cache python3; \
+    python3 /tmp/bei-patch/patch_field_sizes.py \
+        --search-root /app/apps/remix/build/client/assets; \
+    python3 /tmp/bei-patch/patch_field_sizes.py \
+        --search-root /app/apps/remix/build/client/assets --verify-only; \
+    python3 /tmp/bei-patch/patch_cc_notifications.py \
+        --search-root /app/apps/remix/build/server; \
+    python3 /tmp/bei-patch/patch_cc_notifications.py \
+        --search-root /app/apps/remix/build/server --verify-only; \
+    python3 /tmp/bei-patch/patch_resend_id_logging.py \
+        --search-root /app/apps/remix/build/server --kind completed; \
+    python3 /tmp/bei-patch/patch_resend_id_logging.py \
+        --search-root /app/apps/remix/build/server --kind completed --verify-only; \
+    python3 /tmp/bei-patch/patch_resend_id_logging.py \
+        --search-root /app/apps/remix/build/server --kind signing; \
+    python3 /tmp/bei-patch/patch_resend_id_logging.py \
+        --search-root /app/apps/remix/build/server --kind signing --verify-only; \
+    python3 /tmp/bei-patch/patch_session_cookie_stale_closure.py \
+        --search-root /; \
+    python3 /tmp/bei-patch/patch_session_cookie_stale_closure.py \
+        --search-root / --verify-only; \
+    rm -rf /tmp/bei-patch; \
+    apk del python3
+
+USER nodejs
+
+LABEL bei.documenso.patches="field-sizes,cc-notifications,resend-id-logging,session-cookie-maxage"
+LABEL bei.documenso.upstream="documenso/documenso:v2.8.1"
+LABEL bei.documenso.rebuild-cmd="docker build -t documenso/documenso:v2.8.1-bei-patched -f scripts/documenso/Dockerfile scripts/documenso/"

--- a/scripts/documenso/patch_cc_notifications.py
+++ b/scripts/documenso/patch_cc_notifications.py
@@ -1,0 +1,156 @@
+"""Patch (b) — let CC recipients receive the initial signing email.
+
+PROBLEM
+-------
+In `apps/remix/build/server/assets/send-signing-email.handler-<hash>.js` the
+initial-email handler has an early return for CC recipients:
+
+    if (recipient.role === RecipientRole.CC) {
+      return;
+    }
+
+That means CCs get the document completion email later but never see the
+initial "you have been CC'd on document X" notification. BEI's HR + supplier
+flows expect CCs to know about the document at the start, not just at the end.
+
+FIX
+---
+Comment out the body of the if-branch so the function falls through and the
+rest of the send routine runs for CC recipients too. The `if` condition is
+left in place (commented) for human readability — anyone reading the patched
+code sees both the original Documenso intent AND the BEI override.
+
+USAGE
+-----
+    python patch_cc_notifications.py --target /path/to/send-signing-email.handler.js
+    python patch_cc_notifications.py --target /path/to/file --verify-only
+    python patch_cc_notifications.py --search-root /app/apps/remix/build/server
+
+Designed to run inside the Documenso container during image build, or against
+an extracted file on the developer host.
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+BUNDLE_GLOB = "send-signing-email.handler-*.js"
+
+# Original block — needs to match the exact bytes the bundler emits.
+# Documenso v2.8.1 emits this single-line-friendly form (with 2-space indent + LF).
+UNPATCHED_BLOCK = (
+    "  if (recipient.role === RecipientRole.CC) {\n"
+    "    return;\n"
+    "  }\n"
+)
+PATCHED_BLOCK = (
+    "  // BEI patch: CC recipients receive the initial signing email.\n"
+    "  // Upstream skip kept commented for traceability.\n"
+    "  // if (recipient.role === RecipientRole.CC) {\n"
+    "  //   return;\n"
+    "  // }\n"
+)
+PATCH_MARKER = "// BEI patch: CC recipients receive the initial signing email."
+
+
+def detect_state(content: str) -> str:
+    if PATCH_MARKER in content:
+        return "patched"
+    if UNPATCHED_BLOCK in content:
+        return "unpatched"
+    # Tolerate single-line emitted form (no newline before the brace):
+    if re.search(r"if \(recipient\.role === RecipientRole\.CC\) \{\s*return;\s*\}", content):
+        return "unpatched_alt"
+    return "unknown"
+
+
+def apply_patch(content: str) -> tuple[str, str]:
+    state = detect_state(content)
+    if state == "unpatched":
+        return content.replace(UNPATCHED_BLOCK, PATCHED_BLOCK, 1), "OK: standard form replaced"
+    if state == "unpatched_alt":
+        # Single-line variant — replace the whole regex hit with the multi-line patched form.
+        pattern = re.compile(
+            r"if \(recipient\.role === RecipientRole\.CC\) \{\s*return;\s*\}"
+        )
+        return pattern.sub(PATCHED_BLOCK.rstrip("\n"), content, count=1), "OK: alt form replaced"
+    raise ValueError(f"unexpected state for apply_patch: {state}")
+
+
+def resolve_target(target: str | None, search_root: str | None) -> pathlib.Path:
+    if target:
+        p = pathlib.Path(target)
+        if not p.is_file():
+            raise FileNotFoundError(f"--target file not found: {target}")
+        return p
+    if not search_root:
+        raise ValueError("Must give either --target FILE or --search-root DIR.")
+    root = pathlib.Path(search_root)
+    if not root.is_dir():
+        raise FileNotFoundError(f"--search-root not a directory: {search_root}")
+    matches = sorted(p for p in root.rglob(BUNDLE_GLOB) if not p.name.endswith(".map"))
+    if not matches:
+        raise FileNotFoundError(f"No {BUNDLE_GLOB} under {search_root}.")
+    if len(matches) > 1:
+        raise RuntimeError(
+            f"Multiple matches under {search_root}: {[str(p) for p in matches]}. "
+            "Pass --target explicitly."
+        )
+    return matches[0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--target", help="Path to the send-signing-email.handler file.")
+    parser.add_argument(
+        "--search-root",
+        help="Directory to rglob for the handler bundle (e.g. /app/apps/remix/build/server).",
+    )
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Report current state, exit 0 if patched / 1 otherwise. No modifications.",
+    )
+    args = parser.parse_args()
+
+    try:
+        target = resolve_target(args.target, args.search_root)
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    content = target.read_text(encoding="utf-8")
+    state = detect_state(content)
+    print(f"target: {target}")
+    print(f"state:  {state}")
+
+    if args.verify_only:
+        return 0 if state == "patched" else 1
+
+    if state == "patched":
+        print("Already patched. No changes made.")
+        return 0
+    if state == "unknown":
+        print(
+            "ERROR: handler does not match either expected unpatched form. "
+            "Documenso may have changed the CC-skip code shape upstream.",
+            file=sys.stderr,
+        )
+        return 3
+
+    try:
+        new_content, msg = apply_patch(content)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 3
+
+    target.write_text(new_content, encoding="utf-8")
+    print(msg)
+    print(f"wrote: {target} ({len(new_content)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/documenso/patch_field_sizes.py
+++ b/scripts/documenso/patch_field_sizes.py
@@ -1,0 +1,221 @@
+"""Patch (a) — per-field-type size multipliers in Documenso's envelope-editor bundle.
+
+PROBLEM
+-------
+Documenso ships with one default field size (90×30 CSS px) for ALL field types.
+BEI signers need bigger signature fields and wider email/name fields so the placed
+field actually fits the content.
+
+The sizing happens inside the click-handler in
+`envelope-editor-renderer-provider-wrapper-<hash>.js`. The original line is:
+
+    const X=REF.current.width/W*100,Y=REF.current.height/H*100;
+
+Variable names are minified; the bundle filename hash changes per release. The
+sizing line shape is stable.
+
+FIX
+---
+Insert `_fw` (width multipliers) and `_fh` (height multipliers) lookup tables,
+then apply them via the field-type variable:
+
+    const _fw={"SIGNATURE":2.4,"FREE_SIGNATURE":2.4,"EMAIL":3.1,"NAME":2.4,
+               "DATE":1.5,"TEXT":2.2,"NUMBER":1.3},
+          _fh={"SIGNATURE":2.4,"FREE_SIGNATURE":2.4,"EMAIL":0.8,"NAME":0.8,
+               "DATE":0.8,"TEXT":0.8,"NUMBER":0.8},
+          X=(_fw[FIELDTYPE]||1)*REF.current.width/W*100,
+          Y=(_fh[FIELDTYPE]||1)*REF.current.height/H*100;
+
+The field-type variable is found by looking at the nearby `type:VAR` in the
+form-data object the click-handler returns. Field types not in the maps get
+multiplier 1 (default 90×30 px).
+
+Multipliers were chosen to match DocuSign / Adobe Sign / Dropbox Sign defaults
+for A4 documents.
+
+USAGE
+-----
+    python patch_field_sizes.py --target /path/to/bundle.js
+    python patch_field_sizes.py --target /path/to/bundle.js --verify-only
+    python patch_field_sizes.py --search-root /app/apps/remix/build/client/assets
+    python patch_field_sizes.py --search-root /app/apps/remix/build/client/assets --verify-only
+
+In the Dockerfile this is invoked with --search-root so the bundle is auto-discovered
+regardless of the filename hash.
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+# Width multipliers (on base 90px = field default)
+FW = {
+    "SIGNATURE": 2.4,       # 216px — drawn signature needs horizontal room
+    "FREE_SIGNATURE": 2.4,
+    "EMAIL": 3.1,           # 279px — fits firstname.lastname@company.com
+    "NAME": 2.4,            # 216px — fits Filipino names (25+ chars)
+    "DATE": 1.5,            # 135px — fits "2026-03-27" or "March 27, 2026"
+    "TEXT": 2.2,            # 198px — wider for notes/comments
+    "NUMBER": 1.3,          # 117px — fits amounts with commas
+}
+
+# Height multipliers (on base 30px = field default)
+FH = {
+    "SIGNATURE": 2.4,       # 72px — room for handwriting
+    "FREE_SIGNATURE": 2.4,
+    "EMAIL": 0.8,           # 24px — single line
+    "NAME": 0.8,
+    "DATE": 0.8,
+    "TEXT": 0.8,
+    "NUMBER": 0.8,
+}
+
+# The sizing line we expect to find in the unpatched bundle.
+# Matches: const VAR1=VAR2.current.width/VAR3*100,VAR4=VAR5.current.height/VAR6*100;
+SIZING_RE = re.compile(
+    r"const (\w+)=(\w+)\.current\.width/(\w+)\*100,(\w+)=(\w+)\.current\.height/(\w+)\*100;"
+)
+
+# Marker that the patch is already applied
+PATCH_MARKER = "_fw["
+
+# Bundle filename pattern (the hash suffix changes per release)
+BUNDLE_GLOB = "envelope-editor-renderer-provider-wrapper-*.js"
+
+
+def fw_literal() -> str:
+    return "{" + ",".join(f'"{k}":{v}' for k, v in FW.items()) + "}"
+
+
+def fh_literal() -> str:
+    return "{" + ",".join(f'"{k}":{v}' for k, v in FH.items()) + "}"
+
+
+def find_field_type_var(content: str, after_idx: int) -> str | None:
+    """Find the variable that holds the field type string, scanning forward from after_idx."""
+    # The click-handler returns a form-data object that includes `type:VAR`.
+    # Look for the first `type:<identifier>` after the sizing line.
+    m = re.search(r"type:(\w+)", content[after_idx:after_idx + 800])
+    return m.group(1) if m else None
+
+
+def detect_state(content: str) -> str:
+    """Return 'patched' / 'unpatched' / 'unknown'."""
+    if PATCH_MARKER in content:
+        return "patched"
+    if SIZING_RE.search(content):
+        return "unpatched"
+    return "unknown"
+
+
+def apply_patch(content: str) -> tuple[str, str]:
+    """Return (new_content, message). Raises ValueError if the patch can't be applied."""
+    m = SIZING_RE.search(content)
+    if not m:
+        raise ValueError("Sizing pattern not found — bundle layout has changed upstream.")
+
+    field_type_var = find_field_type_var(content, m.end())
+    if not field_type_var:
+        raise ValueError(
+            "Could not locate the field-type variable (`type:VAR`) after the sizing line. "
+            "Bundle layout has changed upstream."
+        )
+
+    old = m.group(0)
+    V1, R1, W, V2, R2, H = m.groups()
+    # R1 and R2 should be the same ref (e.g. both `D` or both `S`); we use R1 in the replacement.
+    new = (
+        f"const _fw={fw_literal()},"
+        f"_fh={fh_literal()},"
+        f"{V1}=(_fw[{field_type_var}]||1)*{R1}.current.width/{W}*100,"
+        f"{V2}=(_fh[{field_type_var}]||1)*{R1}.current.height/{H}*100;"
+    )
+    new_content = content.replace(old, new, 1)
+    if PATCH_MARKER not in new_content:
+        raise ValueError("Replacement did not take effect — internal error.")
+    return new_content, f"OK: patched (field-type variable = `{field_type_var}`)"
+
+
+def resolve_target(target: str | None, search_root: str | None) -> pathlib.Path:
+    """Locate the file to patch."""
+    if target:
+        p = pathlib.Path(target)
+        if not p.is_file():
+            raise FileNotFoundError(f"--target file not found: {target}")
+        return p
+    if not search_root:
+        raise ValueError("Must give either --target FILE or --search-root DIR.")
+    root = pathlib.Path(search_root)
+    if not root.is_dir():
+        raise FileNotFoundError(f"--search-root not a directory: {search_root}")
+    matches = sorted(p for p in root.glob(BUNDLE_GLOB) if not p.name.endswith(".map"))
+    if not matches:
+        raise FileNotFoundError(
+            f"No {BUNDLE_GLOB} under {search_root}. Build layout may have changed."
+        )
+    if len(matches) > 1:
+        raise RuntimeError(
+            f"Multiple bundles match {BUNDLE_GLOB} under {search_root}: {[str(p) for p in matches]}. "
+            "Pass --target explicitly."
+        )
+    return matches[0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--target", help="Path to the bundle file to patch.")
+    parser.add_argument(
+        "--search-root",
+        help=(
+            "Directory to glob for envelope-editor-renderer-provider-wrapper-*.js. "
+            "Typically /app/apps/remix/build/client/assets inside the Documenso container."
+        ),
+    )
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Report current patch state without modifying anything. Exits 0 if patched, 1 otherwise.",
+    )
+    args = parser.parse_args()
+
+    try:
+        target = resolve_target(args.target, args.search_root)
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    content = target.read_text(encoding="utf-8")
+    state = detect_state(content)
+    print(f"target: {target}")
+    print(f"state:  {state}")
+
+    if args.verify_only:
+        return 0 if state == "patched" else 1
+
+    if state == "patched":
+        print("Already patched. No changes made.")
+        return 0
+    if state == "unknown":
+        print(
+            "ERROR: Bundle does not match the expected unpatched OR patched shape. "
+            "Documenso may have changed the click-handler layout upstream.",
+            file=sys.stderr,
+        )
+        return 3
+
+    try:
+        new_content, msg = apply_patch(content)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 3
+
+    target.write_text(new_content, encoding="utf-8")
+    print(msg)
+    print(f"wrote: {target} ({len(new_content)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/documenso/patch_resend_id_logging.py
+++ b/scripts/documenso/patch_resend_id_logging.py
@@ -1,0 +1,194 @@
+"""Patch (c) — capture Resend message id into the DocumentAuditLog.
+
+PROBLEM
+-------
+Documenso writes one `EMAIL_SENT` audit-log row per outgoing email but does NOT
+store the provider message id. When a "CC didn't get the email" claim comes in,
+the only way to confirm delivery is to hand-search Resend's dashboard. Slow
+and brittle.
+
+FIX
+---
+Capture the object returned by `mailer.sendMail(...)` and write its id field
+into the audit-log `data.resendMessageId`. Two transformations are required at
+every send site:
+
+  (1) Wrap the await call:
+      await mailer.sendMail({...})
+        ->
+      const __resendResult = await mailer.sendMail({...})
+
+  (2) Append the captured id to the audit-log payload:
+      isResending: false
+        ->
+      isResending: false,
+        resendMessageId: __resendResult?.id ?? __resendResult?.messageId ?? null
+
+This applies to both `send-completed-email*.js` (the completion notification
+sent to all signers) and `send-signing-email.handler-*.js` (the initial signing
+request sent to each signer). Each file has its own send sites; we patch all
+sites in the chosen file.
+
+After patching, every EMAIL_SENT row has a `resendMessageId` field that can be
+GET'd against `https://api.resend.com/emails/<id>` to confirm delivery status.
+
+USAGE
+-----
+    python patch_resend_id_logging.py --target /path/to/send-completed-email.js
+    python patch_resend_id_logging.py --target /path/to/file --verify-only
+    python patch_resend_id_logging.py --search-root /app/apps/remix/build/server --kind completed
+    python patch_resend_id_logging.py --search-root /app/apps/remix/build/server --kind signing
+
+The `--kind` flag selects which file pattern to discover (`completed` or `signing`).
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+KIND_GLOBS: dict[str, str] = {
+    "completed": "send-completed-email*.js",
+    "signing": "send-signing-email.handler-*.js",
+}
+
+# (1) Wrap the mailer call.
+SEND_OLD = "await mailer.sendMail({"
+SEND_NEW = "const __resendResult = await mailer.sendMail({"
+
+# (2) Append the captured id to the audit-log payload.
+# In both files the `isResending: false` line is the last entry of the data block,
+# so appending a comma + new field is safe.
+LOG_OLD = "isResending: false"
+LOG_NEW = (
+    "isResending: false,\n"
+    "          resendMessageId: __resendResult?.id ?? __resendResult?.messageId ?? null"
+)
+
+# Marker that the patch is already applied
+PATCH_MARKER = "__resendResult"
+
+
+def detect_state(content: str) -> str:
+    if PATCH_MARKER in content and "resendMessageId" in content:
+        return "patched"
+    if SEND_OLD in content and LOG_OLD in content:
+        return "unpatched"
+    if SEND_OLD in content or LOG_OLD in content:
+        return "partial"  # one of the two markers — manual investigation needed
+    return "unknown"
+
+
+def apply_patch(content: str) -> tuple[str, int]:
+    """Apply both replacements. Returns (new_content, total_replacements_made)."""
+    # Count how many sites we have BEFORE replacement so we can verify after.
+    n_send_old = content.count(SEND_OLD)
+    n_log_old = content.count(LOG_OLD)
+
+    new_content = content.replace(SEND_OLD, SEND_NEW)
+    new_content = new_content.replace(LOG_OLD, LOG_NEW)
+
+    n_send_new = new_content.count(SEND_NEW)
+    n_log_new = new_content.count("resendMessageId: __resendResult")
+
+    if n_send_new != n_send_old:
+        raise ValueError(
+            f"sendMail wrap mismatch: expected {n_send_old} replacements, got {n_send_new}"
+        )
+    if n_log_new != n_log_old:
+        raise ValueError(
+            f"audit-log append mismatch: expected {n_log_old} replacements, got {n_log_new}"
+        )
+
+    return new_content, n_send_old + n_log_old
+
+
+def resolve_target(target: str | None, search_root: str | None, kind: str | None) -> pathlib.Path:
+    if target:
+        p = pathlib.Path(target)
+        if not p.is_file():
+            raise FileNotFoundError(f"--target file not found: {target}")
+        return p
+    if not search_root or not kind:
+        raise ValueError("Must give either --target FILE or both --search-root DIR and --kind {completed,signing}.")
+    glob_pattern = KIND_GLOBS[kind]
+    root = pathlib.Path(search_root)
+    if not root.is_dir():
+        raise FileNotFoundError(f"--search-root not a directory: {search_root}")
+    matches = sorted(p for p in root.rglob(glob_pattern) if not p.name.endswith(".map"))
+    if not matches:
+        raise FileNotFoundError(f"No {glob_pattern} under {search_root}.")
+    if len(matches) > 1:
+        raise RuntimeError(
+            f"Multiple matches for {glob_pattern} under {search_root}: {[str(p) for p in matches]}. "
+            "Pass --target explicitly."
+        )
+    return matches[0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--target", help="Path to the email-sending file to patch.")
+    parser.add_argument(
+        "--search-root",
+        help="Directory to rglob inside (e.g. /app/apps/remix/build/server).",
+    )
+    parser.add_argument(
+        "--kind",
+        choices=sorted(KIND_GLOBS.keys()),
+        help="Which file family to patch when using --search-root.",
+    )
+    parser.add_argument(
+        "--verify-only",
+        action="store_true",
+        help="Report current state, exit 0 if patched / 1 otherwise. No modifications.",
+    )
+    args = parser.parse_args()
+
+    try:
+        target = resolve_target(args.target, args.search_root, args.kind)
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    content = target.read_text(encoding="utf-8")
+    state = detect_state(content)
+    print(f"target: {target}")
+    print(f"state:  {state}")
+
+    if args.verify_only:
+        return 0 if state == "patched" else 1
+
+    if state == "patched":
+        print("Already patched. No changes made.")
+        return 0
+    if state == "unknown":
+        print(
+            "ERROR: file does not contain expected mailer.sendMail / isResending markers. "
+            "Documenso may have refactored the email-sending code upstream.",
+            file=sys.stderr,
+        )
+        return 3
+    if state == "partial":
+        print(
+            "ERROR: file has SOME but not ALL of the expected markers. "
+            "Manual inspection required — won't patch automatically.",
+            file=sys.stderr,
+        )
+        return 3
+
+    try:
+        new_content, n = apply_patch(content)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 3
+
+    target.write_text(new_content, encoding="utf-8")
+    print(f"OK: applied {n} total replacements at {n // 2} send sites")
+    print(f"wrote: {target} ({len(new_content)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/documenso/patch_session_cookie_stale_closure.py
+++ b/scripts/documenso/patch_session_cookie_stale_closure.py
@@ -43,19 +43,28 @@ Hono cookie helper accepts `maxAge` in seconds. AUTH_SESSION_LIFETIME is in ms.
 
 USAGE
 -----
+File-on-disk mode (used in the Dockerfile build, or against an extracted file):
+    python patch_session_cookie_stale_closure.py --target /path/to/session-cookies.js
+    python patch_session_cookie_stale_closure.py --target /path/to/file --verify-only
+
+Live container mode (legacy path — patches the running container via AWS SSM):
     python scripts/documenso/patch_session_cookie_stale_closure.py
     python scripts/documenso/patch_session_cookie_stale_closure.py --verify-only
     python scripts/documenso/patch_session_cookie_stale_closure.py --no-restart
     python scripts/documenso/patch_session_cookie_stale_closure.py --no-commit
 
-After a successful patch, restarts the container so Node re-imports the module,
-then commits the patched container to documenso/documenso:v2.8.1-bei-patched
+The live mode restarts the container after patching so Node re-imports the
+module, then commits the patched container to documenso/documenso:v2.8.1-bei-patched
 (deleting the old tag first per the documenso-fields-size skill hygiene rule).
+This path predates the reproducible Dockerfile and is kept for emergency
+live-patching only. The preferred recovery path is now `docker build` from
+scripts/documenso/Dockerfile.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import pathlib
 import subprocess
 import sys
 import time
@@ -170,6 +179,79 @@ def verify_cookies_have_no_expires() -> dict[str, Any]:
     return ssm_run(cmds, timeout=30)
 
 
+def detect_state_in_file(path: pathlib.Path) -> str:
+    """Return 'patched' / 'unpatched' / 'unknown' for an on-disk file."""
+    content = path.read_text(encoding="utf-8")
+    if NEW_LINE in content:
+        return "patched"
+    if OLD_LINE in content:
+        return "unpatched"
+    return "unknown"
+
+
+def apply_patch_to_file(path: pathlib.Path) -> None:
+    """Apply the patch to an on-disk file. Idempotent."""
+    content = path.read_text(encoding="utf-8")
+    new_content = content.replace(OLD_LINE, NEW_LINE, 1)
+    if NEW_LINE not in new_content:
+        raise RuntimeError(f"replacement did not take effect on {path}")
+    path.write_text(new_content, encoding="utf-8")
+
+
+def run_file_mode(target: str | None, search_root: str | None, verify_only: bool) -> int:
+    """Handle the file-on-disk (Dockerfile-friendly) path. No SSM, no Docker."""
+    if target:
+        path = pathlib.Path(target)
+        if not path.is_file():
+            print(f"ERROR: --target file not found: {target}", file=sys.stderr)
+            return 2
+    else:
+        # --search-root mode: PATCH_TARGET is the absolute path inside the container,
+        # so we can use it directly when search_root == "/" (i.e. running in the container).
+        root = pathlib.Path(search_root)
+        if not root.is_dir():
+            print(f"ERROR: --search-root not a directory: {search_root}", file=sys.stderr)
+            return 2
+        # The target is at a known relative path under root.
+        rel = PATCH_TARGET.lstrip("/")
+        path = root / rel
+        if not path.is_file():
+            # Fall back to recursive glob in case the build layout shifts.
+            matches = list(root.rglob("session-cookies.js"))
+            if not matches:
+                print(f"ERROR: session-cookies.js not found under {search_root}", file=sys.stderr)
+                return 2
+            if len(matches) > 1:
+                print(
+                    f"ERROR: multiple session-cookies.js found: {[str(p) for p in matches]}. "
+                    "Pass --target explicitly.",
+                    file=sys.stderr,
+                )
+                return 2
+            path = matches[0]
+
+    state = detect_state_in_file(path)
+    print(f"target: {path}")
+    print(f"state:  {state}")
+
+    if verify_only:
+        return 0 if state == "patched" else 1
+    if state == "patched":
+        print("Already patched. No changes made.")
+        return 0
+    if state == "unknown":
+        print(
+            "ERROR: file does not contain expected unpatched or patched markers. "
+            "Documenso may have changed session-cookies.js upstream.",
+            file=sys.stderr,
+        )
+        return 3
+
+    apply_patch_to_file(path)
+    print(f"OK: patched {path}")
+    return 0
+
+
 def commit_patched_image() -> dict[str, Any]:
     """Delete old patched tag, commit the running container as the new patched image."""
     cmds = [
@@ -183,6 +265,14 @@ def commit_patched_image() -> dict[str, Any]:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     parser.add_argument(
+        "--target",
+        help="File-on-disk mode: path to session-cookies.js. Bypasses SSM/Docker.",
+    )
+    parser.add_argument(
+        "--search-root",
+        help="File-on-disk mode: directory to search for session-cookies.js (e.g. `/` inside the container).",
+    )
+    parser.add_argument(
         "--verify-only",
         action="store_true",
         help="Only report the current patch state; do not modify anything.",
@@ -190,15 +280,20 @@ def main() -> int:
     parser.add_argument(
         "--no-restart",
         action="store_true",
-        help="Apply the patch but do not restart the container (no runtime effect until restart).",
+        help="Live mode only: apply the patch but do not restart the container.",
     )
     parser.add_argument(
         "--no-commit",
         action="store_true",
-        help="Apply + restart but do not commit a new Docker image. Patch will be lost if the container is ever recreated.",
+        help="Live mode only: apply + restart but do not commit a new Docker image.",
     )
     args = parser.parse_args()
 
+    # File-on-disk mode (used by the Dockerfile RUN step or for ad-hoc patching).
+    if args.target or args.search_root:
+        return run_file_mode(args.target, args.search_root, args.verify_only)
+
+    # Live-container mode (legacy): patches the running container via SSM.
     print(f"[1/5] Checking patch state on {CONTAINER}@{INSTANCE_ID}...")
     state = check_patch_state()
     print(f"      state = {state}")

--- a/scripts/documenso/probe_patches.py
+++ b/scripts/documenso/probe_patches.py
@@ -1,0 +1,227 @@
+"""Daily drift-detection probe — verify all four BEI patches are present in the running Documenso container.
+
+WHAT IT CHECKS
+--------------
+For each of the four BEI patches, greps the running container for an indicator
+string that's only present when the patch is applied:
+
+  (a) field-size            : `_fw[` in envelope-editor-renderer-provider-wrapper-*.js
+  (b) CC initial-email      : `// BEI patch: CC recipients` marker in send-signing-email.handler-*.js
+  (c) Resend ID, completed  : `__resendResult` in send-completed-email*.js
+  (c) Resend ID, signing    : `__resendResult` in send-signing-email.handler-*.js
+  (d) Session-cookie maxAge : `maxAge: Math.floor` in session-cookies.js + absence of static expires
+
+WHAT IT DOES ON BROKEN
+----------------------
+- exit code 1 (suitable for cron / monitoring)
+- if --chat-webhook URL is given (or BEI_DOCUMENSO_PROBE_WEBHOOK env var),
+  POSTs a one-line alert to a Google Chat incoming webhook listing which
+  patches are missing
+- prints a per-patch table to stdout regardless of state
+
+USAGE
+-----
+    # Manual run
+    python scripts/documenso/probe_patches.py
+
+    # With chat alert
+    python scripts/documenso/probe_patches.py --chat-webhook 'https://chat.googleapis.com/...'
+
+    # As cron on EC2 host (suggested — runs every 6 hours):
+    #   0 */6 * * * /usr/bin/python3 /opt/bei/probe_patches.py \
+    #     --chat-webhook "$WEBHOOK" >> /var/log/documenso_patches_probe.log 2>&1
+
+This complements probe_signin_cookies.py — that one watches the *live runtime*
+behaviour (cookies in HTTP responses); this one watches *image state* (patched
+files on disk inside the container).
+
+EXIT CODES
+----------
+    0  all four patches present
+    1  one or more patches missing — alert worth sending
+    2  could not probe the container (docker / network / ssm error)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+AWS_REGION = "ap-southeast-1"
+INSTANCE_ID = "i-026b7477d27bd46d6"
+CONTAINER = "documenso"
+
+
+# Each check returns (label, status, evidence_string). Status is True if patch is present.
+# We define checks as one-shot shell expressions that exit 0/1 and echo a single token.
+
+CHECKS: list[dict[str, str]] = [
+    {
+        "id": "a",
+        "label": "field-size multipliers",
+        "expected_path_glob": "/app/apps/remix/build/client/assets/envelope-editor-renderer-provider-wrapper-*.js",
+        "marker": "_fw[",
+    },
+    {
+        "id": "b",
+        "label": "CC initial-email",
+        "expected_path_glob": "/app/apps/remix/build/server/assets/send-signing-email.handler-*.js",
+        "marker": "BEI patch: CC recipients receive the initial signing email",
+    },
+    {
+        "id": "c1",
+        "label": "Resend ID logging (completed)",
+        "expected_path_glob": "/app/apps/remix/build/server/hono/packages/lib/server-only/document/send-completed-email*.js",
+        "marker": "__resendResult",
+    },
+    {
+        "id": "c2",
+        "label": "Resend ID logging (signing)",
+        "expected_path_glob": "/app/apps/remix/build/server/assets/send-signing-email.handler-*.js",
+        "marker": "__resendResult",
+    },
+    {
+        "id": "d",
+        "label": "session-cookie maxAge",
+        "expected_path_glob": "/app/apps/remix/build/server/hono/packages/auth/server/lib/session/session-cookies.js",
+        "marker": "maxAge: Math.floor",
+    },
+]
+
+
+def ssm_run(commands: list[str], timeout: int = 120) -> tuple[str, str, str]:
+    """Returns (status, stdout, stderr)."""
+    params = json.dumps({"commands": commands, "executionTimeout": [str(timeout)]})
+    send = subprocess.run(
+        ["aws", "ssm", "send-command",
+         "--instance-ids", INSTANCE_ID,
+         "--document-name", "AWS-RunShellScript",
+         "--parameters", params,
+         "--region", AWS_REGION,
+         "--output", "json"],
+        capture_output=True, text=True,
+        creationflags=0x08000000 if sys.platform == "win32" else 0,
+    )
+    if send.returncode != 0:
+        return "send_failed", "", send.stderr
+    try:
+        cid = json.loads(send.stdout)["Command"]["CommandId"]
+    except (json.JSONDecodeError, KeyError) as e:
+        return "send_failed", "", str(e)
+    deadline = time.time() + timeout + 60
+    while time.time() < deadline:
+        time.sleep(3)
+        inv = subprocess.run(
+            ["aws", "ssm", "get-command-invocation",
+             "--command-id", cid,
+             "--instance-id", INSTANCE_ID,
+             "--region", AWS_REGION,
+             "--output", "json"],
+            capture_output=True, text=True,
+            creationflags=0x08000000 if sys.platform == "win32" else 0,
+        )
+        if inv.returncode != 0:
+            continue
+        try:
+            data = json.loads(inv.stdout)
+        except json.JSONDecodeError:
+            continue
+        if data["Status"] in ("Success", "Failed", "TimedOut", "Cancelled"):
+            return data["Status"], data.get("StandardOutputContent", ""), data.get("StandardErrorContent", "")
+    return "timeout", "", ""
+
+
+def run_one_check(check: dict[str, str]) -> tuple[bool, str]:
+    """Returns (present, evidence)."""
+    glob = check["expected_path_glob"]
+    marker = check["marker"]
+    # BusyBox-safe one-liner: find -> grep -F -l (literal match). Exit 0 if file contains marker.
+    cmd = (
+        f"FN=$(docker exec {CONTAINER} sh -c \"find $(dirname '{glob}') "
+        f"-maxdepth 4 -name '$(basename '{glob}')' -not -name '*.map' 2>/dev/null | head -1\"); "
+        f"if [ -z \"$FN\" ]; then echo NOTFOUND:no_match; exit 1; fi; "
+        f"if docker exec {CONTAINER} grep -qF '{marker}' \"$FN\"; "
+        f"then echo PRESENT:$FN; else echo MISSING:$FN; fi"
+    )
+    status, stdout, stderr = ssm_run([cmd])
+    if status != "Success":
+        return False, f"ssm_status={status} stderr={stderr.strip()[:200]}"
+    line = stdout.strip().splitlines()[-1] if stdout.strip() else ""
+    if line.startswith("PRESENT:"):
+        return True, line.split(":", 1)[1]
+    return False, line or "no_output"
+
+
+def post_chat_alert(webhook: str, missing: list[dict[str, Any]]) -> None:
+    msg = (
+        ":rotating_light: BEI Documenso patch drift detected on sign.bebang.ph\n\n"
+        + "\n".join(
+            f"• Patch ({m['id']}) {m['label']} — MISSING ({m['evidence']})" for m in missing
+        )
+        + "\n\nRebuild from `scripts/documenso/Dockerfile` and recreate the container."
+    )
+    body = json.dumps({"text": msg}).encode("utf-8")
+    req = urllib.request.Request(
+        webhook,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json; charset=UTF-8"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        print(f"WARNING: chat webhook POST failed: {e}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--chat-webhook",
+        default=os.environ.get("BEI_DOCUMENSO_PROBE_WEBHOOK", ""),
+        help="Optional Google Chat incoming webhook URL. Posted to on drift.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of the human-readable table.",
+    )
+    args = parser.parse_args()
+
+    results: list[dict[str, Any]] = []
+    for check in CHECKS:
+        present, evidence = run_one_check(check)
+        results.append({
+            "id": check["id"],
+            "label": check["label"],
+            "present": present,
+            "evidence": evidence,
+        })
+
+    missing = [r for r in results if not r["present"]]
+
+    if args.json:
+        print(json.dumps({"missing_count": len(missing), "results": results}, indent=2))
+    else:
+        for r in results:
+            sym = "OK" if r["present"] else "MISSING"
+            print(f"  [{sym}] ({r['id']}) {r['label']:30s} {r['evidence']}")
+        if missing:
+            print(f"\n{len(missing)} patch(es) missing.")
+        else:
+            print("\nAll four patches present.")
+
+    if missing and args.chat_webhook:
+        post_chat_alert(args.chat_webhook, missing)
+
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Replaces "manually sed-patch a running container and `docker commit`" with a reproducible `docker build` from `scripts/documenso/Dockerfile` plus four idempotent `patch_*.py` scripts.
- Adds `probe_patches.py` daily drift-detection — would have caught patches (b) and (c)-on-signing-email going silently missing months ago.
- Built and validated on EC2 as `documenso/documenso:v2.8.1-bei-patched-test`; all four patches verified inside the new image.
- **Production behavior unchanged.** The running container still uses the existing `a0c16742c7b6` image. Sam decides when to recreate from the new image.

## What this fixes

On 2026-05-22 I audited the live container against the memory's "all 4 BEI patches applied" claim. Result:

| Patch | Memory said | Actual live state |
|---|---|---|
| (a) field-size | applied | ✅ applied |
| (b) CC initial-email | applied | ❌ **MISSING** — CC return-skip still at line 397 |
| (c) Resend ID on signing | applied | ❌ **MISSING** — 0 `resendMessageId` references |
| (c) Resend ID on completed | applied | ✅ applied |
| (d) session-cookie maxAge | applied | ✅ applied |

Two of three image-only patches were gone with no committed source to recreate them from. This PR closes that gap permanently.

## Architecture change

Before: `documenso/documenso:v2.8.1-bei-patched` was produced by `docker exec documenso sed -i ...` then `docker commit`. Source for patches (a), (b), (c) lived only inside the committed image's layers — irrecoverable if the image was lost.

After: same tag is produced by `docker build -f scripts/documenso/Dockerfile scripts/documenso/`. Source is the four `patch_*.py` scripts in `scripts/documenso/`. Same upstream + same scripts always produces the same image.

## New files

- `scripts/documenso/Dockerfile` — reproducible build from `documenso/documenso:v2.8.1` upstream. Installs Python 3 via `apk add`, runs each patch with `--search-root` + `--verify-only` for confirmation, removes Python — all in one RUN layer (~200 KB delta vs upstream, no Python in final image).
- `scripts/documenso/patch_field_sizes.py` — patch (a), idempotent, regex-finds the sizing line and inserts per-field-type multipliers.
- `scripts/documenso/patch_cc_notifications.py` — patch (b), comments out the CC-skip block with a BEI marker.
- `scripts/documenso/patch_resend_id_logging.py` — patch (c), wraps `mailer.sendMail` and appends `resendMessageId` to the audit-log payload at every send site. `--kind {completed,signing}` selects which file.
- `scripts/documenso/probe_patches.py` — daily drift detection via SSM. Greps the running container for each patch's presence marker, exits non-zero with optional Chat webhook on any missing patch.

## Modified files

- `scripts/documenso/patch_session_cookie_stale_closure.py` — added `--target` / `--search-root` file-on-disk mode for Dockerfile RUN use. Existing SSM-driven live-patch path kept for emergency unblocks.

## Tests / verification

- `python -m py_compile` on all 5 scripts: pass.
- Patch scripts applied to extracted unpatched fixtures, verified idempotent (re-running is a no-op).
- `docker build` on EC2 produced `documenso/documenso:v2.8.1-bei-patched-test` with all 4 patches confirmed present via intra-image grep:
  ```
  (a) _fw[ present
  (b) BEI patch marker present
  (c1) __resendResult x4 in send-completed-email
  (c2) __resendResult x2 in send-signing-email
  (d) maxAge: Math.floor present
  ```
- `probe_patches.py` against current production: correctly reports (b) and (c-on-signing) as MISSING (which they are), exit code 1.

## Test plan (post-merge, manual by Sam)

- [ ] Pull the new branch on EC2 (or rebuild from scratch — same result)
- [ ] `docker tag documenso/documenso:v2.8.1-bei-patched-test documenso/documenso:v2.8.1-bei-patched`
- [ ] `docker stop documenso && docker rm documenso`
- [ ] `docker run -d --name documenso <same-flags-as-before> documenso/documenso:v2.8.1-bei-patched`
- [ ] `python scripts/documenso/probe_patches.py` → all 4 OK
- [ ] Smoke-test sign-in (the cookie probe should still pass)
- [ ] Send a test signing with a CC recipient → confirm the CC inbox now receives the initial email
- [ ] Check `DocumentAuditLog` for `resendMessageId` populated on a new signing-request email

## Risk

The container recreate is a brief outage window (~60s). Patches (b) and (c)-on-signing being newly applied will start sending initial emails to CCs and capturing Resend message IDs on signing emails — both behaviour restorations of what the memory already claimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)