### PR TITLE
fix(S253): before_cancel hook unblocks BKI SI cancel with paired PI/SE

### DIFF
--- a/hrms/api/bki_store_pi_generator.py
+++ b/hrms/api/bki_store_pi_generator.py
@@ -362,6 +362,32 @@ def resolve_account_by_number(company, account_number):
 	return rows[0]["name"]
 
 
+def allow_bki_si_cancel_with_paired_docs(doc, method=None):
+	"""S253 fix — Sales Invoice before_cancel hook.
+
+	Frappe's cancel() calls check_if_doc_is_linked() BEFORE on_cancel hooks fire.
+	The bki_si_reference Custom Field (Link type) on paired PI and SE triggers
+	LinkExistsError, making it impossible to cancel any BKI SI that has generated
+	paired documents.
+
+	This before_cancel hook tells Frappe to skip the link check for Purchase Invoice
+	and Stock Entry, allowing the cancel to proceed to on_cancel where the cascade
+	handlers (cascade_cancel_store_stock_entry + cascade_cancel_store_pi) properly
+	handle the paired docs.
+
+	Only applies to BKI SIs (company == BEBANG KITCHEN INC.). Non-BKI SIs are
+	unaffected — their link checks proceed normally.
+	"""
+	if doc.company != BKI_COMPANY:
+		return
+	if not hasattr(frappe.flags, "ignore_links_for_doctype"):
+		frappe.flags.ignore_links_for_doctype = []
+	if "Purchase Invoice" not in frappe.flags.ignore_links_for_doctype:
+		frappe.flags.ignore_links_for_doctype.append("Purchase Invoice")
+	if "Stock Entry" not in frappe.flags.ignore_links_for_doctype:
+		frappe.flags.ignore_links_for_doctype.append("Stock Entry")
+
+
 def cascade_cancel_store_pi(doc, method=None):
 	"""v2-B3: Sales Invoice on_cancel — cascade to paired store-side PI.
 

--- a/hrms/hooks.py
+++ b/hrms/hooks.py
@@ -230,6 +230,12 @@ doc_events = {
 			"hrms.api.bki_store_pi_generator.maybe_generate_store_pi",
 			"hrms.api.bki_store_stock_entry_generator.maybe_generate_store_stock_entry",
 		],
+		# S253 fix — Frappe's cancel() calls check_if_doc_is_linked() BEFORE
+		# on_cancel hooks fire. The bki_si_reference Link field on paired PI/SE
+		# triggers LinkExistsError, preventing cancellation entirely. The
+		# before_cancel hook sets ignore_links_for_doctype so the link check
+		# passes, then on_cancel cascade handles the paired docs correctly.
+		"before_cancel": "hrms.api.bki_store_pi_generator.allow_bki_si_cancel_with_paired_docs",
 		# S238/S247 — cascade-cancel paired docs on SI cancel. ORDER: SE FIRST, PI SECOND
 		# (reverse-creation, textbook cancellation pattern). Cancelling SE first keeps
 		# SRBNB net at zero throughout the cancellation window. v3 (S247): converted


### PR DESCRIPTION
## Production bug fix — BKI SI cancellation blocked by LinkExistsError

**Found during:** S253 Phase 3 cancel cascade E2E testing
**Impact:** No BKI Sales Invoice with paired PI/SE can be cancelled in production
**Root cause:** `bki_si_reference` Custom Field is Link type → Frappe's `check_if_doc_is_linked()` runs BEFORE `on_cancel` hooks → S247 cascade hooks never fire

### Fix

Added `before_cancel` hook on Sales Invoice (`hrms/hooks.py`) that calls `allow_bki_si_cancel_with_paired_docs` (`hrms/api/bki_store_pi_generator.py`). This function sets `frappe.flags.ignore_links_for_doctype = ["Purchase Invoice", "Stock Entry"]` for BKI SIs only (company == `BEBANG KITCHEN INC.`).

After the link check passes, the existing `on_cancel` cascade fires normally:
1. `cascade_cancel_store_stock_entry` — SE auto-cancels (submitted) or deletes (draft)
2. `cascade_cancel_store_pi` — PI gets Finance review Comment (submitted) or deletes (draft)

Non-BKI SIs are unaffected.

### Why not change Link → Data

Frappe blocks fieldtype changes: `ValidationError: Fieldtype cannot be changed from Link to Data`. The Link type is correct for referential integrity + navigation.

### Test plan

After merge + deploy, S253 Phase 3 cancel cascade test validates:
- SI cancel via `frappe.client.cancel` succeeds (no LinkExistsError)
- SE cancelled (docstatus=2) with GL reversal entries
- PI stays docstatus=1 with "Finance review required" Comment (asymmetry by design)
- SE cancel timestamp < PI action timestamp (SE-first order per hooks.py)

### Also includes

`round_off_cost_center` was set on 44/46 Companies via production API (missing master data that blocked PI submission). 1 remaining (`STA. LUCIA EAST GRAND MALL`) has a parent company validation issue — separate fix needed.